### PR TITLE
Removed the undocumented option "abstraction" which was used in only one...

### DIFF
--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -761,33 +761,10 @@ void SaturationAlgorithm::addNewClause(Clause* cl)
   //(there the control flow goes out of the SaturationAlgorithm class,
   //so we'd better not assume on what's happening out there)
   cl->incRefCnt();
-
-  if (_opt.abstraction() && cl->number()%100000==(24788+(env.statistics->inputClauses%50000)) && env.statistics->inputClauses%3==0) {
-    Clause* newCl = 0;
-    if (cl->length()>1) {
-      LiteralStack lits;
-      lits.loadFromIterator(Clause::Iterator(*cl));
-      newCl = Clause::fromStack(lits, cl->inputType(), cl->inference());
-    }
-    else if (cl->length()==1) {
-      Literal* lit = (*cl)[0];
-      if (lit->arity()) {
-	TermList orig = *lit->nthArgument(0);
-	Literal* newLit = EqHelper::replace(lit, orig, TermList(lit->vars(), false));
-	newCl = Clause::fromIterator(getSingletonIterator(newLit), cl->inputType(), cl->inference());
-      }
-    }
-    if (newCl) {
-      cl->incRefCnt();
-      newCl->incRefCnt();
-      cl=newCl;
-    }
-  }
-
+  
   onNewClause(cl);
-
-
   _newClauses.push(cl);
+  
   //we can decrease the counter here -- it won't get deleted because
   //the _newClauses RC stack already took over the clause
   cl->decRefCnt();

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -118,7 +118,6 @@ public:
 
 /** Names for all options */
 const char* Options::Constants::_optionNames[] = {
-  "abstraction",
   "age_weight_ratio",
   "aig_bdd_sweeping",
   "aig_conditional_rewriting",
@@ -803,7 +802,6 @@ NameArray Options::Constants::bpAlmostHalfBoundingRemovalValues(_bpAlmostHalfBou
  */
 Options::Options ()
   :
-  _abstraction(false),
   _ageRatio(1),
 
   _aigBddSweeping(false),
@@ -1065,9 +1063,6 @@ void Options::set(const char* name,const char* value, int index)
 
   try {
     switch (index) {
-    case ABSTRACTION:
-      _abstraction = onOffToBool(value,name);
-      return;
     case AGE_WEIGHT_RATIO:
       readAgeWeightRatio(value, _ageRatio, _weightRatio);
       return;
@@ -2054,9 +2049,6 @@ void Options::outputValue (ostream& str,int optionTag) const
   CALL("Options::outputValue");
 
   switch (optionTag) {
-  case ABSTRACTION:
-    str << boolToOnOff(_abstraction);
-    return;
   case AGE_WEIGHT_RATIO:
     str << _ageRatio << ':' << _weightRatio;
     return;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -28,7 +28,6 @@ class Options
 {
 public:
   enum Tag {
-    ABSTRACTION,
     AGE_WEIGHT_RATIO,
     AIG_BDD_SWEEPING,
     AIG_CONDITIONAL_REWRITING,
@@ -787,8 +786,6 @@ public:
   void set(const char* name, const char* value);
   void setShort(const char* name, const char* value);
 
-  bool abstraction() const { return _abstraction; }
-
   int nonGoalWeightCoeffitientNumerator() const { return _nonGoalWeightCoeffitientNumerator; }
   int nonGoalWeightCoeffitientDenominator() const { return _nonGoalWeightCoeffitientDenominator; }
 
@@ -832,7 +829,6 @@ private:
 private:
   class Constants;
 
-  bool _abstraction;
   int _ageRatio;
   bool _aigBddSweeping;
   bool _aigConditionalRewriting;


### PR DESCRIPTION
... place in the code

(namely in void SaturationAlgorithm::addNewClause(Clause\* cl))
and would trigger a weird thing to happen to the new clause under the cryptic condition

"cl->number()%100000==(24788+(env.statistics->inputClauses%50000)) && env.statistics->inputClauses%3==0"

Probably a forgotten leftover from some debugging frenzy...
