### PR TITLE
made vampire compile under clang, many warnings remain, though

### DIFF
--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -460,7 +460,7 @@ bool System::fileExists(vstring fname)
   BYPASSING_ALLOCATOR;
 
   ifstream ifile(fname.c_str());
-  return ifile;
+  return ifile.good();
 }
 
 /**

--- a/Minisat/core/SolverTypes.h
+++ b/Minisat/core/SolverTypes.h
@@ -57,7 +57,7 @@ struct Lit {
     int     x;
 
     // Use this as a constructor:
-    friend Lit mkLit(Var var, bool sign = false);
+    friend Lit mkLit(Var var, bool sign);
 
     bool operator == (Lit p) const { return x == p.x; }
     bool operator != (Lit p) const { return x != p.x; }
@@ -65,7 +65,7 @@ struct Lit {
 };
 
 
-inline  Lit  mkLit     (Var var, bool sign) { Lit p; p.x = var + var + (int)sign; return p; }
+inline  Lit  mkLit     (Var var, bool sign  = false) { Lit p; p.x = var + var + (int)sign; return p; }
 inline  Lit  operator ~(Lit p)              { Lit q; q.x = p.x ^ 1; return q; }
 inline  Lit  operator ^(Lit p, bool b)      { Lit q; q.x = p.x ^ (unsigned int)b; return q; }
 inline  bool sign      (Lit p)              { return p.x & 1; }

--- a/SAT/SATClause.cpp
+++ b/SAT/SATClause.cpp
@@ -298,11 +298,11 @@ vstring SATClause::toDIMACSString() const
   return result;
 }
 
-
-};
-
 std::ostream& operator<< (std::ostream& out, const SAT::SATClause& cl )
 {
   return out<<cl.toString();
 }
+
+};
+
 

--- a/SAT/SATClause.hpp
+++ b/SAT/SATClause.hpp
@@ -143,8 +143,8 @@ protected:
   SATLiteral _literals[1];
 }; // class SATClause
 
-};
-
 std::ostream& operator<< (std::ostream& out, const SAT::SATClause& cl );
+
+};
 
 #endif /* __SATClause__ */

--- a/SAT/SATLiteral.cpp
+++ b/SAT/SATLiteral.cpp
@@ -30,12 +30,10 @@ vstring SATLiteral::toString() const
   }
 }
 
-};
-
 std::ostream& operator<< (std::ostream& out, const SAT::SATLiteral& lit )
 {
   return out<<lit.toString();
 }
 
-
+};
 

--- a/SAT/SATLiteral.hpp
+++ b/SAT/SATLiteral.hpp
@@ -78,8 +78,8 @@ private:
  
 };
 
-};
-
 std::ostream& operator<< (std::ostream& out, const SAT::SATLiteral& lit );
+
+};
 
 #endif /* __SATLiteral__ */


### PR DESCRIPTION
Hi Giles, could you have a look at this small pull request?

These were the only changes needed to make vampire compile with clang (mac's default compiler coming with xcode).

Using clang along with gcc could help to improve the quality of our code. (It seems that clang is pickier than gcc as it generated many warning which I didn't fix yet.)
