### PR TITLE
DisagreeementSetIteratori::reset for Term* arguments resets the _stac…

### DIFF
--- a/Indexing/ClauseVariantIndex.cpp
+++ b/Indexing/ClauseVariantIndex.cpp
@@ -301,7 +301,7 @@ struct HashingClauseVariantIndex::VariableIgnoringComparator {
 
     //now get just some total deterministic order while ignoring variables
     static DisagreementSetIterator dsit;
-    dsit.fixedReset(t1, t2, false);
+    dsit.reset(t1, t2, false);
     while(dsit.hasNext()) {
       pair<TermList, TermList> dis=dsit.next();
       if(dis.first.isTerm()) {

--- a/Kernel/TermIterators.hpp
+++ b/Kernel/TermIterators.hpp
@@ -344,23 +344,6 @@ public:
     CALL("Term::DisagreementSetIterator::reset(Term*...)");
     ASS_EQ(t1->functor(), t2->functor());
 
-    _arg1.makeEmpty();
-
-    if(t1->arity()>0) {
-      _stack.push(t1->args());
-      _stack.push(t2->args());
-    }
-  }
-
-  /**
-   * TODO: the function above should take the code of this one and
-   * this one should be deleted (and calls to it replaced).
-   */
-  void fixedReset(Term* t1, Term* t2, bool disjunctVariables=true)
-  {
-    CALL("Term::DisagreementSetIterator::fixedReset(Term*...)");
-    ASS_EQ(t1->functor(), t2->functor());
-
     _stack.reset();
     _disjunctVariables=disjunctVariables;
 

--- a/UnitTests/tDisagreement.cpp
+++ b/UnitTests/tDisagreement.cpp
@@ -1,0 +1,43 @@
+#include <iostream>
+
+#include "Forwards.hpp"
+#include "Lib/Environment.hpp"
+
+#include "Kernel/TermIterators.hpp"
+#include "Kernel/Signature.hpp"
+#include "Kernel/Term.hpp"
+
+#include "Test/UnitTesting.hpp"
+
+#define UNIT_ID disagreement
+UT_CREATE;
+
+using namespace std;
+using namespace Lib;
+
+using namespace Kernel;
+
+TEST_FUN(dis1)
+{
+
+  unsigned p = env.signature->addFunction("p",1);
+  TermList x(0,false);
+  TermList y(1,false);
+  Term* px = Term::create1(p,x);
+  Term* py = Term::create1(p,y);
+
+  cout << endl;
+
+  static DisagreementSetIterator dsit;
+  dsit.reset(px, px, true);
+
+  while (dsit.hasNext()) {
+    pair<TermList, TermList> diff=dsit.next();
+    TermList st1=diff.first;
+    TermList st2=diff.second;
+
+    cout << "st1 " << st1.toString() << endl;
+    cout << "st2 " << st2.toString() << endl;
+  }
+
+}


### PR DESCRIPTION
…k and sets _disjointVariables properly. This first change saves memory; although the previous version was buggy, it seems the bug was actually never exposed. The second change couldn't affect the cases where the iterator was initialized via a non-default constructor as 1) the TermList constructor calls TermList reset which sets _disjointVariables, and 2) the Term\* constructor sets disjoint variables in its initializer list. The cases where static DisagreementIteratorSet was used, either wanted _disjointVariables false and that's what was happening by accident as static local variables are 0 initialized, or used the TermList reset which sets _disjointVaraibles properly. This means the fix should not cause any unexpected behaviour.
