### PR TITLE
Strategy Scheduler.

### DIFF
--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -54,6 +54,11 @@ class PortfolioMode {
 
 public:
   static bool perform(float slowness);
+  // moved to public as I need access from internal classes
+  // probably should be a nicer way to do this
+  // FIXME: have a think
+  void runSlice(vstring slice, unsigned timeLimitInDeciseconds) NO_RETURN;
+  unsigned getSliceTime(vstring sliceCode,vstring& chopped);
 
 private:
 
@@ -63,9 +68,7 @@ private:
   bool performStrategy(Shell::Property* property);
   void getSchedules(Property& prop, Schedule& quick, Schedule& fallback);
   bool runSchedule(Schedule& schedule, int terminationTime);
-  unsigned getSliceTime(vstring sliceCode,vstring& chopped);
   bool waitForChildAndCheckIfProofFound();
-  void runSlice(vstring slice, unsigned timeLimitInDeciseconds) NO_RETURN;
   void runSlice(Options& strategyOpt) NO_RETURN;
 
 #if VDEBUG

--- a/CASC/ScheduleExecutor.cpp
+++ b/CASC/ScheduleExecutor.cpp
@@ -16,147 +16,152 @@ using namespace Lib::Sys;
 #define DECI(milli) (milli/100)
 
 ScheduleExecutor::ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor)
-	: _policy(policy), _executor(executor)
+  : _policy(policy), _executor(executor)
 {
-	CALL("ScheduleExecutor::ScheduleExecutor");
-	_numWorkers = getNumWorkers();
+  CALL("ScheduleExecutor::ScheduleExecutor");
+  _numWorkers = getNumWorkers();
 }
 
 class Item
 {
 public:
-	Item() : _started(true), _process(-1), _code("") {}
-	Item(vstring code)
-		: _started(false), _process(-1), _code(code) {}
-	Item(pid_t process)
-		: _started(true), _process(process), _code("") {}
+  Item() : _started(true), _process(-1), _code("") {}
+  Item(vstring code)
+    : _started(false), _process(-1), _code(code) {}
+  Item(pid_t process)
+    : _started(true), _process(process), _code("") {}
 
-	bool started() const {return _started;}
-	vstring code() const
-	{
-		ASS(!started());
-		return _code;
-	}
-	pid_t process() const
-	{
-		ASS(started());
-		return _process;
-	}
+  bool started() const {return _started;}
+  vstring code() const
+  {
+    ASS(!started());
+    return _code;
+  }
+  pid_t process() const
+  {
+    ASS(started());
+    return _process;
+  }
 
 private:
-	bool _started;
-	pid_t _process;
-	vstring _code;
+  bool _started;
+  pid_t _process;
+  vstring _code;
 };
 
 bool ScheduleExecutor::run(const Schedule &schedule, int terminationTime)
 {
-	CALL("ScheduleExecutor::run");
+  CALL("ScheduleExecutor::run");
 
-	PriorityQueue<Item> queue;
-	Schedule::BottomFirstIterator it(schedule);
+  PriorityQueue<Item> queue;
+  Schedule::BottomFirstIterator it(schedule);
 
-	// insert all strategies into the queue
-	while(it.hasNext())
-	{
-		vstring code = it.next();
-		float priority = _policy->staticPriority(code);
-		queue.insert(priority, code);
-	}
+  // insert all strategies into the queue
+  while(it.hasNext())
+  {
+    vstring code = it.next();
+    float priority = _policy->staticPriority(code);
+    queue.insert(priority, code);
+  }
 
-	typedef List<pid_t> Pool;
-	Pool *pool = Pool::empty();
+  typedef List<pid_t> Pool;
+  Pool *pool = Pool::empty();
 
-	bool success = false;
-	while(Timer::syncClock(), DECI(env.timer->elapsedMilliseconds()) < terminationTime)
-	{
-		unsigned poolSize = pool ? Pool::length(pool) : 0;
+  bool success = false;
+  while(Timer::syncClock(), DECI(env.timer->elapsedMilliseconds()) < terminationTime)
+  {
+    unsigned poolSize = pool ? Pool::length(pool) : 0;
 
-		// running under capacity, wake up more tasks
-		while(poolSize < _numWorkers && !queue.isEmpty())
-		{
-			Item item = queue.pop();
-			pid_t process;
-			if(!item.started())
-			{
-				process = spawn(item.code(), terminationTime);
-			}
-			else
-			{
-				process = item.process();
-				Multiprocessing::instance()->kill(process, SIGCONT);
-			}
-			Pool::push(process, pool);
-			poolSize++;
-		}
+    // running under capacity, wake up more tasks
+    while(poolSize < _numWorkers && !queue.isEmpty())
+    {
+      Item item = queue.pop();
+      pid_t process;
+      if(!item.started())
+      {
+        process = spawn(item.code(), terminationTime);
+      }
+      else
+      {
+        process = item.process();
+        Multiprocessing::instance()->kill(process, SIGCONT);
+      }
+      Pool::push(process, pool);
+      poolSize++;
+    }
 
-		bool stopped, exited;
-		int code;
-		// sleep until process changes state
-		pid_t process = Multiprocessing::instance()
-			->poll_children(stopped, exited, code);
+    bool stopped, exited;
+    int code;
+    // sleep until process changes state
+    pid_t process = Multiprocessing::instance()
+      ->poll_children(stopped, exited, code);
 
-		// child died, remove it from the pool and check if succeeded
-		if(exited)
-		{
-			pool = Pool::remove(process, pool);
-			if(!code)
-			{
-				success = true;
-				goto exit;
-			}
-		}
-		// child stopped, re-insert it in the queue
-		else if(stopped)
-		{
-			pool = Pool::remove(process, pool);
-			float priority = _policy->dynamicPriority(process);
-			queue.insert(priority, Item(process));
-		}
+    // child died, remove it from the pool and check if succeeded
+    if(exited)
+    {
+      pool = Pool::remove(process, pool);
+      if(!code)
+      {
+        success = true;
+        goto exit;
+      }
+    }
+    // child stopped, re-insert it in the queue
+    else if(stopped)
+    {
+      pool = Pool::remove(process, pool);
+      float priority = _policy->dynamicPriority(process);
+      queue.insert(priority, Item(process));
+    }
 
-		// pool empty and queue exhausted - we failed
-		if(!pool && queue.isEmpty())
-		{
-			goto exit;
-		}
-	}
+    // pool empty and queue exhausted - we failed
+    if(!pool && queue.isEmpty())
+    {
+      goto exit;
+    }
+  }
 
 exit:
-	// kill all running processes first
-	Pool::DestructiveIterator killIt(pool);
-	while(killIt.hasNext())
-	{
-		pid_t process = killIt.next();
-		Multiprocessing::instance()->killNoCheck(process, SIGKILL);
-	}
-	return success;
+  // kill all running processes first
+  Pool::DestructiveIterator killIt(pool);
+  while(killIt.hasNext())
+  {
+    pid_t process = killIt.next();
+    Multiprocessing::instance()->killNoCheck(process, SIGKILL);
+  }
+  return success;
 }
 
 unsigned ScheduleExecutor::getNumWorkers()
 {
-	CALL("ScheduleExecutor::getNumWorkers");
+  CALL("ScheduleExecutor::getNumWorkers");
 
-	unsigned cores = System::getNumberOfCores();
-	cores = cores < 1 ? 1 : cores;
-	unsigned workers = min(cores, env.options->multicore());
-	if(!workers)
-		workers = cores >= 8 ? cores - 2 : cores;
-	return workers;
+  unsigned cores = System::getNumberOfCores();
+  cores = cores < 1 ? 1 : cores;
+  unsigned workers = min(cores, env.options->multicore());
+  if(!workers)
+  {
+    workers = cores >= 8 ? cores - 2 : cores;
+  }
+  return workers;
 }
 
 pid_t ScheduleExecutor::spawn(vstring code, int terminationTime)
 {
-	CALL("ScheduleExecutor::spawn");
+  CALL("ScheduleExecutor::spawn");
 
-	pid_t pid = Multiprocessing::instance()->fork();
-	ASS_NEQ(pid, -1);
+  pid_t pid = Multiprocessing::instance()->fork();
+  ASS_NEQ(pid, -1);
 
-	// parent
-	if(pid)	return pid;
-	// child
-	else
-	{
-		_executor->runSlice(code, terminationTime);
-		ASSERTION_VIOLATION; // should not return
-	}
+  // parent
+  if(pid)
+  {
+    return pid;
+  }
+  // child
+  else
+  {
+    _executor->runSlice(code, terminationTime);
+    ASSERTION_VIOLATION; // should not return
+  }
 }

--- a/CASC/ScheduleExecutor.cpp
+++ b/CASC/ScheduleExecutor.cpp
@@ -1,0 +1,164 @@
+#include "ScheduleExecutor.hpp"
+
+#include "Lib/Array.hpp"
+#include "Lib/Environment.hpp"
+#include "Lib/List.hpp"
+#include "Lib/PriorityQueue.hpp"
+#include "Lib/System.hpp"
+#include "Lib/Sys/Multiprocessing.hpp"
+#include "Lib/Timer.hpp"
+#include "Shell/Options.hpp"
+
+using namespace CASC;
+using namespace Lib;
+using namespace Lib::Sys;
+
+#define DECI(milli) (milli/100)
+
+ScheduleExecutor::ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor)
+	: _policy(policy), _executor(executor)
+{
+	CALL("ScheduleExecutor::ScheduleExecutor");
+	_numWorkers = getNumWorkers();
+}
+
+class Item
+{
+public:
+	Item() : _started(true), _process(-1), _code("") {}
+	Item(vstring code)
+		: _started(false), _process(-1), _code(code) {}
+	Item(pid_t process)
+		: _started(true), _process(process), _code("") {}
+
+	bool started() const {return _started;}
+	vstring code() const
+	{
+		ASS(!started());
+		return _code;
+	}
+	pid_t process() const
+	{
+		ASS(started());
+		return _process;
+	}
+
+private:
+	bool _started;
+	pid_t _process;
+	vstring _code;
+};
+
+bool ScheduleExecutor::run(const Schedule &schedule, int terminationTime)
+{
+	CALL("ScheduleExecutor::run");
+
+	PriorityQueue<Item> queue;
+	Schedule::BottomFirstIterator it(schedule);
+
+	// insert all strategies into the queue
+	while(it.hasNext())
+	{
+		vstring code = it.next();
+		float priority = _policy->staticPriority(code);
+		queue.insert(priority, code);
+	}
+
+	typedef List<pid_t> Pool;
+	Pool *pool = Pool::empty();
+
+	bool success = false;
+	while(Timer::syncClock(), DECI(env.timer->elapsedMilliseconds()) < terminationTime)
+	{
+		unsigned poolSize = pool ? Pool::length(pool) : 0;
+
+		// running under capacity, wake up more tasks
+		while(poolSize < _numWorkers && !queue.isEmpty())
+		{
+			Item item = queue.pop();
+			pid_t process;
+			if(!item.started())
+			{
+				process = spawn(item.code(), terminationTime);
+			}
+			else
+			{
+				process = item.process();
+				Multiprocessing::instance()->kill(process, SIGCONT);
+			}
+			Pool::push(process, pool);
+			poolSize++;
+		}
+
+		// check if any pool processes died or suspended
+		Pool::Iterator deathIt(pool);
+		while(deathIt.hasNext())
+		{
+			pid_t process = deathIt.next();
+			bool stopped, exited;
+			int code;
+			Multiprocessing::instance()->poll_child(process, stopped, exited, code);
+
+			if(exited)
+			{
+				pool = Pool::remove(process, pool);
+				if(!code)
+				{
+					success = true;
+					goto exit;
+				}
+			}
+			else if(stopped)
+			{
+				pool = Pool::remove(process, pool);
+				float priority = _policy->dynamicPriority(process);
+				queue.insert(priority, Item(process));
+			}
+		}
+
+		// pool empty and queue exhausted - we failed
+		if(!pool && queue.isEmpty())
+		{
+			goto exit;
+		}
+	}
+
+exit:
+	// kill all running processes first
+	Pool::DestructiveIterator killIt(pool);
+	while(killIt.hasNext())
+	{
+		pid_t process = killIt.next();
+		Multiprocessing::instance()->killNoCheck(process, SIGKILL);
+	}
+	return success;
+}
+
+unsigned ScheduleExecutor::getNumWorkers()
+{
+	CALL("ScheduleExecutor::getNumWorkers");
+
+	unsigned cores = System::getNumberOfCores();
+	cores = cores < 1 ? 1 : cores;
+	unsigned workers = min(cores, env.options->multicore());
+	if(!workers)
+		workers = cores >= 8 ? cores - 2 : cores;
+	return workers;
+}
+
+pid_t ScheduleExecutor::spawn(vstring code, int terminationTime)
+{
+	CALL("ScheduleExecutor::spawn");
+
+	pid_t pid = Multiprocessing::instance()->fork();
+	ASS_NEQ(pid, -1);
+
+	// parent
+	if(pid)	return pid;
+	// child
+	else
+	{
+		_executor->runSlice(code, terminationTime);
+		ASSERTION_VIOLATION; // should not return
+	}
+}

--- a/CASC/ScheduleExecutor.hpp
+++ b/CASC/ScheduleExecutor.hpp
@@ -10,29 +10,29 @@ namespace CASC
 class ProcessPriorityPolicy
 {
 public:
-	virtual float staticPriority(Lib::vstring sliceCode) = 0;
-	virtual float dynamicPriority(pid_t pid) = 0;
+  virtual float staticPriority(Lib::vstring sliceCode) = 0;
+  virtual float dynamicPriority(pid_t pid) = 0;
 };
 
 class SliceExecutor
 {
 public:
-	virtual void runSlice(Lib::vstring sliceCode, int terminationTime) NO_RETURN = 0;
+  virtual void runSlice(Lib::vstring sliceCode, int terminationTime) NO_RETURN = 0;
 };
 
 class ScheduleExecutor
 {
 public:
-	ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor);
-	bool run(const Schedule &schedule, int terminationTime);
+  ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor);
+  bool run(const Schedule &schedule, int terminationTime);
 
 private:
-	pid_t spawn(Lib::vstring code, int terminationTime);
-	unsigned getNumWorkers();
+  pid_t spawn(Lib::vstring code, int terminationTime);
+  unsigned getNumWorkers();
 
-	ProcessPriorityPolicy *_policy;
-	SliceExecutor *_executor;
-	unsigned _numWorkers;
+  ProcessPriorityPolicy *_policy;
+  SliceExecutor *_executor;
+  unsigned _numWorkers;
 };
 }
 

--- a/CASC/ScheduleExecutor.hpp
+++ b/CASC/ScheduleExecutor.hpp
@@ -1,0 +1,39 @@
+#ifndef __ScheduleExecutor__
+#define __ScheduleExector__
+
+#include <unistd.h>
+#include "Schedules.hpp"
+
+namespace CASC
+{
+
+class ProcessPriorityPolicy
+{
+public:
+	virtual float staticPriority(Lib::vstring sliceCode) = 0;
+	virtual float dynamicPriority(pid_t pid) = 0;
+};
+
+class SliceExecutor
+{
+public:
+	virtual void runSlice(Lib::vstring sliceCode, int terminationTime) NO_RETURN = 0;
+};
+
+class ScheduleExecutor
+{
+public:
+	ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor);
+	bool run(const Schedule &schedule, int terminationTime);
+
+private:
+	pid_t spawn(Lib::vstring code, int terminationTime);
+	unsigned getNumWorkers();
+
+	ProcessPriorityPolicy *_policy;
+	SliceExecutor *_executor;
+	unsigned _numWorkers;
+};
+}
+
+#endif

--- a/Lib/PriorityQueue.hpp
+++ b/Lib/PriorityQueue.hpp
@@ -9,48 +9,54 @@ namespace Lib
 template<typename T>
 struct PriorityPair
 {
-	float priority;
-	T data;
+  float priority;
+  T data;
 };
 
 template<typename T>
 class PriorityPairComparator
 {
 public:
-	static inline Lib::Comparison compare(float key, PriorityPair<T> value)
-	{
-		if(key < value.priority)
-			return Lib::LESS;
-		else if(key > value.priority)
-			return Lib::GREATER;
-		else
-			return Lib::EQUAL;
-	}
+  static inline Lib::Comparison compare(float key, PriorityPair<T> value)
+  {
+    if(key < value.priority)
+    {
+      return Lib::LESS;
+    }
+    else if(key > value.priority)
+    {
+      return Lib::GREATER;
+    }
+    else
+    {
+      return Lib::EQUAL;
+    }
+  }
 };
 
 template<typename T>
 class PriorityQueue
 {
 public:
-	void insert(float priority, T data)
-	{
-		auto ptr = _underlying.insertPosition(priority);
-		ptr->data = data;
-		ptr->priority = priority;
-	}
+  void insert(float priority, T data)
+  {
+    auto ptr = _underlying.insertPosition(priority);
+    ptr->data = data;
+    ptr->priority = priority;
+  }
 
-	T pop()
-	{
-		return _underlying.pop().data;
-	}
+  T pop()
+  {
+    return _underlying.pop().data;
+  }
 
-	bool isEmpty() const
-	{
-		return _underlying.isEmpty();
-	}
+  bool isEmpty() const
+  {
+    return _underlying.isEmpty();
+  }
 
 private:
-	Lib::SkipList<PriorityPair<T>, PriorityPairComparator<T>> _underlying;
+  Lib::SkipList<PriorityPair<T>, PriorityPairComparator<T>> _underlying;
 };
 }
 

--- a/Lib/PriorityQueue.hpp
+++ b/Lib/PriorityQueue.hpp
@@ -1,0 +1,57 @@
+#ifndef __PriorityQueue__
+#define __PriorityQueue__
+
+#include "Lib/Comparison.hpp"
+#include "Lib/SkipList.hpp"
+
+namespace Lib
+{
+template<typename T>
+struct PriorityPair
+{
+	float priority;
+	T data;
+};
+
+template<typename T>
+class PriorityPairComparator
+{
+public:
+	static inline Lib::Comparison compare(float key, PriorityPair<T> value)
+	{
+		if(key < value.priority)
+			return Lib::LESS;
+		else if(key > value.priority)
+			return Lib::GREATER;
+		else
+			return Lib::EQUAL;
+	}
+};
+
+template<typename T>
+class PriorityQueue
+{
+public:
+	void insert(float priority, T data)
+	{
+		auto ptr = _underlying.insertPosition(priority);
+		ptr->data = data;
+		ptr->priority = priority;
+	}
+
+	T pop()
+	{
+		return _underlying.pop().data;
+	}
+
+	bool isEmpty() const
+	{
+		return _underlying.isEmpty();
+	}
+
+private:
+	Lib::SkipList<PriorityPair<T>, PriorityPairComparator<T>> _underlying;
+};
+}
+
+#endif

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -230,16 +230,17 @@ void Multiprocessing::killNoCheck(pid_t child, int signal)
   ::kill(child, signal);
 }
 
-void Multiprocessing::poll_child(pid_t child, bool &stopped, bool &exited, int &code)
+pid_t Multiprocessing::poll_children(bool &stopped, bool &exited, int &code)
 {
   CALL("Multiprocessing::poll_child");
 
   int status;
-  waitpid(child, &status, WNOHANG | WUNTRACED);
+  pid_t pid = waitpid(-1, &status, WUNTRACED);
   stopped = WIFSTOPPED(status);
   exited = WIFEXITED(status);
   if(exited)
     code = WEXITSTATUS(status);
+  return pid;
 }
 
 }

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -224,6 +224,23 @@ void Multiprocessing::kill(pid_t child, int signal)
   }
 }
 
-}
+void Multiprocessing::killNoCheck(pid_t child, int signal)
+{
+  CALL("Multiprocessing::killNoCheck");
+  ::kill(child, signal);
 }
 
+void Multiprocessing::poll_child(pid_t child, bool &stopped, bool &exited, int &code)
+{
+  CALL("Multiprocessing::poll_child");
+
+  int status;
+  waitpid(child, &status, WNOHANG | WUNTRACED);
+  stopped = WIFSTOPPED(status);
+  exited = WIFEXITED(status);
+  if(exited)
+    code = WEXITSTATUS(status);
+}
+
+}
+}

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -239,7 +239,9 @@ pid_t Multiprocessing::poll_children(bool &stopped, bool &exited, int &code)
   stopped = WIFSTOPPED(status);
   exited = WIFEXITED(status);
   if(exited)
+  {
     code = WEXITSTATUS(status);
+  }
   return pid;
 }
 

--- a/Lib/Sys/Multiprocessing.hpp
+++ b/Lib/Sys/Multiprocessing.hpp
@@ -25,6 +25,8 @@ public:
 
   void sleep(unsigned ms);
   void kill(pid_t child, int signal);
+  void killNoCheck(pid_t child, int signal);
+  void poll_child(pid_t child, bool &stopped, bool &exited, int &code);
 private:
   Multiprocessing();
   ~Multiprocessing();

--- a/Lib/Sys/Multiprocessing.hpp
+++ b/Lib/Sys/Multiprocessing.hpp
@@ -26,7 +26,7 @@ public:
   void sleep(unsigned ms);
   void kill(pid_t child, int signal);
   void killNoCheck(pid_t child, int signal);
-  void poll_child(pid_t child, bool &stopped, bool &exited, int &code);
+  pid_t poll_children(bool &stopped, bool &exited, int &code);
 private:
   Multiprocessing();
   ~Multiprocessing();

--- a/Makefile
+++ b/Makefile
@@ -411,7 +411,7 @@ LTB_OBJ = Shell/LTB/Builder.o\
 
 CASC_OBJ = CASC/PortfolioMode.o\
            CASC/Schedules.o\
-		   CASC/ScheduleExecutor.o\
+	   CASC/ScheduleExecutor.o\
            CASC/CLTBMode.o\
            CASC/CLTBModeLearning.o
 

--- a/Makefile
+++ b/Makefile
@@ -411,6 +411,7 @@ LTB_OBJ = Shell/LTB/Builder.o\
 
 CASC_OBJ = CASC/PortfolioMode.o\
            CASC/Schedules.o\
+		   CASC/ScheduleExecutor.o\
            CASC/CLTBMode.o\
            CASC/CLTBModeLearning.o
 


### PR DESCRIPTION
This PR implements a scheduler within Vampire to execute strategy sets with. The current `PortfolioMode` is then re-implemented as a degenerate case where the scheduler simply returns schedules in sequential order.

This should likely not be merged without scrutiny - there's a couple of architectural problems at the very least that should be fixed first - see FIXME in `PortfolioMode.hpp`. Plus bugs, probably. Seems to work alright on a few problems though.