### PR TITLE
Don't define __APPLE__ or __CYGWIN__ macros to 0, use as intended

### DIFF
--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -45,7 +45,7 @@
 #endif
 
 #if USE_SYSTEM_ALLOCATION
-# if __APPLE__
+# if defined(__APPLE__)
 #  include <malloc/malloc.h>
 # else
 #  include <malloc.h>

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -22,17 +22,6 @@
 #include "Debug/Assertion.hpp"
 
 //////////////////////////////////////////////////////
-// Detect compiler
-
-#ifndef __APPLE__
-# define __APPLE__ 0
-#endif
-
-#ifndef __CYGWIN__
-# define __CYGWIN__ 0
-#endif
-
-//////////////////////////////////////////////////////
 // Detect architecture
 
 #ifdef _LP64

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -26,7 +26,7 @@
 
 #include <stdlib.h>
 #  include <unistd.h>
-#  if !__APPLE__ && !__CYGWIN__
+#  if !defined(__APPLE__) && !defined(__CYGWIN__)
 #    include <sys/prctl.h>
 #  endif
 
@@ -59,7 +59,7 @@
 
 long long Lib::System::getSystemMemory()
 {
-#if __APPLE__ || __CYGWIN__
+#if defined(__APPLE__) || defined(__CYGWIN__)
   NOT_IMPLEMENTED;
 #else
   long pages = sysconf(_SC_PHYS_PAGES);
@@ -360,7 +360,7 @@ void System::terminateImmediately(int resultStatus)
  */
 void System::registerForSIGHUPOnParentDeath()
 {
-#if __APPLE__ || __CYGWIN__
+#if defined(__APPLE__) || defined(__CYGWIN__)
   // cerr<<"Death of parent process not being handled on Mac and Windows"<<endl;
   // NOT_IMPLEMENTED;
 #else

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -101,7 +101,7 @@ void Options::Options::init()
                                        );
     _memoryLimit.description="Memory limit in MB";
     _lookup.insert(&_memoryLimit);
-#if !__APPLE__ && !__CYGWIN__
+#if !defined(__APPLE__) && !defined(__CYGWIN__)
     _memoryLimit.addHardConstraint(lessThanEq((unsigned)Lib::System::getSystemMemory()));
 #endif
 


### PR DESCRIPTION
Instead just leave them be and check if they're defined,
as opposed to define'ing to 0 if they're not already set.

In particular this was causing problems with libc++ on Linux,
but likely breaks things on other platforms as well.