### PR TITLE
minisat: use fenv.h instead of non-standard fpu_control.h

### DIFF
--- a/Minisat/utils/System.cc
+++ b/Minisat/utils/System.cc
@@ -104,10 +104,14 @@ double Minisat::memUsedPeak(bool) {
 
 void Minisat::setX86FPUPrecision()
 {
-#if defined(__linux__) && defined(_FPU_EXTENDED) && defined(_FPU_DOUBLE) && defined(_FPU_GETCW)
+#if defined(__linux__)
     // Only correct FPU precision on Linux architectures that needs and supports it:
-    fpu_control_t oldcw, newcw;
-    _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
+    fenv_t fenv;
+
+    fegetenv(&fenv);
+    fenv.__control_word &= ~0x300; /* _FPU_EXTENDED */
+    fenv.__control_word |= 0x200; /* _FPU_DOUBLE */
+    fesetenv(&fenv);
     printf("WARNING: for repeatability, setting FPU to use double precision\n");
 #endif
 }

--- a/Minisat/utils/System.h
+++ b/Minisat/utils/System.h
@@ -27,7 +27,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #define Minisat_System_h
 
 #if defined(__linux__)
-#include <fpu_control.h>
+#include <fenv.h>
 #endif
 
 #include "Minisat/mtl/IntTypes.h"


### PR DESCRIPTION
I'm not sure if this still needs to be guarded to only
be used on Linux, but leaving as-is to match current behavior.

Fixes compilation with musl.