### PR TITLE
Comply with the TFX syntax for FOOL

### DIFF
--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -427,10 +427,6 @@ vstring Term::headToString() const
         for (unsigned i = 0; i < IntList::length(variables); i++) {
           unsigned var = (unsigned) IntList::nth(variables, i);
           variablesList += Term::variableToString(var);
-          unsigned sort = type->arg((unsigned)i);
-          if (sort != Sorts::SRT_DEFAULT) {
-            variablesList += " : " + env.sorts->sortName(sort);
-          }
           if (i < IntList::length(variables) - 1) {
             variablesList += ", ";
           }
@@ -438,7 +434,7 @@ vstring Term::headToString() const
         if (IntList::length(variables)) {
           variablesList = "(" + variablesList + ")";
         }
-        return "$let(" + functor + variablesList + " := " + binding.toString() + ",";
+        return "$let(" + functor + ": " + type->toString() + ", " + functor + variablesList + " := " + binding.toString() + ", ";
       }
       case Term::SF_ITE: {
         ASS_EQ(arity(),2);
@@ -467,17 +463,20 @@ vstring Term::headToString() const
         OperatorType* fnType = env.signature->getFunction(tupleFunctor)->fnType();
 
         vstring symbolsList = "";
+        vstring typesList = "";
         for (unsigned i = 0; i < IntList::length(symbols); i++) {
           Signature::Symbol* symbol = (fnType->arg(i) == Sorts::SRT_BOOL)
             ? env.signature->getPredicate((unsigned)IntList::nth(symbols, i))
             : env.signature->getFunction((unsigned)IntList::nth(symbols, i));
           symbolsList += symbol->name();
+          typesList += symbol->name() + ": " + env.sorts->sortName(fnType->arg(i));
           if (i != IntList::length(symbols) - 1) {
             symbolsList += ", ";
+            typesList += ", ";
           }
         }
 
-        return "$let([" + symbolsList + "] := " + binding.toString() + ", ";
+        return "$let([" + typesList + "], [" + symbolsList + "] := " + binding.toString() + ", ";
       }
       default:
         ASSERTION_VIOLATION;

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -483,7 +483,7 @@ vstring Term::headToString() const
     }
   } else {
     unsigned proj;
-    if (Theory::tuples()->findProjection(functor(), false, proj)) {
+    if (Theory::tuples()->findProjection(functor(), isLiteral(), proj)) {
       return "$proj(" + Int::toString(proj) + ", ";
     }
     return (isLiteral() ? static_cast<const Literal *>(this)->predicateName() : functionName()) + (arity() ? "(" : "");

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -239,7 +239,7 @@ TermList TermTransformer::transform(TermList ts)
 Formula* TermTransformer::transform(Formula* f)
 {
   CALL("TermTransformer::transform(Formula* f)");
-  static TermTransformingFormulaTransformer ttft(*this);
+  TermTransformingFormulaTransformer ttft(*this);
   return ttft.transform(f);
 }
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -251,6 +251,7 @@ public:
     END_LET,
     /** start of a binding inside $let */
     BINDING,
+    MID_BINDING,
     /** end of a binding inside $let */
     END_BINDING,
     /** start of a binding of a function or predicate symbol */
@@ -736,6 +737,7 @@ private:
   void type();
   void endIte();
   void binding();
+  void midBinding();
   void endBinding();
   void endSymbolBinding();
   void endTupleBinding();

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -764,6 +764,8 @@ private:
 
   bool findInterpretedPredicate(vstring name, unsigned arity);
 
+  OperatorType* constructOperatorType(Type* t);
+
 public:
   // make the tptp routines for dealing with overflown constants available to other parsers
   static unsigned addIntegerConstant(const vstring&, Set<vstring>& overflow, bool defaultSort);

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -254,14 +254,14 @@ public:
     /** end of let type signature */
     END_LET_TYPES,
     /** start of a binding inside $let */
-    BINDING,
-    MID_BINDING,
-    /** end of a binding inside $let */
-    END_BINDING,
-    /** start of a binding of a function or predicate symbol */
-    SYMBOL_BINDING,
-    /** start of tuple binding inside $let */
-    TUPLE_BINDING,
+    DEFINITION,
+    MID_DEFINITION,
+    /** end of a definition inside $let */
+    END_DEFINITION,
+    /** start of a definition of a function or predicate symbol */
+    SYMBOL_DEFINITION,
+    /** start of tuple definition inside $let */
+    TUPLE_DEFINITION,
     /** end of a theory function */
     END_THEORY_FUNCTION
   };
@@ -580,25 +580,31 @@ private:
   Set<vstring> _overflow;
   /** current color, if the input contains colors */
   Color _currentColor;
+
   /** a function name and arity */
-  typedef pair<vstring, unsigned> LetFunctionName;
+  typedef pair<vstring, unsigned> LetSymbolName;
+
   /** a symbol number with a predicate/function flag */
-  typedef pair<unsigned, bool> LetFunctionReference;
+  typedef pair<unsigned, bool> LetSymbolReference;
   #define SYMBOL(ref) (ref.first)
   #define IS_PREDICATE(ref) (ref.second)
-  /** a definition of a function symbol, defined in $let */
-  typedef pair<LetFunctionName, LetFunctionReference> LetFunction;
-  /** a scope of function definitions */
-  typedef Stack<LetFunction> LetFunctionsScope;
-  /** a stack of scopes */
-  Stack<LetFunctionsScope> _letScopes;
-  Stack<LetFunctionsScope> _currentLetScopes;
-  /** finds if the symbol has been defined in an enclosing $let */
-  bool findLetSymbol(LetFunctionName functionName, LetFunctionReference& functionReference);
-  bool findLetSymbol(LetFunctionName functionName, LetFunctionsScope scope, LetFunctionReference& functionReference);
 
-  typedef Stack<LetFunctionReference> LetBindingScope;
-  Stack<LetBindingScope> _letBindings;
+  /** a definition of a function symbol, defined in $let */
+  typedef pair<LetSymbolName, LetSymbolReference> LetSymbol;
+
+  /** a scope of function definitions */
+  typedef Stack<LetSymbol> LetSymbols;
+
+  /** a stack of scopes */
+  Stack<LetSymbols> _letSymbols;
+  Stack<LetSymbols> _letTypedSymbols;
+
+  /** finds if the symbol has been defined in an enclosing $let */
+  bool findLetSymbol(LetSymbolName symbolName, LetSymbolReference& symbolReference);
+  bool findLetSymbol(LetSymbolName symbolName, LetSymbols scope, LetSymbolReference& symbolReference);
+
+  typedef Stack<LetSymbolReference> LetDefinitions;
+  Stack<LetDefinitions> _letDefinitions;
 
   /** model definition formula */
   bool _modelDefinition;
@@ -713,8 +719,8 @@ private:
   void simpleType();
   void args();
   void varList();
-  void symbolBinding();
-  void tupleBinding();
+  void symbolDefinition();
+  void tupleDefinition();
   void term();
   void termInfix();
   void endTerm();
@@ -738,9 +744,9 @@ private:
   void endIte();
   void letType();
   void endLetTypes();
-  void binding();
-  void midBinding();
-  void endBinding();
+  void definition();
+  void midDefinition();
+  void endDefinition();
   void endLet();
   void endTheoryFunction();
   void endTuple();

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -598,8 +598,7 @@ private:
   /** the scope of the currently parsed $let-term */
   LetFunctionsScope _currentLetScope;
 
-  typedef pair<unsigned, bool> LetBinding;
-  typedef Stack<LetBinding> LetBindingScope;
+  typedef Stack<LetFunctionReference> LetBindingScope;
   Stack<LetBindingScope> _letBindings;
   LetBindingScope _currentBindingScope;
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -249,6 +249,10 @@ public:
     MID_EQ,
     /** end of $let expression */
     END_LET,
+    /** a type signature in a let expression */
+    LET_TYPE,
+    /** end of let type signature */
+    END_LET_TYPES,
     /** start of a binding inside $let */
     BINDING,
     MID_BINDING,
@@ -256,12 +260,8 @@ public:
     END_BINDING,
     /** start of a binding of a function or predicate symbol */
     SYMBOL_BINDING,
-    /** end of function or predicate binding inside $let */
-    END_SYMBOL_BINDING,
     /** start of tuple binding inside $let */
     TUPLE_BINDING,
-    /** end of tuple binding inside $let */
-    END_TUPLE_BINDING,
     /** end of a theory function */
     END_THEORY_FUNCTION
   };
@@ -592,15 +592,13 @@ private:
   typedef Stack<LetFunction> LetFunctionsScope;
   /** a stack of scopes */
   Stack<LetFunctionsScope> _letScopes;
+  Stack<LetFunctionsScope> _currentLetScopes;
   /** finds if the symbol has been defined in an enclosing $let */
   bool findLetSymbol(LetFunctionName functionName, LetFunctionReference& functionReference);
   bool findLetSymbol(LetFunctionName functionName, LetFunctionsScope scope, LetFunctionReference& functionReference);
-  /** the scope of the currently parsed $let-term */
-  LetFunctionsScope _currentLetScope;
 
   typedef Stack<LetFunctionReference> LetBindingScope;
   Stack<LetBindingScope> _letBindings;
-  LetBindingScope _currentBindingScope;
 
   /** model definition formula */
   bool _modelDefinition;
@@ -738,11 +736,11 @@ private:
   void include();
   void type();
   void endIte();
+  void letType();
+  void endLetTypes();
   void binding();
   void midBinding();
   void endBinding();
-  void endSymbolBinding();
-  void endTupleBinding();
   void endLet();
   void endTheoryFunction();
   void endTuple();

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -79,8 +79,6 @@ public:
     T_COMMA,
     /** ':' */
     T_COLON,
-    /** ';' */
-    T_SEMICOLON,
     /** '~' */
     T_NOT,
     /** '&' */
@@ -251,14 +249,16 @@ public:
     MID_EQ,
     /** end of $let expression */
     END_LET,
-    /** start of function or predicate binding inside $let */
+    /** start of a binding inside $let */
     BINDING,
+    /** end of a binding inside $let */
+    END_BINDING,
     /** start of a binding of a function or predicate symbol */
     SYMBOL_BINDING,
+    /** end of function or predicate binding inside $let */
+    END_SYMBOL_BINDING,
     /** start of tuple binding inside $let */
     TUPLE_BINDING,
-    /** end of function or predicate binding inside $let */
-    END_BINDING,
     /** end of tuple binding inside $let */
     END_TUPLE_BINDING,
     /** end of a theory function */
@@ -737,6 +737,7 @@ private:
   void endIte();
   void binding();
   void endBinding();
+  void endSymbolBinding();
   void endTupleBinding();
   void endLet();
   void endTheoryFunction();

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -253,6 +253,8 @@ public:
     END_LET,
     /** start of function or predicate binding inside $let */
     BINDING,
+    /** start of a binding of a function or predicate symbol */
+    SYMBOL_BINDING,
     /** start of tuple binding inside $let */
     TUPLE_BINDING,
     /** end of function or predicate binding inside $let */
@@ -710,6 +712,7 @@ private:
   void simpleType();
   void args();
   void varList();
+  void symbolBinding();
   void tupleBinding();
   void term();
   void termInfix();

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -584,6 +584,8 @@ private:
   typedef pair<vstring, unsigned> LetFunctionName;
   /** a symbol number with a predicate/function flag */
   typedef pair<unsigned, bool> LetFunctionReference;
+  #define SYMBOL(ref) (ref.first)
+  #define IS_PREDICATE(ref) (ref.second)
   /** a definition of a function symbol, defined in $let */
   typedef pair<LetFunctionName, LetFunctionReference> LetFunction;
   /** a scope of function definitions */
@@ -591,7 +593,8 @@ private:
   /** a stack of scopes */
   Stack<LetFunctionsScope> _letScopes;
   /** finds if the symbol has been defined in an enclosing $let */
-  bool findLetSymbol(bool isPredicate, vstring name, unsigned arity, unsigned& symbol);
+  bool findLetSymbol(LetFunctionName functionName, LetFunctionReference& functionReference);
+  bool findLetSymbol(LetFunctionName functionName, LetFunctionsScope scope, LetFunctionReference& functionReference);
   /** the scope of the currently parsed $let-term */
   LetFunctionsScope _currentLetScope;
 


### PR DESCRIPTION
The syntax of let expressions in [TFX](http://tptp.cs.miami.edu/~tptp/) differs from the syntax for FOOL supported by Vampire in the following.
1) TFX uses square brackets and commas, and not semicolons, for parallel let definitions.
2) TFX requires each let expression to provide as its first argument a list of type declarations for all symbols defined in it.
3) TFX does not use sort declarations for variable arguments in symbols definitions. 

This pull request fixes the TPTP parser for let expressions and makes Vampire TFX-compliant.

Here are a few examples in the old syntax and equivalent ones in the TFX syntax.

---
Old syntax:
```
$let(f(X : $i) := X = X, p(i))
```
or
```
$let(f(X) := X = X, p(i))
```

New syntax:
```
$let(p: $i > $o,
     f(X) := X = X,
     p(i))
```
---
Old syntax:
```
$let(f(X) := X; p(X) := X = X,
     p(f(X)))
```

New syntax:
```
$let([f: $i > $i, p: $i > $o],
     [f(X) := X, p(X) := X = X],
     p(f(X)))
```
---
Old syntax:
```
$let([a, b, c] := [c, a, b],
     a = b | b = c)
```

New syntax:
```
$let([a: $i, b: $i, c: $i],
     [a, b, c] := [c, a, b],
     a = b | b = c)
```
---
Old syntax:
```
$let(f(X : $i) := X; [a, b] := [b, a],
     f(a) = f(b)).
```

New syntax:
```
$let([a: $i, b: $i, f: $i > $i]
     [f(X) := X, [a, b] := [b, a]],
     f(a) = f(b)).
```