### PR TITLE
Extend smtlib parser with assert-not and color-symbol

### DIFF
--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -423,7 +423,7 @@ private:
    *
    * On success results in a single formula added to _formulas.
    */
-  void readAssert(LExpr* body);
+  void readAssert(LExpr* body, bool negated = false);
 
   /**
    * Units collected during parsing.

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -423,7 +423,21 @@ private:
    *
    * On success results in a single formula added to _formulas.
    */
-  void readAssert(LExpr* body, bool negated = false);
+  void readAssert(LExpr* body);
+
+  /**
+   * Unofficial command
+   *
+   * Behaves like conjecture declaration in TPTP
+   */
+  void readAssertNot(LExpr* body);
+
+  /**
+   * Unofficial command
+   *
+   * Behaves like conjecture declaration in TPTP
+   */
+  void colorSymbol(const vstring& name, Color color);
 
   /**
    * Units collected during parsing.


### PR DESCRIPTION
assert-not mimics conjecture from TPTP.