### PR TITLE
improve output format for clauses

### DIFF
--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -417,34 +417,49 @@ vstring Clause::toString() const
 {
   CALL("Clause::toString()");
 
+  // print id and literals of clause
   vstring result = Int::toString(_number) + ". " + literalsOnlyToString();
 
+  // print avatar components clause depends on
   if (splits() && !splits()->isEmpty()) {
-    result += vstring(" {") + splits()->toString() + "}";
+    result += vstring(" <- (") + splits()->toString() + ")";
   }
 
-  if (env.colorUsed) {
-    result += " C" + Int::toString(color()) + " ";
+  // print inference and ids of parent clauses
+  result += " " + inferenceAsString();
+
+  if(env.options->proofExtra()!=Options::ProofExtra::OFF){
+    // print statistics: each entry should have the form key:value
+    result += vstring(" {");
+      
+    result += vstring("a:") + Int::toString(_age);
+    result += vstring(",w:") + Int::toString(weight());
+    
+    float ew = const_cast<Clause*>(this)->getEffectiveWeight(const_cast<Shell::Options&>(*(env.options)));
+    unsigned effective = static_cast<int>(ceil(ew));
+    if(effective!=weight()){
+      result += vstring(",effW:") + Int::toString(effective);
+    }
+
+    if (numSelected()>0) {
+      result += vstring(",nSel:") + Int::toString(numSelected());
+    }
+
+    if (env.colorUsed) {
+      result += vstring(",col:") + Int::toString(color());
+    }
+
+    if(isGoal()){
+      result += vstring(",goal:1");
+    }
+    if(isTheoryDescendant()){
+      result += vstring(",tD:1");
+    }
+
+    result += vstring(",inD:") + Int::toString(inductionDepth());
+    result += vstring("}");
   }
 
-  result += vstring(" (") + Int::toString(_age) + ':' + Int::toString(weight());
-  float ew = const_cast<Clause*>(this)->getEffectiveWeight(const_cast<Shell::Options&>(*(env.options)));
-  unsigned effective = static_cast<int>(ceil(ew));
-  if(effective!=weight()){
-    result += "["+Int::toString(effective)+"]";
-  }
-  if (numSelected()>0) {
-    result += ':' + Int::toString(numSelected());
-  }
-  if(isGoal()){ result += ":G"; }
-  result += ") ";
-  if(isTheoryDescendant()){
-    result += "T ";
-  }
-  //if(inductionDepth()>0){
-    result += "I("+Int::toString(inductionDepth())+") ";
-  //}
-  result +=  inferenceAsString();
   return result;
 }
 

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -324,68 +324,46 @@ protected:
     UnitIterator parents=_is->getParents(cs, rule);
 
     if(rule == Inference::INDUCTION){
-      //cout << "ping" << endl;
       env.statistics->inductionInProof++;
     }
 
-    out << _is->getUnitIdStr(cs) << ". ";
     if (cs->isClause()) {
       Clause* cl=cs->asClause();
-
-      if (env.colorUsed) {
-        out << " C" << cl->color() << " ";
-      }
-
-      out << cl->literalsOnlyToString() << " ";
-      if (cl->splits() && !cl->splits()->isEmpty()) {
-        out << "<- {" << cl->splits()->toString() << "} ";
-      }
-      if(proofExtra){
-        out << "("<<cl->age()<<':'<<cl->weight();
-        if (cl->numSelected()>0) {
-          out<< ':'<< cl->numSelected();
-        }
-        out<<") ";
-      }
-      if(cl->isTheoryDescendant()){
-        out << "(TD) ";
-      }
-      if(cl->inductionDepth()>0){
-        out << "(I " << cl->inductionDepth() << ") ";
-      }
+      out << cl->toString() << vstring("\n");
     }
     else {
+      out << _is->getUnitIdStr(cs) << ". ";
       FormulaUnit* fu=static_cast<FormulaUnit*>(cs);
       if (env.colorUsed && fu->inheritedColor() != COLOR_INVALID) {
         out << " IC" << fu->inheritedColor() << " ";
       }
       out << fu->formula()->toString() << ' ';
-    }
 
-    out <<"["<<Inference::ruleName(rule);
+      out <<"["<<Inference::ruleName(rule);
 
-    if (outputAxiomNames && rule==Inference::INPUT) {
-      ASS(!parents.hasNext()); //input clauses don't have parents
-      vstring name;
-      if (Parse::TPTP::findAxiomName(cs, name)) {
-	out << " " << name;
+      if (outputAxiomNames && rule==Inference::INPUT) {
+        ASS(!parents.hasNext()); //input clauses don't have parents
+        vstring name;
+        if (Parse::TPTP::findAxiomName(cs, name)) {
+          out << " " << name;
+        }
       }
-    }
 
-    bool first=true;
-    while(parents.hasNext()) {
-      Unit* prem=parents.next();
-      out << (first ? ' ' : ',');
-      out << _is->getUnitIdStr(prem);
-      first=false;
-    }
+      bool first=true;
+      while(parents.hasNext()) {
+        Unit* prem=parents.next();
+        out << (first ? ' ' : ',');
+        out << _is->getUnitIdStr(prem);
+        first=false;
+      }
 
-    // print Extra
-    vstring extra = cs->inference()->extra(); 
-    if(extra != ""){
-      out << ", " << extra;
+      // print Extra
+      vstring extra = cs->inference()->extra(); 
+      if(extra != ""){
+        out << ", " << extra;
+      }
+      out << "]" << endl;
     }
-    out << "]" << endl;
   }
 
   void handleStep(Unit* cs)


### PR DESCRIPTION
Recently there were several additions to the saturation output,
which all can be seen as some form of statistics:
- age a, weight w, optionally number of selected literals s,
  the fact that the clause is ground;
  with syntax (a:w) / (a:w:s) / (a:w:G) / (a:w:s:G)
- optionally the fact that a clause is derived only from
  theory-axioms, with syntax T
- some information i regarding induction, with syntax I(i)

This commit puts all of these into a single statistics object
of the form {key1:value1,...,keyN:valueN}, which is placed at
the end of the line.
The new format is more uniform and therefore easier to parse,
in particular for automated tools like the visualization.
Furthermore, it can easily be extended in the future by adding
new key-value pairs.

The statistics are only printed, if proof_extra is different from
OFF. This allows us to use the same code for printing saturation
information and for printing (the units which are clauses in) the
proof.