### PR TITLE
theory evaluation: handle arithmetic errors (e.g. overflows) better

### DIFF
--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -117,8 +117,12 @@ public:
       T thing;
       if(t->isTerm() && theory->tryInterpretConstant(t->term(),thing)){
         TermList tmp;
-	      Term* evalThis = Term::create2(_fun,TermList(acc),*t);
-        ALWAYS(_eval->tryEvaluateFunc(evalThis,tmp));
+        Term* evalThis = Term::create2(_fun,TermList(acc),*t);
+        bool error = _eval->tryEvaluateFunc(evalThis,tmp);
+        ASS(!error); //we want to be informed of evaluation failures in debug mode
+        if (error) {
+          return false;
+        }
         ASS(tmp.isTerm());
         acc = tmp.term();
         acc_cnt++;


### PR DESCRIPTION
Evaluation of large expressions like `$product(143496441.0,121.0)` lead to an arithmetic overflow. In some cases the overflow is ignored and we reduce the product to the first argument (`143496441.0` in this case). For regression tests, run vampire with lrs+10_5_add=off:afp=10000:afq=1.0:amm=off:anc=none:bsr=on:fde=unused:gs=on:irw=on:nm=2:newcnf=on:nwc=1:nicw=on:sas=z3:sos=on:sac=on:sp=occurrence:updr=off:uhcvi=on_300 on LRA/2010-Monniaux-QE/mjollnir1/formula_265.smt2 in smtlib.