### PR TITLE
Sine2age

### DIFF
--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -192,6 +192,31 @@ unsigned Unit::getPriority() const
     return priority;
 }
 
+/**
+ * Unlike the above function, which was designed to assign value to all clauses using a kind of average,
+ * here we only aspire to give sine level to input clauses, which should inherit it, each from its formula parent.
+ */
+unsigned Unit::getSineLevel() const
+{
+  CALL("Unit::getInitialPriority");
+
+  unsigned level = UINT_MAX;
+  if(env.clauseSineLevels->find(this,level)){
+    return level;
+  }
+
+  Inference::Iterator iit = _inference->iterator();
+  while(_inference->hasNext(iit)) {
+    Unit* premUnit = _inference->next(iit);
+    unsigned premLel = premUnit->getSineLevel();
+    if (premLel < level) {
+      level = premLel;
+    }
+  }
+  env.clauseSineLevels->insert(this,level);
+  return level;
+}
+
 
 void Unit::incRefCnt()
 {

--- a/Kernel/Unit.hpp
+++ b/Kernel/Unit.hpp
@@ -82,6 +82,8 @@ public:
   unsigned varCnt();
   unsigned getPriority() const;
 
+  unsigned getSineLevel() const;
+
   vstring inferenceAsString() const;
 
   /** True if a clause unit */

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -56,6 +56,7 @@ Environment::Environment()
     property(0),
     clausePriorities(0),
     maxClausePriority(1),
+    clauseSineLevels(nullptr),
     colorUsed(false),
     _outputDepth(0),
     _priorityOutput(0),

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -67,6 +67,8 @@ public:
   DHMap<const Kernel::Unit*,unsigned>* clausePriorities;
   unsigned maxClausePriority;
 
+  DHMap<const Kernel::Unit*,unsigned>* clauseSineLevels;
+
   bool haveOutput();
   void beginOutput();
   void endOutput();

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -562,12 +562,14 @@ void SaturationAlgorithm::addInputClause(Clause* cl)
   bool sosForTheory = _opt.sos() == Options::Sos::THEORY && _opt.sosTheoryLimit() == 0;
 
   if (_opt.sineToAge()) {
-    unsigned prio = cl->getSineLevel();
-    if (prio == UINT_MAX) {
-      prio = env.maxClausePriority;
+    unsigned level = cl->getSineLevel();
+    // cout << "Adding " << cl->toString() << " level " << level;
+    if (level == UINT_MAX) {
+      level = env.maxClausePriority;
+      // cout << " -> " << level;
     }
-
-   cl->setAge(prio);
+    // cout << endl;
+    cl->setAge(level);
   }
 
   if (sosForAxioms || (isTheory && sosForTheory)){

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -561,6 +561,15 @@ void SaturationAlgorithm::addInputClause(Clause* cl)
   bool isTheory = cl->inference()->rule()==Inference::THEORY;
   bool sosForTheory = _opt.sos() == Options::Sos::THEORY && _opt.sosTheoryLimit() == 0;
 
+  if (_opt.sineToAge()) {
+    unsigned prio = cl->getSineLevel();
+    if (prio == UINT_MAX) {
+      prio = env.maxClausePriority;
+    }
+
+   cl->setAge(prio);
+  }
+
   if (sosForAxioms || (isTheory && sosForTheory)){
     addInputSOSClause(cl);
   } else {

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -632,6 +632,10 @@ void Options::Options::init()
     _lookup.insert(&_showNew);
     _showNew.tag(OptionTag::DEVELOPMENT);
 
+    _sineToAge = BoolOptionValue("sine_to_age","s2a",false);
+    _lookup.insert(&_sineToAge);
+    _sineToAge.tag(OptionTag::DEVELOPMENT);
+
     _showSplitting = BoolOptionValue("show_splitting","",false);
     _showSplitting.description="Show updates within AVATAR";
     _lookup.insert(&_showSplitting);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1876,6 +1876,7 @@ public:
   bool showBlocked() const { return showAll() || _showBlocked.actualValue; }
   bool showDefinitions() const { return showAll() || _showDefinitions.actualValue; }
   bool showNew() const { return showAll() || _showNew.actualValue; }
+  bool sineToAge() const { return _sineToAge.actualValue; }
   bool showSplitting() const { return showAll() || _showSplitting.actualValue; }
   bool showNewPropositional() const { return showAll() || _showNewPropositional.actualValue; }
   bool showPassive() const { return showAll() || _showPassive.actualValue; }
@@ -2394,6 +2395,7 @@ private:
   BoolOptionValue _showDefinitions;
   ChoiceOptionValue<InterpolantMode> _showInterpolant;
   BoolOptionValue _showNew;
+  BoolOptionValue _sineToAge;
   BoolOptionValue _showSplitting;
   BoolOptionValue _showNewPropositional;
   BoolOptionValue _showNonconstantSkolemFunctionTrace;

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -236,6 +236,13 @@ void Preprocess::preprocess(Problem& prb)
     Normalisation().normalise(prb);
   }
 
+  if (_options.sineToAge()) {
+    env.statistics->phase=Statistics::SINE_SELECTION;
+
+    // just to initialize ``env.clauseSineLevels''
+    SineSelector(false,1.0,0,0,true).perform(prb);
+  }
+
   if (_options.sineSelection()!=Options::SineSelection::OFF) {
     env.statistics->phase=Statistics::SINE_SELECTION;
     if (env.options->showPreprocessing())

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -270,24 +270,30 @@ SineSelector::SineSelector(const Options& opt)
 : _onIncluded(opt.sineSelection()==Options::SineSelection::INCLUDED),
   _genThreshold(opt.sineGeneralityThreshold()),
   _tolerance(opt.sineTolerance()),
-  _depthLimit(opt.sineDepth())
+  _depthLimit(opt.sineDepth()),
+  _justForSineLevels(false)
 {
   CALL("SineSelector::SineSelector/0");
 
-  if(opt.sineSelection()==Options::SineSelection::PRIORITY){
+  if(opt.sineSelection()==Options::SineSelection::PRIORITY) {
     env.clausePriorities = new DHMap<const Unit*,unsigned>();
   }
 
   init();
 }
 
-SineSelector::SineSelector(bool onIncluded, float tolerance, unsigned depthLimit, unsigned genThreshold)
+SineSelector::SineSelector(bool onIncluded, float tolerance, unsigned depthLimit, unsigned genThreshold, bool justForSineLevels)
 : _onIncluded(onIncluded),
   _genThreshold(genThreshold),
   _tolerance(tolerance),
-  _depthLimit(depthLimit)
+  _depthLimit(depthLimit),
+  _justForSineLevels(justForSineLevels)
 {
   CALL("SineSelector::SineSelector/4");
+
+  if (_justForSineLevels) {
+    env.clauseSineLevels = new DHMap<const Unit*,unsigned>();
+  }
 
   init();
 }
@@ -312,6 +318,9 @@ void SineSelector::updateDefRelation(Unit* u)
   if (!sit.hasNext()) {
     if(env.clausePriorities){
       env.clausePriorities->insert(u,1);
+    }
+    if(env.clauseSineLevels){
+      env.clauseSineLevels->insert(u,1);
     }
     _unitsWithoutSymbols.push(u);
     return;
@@ -424,6 +433,9 @@ bool SineSelector::perform(UnitList*& units)
         env.clausePriorities->insert(u,1);
         //cout << "set priority for " << u->toString() << " as " << (1) << endl;
       }
+      if(env.clauseSineLevels && !env.clauseSineLevels->find(u)) {
+        env.clauseSineLevels->insert(u,1);
+      }
     }
   }
 
@@ -469,13 +481,27 @@ bool SineSelector::perform(UnitList*& units)
           env.clausePriorities->insert(du,env.maxClausePriority);
           //cout << "set priority for " << du->toString() << " as " << env.maxClausePriority << endl;
         }
-
+        if(env.clauseSineLevels && !env.clauseSineLevels->find(du)){
+          env.clauseSineLevels->insert(du,env.maxClausePriority);
+        }
       }
       //all defining units for the symbol sym were selected,
       //so we can remove them from the relation
       UnitList::destroy(_def[sym]);
       _def[sym]=0;
     }
+  }
+
+  if (_justForSineLevels) {
+    UnitList::Iterator uit(units);
+    while (uit.hasNext()) {
+      Unit* u=uit.next();
+      if(env.clauseSineLevels && !env.clauseSineLevels->find(u)) {
+        env.clauseSineLevels->insert(u,UINT_MAX);
+      }
+    }
+
+    return false;
   }
 
   env.statistics->sineIterations=depth;
@@ -567,6 +593,9 @@ void SineTheorySelector::updateDefRelation(Unit* u)
 
     if(env.clausePriorities){
       env.clausePriorities->insert(u,1);
+    }
+    if(env.clauseSineLevels){
+      env.clauseSineLevels->insert(u,1);
     }
 
     _unitsWithoutSymbols.push(u);

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -321,6 +321,7 @@ void SineSelector::updateDefRelation(Unit* u)
     }
     if(env.clauseSineLevels){
       env.clauseSineLevels->insert(u,1);
+      // cout << "set level for a non-symboler " << u->toString() << " as " << "(1)" << endl;
     }
     _unitsWithoutSymbols.push(u);
     return;
@@ -435,12 +436,15 @@ bool SineSelector::perform(UnitList*& units)
       }
       if(env.clauseSineLevels && !env.clauseSineLevels->find(u)) {
         env.clauseSineLevels->insert(u,1);
+        // cout << "set level for " << u->toString() << " as " << "(1)" << endl;
       }
     }
   }
 
   unsigned depth=0;
   newlySelected.push_back(0);
+
+  // cout << "env.maxClausePriority starts as" << env.maxClausePriority << endl;
 
   //select required axiom formulas
   while (newlySelected.isNonEmpty()) {
@@ -455,6 +459,7 @@ bool SineSelector::perform(UnitList*& units)
       }
       ASS(!_depthLimit || depth<_depthLimit);
       env.maxClausePriority++;
+      // cout << "Time to inc" << endl;
 
       if (newlySelected.isNonEmpty()) {
 	//we must push another mark if we're not done yet
@@ -482,7 +487,8 @@ bool SineSelector::perform(UnitList*& units)
           //cout << "set priority for " << du->toString() << " as " << env.maxClausePriority << endl;
         }
         if(env.clauseSineLevels && !env.clauseSineLevels->find(du)){
-          env.clauseSineLevels->insert(du,env.maxClausePriority);
+          env.clauseSineLevels->insert(du,env.maxClausePriority+1);
+          // cout << "set level for " << du->toString() << " in iteration as " << env.maxClausePriority+1 << endl;
         }
       }
       //all defining units for the symbol sym were selected,

--- a/Shell/SineUtils.hpp
+++ b/Shell/SineUtils.hpp
@@ -75,7 +75,8 @@ class SineSelector
 {
 public:
   SineSelector(const Options& opt);
-  SineSelector(bool onIncluded, float tolerance, unsigned depthLimit, unsigned genThreshold=0);
+  SineSelector(bool onIncluded, float tolerance, unsigned depthLimit,
+      unsigned genThreshold=0, bool justForSineLevels=false);
 
   bool perform(UnitList*& units); // returns true iff removed something
   void perform(Problem& prb);
@@ -89,6 +90,8 @@ private:
   unsigned _genThreshold;
   float _tolerance;
   unsigned _depthLimit;
+
+  bool _justForSineLevels;
 
   /** Stored the D-relation */
   DArray<UnitList*> _def;


### PR DESCRIPTION
A new experimental option affecting clause selection. Performs SinE selection on the input recoding the levels at which clauses are added into the D-relation. Thus conjectures comes first, then formulas immediately relevant to the conjecture, etc. During saturation these levels become (fake) age of the input clauses. Thus conjecture clauses are processed before the less relevant ones. 