### PR TITLE
Skip-small-neg

### DIFF
--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -196,9 +196,8 @@ ClauseIterator Superposition::generateClauses(Clause* premise)
   auto itf1 = premise->getSelectedLiteralIterator();
 
   // Get an iterator of pairs of selected literals and rewritable subterms of those literals
-  // A subterm is rewritable (see EqHelper) if
-  //  a) The literal is a positive equality t1=t2 and the subterm is max(t1,t2) wrt ordering
-  //  b) The subterm is not a variable
+  // A subterm is rewritable (see EqHelper) if it is a non-variable subterm of either
+  // a maximal side of an equality or of a non-equational literal
   auto itf2 = getMapAndFlattenIterator(itf1,RewriteableSubtermsFn(_salg->getOrdering()));
 
   // Get clauses with a literal whose complement unifies with the rewritable subterm,
@@ -282,7 +281,7 @@ int Superposition::getWeightLimit(Clause* eqClause, Clause* rwClause, Limits* li
  * performed.
  *
  * This function checks that we don't perform superpositions from
- * variables that occurr in the remainin part of the clause either in
+ * variables that occur in the remaining part of the clause either in
  * a literal which is not an equality, or in a as an argument of a function.
  * Such situation would mean that there is no ground substitution in which
  * @c eqLHS would be the larger argument of the largest literal.

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -180,10 +180,6 @@ TermIterator EqHelper::getRewritableSubtermIterator(Literal* lit, const Ordering
 {
   CALL("EqHelper::getRewritableSubtermIterator");
 
-//  if (lit->isEquality()) {
-//    if (lit->isNegative()) {
-//      return TermIterator::getEmpty();
-//    }
   if (lit->isEquality() && lit->isPositive()) {
     TermList sel;
     switch(ord.getEqualityArgumentOrder(lit)) {

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -180,7 +180,7 @@ TermIterator EqHelper::getRewritableSubtermIterator(Literal* lit, const Ordering
 {
   CALL("EqHelper::getRewritableSubtermIterator");
 
-  if (lit->isEquality() && lit->isPositive()) {
+  if (lit->isEquality()) {
     TermList sel;
     switch(ord.getEqualityArgumentOrder(lit)) {
     case Ordering::INCOMPARABLE:


### PR DESCRIPTION
Implementing Ahmed's proposal to skip the smaller sides of negative equations for rewriting by superposition.

The change (across TPTP, single 10s discount run) brings close to no improvement, but is a reasonable one, so should probably be merged when issues with CASC are resolved.