### PR TITLE
Making multiprocessing more robust

### DIFF
--- a/CASC/ScheduleExecutor.cpp
+++ b/CASC/ScheduleExecutor.cpp
@@ -90,11 +90,16 @@ bool ScheduleExecutor::run(const Schedule &schedule, int terminationTime)
       poolSize++;
     }
 
-    bool stopped, exited;
+    bool stopped, exited, signalled;
     int code;
     // sleep until process changes state
     pid_t process = Multiprocessing::instance()
-      ->poll_children(stopped, exited, code);
+      ->poll_children(stopped, exited, signalled, code);
+
+    cout << "Child " << process
+        << " stop " << stopped
+        << " exit " << exited
+        << " sig " << signalled << " code " << code << endl;
 
     // child died, remove it from the pool and check if succeeded
     if(exited)

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -230,17 +230,26 @@ void Multiprocessing::killNoCheck(pid_t child, int signal)
   ::kill(child, signal);
 }
 
-pid_t Multiprocessing::poll_children(bool &stopped, bool &exited, int &code)
+pid_t Multiprocessing::poll_children(bool &stopped, bool &exited, bool &signalled, int &code)
 {
   CALL("Multiprocessing::poll_child");
 
   int status;
-  pid_t pid = waitpid(-1, &status, WUNTRACED);
+  pid_t pid = waitpid(-1 /*wait for any child*/, &status, WUNTRACED);
   stopped = WIFSTOPPED(status);
   exited = WIFEXITED(status);
+  signalled = WIFSIGNALED(status);
   if(exited)
   {
     code = WEXITSTATUS(status);
+  }
+  if(signalled)
+  {
+    code = WTERMSIG(status);
+  }
+  if(stopped)
+  {
+    code = WSTOPSIG(status);
   }
   return pid;
 }

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -236,6 +236,11 @@ pid_t Multiprocessing::poll_children(bool &stopped, bool &exited, bool &signalle
 
   int status;
   pid_t pid = waitpid(-1 /*wait for any child*/, &status, WUNTRACED);
+
+  if (pid == -1) {
+    SYSTEM_FAIL("Call to waitpid() function failed.", errno);
+  }
+
   stopped = WIFSTOPPED(status);
   exited = WIFEXITED(status);
   signalled = WIFSIGNALED(status);

--- a/Lib/Sys/Multiprocessing.hpp
+++ b/Lib/Sys/Multiprocessing.hpp
@@ -26,7 +26,7 @@ public:
   void sleep(unsigned ms);
   void kill(pid_t child, int signal);
   void killNoCheck(pid_t child, int signal);
-  pid_t poll_children(bool &stopped, bool &exited, int &code);
+  pid_t poll_children(bool &stopped, bool &exited, bool &signalled, int &code);
 private:
   Multiprocessing();
   ~Multiprocessing();


### PR DESCRIPTION
waitpid may return -1, when no children to be still polled. This is an error
moreover
poll_children can return signalled state, if a child has be killed by an external signal (this may happen when an external tool is shooting misbehaving children down)