### PR TITLE
Add max_age option and implementation.

### DIFF
--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -161,8 +161,8 @@ SaturationAlgorithm::SaturationAlgorithm(Problem& prb, const Options& opt)
     _extensionality = 0;
   }
   
-  if (opt.maxWeight()) {
-    _limits.setLimits(0,opt.maxWeight(),true);
+  if (opt.maxAge() || opt.maxWeight()) {
+    _limits.setLimits(opt.maxAge(),opt.maxWeight(),true);
   }
 
   s_instance=this;

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1681,6 +1681,11 @@ void Options::Options::init()
     //_lookup.insert(&_maxPassive);
     _maxPassive.tag(OptionTag::OTHER);
 
+    _maxAge = IntOptionValue("max_age","",0);
+    _maxAge.description="Age limit for clauses (0 means no age limit)";
+    _lookup.insert(&_maxAge);
+    _maxAge.tag(OptionTag::SATURATION);
+
     _maxWeight = IntOptionValue("max_weight","",0);
     _maxWeight.description="Weight limit for clauses (0 means no weight limit)";
     _lookup.insert(&_maxWeight);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1970,6 +1970,7 @@ public:
   long maxAnswers() const { return _maxAnswers.actualValue; }
   //void setMaxAnswers(int newVal) { _maxAnswers = newVal; }
   long maxPassive() const { return _maxPassive.actualValue; }
+  int maxAge() const { return _maxAge.actualValue; }
   int maxWeight() const { return _maxWeight.actualValue; }
   int ageRatio() const { return _ageWeightRatio.actualValue; }
   void setAgeRatio(int v){ _ageWeightRatio.actualValue = v; }
@@ -2352,6 +2353,7 @@ private:
   IntOptionValue _maxAnswers;
   IntOptionValue _maxInferenceDepth;
   LongOptionValue _maxPassive;
+  IntOptionValue _maxAge;
   IntOptionValue _maxWeight;
   UnsignedOptionValue _maximalPropagatedEqualityLength;
   UnsignedOptionValue _memoryLimit; // should be size_t, making an assumption


### PR DESCRIPTION
Hi folks,

I recently hacked Vampire to print all clauses generated by one inference step from a given set. The hack is not very useful in general. However, I noticed that there is a maximum-weight setting, but not a maximum-age setting for some reason - possibly there is one, but I'm not aware of any reason why it shouldn't work. Since it's a minimal change we might consider merging this to implement that option. What do you think?

Obviously this renders the prover incomplete in some cases, but presumably this is the same as the maximum-weight setting.