### PR TITLE
implement interactive clause selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,8 @@ VST_OBJ= Saturation/AWPassiveClauseContainer.o\
          Saturation/ProvingHelper.o\
          Saturation/SaturationAlgorithm.o\
          Saturation/Splitter.o\
-         Saturation/SymElOutput.o
+         Saturation/SymElOutput.o\
+         Saturation/ManCSPassiveClauseContainer.o\
 
 VS_OBJ = Shell/AnswerExtractor.o\
          Shell/BFNT.o\

--- a/Saturation/ManCSPassiveClauseContainer.cpp
+++ b/Saturation/ManCSPassiveClauseContainer.cpp
@@ -1,0 +1,84 @@
+
+#include <iostream>
+#include "ManCSPassiveClauseContainer.hpp"
+#include "Lib/VirtualIterator.hpp"
+
+namespace Saturation
+{
+using namespace Lib;
+using namespace Kernel;
+
+/*
+ * this class wraps the iterator of std::vector into IteratorCore required by Vampire.
+ */
+class VectorIteratorWrapper : public IteratorCore<Clause*>
+{
+public:
+	CLASS_NAME(VectorIteratorWrapper);
+	USE_ALLOCATOR(VectorIteratorWrapper);
+  
+	explicit VectorIteratorWrapper(const std::vector<Clause*>& v) : curr(v.begin()), end(v.end()) {}
+	bool hasNext() { return curr != end; };
+	Clause* next() { auto cl = *curr; curr = std::next(curr); return cl;};
+
+private:
+	std::vector<Clause*>::const_iterator curr;
+	const std::vector<Clause*>::const_iterator end;
+};
+
+
+ClauseIterator ManCSPassiveClauseContainer::iterator()
+{
+	return vi( new VectorIteratorWrapper(clauses));
+}
+
+void ManCSPassiveClauseContainer::add(Clause* cl)
+{
+	clauses.push_back(cl);
+	addedEvent.fire(cl);
+}
+
+void ManCSPassiveClauseContainer::remove(Clause* cl)
+{
+	ASS(cl->store()==Clause::PASSIVE);
+	
+	auto it = std::find(clauses.begin(),clauses.end(),cl);
+	ASS(it != clauses.end();)
+	clauses.erase(it);
+
+	removedEvent.fire(cl);
+	ASS(cl->store()!=Clause::PASSIVE);
+}
+
+Clause* ManCSPassiveClauseContainer::popSelected()
+{
+  	ASS(!clauses.empty());
+
+	// print existing clauses
+	std::cout << "Pick a clause from: ";
+	for (const auto& cl : clauses)
+	{
+		std::cout << cl->number() << ",";
+	}
+	std::cout << std::endl;
+
+	// let user pick a clause id
+	std::string id;
+	std::cin >> id;
+	unsigned selectedId = std::stoi(id);
+
+	// find clause with that id
+	auto selectedClauseIt = std::find_if(clauses.begin(), clauses.end(), 
+		[&](Clause* c) -> bool { return c->number() == selectedId; });	
+	ASS(selectedClauseIt != clauses.end());
+
+	auto selectedClause	= *selectedClauseIt;
+	clauses.erase(selectedClauseIt);
+	selectedEvent.fire(selectedClause);
+	
+	return selectedClause;
+}
+
+unsigned ManCSPassiveClauseContainer::size() const { return clauses.size(); }
+bool ManCSPassiveClauseContainer::isEmpty() const { return clauses.empty(); }
+}

--- a/Saturation/ManCSPassiveClauseContainer.hpp
+++ b/Saturation/ManCSPassiveClauseContainer.hpp
@@ -1,0 +1,42 @@
+#ifndef __MANCSPASSIVECLAUSECONTAINER__
+#define __MANCSPASSIVECLAUSECONTAINER__
+
+#include <vector>
+#include "Kernel/Clause.hpp"
+#include "ClauseContainer.hpp"
+#include "Kernel/ClauseQueue.hpp"
+
+namespace Saturation {
+
+using namespace Kernel;
+
+/*
+ * Subclass of PassiveClauseContainer for manual selection of clauses
+ * asks in each iteration the user to pick the id of the clause which should be activated next
+ */
+class ManCSPassiveClauseContainer : public PassiveClauseContainer
+{
+public:
+  CLASS_NAME(ManCSPassiveClauseContainer);
+  USE_ALLOCATOR(ManCSPassiveClauseContainer);
+
+  ManCSPassiveClauseContainer(const Options& opt) : opt(opt), clauses() {}
+  virtual ~ManCSPassiveClauseContainer(){}
+  
+  virtual unsigned size() const;
+  bool isEmpty() const;
+  ClauseIterator iterator();
+
+  void add(Clause* cl);
+  void remove(Clause* cl);
+
+  Clause* popSelected();
+  
+private:
+  std::vector<Clause*> clauses;
+  const Options& opt;
+};
+
+}
+
+#endif /* __MANCSPASSIVECLAUSECONTAINER__ */

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -85,6 +85,7 @@
 #include "Splitter.hpp"
 #include "SymElOutput.hpp"
 #include "SaturationAlgorithm.hpp"
+#include "ManCSPassiveClauseContainer.hpp"
 #include "AWPassiveClauseContainer.hpp"
 #include "Discount.hpp"
 #include "LRS.hpp"
@@ -139,7 +140,15 @@ SaturationAlgorithm::SaturationAlgorithm(Problem& prb, const Options& opt)
   _completeOptionSettings = opt.complete(prb);
 
   _unprocessed = new UnprocessedClauseContainer();
-  _passive = new AWPassiveClauseContainer(opt);
+  if (opt.useManualClauseSelection())
+  {
+    _passive = new ManCSPassiveClauseContainer(opt);
+  }
+  else
+  {
+    _passive = new AWPassiveClauseContainer(opt);
+  }
+    
   _active = new ActiveClauseContainer(opt);
 
   _active->attach(this);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -721,6 +721,11 @@ void Options::Options::init()
     _lookup.insert(&_showFMBsortInfo);
     _showFMBsortInfo.tag(OptionTag::OUTPUT);
 
+    _manualClauseSelection = BoolOptionValue("manual_cs","",false);
+    _manualClauseSelection.description="Run Vampire interactively by manually picking the clauses to be selected";
+    _lookup.insert(&_manualClauseSelection);
+    _manualClauseSelection.tag(OptionTag::DEVELOPMENT);
+    
 //************************************************************************
 //*********************** VAMPIRE (includes CASC)  ***********************
 //************************************************************************

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2119,6 +2119,9 @@ public:
   bool newCNF() const { return _newCNF.actualValue; }
   int getIteInliningThreshold() const { return _iteInliningThreshold.actualValue; }
   bool getIteInlineLet() const { return _inlineLet.actualValue; }
+
+  bool useManualClauseSelection() const { return _manualClauseSelection.actualValue; }
+
 private:
     
     /**
@@ -2499,6 +2502,8 @@ private:
   BoolOptionValue _newCNF;
   IntOptionValue _iteInliningThreshold;
   BoolOptionValue _inlineLet;
+
+  BoolOptionValue _manualClauseSelection;
 
 
 }; // class Options


### PR DESCRIPTION
Adds an option manual_cs (with default off) to
perform clause selection interactively.
If manual_cs is set to on, then whenever a
clause has to be selected, the user is asked
to enter the id of a clause currently in the
set of passive clauses. The corresponding
clause then gets activated.
While this mechanism can be used on
its own, it is designed to be used in
conjunction with the Saturation Visualization.