### PR TITLE
Use subsets of induction term occurrences instead of all occurrences

### DIFF
--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -87,6 +87,7 @@ Literal* LiteralSubsetReplacement::transformSubset() {
   // Increment _iteration, since it either is 0, or was already used.
   _iteration++;
   static unsigned maxSubsetSize = env.options->maxInductionTermSubsetSize();
+  // Note: __builtin_popcount() is a GCC built-in function.
   int setBits = __builtin_popcount(_iteration);
   // Skip this iteration if not all bits are set, but more than maxSubset are set.
   while ((_iteration <= _maxIterations) &&
@@ -724,9 +725,12 @@ bool InductionClauseIterator::notDone(Literal* lit, Term* term)
 Term* InductionClauseIterator::getPlaceholderForTerm(Term* t) {
   CALL("InductionClauseIterator::getPlaceholderForTerm");
 
-  unsigned termType = env.signature->getFunction(t->functor())->fnType()->result();
-  unsigned placeholderConstNumber = env.signature->addFreshFunction(0, "placeholder");
-  env.signature->getFunction(placeholderConstNumber)->setType(OperatorType::getConstantsType(termType));
+  OperatorType* ot = env.signature->getFunction(t->functor())->fnType();
+  bool added; 
+  unsigned placeholderConstNumber = env.signature->addFunction("placeholder_" + ot->toString(), 0, added);
+  if (added) {
+    env.signature->getFunction(placeholderConstNumber)->setType(OperatorType::getConstantsType(ot->result()));
+  }
   return Term::createConstant(placeholderConstNumber);
 }
 

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -87,9 +87,12 @@ Literal* LiteralSubsetReplacement::transformSubset() {
   // Increment _iteration, since it either is 0, or was already used.
   _iteration++;
   static unsigned maxSubsetSize = env.options->maxInductionTermSubsetSize();
+  int setBits = __builtin_popcount(_iteration);
+  // Skip this iteration if not all bits are set, but more than maxSubset are set.
   while ((_iteration <= _maxIterations) &&
-         ((maxSubsetSize > 0) && (__builtin_popcount(_iteration) > maxSubsetSize))) {
+         ((maxSubsetSize > 0) && (setBits < _occurrences) && (setBits > maxSubsetSize))) {
     _iteration++;
+    setBits = __builtin_popcount(_iteration);
   }
   if ((_iteration >= _maxIterations) ||
       ((_occurrences > _maxOccurrences) && (_iteration > 1))) {

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -86,7 +86,7 @@ Literal* LiteralSubsetReplacement::transformSubset() {
   CALL("LiteralSubsetReplacement::transformSubset");
   // Increment _iteration, since it either is 0, or was already used.
   _iteration++;
-  static unsigned maxSubsetSize = env.options->maxInductionTermSubsetSize();
+  static unsigned maxSubsetSize = env.options->maxInductionGenSubsetSize();
   // Note: __builtin_popcount() is a GCC built-in function.
   int setBits = __builtin_popcount(_iteration);
   // Skip this iteration if not all bits are set, but more than maxSubset are set.
@@ -149,7 +149,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
                          env.options->induction() == Options::Induction::STRUCTURAL;
   static bool mathInd = env.options->induction() == Options::Induction::BOTH ||
                          env.options->induction() == Options::Induction::MATHEMATICAL;
-  static bool useTermSubset = env.options->inductionTermSubset();
+  static bool generalize = env.options->inductionGen();
 
   if((!negOnly || lit->isNegative() || 
          (theory->isInterpretedPredicate(lit) && theory->isInequality(theory->interpretPredicate(lit)))
@@ -195,9 +195,9 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         static bool two = env.options->mathInduction() == Options::MathInductionKind::TWO ||
                           env.options->mathInduction() == Options::MathInductionKind::ALL;
         if(notDone(lit,t)){
-          Term* inductionTerm = useTermSubset ? getPlaceholderForTerm(t) : t;
+          Term* inductionTerm = generalize ? getPlaceholderForTerm(t) : t;
           Kernel::LiteralSubsetReplacement subsetReplacement(lit, t, TermList(inductionTerm));
-          Literal* ilit = useTermSubset ? subsetReplacement.transformSubset() : lit;
+          Literal* ilit = generalize ? subsetReplacement.transformSubset() : lit;
           ASS(ilit != nullptr);
           do {
             if(one){
@@ -206,7 +206,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
             if(two){
               performMathInductionTwo(premise,lit,ilit,inductionTerm);
             }
-          } while (useTermSubset && (ilit = subsetReplacement.transformSubset()));
+          } while (generalize && (ilit = subsetReplacement.transformSubset()));
         }
       }
       Set<Term*>::Iterator citer2(ta_terms);
@@ -220,9 +220,9 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         static bool three = env.options->structInduction() == Options::StructuralInductionKind::THREE ||
                           env.options->structInduction() == Options::StructuralInductionKind::ALL;
         if(notDone(lit,t)){
-          Term* inductionTerm = useTermSubset ? getPlaceholderForTerm(t) : t;
+          Term* inductionTerm = generalize ? getPlaceholderForTerm(t) : t;
           Kernel::LiteralSubsetReplacement subsetReplacement(lit, t, TermList(inductionTerm));
-          Literal* ilit = useTermSubset ? subsetReplacement.transformSubset() : lit;
+          Literal* ilit = generalize ? subsetReplacement.transformSubset() : lit;
           ASS(ilit != nullptr);
           do {
             if(one){
@@ -234,7 +234,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
             if(three){
               performStructInductionThree(premise,lit,ilit,inductionTerm);
             }
-          } while (useTermSubset && (ilit = subsetReplacement.transformSubset()));
+          } while (generalize && (ilit = subsetReplacement.transformSubset()));
         }
       } 
    }

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -63,9 +63,38 @@ TermList TermReplacement::transformSubterm(TermList trm)
   CALL("TermReplacement::transformSubterm");
 
   if(trm.isTerm() && trm.term()==_o){
-   return _r;
+    return _r;
   }
   return trm;
+}
+
+TermList LiteralSubsetReplacement::transformSubterm(TermList trm)
+{
+  CALL("LiteralSubsetReplacement::transformSubterm");
+
+  if(trm.isTerm() && trm.term() == _o){
+    // Replace either if there are too many occurrences (>10) to try all possibilities,
+    // or if the bit in _iteration corresponding to this match is set to 1.
+    if ((_occurrences > 10) || (1 & (_iteration >> _matchCount++))) {
+      return _r;
+    }
+  }
+  return trm;
+}
+
+Literal* LiteralSubsetReplacement::transformSubset() {
+  CALL("LiteralSubsetReplacement::transformSubset");
+  // Increment _iteration, since it either is 0, or was already used.
+  _iteration++;
+  // TODO: add a flag for the maximum number of selected occurrences.
+  //int setBits = countSetBits(_iteration);
+  //while ((countSetBits(_iteration) > 3) && (_iteration <= _maxIterations)) _iteration++;
+  if (_iteration >= _maxIterations) {
+    return nullptr;
+  }
+  _matchCount = 0;
+  Literal* lit = transform(_lit);
+  return lit;
 }
 
 ClauseIterator Induction::generateClauses(Clause* premise)

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -69,6 +69,7 @@ private:
   // Counts how many occurrences were already encountered in one transformation
   unsigned _matchCount = 0;
   unsigned _occurrences;
+  const unsigned _maxOccurrences = 10;
   Literal* _lit;
   Term* _o;
   TermList _r;
@@ -106,14 +107,15 @@ public:
 private:
   void process(Clause* premise, Literal* lit);
 
-  void performMathInductionOne(Clause* premise, Literal* lit, Term* t); 
-  void performMathInductionTwo(Clause* premise, Literal* lit, Term* t);
+  void performMathInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t); 
+  void performMathInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t);
 
-  void performStructInductionOne(Clause* premise, Literal* lit, Term* t);
-  void performStructInductionTwo(Clause* premise, Literal* lit, Term* t);
-  void performStructInductionThree(Clause* premise, Literal* lit, Term* t);
+  void performStructInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t);
+  void performStructInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t);
+  void performStructInductionThree(Clause* premise, Literal* origLit, Literal* lit, Term* t);
 
   bool notDone(Literal* lit, Term* t);
+  Term* getPlaceholderForTerm(Term* t);
 
   Stack<Clause*> _clauses;
 };

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -69,7 +69,7 @@ private:
   // Counts how many occurrences were already encountered in one transformation
   unsigned _matchCount = 0;
   unsigned _occurrences;
-  const unsigned _maxOccurrences = 10;
+  const unsigned _maxOccurrences = 20;
   Literal* _lit;
   Term* _o;
   TermList _r;

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -24,6 +24,8 @@
 #ifndef __Induction__
 #define __Induction__
 
+#include <math.h>
+
 #include "Forwards.hpp"
 
 #include "Kernel/TermTransformer.hpp"
@@ -42,6 +44,32 @@ public:
   TermReplacement(Term* o, TermList r) : _o(o), _r(r) {} 
   virtual TermList transformSubterm(TermList trm);
 private:
+  Term* _o;
+  TermList _r;
+};
+
+class LiteralSubsetReplacement : TermTransformer {
+public:
+  LiteralSubsetReplacement(Literal* lit, Term* o, TermList r)
+      : _lit(lit), _o(o), _r(r) {
+    _occurrences = _lit->countSubtermOccurrences(TermList(_o));
+    _maxIterations = pow(2, _occurrences);
+  }
+
+  // Returns transformed lit for the first 2^(_occurences) - 1 calls, then returns nullptr.
+  Literal* transformSubset();
+
+protected:
+  virtual TermList transformSubterm(TermList trm);
+
+private:
+  // _iteration serves as a map of occurrences to replace
+  unsigned _iteration = 0;
+  unsigned _maxIterations;
+  // Counts how many occurrences were already encountered in one transformation
+  unsigned _matchCount = 0;
+  unsigned _occurrences;
+  Literal* _lit;
   Term* _o;
   TermList _r;
 };

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -370,7 +370,7 @@ bool Superposition::earlyWeightLimitCheck(Clause* eqClause, Literal* eqLit,
     }
   }
   //if rewrite balance is 0, it doesn't matter how many times we rewrite
-  size_t rwrCnt = (rwrBalance==0) ? 0 : getSubtermOccurrenceCount(rwLit, rwTerm);
+  size_t rwrCnt = (rwrBalance==0) ? 0 : rwLit->countSubtermOccurrences(rwTerm);
   if(rwrCnt>1) {
     ASS_GE(rwrCnt, 1);
     int approxWeight = rwLit->weight()+static_cast<int>(rwrBalance*rwrCnt);
@@ -391,29 +391,6 @@ bool Superposition::earlyWeightLimitCheck(Clause* eqClause, Literal* eqLit,
   }
 
   return true;
-}
-
-size_t Superposition::getSubtermOccurrenceCount(Term* trm, TermList subterm)
-{
-  CALL("Superposition::getSubtermOccurrenceCount");
-
-  size_t res = 0;
-
-  unsigned stWeight = subterm.isTerm() ? subterm.term()->weight() : 1;
-  SubtermIterator stit(trm);
-  while(stit.hasNext()) {
-    TermList t = stit.next();
-    if(t==subterm) {
-      res++;
-      stit.right();
-    }
-    else if(t.isTerm()) {
-      if(t.term()->weight()<=stWeight) {
-	stit.right();
-      }
-    }
-  }
-  return res;
 }
 
 /**

--- a/Inferences/Superposition.hpp
+++ b/Inferences/Superposition.hpp
@@ -64,8 +64,6 @@ private:
 
   static bool checkSuperpositionFromVariable(Clause* eqClause, Literal* eqLit, TermList eqLHS);
 
-  static size_t getSubtermOccurrenceCount(Term* trm, TermList subterm);
-
   struct ForwardResultFn;
   struct RewriteableSubtermsFn;
   struct ApplicableRewritesFn;

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -299,6 +299,28 @@ bool Term::containsSubterm(TermList trm)
   }
 }
 
+size_t Term::countSubtermOccurrences(TermList subterm) {
+  CALL("Term::countSubtermOccurrences");
+
+  size_t res = 0;
+
+  unsigned stWeight = subterm.isTerm() ? subterm.term()->weight() : 1;
+  SubtermIterator stit(this);
+  while(stit.hasNext()) {
+    TermList t = stit.next();
+    if(t==subterm) {
+      res++;
+      stit.right();
+    }
+    else if(t.isTerm()) {
+      if(t.term()->weight()<=stWeight) {
+        stit.right();
+      }
+    }
+  }
+  return res;
+}
+
 bool TermList::containsAllVariablesOf(TermList t)
 {
   CALL("Term::containsAllVariablesOf");

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -530,6 +530,7 @@ public:
 
   bool containsSubterm(TermList v);
   bool containsAllVariablesOf(Term* t);
+  size_t countSubtermOccurrences(TermList subterm);
   /** Return true if term has no non-constant functions as subterms */
   bool isShallow() const;
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1003,22 +1003,22 @@ void Options::Options::init()
             _inductionUnitOnly.reliesOn(_induction.is(notEqual(Induction::NONE)));
             _lookup.insert(&_inductionUnitOnly);
 
-            _inductionTermSubset = BoolOptionValue("induction_term_subset","indts",false);
-            _inductionTermSubset.description = "Try using subsets of occurrences of the induction term"
-                                               " instead of all occurrences.";
-            _inductionTermSubset.setExperimental();
-            _inductionTermSubset.tag(OptionTag::INFERENCES);
-            _inductionTermSubset.reliesOn(_induction.is(notEqual(Induction::NONE)));
-            _lookup.insert(&_inductionTermSubset);
+            _inductionGen = BoolOptionValue("induction_gen","indgen",false);
+            _inductionGen.description = "Apply induction with generalization (on both all & selected occurrences)";
+            _inductionGen.setExperimental();
+            _inductionGen.tag(OptionTag::INFERENCES);
+            _inductionGen.reliesOn(_induction.is(notEqual(Induction::NONE)));
+            _lookup.insert(&_inductionGen);
 
-            _maxInductionTermSubsetSize = UnsignedOptionValue("induction_term_subset_size","indtss",3);
-            _maxInductionTermSubsetSize.description = "Set maximum number of occurrences of the induction term to"
-                                                      " be used for indution, where 0 means no max.";
-            _maxInductionTermSubsetSize.setExperimental();
-            _maxInductionTermSubsetSize.tag(OptionTag::INFERENCES);
-            _maxInductionTermSubsetSize.reliesOn(_inductionTermSubset.is(equal(true)));
-            _maxInductionTermSubsetSize.addHardConstraint(lessThan(10u));
-            _lookup.insert(&_maxInductionTermSubsetSize);
+            _maxInductionGenSubsetSize = UnsignedOptionValue("max_induction_gen_subset_size","indgenss",3);
+            _maxInductionGenSubsetSize.description = "Set maximum number of occurrences of the induction term to be"
+                                                      " generalized, where 0 means no max. (Regular induction will"
+                                                      " be applied without this restriction.)";
+            _maxInductionGenSubsetSize.setExperimental();
+            _maxInductionGenSubsetSize.tag(OptionTag::INFERENCES);
+            _maxInductionGenSubsetSize.reliesOn(_inductionGen.is(equal(true)));
+            _maxInductionGenSubsetSize.addHardConstraint(lessThan(10u));
+            _lookup.insert(&_maxInductionGenSubsetSize);
 
 	    _instantiation = ChoiceOptionValue<Instantiation>("instantiation","inst",Instantiation::OFF,{"off","on"});
 	    _instantiation.description = "Heuristically instantiate variables";

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1003,6 +1003,23 @@ void Options::Options::init()
             _inductionUnitOnly.reliesOn(_induction.is(notEqual(Induction::NONE)));
             _lookup.insert(&_inductionUnitOnly);
 
+            _inductionTermSubset = BoolOptionValue("induction_term_subset","indts",false);
+            _inductionTermSubset.description = "Try using subsets of occurrences of the induction term"
+                                               " instead of all occurrences.";
+            _inductionTermSubset.setExperimental();
+            _inductionTermSubset.tag(OptionTag::INFERENCES);
+            _inductionTermSubset.reliesOn(_induction.is(notEqual(Induction::NONE)));
+            _lookup.insert(&_inductionTermSubset);
+
+            _maxInductionTermSubsetSize = UnsignedOptionValue("induction_term_subset_size","indtss",3);
+            _maxInductionTermSubsetSize.description = "Set maximum number of occurrences of the induction term to"
+                                                      " be used for indution, where 0 means no max.";
+            _maxInductionTermSubsetSize.setExperimental();
+            _maxInductionTermSubsetSize.tag(OptionTag::INFERENCES);
+            _maxInductionTermSubsetSize.reliesOn(_inductionTermSubset.is(equal(true)));
+            _maxInductionTermSubsetSize.addHardConstraint(lessThan(10u));
+            _lookup.insert(&_maxInductionTermSubsetSize);
+
 	    _instantiation = ChoiceOptionValue<Instantiation>("instantiation","inst",Instantiation::OFF,{"off","on"});
 	    _instantiation.description = "Heuristically instantiate variables";
 	    _instantiation.tag(OptionTag::INFERENCES);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2053,6 +2053,8 @@ public:
   unsigned maxInductionDepth() const { return _maxInductionDepth.actualValue; }
   bool inductionNegOnly() const { return _inductionNegOnly.actualValue; }
   bool inductionUnitOnly() const { return _inductionUnitOnly.actualValue; }
+  bool inductionTermSubset() const { return _inductionTermSubset.actualValue; }
+  unsigned maxInductionTermSubsetSize() const { return _maxInductionTermSubsetSize.actualValue; }
 
   float instGenBigRestartRatio() const { return _instGenBigRestartRatio.actualValue; }
   bool instGenPassiveReactivation() const { return _instGenPassiveReactivation.actualValue; }
@@ -2345,6 +2347,8 @@ private:
   UnsignedOptionValue _maxInductionDepth;
   BoolOptionValue _inductionNegOnly;
   BoolOptionValue _inductionUnitOnly;
+  BoolOptionValue _inductionTermSubset;
+  UnsignedOptionValue _maxInductionTermSubsetSize;
 
   StringOptionValue _latexOutput;
   BoolOptionValue _latexUseDefaultSymbols;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2053,8 +2053,8 @@ public:
   unsigned maxInductionDepth() const { return _maxInductionDepth.actualValue; }
   bool inductionNegOnly() const { return _inductionNegOnly.actualValue; }
   bool inductionUnitOnly() const { return _inductionUnitOnly.actualValue; }
-  bool inductionTermSubset() const { return _inductionTermSubset.actualValue; }
-  unsigned maxInductionTermSubsetSize() const { return _maxInductionTermSubsetSize.actualValue; }
+  bool inductionGen() const { return _inductionGen.actualValue; }
+  unsigned maxInductionGenSubsetSize() const { return _maxInductionGenSubsetSize.actualValue; }
 
   float instGenBigRestartRatio() const { return _instGenBigRestartRatio.actualValue; }
   bool instGenPassiveReactivation() const { return _instGenPassiveReactivation.actualValue; }
@@ -2347,8 +2347,8 @@ private:
   UnsignedOptionValue _maxInductionDepth;
   BoolOptionValue _inductionNegOnly;
   BoolOptionValue _inductionUnitOnly;
-  BoolOptionValue _inductionTermSubset;
-  UnsignedOptionValue _maxInductionTermSubsetSize;
+  BoolOptionValue _inductionGen;
+  UnsignedOptionValue _maxInductionGenSubsetSize;
 
   StringOptionValue _latexOutput;
   BoolOptionValue _latexUseDefaultSymbols;


### PR DESCRIPTION
When instantiating the induction schemas, try to use all possible subsets of occurrences of the induction term as a variable (and keep all other occurrences constant, as they are in the input literal). However, only do this if there are <=10 occurrences (somewhat arbitrary cutoff; if there are >10, there would be too many possibilities to try).

This change adds two options:
--induction_term_subset - turns on the behavior (default is off).
--max_induction_term_subset_size - maximum number of occurrences of the induction term to use as a variable (default is 3).