### PR TITLE
Apply induction on complex terms + add generalized induction stats

### DIFF
--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -155,6 +155,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
   static bool mathInd = env.options->induction() == Options::Induction::BOTH ||
                          env.options->induction() == Options::Induction::MATHEMATICAL;
   static bool generalize = env.options->inductionGen();
+  static bool complexTermsAllowed = env.options->inductionOnComplexTerms();
 
   if((!negOnly || lit->isNegative() || 
          (theory->isInterpretedPredicate(lit) && theory->isInequality(theory->interpretPredicate(lit)))
@@ -169,7 +170,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         TermList ts = it.next();
         if(!ts.term()){ continue; }
         unsigned f = ts.term()->functor(); 
-        if(//env.signature->functionArity(f)==0 &&
+        if((complexTermsAllowed || env.signature->functionArity(f)==0) &&
            (
                all
             || env.signature->getFunction(f)->inGoal()
@@ -178,7 +179,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         ){
          if(structInd && 
             env.signature->isTermAlgebraSort(env.signature->getFunction(f)->fnType()->result()) &&
-            !(env.signature->functionArity(f) == 0 && env.signature->getFunction(f)->termAlgebraCons()) // base constructor
+            ((complexTermsAllowed && env.signature->functionArity(f) != 0) || !env.signature->getFunction(f)->termAlgebraCons()) // skip base constructors
            ){
             ta_terms.insert(ts.term());
           }

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -83,7 +83,7 @@ TermList LiteralSubsetReplacement::transformSubterm(TermList trm)
   return trm;
 }
 
-Literal* LiteralSubsetReplacement::transformSubset() {
+Literal* LiteralSubsetReplacement::transformSubset(InferenceRule& rule) {
   CALL("LiteralSubsetReplacement::transformSubset");
   // Increment _iteration, since it either is 0, or was already used.
   _iteration++;
@@ -100,6 +100,11 @@ Literal* LiteralSubsetReplacement::transformSubset() {
       ((_occurrences > _maxOccurrences) && (_iteration > 1))) {
     // All combinations were already returned.
     return nullptr;
+  }
+  if (setBits == _occurrences) {
+    rule = InferenceRule::INDUCTION_AXIOM;
+  } else {
+    rule = InferenceRule::GEN_INDUCTION_AXIOM;
   }
   _matchCount = 0;
   return transform(_lit);
@@ -200,18 +205,19 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         static bool two = env.options->mathInduction() == Options::MathInductionKind::TWO ||
                           env.options->mathInduction() == Options::MathInductionKind::ALL;
         if(notDone(lit,t)){
+          InferenceRule rule = InferenceRule::INDUCTION_AXIOM;
           Term* inductionTerm = generalize ? getPlaceholderForTerm(t) : t;
           Kernel::LiteralSubsetReplacement subsetReplacement(lit, t, TermList(inductionTerm));
-          Literal* ilit = generalize ? subsetReplacement.transformSubset() : lit;
+          Literal* ilit = generalize ? subsetReplacement.transformSubset(rule) : lit;
           ASS(ilit != nullptr);
           do {
             if(one){
-              performMathInductionOne(premise,lit,ilit,inductionTerm);
+              performMathInductionOne(premise,lit,ilit,inductionTerm,rule);
             }
             if(two){
-              performMathInductionTwo(premise,lit,ilit,inductionTerm);
+              performMathInductionTwo(premise,lit,ilit,inductionTerm,rule);
             }
-          } while (generalize && (ilit = subsetReplacement.transformSubset()));
+          } while (generalize && (ilit = subsetReplacement.transformSubset(rule)));
         }
       }
       Set<Term*>::Iterator citer2(ta_terms);
@@ -225,21 +231,22 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         static bool three = env.options->structInduction() == Options::StructuralInductionKind::THREE ||
                           env.options->structInduction() == Options::StructuralInductionKind::ALL;
         if(notDone(lit,t)){
+          InferenceRule rule = InferenceRule::INDUCTION_AXIOM;
           Term* inductionTerm = generalize ? getPlaceholderForTerm(t) : t;
           Kernel::LiteralSubsetReplacement subsetReplacement(lit, t, TermList(inductionTerm));
-          Literal* ilit = generalize ? subsetReplacement.transformSubset() : lit;
+          Literal* ilit = generalize ? subsetReplacement.transformSubset(rule) : lit;
           ASS(ilit != nullptr);
           do {
             if(one){
-              performStructInductionOne(premise,lit,ilit,inductionTerm);
+              performStructInductionOne(premise,lit,ilit,inductionTerm,rule);
             }
             if(two){
-              performStructInductionTwo(premise,lit,ilit,inductionTerm);
+              performStructInductionTwo(premise,lit,ilit,inductionTerm,rule);
             }
             if(three){
-              performStructInductionThree(premise,lit,ilit,inductionTerm);
+              performStructInductionThree(premise,lit,ilit,inductionTerm,rule);
             }
-          } while (generalize && (ilit = subsetReplacement.transformSubset()));
+          } while (generalize && (ilit = subsetReplacement.transformSubset(rule)));
         }
       } 
    }
@@ -249,7 +256,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
 // (L[0] & (![X] : (X>=0 & L[X]) -> L[x+1])) -> (![Y] : Y>=0 -> L[Y])
 // (L[0] & (![X] : (X<=0 & L[X]) -> L[x-1])) -> (![Y] : Y<=0 -> L[Y])
 // for some ~L[a]
-void InductionClauseIterator::performMathInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* term) 
+void InductionClauseIterator::performMathInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* term, InferenceRule rule) 
 {
   CALL("InductionClauseIterator::performMathInductionOne");
 
@@ -324,10 +331,10 @@ void InductionClauseIterator::performMathInductionOne(Clause* premise, Literal* 
   cnf.setForInduction();
   Stack<Clause*> hyp_clauses;
   unsigned prev_depth = premise->inference().inductionDepth();
-  Inference inf1 = TheoryAxiom(InferenceRule::INDUCTION_AXIOM);
+  Inference inf1 = TheoryAxiom(rule);
   inf1.setInductionDepth(prev_depth+1);
   FormulaUnit* fu1 = new FormulaUnit(hyp1,inf1);
-  Inference inf2 = TheoryAxiom(InferenceRule::INDUCTION_AXIOM);
+  Inference inf2 = TheoryAxiom(rule);
   inf2.setInductionDepth(prev_depth+1);
   FormulaUnit* fu2 = new FormulaUnit(hyp2,inf2);
   cnf.clausify(NNF::ennf(fu1), hyp_clauses);
@@ -346,9 +353,12 @@ void InductionClauseIterator::performMathInductionOne(Clause* premise, Literal* 
     _clauses.push(r);
   }
   env.statistics->induction++;
+  if (rule == InferenceRule::GEN_INDUCTION_AXIOM) {
+    env.statistics->generalizedInduction++;
+  }
 }
 
-void InductionClauseIterator::performMathInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* term) 
+void InductionClauseIterator::performMathInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* term, InferenceRule rule) 
 {
   CALL("InductionClauseIterator::performMathInductionTwo");
 
@@ -362,7 +372,7 @@ void InductionClauseIterator::performMathInductionTwo(Clause* premise, Literal* 
  * and then force binary resolution on L for each resultant clause
  */
 
-void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* term)
+void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* term, InferenceRule rule)
 {
   CALL("InductionClauseIterator::performStructInductionOne"); 
 
@@ -444,7 +454,7 @@ void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal
   NewCNF cnf(0);
   cnf.setForInduction();
   Stack<Clause*> hyp_clauses;
-  Inference inf = TheoryAxiom(InferenceRule::INDUCTION_AXIOM);
+  Inference inf = TheoryAxiom(rule);
   inf.setInductionDepth(premise->inference().inductionDepth()+1);
   FormulaUnit* fu = new FormulaUnit(hypothesis,inf);
   cnf.clausify(NNF::ennf(fu), hyp_clauses);
@@ -461,6 +471,9 @@ void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal
     _clauses.push(r);
   }
   env.statistics->induction++;
+  if (rule == InferenceRule::GEN_INDUCTION_AXIOM) {
+    env.statistics->generalizedInduction++;
+  }
 }
 
 /**
@@ -468,7 +481,7 @@ void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal
  * We produce the clause ~L[x] \/ ?y : L[y] & !z (z subterm y -> ~L[z])
  * and perform resolution with lit L[c]
  */
-void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* term) 
+void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* term, InferenceRule rule) 
 {
   //cout << "TWO " << premise->toString() << endl;
 
@@ -552,7 +565,7 @@ void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal
   NewCNF cnf(0);
   cnf.setForInduction();
   Stack<Clause*> hyp_clauses;
-  Inference inf = TheoryAxiom(InferenceRule::INDUCTION_AXIOM);
+  Inference inf = TheoryAxiom(rule);
   inf.setInductionDepth(premise->inference().inductionDepth()+1);
   FormulaUnit* fu = new FormulaUnit(hypothesis,inf);
   cnf.clausify(NNF::ennf(fu), hyp_clauses);
@@ -569,7 +582,9 @@ void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal
     _clauses.push(r);
   }
   env.statistics->induction++;  
-
+  if (rule == InferenceRule::GEN_INDUCTION_AXIOM) {
+    env.statistics->generalizedInduction++;
+  }
 }
 
 /*
@@ -582,10 +597,9 @@ void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal
  * i.e. we add a new special predicat that is true when its argument is smaller than Y
  *
  */
-void InductionClauseIterator::performStructInductionThree(Clause* premise, Literal* origLit, Literal* lit, Term* term) 
+void InductionClauseIterator::performStructInductionThree(Clause* premise, Literal* origLit, Literal* lit, Term* term, InferenceRule rule) 
 {
   CALL("InductionClauseIterator::performStructInductionThree");
-
 
   TermAlgebra* ta = env.signature->getTermAlgebraOfSort(env.signature->getFunction(term->functor())->fnType()->result());
   unsigned ta_sort = ta->sort();
@@ -698,7 +712,7 @@ void InductionClauseIterator::performStructInductionThree(Clause* premise, Liter
   NewCNF cnf(0);
   cnf.setForInduction();
   Stack<Clause*> hyp_clauses;
-  Inference inf = TheoryAxiom(InferenceRule::INDUCTION_AXIOM);
+  Inference inf = TheoryAxiom(rule);
   inf.setInductionDepth(premise->inference().inductionDepth()+1);
   FormulaUnit* fu = new FormulaUnit(hypothesis,inf);
   cnf.clausify(NNF::ennf(fu), hyp_clauses);
@@ -715,6 +729,9 @@ void InductionClauseIterator::performStructInductionThree(Clause* premise, Liter
     _clauses.push(r);
   }
   env.statistics->induction++; 
+  if (rule == InferenceRule::GEN_INDUCTION_AXIOM) {
+    env.statistics->generalizedInduction++;
+  }
 }
 
 bool InductionClauseIterator::notDone(Literal* lit, Term* term)

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -483,7 +483,7 @@ void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal
  */
 void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* term, InferenceRule rule) 
 {
-  //cout << "TWO " << premise->toString() << endl;
+  CALL("InductionClauseIterator::performStructInductionTwo"); 
 
   TermAlgebra* ta = env.signature->getTermAlgebraOfSort(env.signature->getFunction(term->functor())->fnType()->result());
   unsigned ta_sort = ta->sort();

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -169,7 +169,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         TermList ts = it.next();
         if(!ts.term()){ continue; }
         unsigned f = ts.term()->functor(); 
-        if(env.signature->functionArity(f)==0 &&
+        if(//env.signature->functionArity(f)==0 &&
            (
                all
             || env.signature->getFunction(f)->inGoal()
@@ -178,7 +178,7 @@ void InductionClauseIterator::process(Clause* premise, Literal* lit)
         ){
          if(structInd && 
             env.signature->isTermAlgebraSort(env.signature->getFunction(f)->fnType()->result()) &&
-            !env.signature->getFunction(f)->termAlgebraCons()
+            !(env.signature->functionArity(f) == 0 && env.signature->getFunction(f)->termAlgebraCons()) // base constructor
            ){
             ta_terms.insert(ts.term());
           }

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -57,7 +57,9 @@ public:
   }
 
   // Returns transformed lit for the first 2^(_occurences) - 1 calls, then returns nullptr.
-  Literal* transformSubset();
+  // Sets rule to INDUCTION_AXIOM if all occurrences were transformed, otherwise sets rule
+  // to GEN_INDUCTION_AXIOM.
+  Literal* transformSubset(InferenceRule& rule);
 
 protected:
   virtual TermList transformSubterm(TermList trm);
@@ -111,12 +113,12 @@ public:
 private:
   void process(Clause* premise, Literal* lit);
 
-  void performMathInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t); 
-  void performMathInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t);
+  void performMathInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule); 
+  void performMathInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule);
 
-  void performStructInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t);
-  void performStructInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t);
-  void performStructInductionThree(Clause* premise, Literal* origLit, Literal* lit, Term* t);
+  void performStructInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule);
+  void performStructInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule);
+  void performStructInductionThree(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule);
 
   bool notDone(Literal* lit, Term* t);
   Term* getPlaceholderForTerm(Term* t);

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -869,6 +869,8 @@ vstring Kernel::ruleName(InferenceRule rule)
     return "finite model not found";
   case InferenceRule::INDUCTION_AXIOM:
     return "induction hypothesis";
+  case InferenceRule::GEN_INDUCTION_AXIOM:
+    return "generalized induction hypothesis";
   default:
     ASSERTION_VIOLATION;
     return "!UNKNOWN INFERENCE RULE!";

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -349,6 +349,8 @@ enum class InferenceRule : unsigned char {
 
   /* Induction hypothesis*/
   INDUCTION_AXIOM,
+  /* Generalized nduction hypothesis*/
+  GEN_INDUCTION_AXIOM,
 
   /* the unit clause against which the Answer is extracted in the last step */
   ANSWER_LITERAL_RESOLVER,
@@ -421,7 +423,7 @@ enum class InferenceRule : unsigned char {
   INTERNAL_THEORY_AXIOM_LAST,
   /** a theory axiom which is not generated internally in Vampire */
   EXTERNAL_THEORY_AXIOM
-}; // class Inference::Rule
+}; // class InferenceRule
 
 inline std::underlying_type<InferenceRule>::type toNumber(InferenceRule r) { return static_cast<std::underlying_type<InferenceRule>::type>(r); }
 

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -325,8 +325,11 @@ protected:
 
     cs->inference().updateStatistics(); // in particular, update inductionDepth (which could have decreased, since we might have fewer parents after miniminization)
 
-    if(rule == InferenceRule::INDUCTION_AXIOM){
+    if((rule == InferenceRule::INDUCTION_AXIOM) || (rule == InferenceRule::GEN_INDUCTION_AXIOM)){
       env.statistics->inductionInProof++;
+      if (rule == InferenceRule::GEN_INDUCTION_AXIOM) {
+        env.statistics->generalizedInductionInProof++;
+      }
     }
 
     if (cs->isClause()) {

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1131,6 +1131,13 @@ void Options::Options::init()
             _maxInductionGenSubsetSize.addHardConstraint(lessThan(10u));
             _lookup.insert(&_maxInductionGenSubsetSize);
 
+            _inductionOnComplexTerms = BoolOptionValue("induction_on_complex_terms","indoct",false);
+            _inductionOnComplexTerms.description = "Apply induction on complex (ground) terms vs. only on constants";
+            _inductionOnComplexTerms.setExperimental();
+            _inductionOnComplexTerms.tag(OptionTag::INFERENCES);
+            _inductionOnComplexTerms.reliesOn(_induction.is(notEqual(Induction::NONE)));
+            _lookup.insert(&_inductionOnComplexTerms);
+
 	    _instantiation = ChoiceOptionValue<Instantiation>("instantiation","inst",Instantiation::OFF,{"off","on"});
 	    _instantiation.description = "Heuristically instantiate variables";
 	    _instantiation.tag(OptionTag::INFERENCES);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2075,6 +2075,7 @@ public:
   bool inductionUnitOnly() const { return _inductionUnitOnly.actualValue; }
   bool inductionGen() const { return _inductionGen.actualValue; }
   unsigned maxInductionGenSubsetSize() const { return _maxInductionGenSubsetSize.actualValue; }
+  bool inductionOnComplexTerms() const {return _inductionOnComplexTerms.actualValue;}
 
   float instGenBigRestartRatio() const { return _instGenBigRestartRatio.actualValue; }
   bool instGenPassiveReactivation() const { return _instGenPassiveReactivation.actualValue; }
@@ -2383,6 +2384,7 @@ private:
   BoolOptionValue _inductionUnitOnly;
   BoolOptionValue _inductionGen;
   UnsignedOptionValue _maxInductionGenSubsetSize;
+  BoolOptionValue _inductionOnComplexTerms;
 
   StringOptionValue _latexOutput;
   BoolOptionValue _latexUseDefaultSymbols;

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -88,6 +88,8 @@ Statistics::Statistics()
     induction(0),
     maxInductionDepth(0),
     inductionInProof(0),
+    generalizedInduction(0),
+    generalizedInductionInProof(0),
     duplicateLiterals(0),
     trivialInequalities(0),
     forwardSubsumptionResolution(0),
@@ -336,6 +338,8 @@ void Statistics::print(ostream& out)
   COND_OUT("Induction",induction);
   COND_OUT("MaxInductionDepth",maxInductionDepth);
   COND_OUT("InductionStepsInProof",inductionInProof);
+  COND_OUT("GeneralizedInduction",generalizedInduction);
+  COND_OUT("GeneralizedInductionInProof",generalizedInductionInProof);
   SEPARATOR;
 
   HEADING("Term algebra simplifications",taDistinctnessSimplifications+

--- a/Shell/Statistics.hpp
+++ b/Shell/Statistics.hpp
@@ -138,6 +138,8 @@ public:
   unsigned induction;
   unsigned maxInductionDepth;
   unsigned inductionInProof;
+  unsigned generalizedInduction;
+  unsigned generalizedInductionInProof;
 
   // Simplifying inferences
   /** number of duplicate literals deleted */


### PR DESCRIPTION
1. Add the option "-indoct on/off" to apply induction on any ground complex term (default is off). Before it was only applied on constants.
2. Add "GeneralizedInduction" and "GeneralizedInductionInProof" to stats. In order to do this, split INDUCTION_AXIOM rule to two - INDUCTION_AXIOM (when it's applied on all occurrences) and GEN_INDUCTION_AXIOM (when it's applied only on some occurrences).