### PR TITLE
fix z3 static build instructions for version 4.8.8+

### DIFF
--- a/README-CMake.md
+++ b/README-CMake.md
@@ -37,7 +37,7 @@ All compile flags are added as additional arguments to cmake - for example
   
   Please refer to `README-CMake.md` for detailed instructions on how to build Z3 using
   cmake. Notable options are:
-  * `-DBUILD_LIBZ3_SHARED=0`: static library
+  * `-DZ3_BUILD_LIBZ3_SHARED=0`: static library (z3 up to version 4.8.7 needs `-DBUILD_LIBZ3_SHARED=0` instead)
   * `-DCMAKE_INSTALL_PREFIX=/opt/z3-devel`: installation path
 
 ## Other Features ##


### PR DESCRIPTION
Newer versions of z3 need -DZ3_BUILD_LIBZ3_SHARED=off for static builds.