### PR TITLE
Fix pre-check in BSD

### DIFF
--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -180,13 +180,8 @@ void BackwardSubsumptionDemodulation::perform(Clause* sideCl, BwSimplificationRe
 
 void BackwardSubsumptionDemodulation::performWithQueryLit(Clause* sideCl, Literal* candidateQueryLit, vvector<BwSimplificationRecord>& simplifications)
 {
-
-  //                      candidate
-  //                 vvvvvvvvvvvvvvvv
-  //     cl        matched      /-- only look for a term to demodulate in this part!
-  // vvvvvvvvvv      vv    vvvvvvvvvv
-  // eqLit                  dlit
-  // vvvvv                 vvvvv
+  //   sideCl
+  // vvvvvvvvvv
   //
   // l = r \/ C      CΘ \/ L[lΘ] \/ D
   // --------------------------------
@@ -201,7 +196,7 @@ void BackwardSubsumptionDemodulation::performWithQueryLit(Clause* sideCl, Litera
 #endif
 
   bool mustPredInit = false;
-  // bool mustPredActive = false;
+  bool mustPredActive = false;
   unsigned mustPred;
 
   SLQueryResultIterator rit = _index->getInstances(candidateQueryLit, false, false);
@@ -268,29 +263,29 @@ void BackwardSubsumptionDemodulation::performWithQueryLit(Clause* sideCl, Litera
           mustPred = pred;
         }
       }
-      /*
       if (mustPred == 0) {
         // for positive equality we need to have skipped at least in the remaining literals
         mustPredActive = (numPosEqs >= 2);
       } else {
         mustPredActive = true;
       }
-      */
     }
-    bool haveMustPred = false;
-    for (unsigned ii = 0; ii < candidate->length(); ++ii) {
-      Literal* lit = (*candidate)[ii];
-      if (lit == qr.literal) {
+    if (mustPredActive) {
+      bool haveMustPred = false;
+      for (unsigned ii = 0; ii < candidate->length(); ++ii) {
+        Literal* lit = (*candidate)[ii];
+        if (lit == qr.literal) {
+          continue;
+        }
+        unsigned pred = lit->header();
+        if (pred == mustPred) {
+          haveMustPred = true;
+          break;
+        }
+      }
+      if (!haveMustPred) {
         continue;
       }
-      unsigned pred = lit->header();
-      if (pred == mustPred) {
-        haveMustPred = true;
-        break;
-      }
-    }
-    if (!haveMustPred) {
-      continue;
     }
     RSTAT_CTR_INC("bsd 1 mustPred survivors");
 


### PR DESCRIPTION
Effect of the bug:
we mistakenly skipped potential applications of BSD
with side clauses that consist of exactly two positive equalities.