### PR TITLE
Random literal selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,6 +281,7 @@ set(VAMPIRE_KERNEL_SOURCES
     Kernel/SortHelper.cpp
     Kernel/Sorts.cpp
     Kernel/SpassLiteralSelector.cpp
+    Kernel/RndLiteralSelector.cpp    
     Kernel/SubformulaIterator.cpp
     Kernel/Substitution.cpp
     Kernel/Term.cpp
@@ -333,6 +334,7 @@ set(VAMPIRE_KERNEL_SOURCES
     Kernel/SortHelper.hpp
     Kernel/Sorts.hpp
     Kernel/SpassLiteralSelector.hpp
+    Kernel/RndLiteralSelector.hpp    
     Kernel/SubformulaIterator.hpp
     Kernel/SubstHelper.hpp
     Kernel/Substitution.hpp

--- a/Kernel/LiteralSelector.cpp
+++ b/Kernel/LiteralSelector.cpp
@@ -37,6 +37,7 @@
 #include "LookaheadLiteralSelector.hpp"
 #include "SpassLiteralSelector.hpp"
 #include "ELiteralSelector.hpp"
+#include "RndLiteralSelector.hpp"
 
 #include "LiteralComparators.hpp"
 
@@ -141,12 +142,14 @@ LiteralSelector* LiteralSelector::getSelector(const Ordering& ordering, const Op
     res = new ELiteralSelector(ordering, options,static_cast<ELiteralSelector::Values>(absNum-30));
     break;
 
+  case 666: res = new RndLiteralSelector(ordering, options,true /*complete*/); break;
+
   case 1002: res = new BestLiteralSelector<Comparator2>(ordering, options); break;
   case 1003: res = new BestLiteralSelector<Comparator3>(ordering, options); break;
   case 1004: res = new BestLiteralSelector<Comparator4>(ordering, options); break;
   case 1010: res = new BestLiteralSelector<Comparator10>(ordering, options); break;
-
   case 1011: res = new LookaheadLiteralSelector(false, ordering, options); break;
+  case 1666: res = new RndLiteralSelector(ordering, options,false /*incomplete*/); break;
 
   default:
     INVALID_OPERATION("Undefined selection function");

--- a/Kernel/LiteralSelector.cpp
+++ b/Kernel/LiteralSelector.cpp
@@ -47,14 +47,6 @@ namespace Kernel
 {
 
 /**
- * Array that for each predicate contains bol value determining whether
- * the polarity of the predicate should be reversed for the purposes of
- * literal selection
- */
-ZIArray<bool> LiteralSelector::_reversePredicate;
-
-
-/**
  * Return true if literal @b l is positive for the purpose of
  * literal selection
  *
@@ -68,16 +60,7 @@ bool LiteralSelector::isPositiveForSelection(Literal* l) const
   if(l->isEquality()) {
     return l->isPositive(); //we don't change polarity for equality
   }
-  unsigned pred = l->functor();
-  return l->isPositive() ^ _reversePolarity ^ _reversePredicate[pred];
-}
-
-void LiteralSelector::reversePredicatePolarity(unsigned pred, bool reverse)
-{
-  CALL("reversePredicatePolarity");
-  ASS(pred!=0 || !reverse); //we never reverse polarity of equality
-
-  _reversePredicate[pred] = reverse;
+  return l->isPositive() ^ _reversePolarity;
 }
 
 /**
@@ -233,20 +216,19 @@ void LiteralSelector::select(Clause* c, unsigned eligibleInp)
   int maxPriority=getSelectionPriority((*c)[0]);
   bool modified=false;
 
-  for(unsigned i=1;i<eligibleInp;i++) {
-    int priority=getSelectionPriority((*c)[i]);
-    if(priority==maxPriority) {
-      if(eligible!=i) {
-	swap((*c)[i],(*c)[eligible]);
-	modified=true;
+  for (unsigned i = 1; i < eligibleInp; i++) {
+    int priority = getSelectionPriority((*c)[i]);
+    if (priority == maxPriority) {
+      if (eligible != i) {
+        swap((*c)[i], (*c)[eligible]);
+        modified = true;
       }
       eligible++;
-    }
-    else if(priority>maxPriority) {
-      maxPriority=priority;
-      eligible=1;
-      swap((*c)[i],(*c)[0]);
-      modified=true;
+    } else if (priority > maxPriority) {
+      maxPriority = priority;
+      eligible = 1;
+      swap((*c)[i], (*c)[0]);
+      modified = true;
     }
   }
   ASS_LE(eligible,eligibleInp);

--- a/Kernel/LiteralSelector.hpp
+++ b/Kernel/LiteralSelector.hpp
@@ -73,8 +73,6 @@ public:
    */
   bool isPositiveForSelection(Literal* l) const;
 
-  static void reversePredicatePolarity(unsigned pred, bool reverse);
-
   /**
    * Return true if literal @b l is negative for the purpose of
    * literal selection
@@ -115,8 +113,6 @@ private:
    * @see isPositiveForSelection
    */
   bool _reversePolarity;
-
-  static ZIArray<bool> _reversePredicate;
 };
 
 /**

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -217,25 +217,25 @@ void Ordering::removeNonMaximal(LiteralList*& lits) const
 {
   CALL("Ordering::removeNonMaximal");
 
-  LiteralList** ptr1=&lits;
-  while(*ptr1) {
-    LiteralList** ptr2=&(*ptr1)->tailReference();
-    while(*ptr2 && *ptr1) {
-      Ordering::Result res=compare((*ptr1)->head(), (*ptr2)->head());
+  LiteralList** ptr1 = &lits;
+  while (*ptr1) {
+    LiteralList** ptr2 = &(*ptr1)->tailReference();
+    while (*ptr2 && *ptr1) {
+      Ordering::Result res = compare((*ptr1)->head(), (*ptr2)->head());
 
-      if(res==Ordering::GREATER || res==Ordering::GREATER_EQ || res==Ordering::EQUAL) {
-	LiteralList::pop(*ptr2);
-	continue;
-      } else if(res==Ordering::LESS || res==Ordering::LESS_EQ) {
-	LiteralList::pop(*ptr1);
-	goto topLevelContinue;
+      if (res == Ordering::GREATER || res == Ordering::GREATER_EQ
+          || res == Ordering::EQUAL) {
+        LiteralList::pop(*ptr2);
+        continue;
+      } else if (res == Ordering::LESS || res == Ordering::LESS_EQ) {
+        LiteralList::pop(*ptr1);
+        goto topLevelContinue;
       }
-      ptr2=&(*ptr2)->tailReference();
+      ptr2 = &(*ptr2)->tailReference();
     }
-    ptr1=&(*ptr1)->tailReference();
-topLevelContinue: ;
+    ptr1 = &(*ptr1)->tailReference();
+    topLevelContinue: ;
   }
-
 }
 
 Ordering::Result Ordering::getEqualityArgumentOrder(Literal* eq) const

--- a/Kernel/RndLiteralSelector.cpp
+++ b/Kernel/RndLiteralSelector.cpp
@@ -70,9 +70,9 @@ void RndLiteralSelector::doSelection(Clause* c, unsigned eligible)
         cntNeg++;
       }
     }
-    if (cntNeg > 0) {
+    if (cntNeg > 0 && Random::getBit() /*allow sometimes selecting maximals, even when there are negative*/) {
       singleSel = LiteralList::nth(neg,Random::getInteger(cntNeg));
-    } else { // there are no negative literals, we take the maximal ones to be complete
+    } else { // there are no negative literals (or we don't want them), so we take the maximal ones to be complete
       sel = getMaximalsInOrder(c,eligible);
       ASS(LiteralList::isNonEmpty(sel));
     }

--- a/Kernel/RndLiteralSelector.cpp
+++ b/Kernel/RndLiteralSelector.cpp
@@ -1,0 +1,105 @@
+
+/*
+ * File SpassLiteralSelector.cpp.
+ *
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ *
+ * In summary, you are allowed to use Vampire for non-commercial
+ * purposes but not allowed to distribute, modify, copy, create derivatives,
+ * or use in competitions. 
+ * For other uses of Vampire please contact developers for a different
+ * licence, which we will make an effort to provide. 
+ */
+/**
+ * @file SpassLiteralSelector.cpp
+ * Implements class SpassLiteralSelector.
+ */
+
+#include <algorithm>
+
+#include "Lib/List.hpp"
+#include "Lib/Random.hpp"
+
+#include "Term.hpp"
+#include "Clause.hpp"
+
+#include "RndLiteralSelector.hpp"
+
+using namespace std;
+using namespace Lib;
+using namespace Kernel;
+
+LiteralList* RndLiteralSelector::getMaximalsInOrder(Clause* c, unsigned eligible)
+{
+  CALL("RndLiteralSelector::getMaximalsInOrder");
+
+  LiteralList* res = LiteralList::empty();
+
+  for(int li=((int)eligible)-1; li>=0; li--) {
+    LiteralList::push((*c)[li],res);
+  }
+
+  _ord.removeNonMaximal(res);
+
+  return res;
+}
+
+void RndLiteralSelector::doSelection(Clause* c, unsigned eligible)
+{
+  CALL("RndLiteralSelector::doSelection");
+
+  LiteralList* sel = LiteralList::empty();
+  Literal* singleSel = nullptr;
+
+  if (!_complete) {
+    singleSel = (*c)[Random::getInteger(eligible)];
+  } else {
+    int cntNeg = 0;
+    LiteralList* neg = LiteralList::empty();
+    // collect in sel the literals negative for selection
+    for(int li=((int)eligible)-1; li>=0; li--) {
+      Literal* lit=(*c)[li];
+      if(isNegativeForSelection(lit)) {
+        LiteralList::push(lit,neg);
+        cntNeg++;
+      }
+    }
+    if (cntNeg > 0) {
+      singleSel = LiteralList::nth(neg,Random::getInteger(cntNeg));
+    } else { // there are no negative literals, we take the maximal ones to be complete
+      sel = getMaximalsInOrder(c,eligible);
+      ASS(LiteralList::isNonEmpty(sel));
+    }
+  }
+
+  if(singleSel) {
+    ASS(LiteralList::isEmpty(sel));
+    LiteralList::push(singleSel,sel);
+  }
+  ASS(LiteralList::isNonEmpty(sel));
+
+  unsigned selCnt=0;
+
+  for (unsigned li = 0; sel; li++) {
+    ASS(li < eligible);
+    if ((*c)[li] == sel->head()) {
+      if (li != selCnt) {
+        swap((*c)[li], (*c)[selCnt]);
+      }
+      selCnt++;
+      LiteralList::pop(sel);
+    }
+  }
+
+  ASS(selCnt>0);
+
+  c->setSelected(selCnt);
+
+  ensureSomeColoredSelected(c, eligible);
+}

--- a/Kernel/RndLiteralSelector.cpp
+++ b/Kernel/RndLiteralSelector.cpp
@@ -1,6 +1,6 @@
 
 /*
- * File SpassLiteralSelector.cpp.
+ * File RndLiteralSelector.cpp.
  *
  * This file is part of the source code of the software program
  * Vampire. It is protected by applicable
@@ -17,8 +17,8 @@
  * licence, which we will make an effort to provide. 
  */
 /**
- * @file SpassLiteralSelector.cpp
- * Implements class SpassLiteralSelector.
+ * @file RndLiteralSelector.cpp
+ * Implements class RndLiteralSelector.
  */
 
 #include <algorithm>

--- a/Kernel/RndLiteralSelector.hpp
+++ b/Kernel/RndLiteralSelector.hpp
@@ -1,0 +1,62 @@
+
+/*
+ * File RndLiteralSelector.hpp.
+ *
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ *
+ * In summary, you are allowed to use Vampire for non-commercial
+ * purposes but not allowed to distribute, modify, copy, create derivatives,
+ * or use in competitions. 
+ * For other uses of Vampire please contact developers for a different
+ * licence, which we will make an effort to provide. 
+ */
+/**
+ * @file RndLiteralSelector.hpp
+ * Defines class RndLiteralSelector.
+ */
+
+
+#ifndef __RndLiteralSelector__
+#define __RndLiteralSelector__
+
+#include "Forwards.hpp"
+#include "Lib/SmartPtr.hpp"
+#include "Ordering.hpp"
+
+#include "LiteralSelector.hpp"
+
+namespace Kernel {
+
+/**
+ * Class SpassLiteralSelector implements literal
+ * selectors as understood from the code of SPASS 3.7.
+ */
+class RndLiteralSelector
+: public LiteralSelector
+{
+public:
+  CLASS_NAME(RndLiteralSelector);
+  USE_ALLOCATOR(RndLiteralSelector);
+
+  RndLiteralSelector(const Ordering& ordering, const Options& options, bool complete) :
+    LiteralSelector(ordering, options), _complete(complete) {}
+
+  bool isBGComplete() const override { return _complete; }
+protected:
+  void doSelection(Clause* c, unsigned eligible) override;
+
+private:
+  LiteralList* getMaximalsInOrder(Clause* c, unsigned eligible);
+
+  bool _complete;
+};
+
+};
+
+#endif /* __RndLiteralSelector__ */

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,8 @@ VK_OBJ= Kernel/Clause.o\
         Kernel/Matcher.o\
         Kernel/MaximalLiteralSelector.o\
         Kernel/SpassLiteralSelector.o\
-        Kernel/ELiteralSelector.o\
+  Kernel/ELiteralSelector.o\
+  Kernel/RndLiteralSelector.o\
         Kernel/MLMatcher.o\
         Kernel/MLMatcherSD.o\
         Kernel/MLVariant.o\

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -865,11 +865,13 @@ void Options::Options::init()
     " 4     - ColoredFirst, NoPositiveEquality, LeastTopLevelVariables,\n          LeastVariables, MaximalSize then Lexigraphical\n"
     " 10    - ColoredFirst, NegativeEquality, MaximalSize, Negative then Lexigraphical\n"
     " 11    - Lookahead\n"
+    " 666   - Random\n"
     " 1002  - Incomplete version of 2\n"
     " 1003  - Incomplete version of 3\n"
     " 1004  - Incomplete version of 4\n"
     " 1010  - Incomplete version of 10\n"
     " 1011  - Incomplete version of 11\n"
+    " 1666  - Incomplete version of 666\n"
     "Or negated, which means that reversePolarity is true i.e. for selection we treat all negative non-equalty literals as "
     "positive and vice versa (can only apply to non-equality literals).\n";
 
@@ -2678,11 +2680,14 @@ bool Options::SelectionOptionValue::setValue(const vstring& value)
   case 34:
   case 35:
 
+  case 666:
+
   case 1002:
   case 1003:
   case 1004:
   case 1010:
   case 1011:
+  case 1666:
   case -1:
   case -2:
   case -3:
@@ -2698,6 +2703,8 @@ bool Options::SelectionOptionValue::setValue(const vstring& value)
   case -33:
   case -34:
   case -35:
+
+  case -666:
 
   case -1002:
   case -1003:
@@ -3173,7 +3180,7 @@ bool Options::complete(const Problem& prb) const
   bool hasEquality = (prop.equalityAtoms() != 0);
 
   if (!unitEquality) {
-    if (_selection.actualValue <= -100 || _selection.actualValue >= 100) return false;
+    if (_selection.actualValue <= -1000 || _selection.actualValue >= 1000) return false;
     if (_literalComparisonMode.actualValue == LiteralComparisonMode::REVERSE) return false;
   }
 
@@ -3214,7 +3221,7 @@ bool Options::completeForNNE() const
   // run-time rule causing incompleteness
   if (_forwardLiteralRewriting.actualValue) return false;
   
-  if (_selection.actualValue <= -100 || _selection.actualValue >= 100) return false;
+  if (_selection.actualValue <= -1000 || _selection.actualValue >= 1000) return false;
 
   return _binaryResolution.actualValue;
 } // Options::completeForNNE


### PR DESCRIPTION
Implements random literal selector (complete and an incomplete version).

Additionally, cleans the selection code a bit. Plus an update in Options::complete* to consider selections incomplete whenever ">=1000 or <=-1000" (was ">=100 or <=-100", probably by mistake).