### PR TITLE
fix LRS-simulation for -awr 0:n and -awr n:0

### DIFF
--- a/Saturation/AWPassiveClauseContainer.cpp
+++ b/Saturation/AWPassiveClauseContainer.cpp
@@ -313,7 +313,8 @@ void AWPassiveClauseContainer::onLimitsUpdated()
 {
   CALL("AWPassiveClauseContainer::onLimitsUpdated");
 
-  if ( (!ageLimited() && _ageRatio) || (!weightLimited() && _weightRatio) ) {
+  if ( (_ageRatio > 0 && !ageLimited()) || (_weightRatio > 0 && !weightLimited()) )
+  {
     return;
   }
 
@@ -353,63 +354,121 @@ void AWPassiveClauseContainer::simulationInit()
   _simulationBalance = _balance;
 
   // initialize iterators
-  _simulationCurrAgeIt = ClauseQueue::Iterator(_ageQueue);
-  _simulationCurrWeightIt = ClauseQueue::Iterator(_weightQueue);
-  _simulationCurrAgeCl = _simulationCurrAgeIt.hasNext() ? _simulationCurrAgeIt.next() : nullptr;
-  _simulationCurrWeightCl = _simulationCurrWeightIt.hasNext() ? _simulationCurrWeightIt.next() : nullptr;
+  if (_ageRatio > 0)
+  {
+    _simulationCurrAgeIt = ClauseQueue::Iterator(_ageQueue);
+    _simulationCurrAgeCl = _simulationCurrAgeIt.hasNext() ? _simulationCurrAgeIt.next() : nullptr;
+  }
+  if (_weightRatio > 0)
+  {
+    _simulationCurrWeightIt = ClauseQueue::Iterator(_weightQueue);
+    _simulationCurrWeightCl = _simulationCurrWeightIt.hasNext() ? _simulationCurrWeightIt.next() : nullptr;
+  }
 
-  // have to consider two possibilities for simulation:
-  // standard case: both container are initially non-empty, then have invariants
-  // - _simulationCurrAgeCl != nullptr
-  // - _simulationCurrWeightCl != nullptr
-  // degenerate case: both containers are initially empty, then have invariant
-  // - _simulationCurrAgeCl == nullptr
-  // - _simulationCurrWeightCl == nullptr
-  ASS(_simulationCurrAgeCl != nullptr || _simulationCurrWeightCl == nullptr);
-  ASS(_simulationCurrAgeCl == nullptr || _simulationCurrWeightCl != nullptr);
+  if (_ageRatio > 0 && _weightRatio > 0)
+  {
+    // have to consider two possibilities for simulation:
+    // standard case: both container are initially non-empty, then have invariants
+    // - _simulationCurrAgeCl != nullptr
+    // - _simulationCurrWeightCl != nullptr
+    // degenerate case: both containers are initially empty (e.g. happens sometimes if layered clause selection is used), then have invariant
+    // - _simulationCurrAgeCl == nullptr
+    // - _simulationCurrWeightCl == nullptr
+    ASS(_simulationCurrAgeCl != nullptr || _simulationCurrWeightCl == nullptr);
+    ASS(_simulationCurrAgeCl == nullptr || _simulationCurrWeightCl != nullptr);
+  }
 }
 
 bool AWPassiveClauseContainer::simulationHasNext()
 {
   CALL("AWPassiveClauseContainer::simulationHasNext");
 
-  ASS(_simulationCurrAgeCl != nullptr || _simulationCurrWeightCl == nullptr);
-  ASS(_simulationCurrAgeCl == nullptr || _simulationCurrWeightCl != nullptr);
-  if (_simulationCurrAgeCl == nullptr)
+  // Part 1: Return false if aw-container is empty
+  if (_ageRatio == 0)
   {
-    // degenerate case, both containers are empty, so return false
-    return false;
+    if (_simulationCurrWeightCl == nullptr)
+    {
+      // degenerate case: weight-container is empty (and we don't use the age-container), so return false
+      return false;
+    }
+  }
+  else if (_weightRatio == 0)
+  {
+    if (_simulationCurrAgeCl == nullptr)
+    {
+      // degenerate case: age-container is empty (and we don't use the weight-container), so return false
+      return false;
+    }
+  }
+  else
+  {
+    ASS(_ageRatio > 0 && _weightRatio > 0);
+    ASS(_simulationCurrAgeCl != nullptr || _simulationCurrWeightCl == nullptr);
+    ASS(_simulationCurrAgeCl == nullptr || _simulationCurrWeightCl != nullptr);
+
+    if (_simulationCurrAgeCl == nullptr)
+    {
+      // degenerate case: both containers are empty, so return false
+      return false;
+    }
   }
 
-  // advance _simulationCurrAgeIt, until _simulationCurrAgeCl points to a
-  // clause which has not been deleted in the simulation or _simulationCurrAgeIt
-  // reaches the end of the age-queue
-  // establishes invariant: if there is a clause which is not deleted in the simulation, then _simulationCurrAgeCl is not deleted.
-  while (_simulationCurrAgeCl->hasAux() && _simulationCurrAgeIt.hasNext())
+  // if we reach this point, we know that there is at least one clause in the aw-container (but it could already been deleted in the simulation)
+  // Part 2: advance each iterator to point to a clause not deleted in the simulation (if possible)
+  if (_ageRatio > 0)
   {
-    _simulationCurrAgeCl = _simulationCurrAgeIt.next();
+    // advance _simulationCurrAgeIt, until _simulationCurrAgeCl points to a
+    // clause which has not been deleted in the simulation or _simulationCurrAgeIt
+    // reaches the end of the age-queue
+    // establishes invariant: if there is a clause which is not deleted in the simulation, then _simulationCurrAgeCl is not deleted.
+    while (_simulationCurrAgeCl->hasAux() && _simulationCurrAgeIt.hasNext())
+    {
+      _simulationCurrAgeCl = _simulationCurrAgeIt.next();
+    }
+    ASS(_simulationCurrAgeCl != nullptr);
   }
-  // same for weight-queue
-  while (_simulationCurrWeightCl->hasAux() && _simulationCurrWeightIt.hasNext())
+  if (_weightRatio > 0)
   {
-    _simulationCurrWeightCl = _simulationCurrWeightIt.next();
+    // advance _simulationCurrWeightIt, until _simulationCurrWeightCl points to a
+    // clause which has not been deleted in the simulation or _simulationCurrWeightIt
+    // reaches the end of the weight-queue
+    // establishes invariant: if there is a clause which is not deleted in the simulation, then _simulationCurrWeightCl is not deleted.
+    while (_simulationCurrWeightCl->hasAux() && _simulationCurrWeightIt.hasNext())
+    {
+      _simulationCurrWeightCl = _simulationCurrWeightIt.next();
+    }
+    ASS(_simulationCurrWeightCl != nullptr);
   }
 
-  ASS(_simulationCurrAgeCl != nullptr);
-  ASS(_simulationCurrWeightCl != nullptr);
-  ASS(!_simulationCurrAgeCl->hasAux() || _simulationCurrWeightCl->hasAux());
-  ASS(_simulationCurrAgeCl->hasAux() || !_simulationCurrWeightCl->hasAux());
+  // Part 3: return whether clause was found which is not deleted in the simulation
+  if (_ageRatio == 0)
+  {
+    return !_simulationCurrWeightCl->hasAux();
+  }
+  else if (_weightRatio == 0)
+  {
+    return !_simulationCurrAgeCl->hasAux();
+  }
+  else
+  {
+    ASS(_ageRatio > 0 && _weightRatio > 0);
+    ASS(!_simulationCurrAgeCl->hasAux() || _simulationCurrWeightCl->hasAux());
+    ASS(_simulationCurrAgeCl->hasAux() || !_simulationCurrWeightCl->hasAux());
 
-  return !_simulationCurrAgeCl->hasAux();
+    return !_simulationCurrAgeCl->hasAux();
+  }
 }
 
 // assumes that simulationHasNext() has been called before and returned true,
-// so both iterators point to a clause which is not deleted in the simulation
+// so each iterator (if used) does point to a clause which is not deleted in the simulation
 void AWPassiveClauseContainer::simulationPopSelected()
 {
   CALL("AWPassiveClauseContainer::simulationPopSelected");
-  // invariant: both queues contain the same clauses and
-  // the fact that both queues share the aux-field which denotes whether a clause was deleted during the simulation.
+
+  // invariants:
+  // - both queues share the aux-field which denotes whether a clause was deleted during the simulation
+  // - if _ageRatio > 0 and _weightRatio > 0, then both queues contain the same clauses
+  // note: byWeight() already takes care of the cases where _ageRatio == 0 or _weightRatio == 0
   if (byWeight(_simulationBalance)) {
     // simulate selection by weight
     _simulationBalance -= _ageRatio;
@@ -433,16 +492,39 @@ bool AWPassiveClauseContainer::setLimitsFromSimulation()
 {
   CALL("AWPassiveClauseContainer::setLimitsFromSimulation");
 
-  ASS(_simulationCurrAgeCl != nullptr || _simulationCurrWeightCl == nullptr);
-  ASS(_simulationCurrAgeCl == nullptr || _simulationCurrWeightCl != nullptr);
-  if (_simulationCurrAgeCl == nullptr)
+  if (_ageRatio == 0)
   {
-    // degenerate case: both queues are empty (independently from the simulation), so set limits to max.
-    return setLimitsToMax();
+    if (_simulationCurrWeightCl == nullptr)
+    {
+      // degenerate case: weight-container is empty (and we don't use the age-container), so set limits to max.
+      return setLimitsToMax();
+    }
   }
+  else if (_weightRatio == 0)
+  {
+    if (_simulationCurrAgeCl == nullptr)
+    {
+      // degenerate case: age-container is empty (and we don't use the weight-container), so set limits to max.
+      return setLimitsToMax();
+    }
+  }
+  else
+  {
+    ASS(_ageRatio > 0 && _weightRatio > 0);
+    ASS(_simulationCurrAgeCl != nullptr || _simulationCurrWeightCl == nullptr);
+    ASS(_simulationCurrAgeCl == nullptr || _simulationCurrWeightCl != nullptr);
 
-  ASS(!_simulationCurrAgeCl->hasAux() || _simulationCurrWeightCl->hasAux());
-  ASS(_simulationCurrAgeCl->hasAux() || !_simulationCurrWeightCl->hasAux());
+    if (_simulationCurrAgeCl == nullptr)
+    {
+      // degenerate case: both containers are empty, so set limits to max.
+      return setLimitsToMax();
+    }
+    else
+    {
+      ASS(!_simulationCurrAgeCl->hasAux() || _simulationCurrWeightCl->hasAux());
+      ASS(_simulationCurrAgeCl->hasAux() || !_simulationCurrWeightCl->hasAux());
+    }
+  }
 
   unsigned maxAgeQueueAge;
   unsigned maxAgeQueueWeight;
@@ -450,7 +532,7 @@ bool AWPassiveClauseContainer::setLimitsFromSimulation()
   unsigned maxWeightQueueAge;
 
   // compute limits for age-queue
-  if (_ageRatio != 0)
+  if (_ageRatio > 0)
   {
     if (_simulationCurrAgeIt.hasNext())
     {
@@ -473,7 +555,7 @@ bool AWPassiveClauseContainer::setLimitsFromSimulation()
   }
 
   // compute limits for weight-queue
-  if (_weightRatio != 0)
+  if (_weightRatio > 0)
   {
     if (_simulationCurrWeightIt.hasNext())
     {
@@ -497,10 +579,10 @@ bool AWPassiveClauseContainer::setLimitsFromSimulation()
 
   // note: we ignore the option lrsWeightLimitOnly() if weightRatio is set to 0
   // TODO: force in Options that weightRatio is positive if lrsWeightLimitOnly() is set to 'on'.
-  if (_opt.lrsWeightLimitOnly() && _weightRatio!=0)
+  if (_opt.lrsWeightLimitOnly() && _weightRatio > 0)
   {
     // if the option lrsWeightLimitOnly() is set, we want to discard all clauses which are too heavy, regardless of the age.
-    // we therefore make sure that ageLimited() always fails.
+    // we therefore make sure that fulfilsAgeLimit() always fails.
     maxAgeQueueAge = 0;
     maxAgeQueueWeight = 0;
   }
@@ -566,13 +648,13 @@ bool AWPassiveClauseContainer::ageLimited() const
 {
   CALL("AWPassiveClauseContainer::ageLimited");
 
-  return _ageSelectionMaxAge != UINT_MAX && _ageSelectionMaxWeight != UINT_MAX;
+  return _ageRatio > 0 && _ageSelectionMaxAge != UINT_MAX && _ageSelectionMaxWeight != UINT_MAX;
 }
 
 bool AWPassiveClauseContainer::weightLimited() const
 {
   CALL("AWPassiveClauseContainer::weightLimited");
-  return _weightSelectionMaxWeight != UINT_MAX && _weightSelectionMaxAge != UINT_MAX;
+  return _weightRatio > 0 && _weightSelectionMaxWeight != UINT_MAX && _weightSelectionMaxAge != UINT_MAX;
 }
 
 bool AWPassiveClauseContainer::fulfilsAgeLimit(Clause* cl) const


### PR DESCRIPTION
The current implementation supports clause-selection using only
age or weight as criterion, by setting an awr-value n:0 resp. 0:n.

The recent implementation of layered-clause selection did not support
this corner case yet in its LRS-simulation implementation, leading to
assertion-violations in debug-mode and incorrect clause selection in
release-mode for this corner case.

This commit fixes these problems, by adapting the LRS-simulation methods.

Furthermore, it adapts ageLimited() and weightLimited() to only return
true, if the age- resp. weight-queue is actually used. As a result,
we are able to conclude more often, that we saturated the set of input
without deleting non-redundant clauses.

As a future change, it could make sense to modularize the implementation
of the age-weight-container into an age-container, a weight-container,
and a round-robin container, which has the age-container and the
weight-container as child-containers, to which it alternatingly delegates
clause-selection.
We could then use the age-container and the weight-container directly to
implement clause selection using age resp. weight as only criterion,
instead of the current implementation which in a nutshell hacks a
round-robin container to ignore one of its child-containers.
Such an implementation would have avoided the current bug, and should
be easier to maintain in general.