### PR TITLE
Fix math induction (use correct substitution; use BR only when needed)

### DIFF
--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -113,7 +113,7 @@ public:
 private:
   void process(Clause* premise, Literal* lit);
 
-  void produceClauses(Clause* premise, Literal* origLit, Formula* hypothesis, Literal* conclusion, InferenceRule rule);
+  void produceClauses(Clause* premise, Literal* origLit, Formula* hypothesis, Literal* conclusion, InferenceRule rule, ResultSubstitutionSP& substitution);
 
   void performMathInductionOne(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule); 
   void performMathInductionTwo(Clause* premise, Literal* origLit, Literal* lit, Term* t, InferenceRule rule);


### PR DESCRIPTION
This commit changes math induction to use produceClauses(...) (similarly to struct induction).
To this end, I changed the parameters of produceClauses(...) to include the substitution, which is used in binary resolution of the CNF of the induction hypothesis with the premise. Note that the substitution is the same for all the applications of BR within one application of math induction (y -> induction term); and it is always identity for struct induction (for struct induction, the substituted variable only has one occurrence in the induction hypothesis, and the literal containing it is removed in BR).

A sample SMT2 input to check that the math induction works (it proves that 2*(1 + ... + n) = n*(n+1)):
;; Definition: triangle(n) = 1 + ... + n
(declare-fun triangle (Int) Int)
(assert (forall ((x Int)) (= (triangle 0) 0)))
(assert (forall ((x Int)) (=> (< 0 (+ x 1)) (= (triangle (+ x 1)) (+ (triangle x) (+ x 1))))))
;; Conjecture: 2*triangle(n) = n*(n+1)
(assert (not (forall ((x Int)) (=> (not (< x 0)) (= (* 2 (triangle x)) (* x (+ x 1)))))))

Run it using the following command (it should find the proof within 30-45 seconds):
vampire -ind math --input_syntax smtlib2 triangle_formula.smt2