### PR TITLE
Print version of the linked z3

### DIFF
--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -67,7 +67,13 @@ Z3Interfacing::Z3Interfacing(const Shell::Options& opts,SAT2FO& s2f, bool unsatC
     //p.set(":smtlib2-compliant",true);
     _solver.set(p);
 }
-  
+
+char const* Z3Interfacing::z3_full_version()
+{
+  CALL("Z3Interfacing::z3_version");
+  return Z3_get_full_version();
+}
+
 unsigned Z3Interfacing::newVar()
 {
   CALL("Z3Interfacing::newVar");

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -67,6 +67,8 @@ public:
    */
   Z3Interfacing(const Shell::Options& opts, SAT2FO& s2f, bool unsatCoresForAssumptions = false);
 
+  static char const* z3_full_version();
+
   void addClause(SATClause* cl, bool withGuard);
   void addClause(SATClause* cl) override { addClause(cl,false); }
 

--- a/Shell/CommandLine.cpp
+++ b/Shell/CommandLine.cpp
@@ -32,6 +32,7 @@
 #include "Lib/VString.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Exception.hpp"
+#include "SAT/Z3Interfacing.hpp"
 
 #include "CommandLine.hpp"
 #include "Options.hpp"
@@ -65,6 +66,9 @@ void CommandLine::interpret (Options& options)
     const char* arg = *_next++;
     if (strcmp(arg, "--version")==0) {
       cout<<VERSION_STRING<<endl;
+#if VZ3
+      cout << "Linked with Z3 " << Z3Interfacing::z3_full_version() << endl;
+#endif
       exit(0);
     }
     // If --help or -h are used without arguments we still print help

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -31,6 +31,7 @@
 #include "Lib/Environment.hpp"
 #include "Lib/TimeCounter.hpp"
 #include "Lib/Timer.hpp"
+#include "SAT/Z3Interfacing.hpp"
 
 #include "Shell/UIHelper.hpp"
 
@@ -201,6 +202,10 @@ void Statistics::print(ostream& out)
   out << "------------------------------\n";
   addCommentSignForSZS(out);
   out << "Version: " << VERSION_STRING << endl;
+#if VZ3
+  addCommentSignForSZS(out);
+  out << "Linked with Z3 " << Z3Interfacing::z3_full_version() << endl;
+#endif
 
   addCommentSignForSZS(out);
   out << "Termination reason: ";


### PR DESCRIPTION
Adds the version of the linked Z3 library to the output:

```
Vampire 4.5.1 (commit f91153d5 on 2020-09-07 13:58:01 +0200)
Linked with Z3 4.8.9.0 558233dd8e48a2bd62d53a0bb9e8fd84ff463522
```

This makes it easier to confirm that the right version of Z3 is being used.