### PR TITLE
fixes theory instantiation tautology deletion

### DIFF
--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -915,6 +915,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
     // measure time of the overall processing
     auto it4 = getTimeCountedIterator(it3,TC_THEORY_INST_SIMP);
 
+    // persistent iterator is needed for the flag `premiseRedundant` to be set before returning from the function
     return getPersistentIterator(it4);
   }
 }

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -915,7 +915,13 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
     // measure time of the overall processing
     auto it4 = getTimeCountedIterator(it3,TC_THEORY_INST_SIMP);
 
-    return getPersistentIterator(it4); // we need immediate evaluation, so that premiseRedundant is set just after the call!
+    auto out = getPersistentIterator(it4); // we need immediate evaluation, so that premiseRedundant is set just after the call!
+
+    if (!env.options->thiTautologyDeletion()) {
+      premiseRedundant = false;
+    }
+
+    return out;
   }
 }
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -915,7 +915,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
     // measure time of the overall processing
     auto it4 = getTimeCountedIterator(it3,TC_THEORY_INST_SIMP);
 
-    return pvi(it4);
+    return getPersistentIterator(it4);
   }
 }
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -915,7 +915,6 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
     // measure time of the overall processing
     auto it4 = getTimeCountedIterator(it3,TC_THEORY_INST_SIMP);
 
-    // persistent iterator is needed for the flag `premiseRedundant` to be set before returning from the function
     return getPersistentIterator(it4);
   }
 }

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -919,6 +919,12 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
   }
 }
 
+std::ostream& operator<<(std::ostream& out, Solution const& self) 
+{
+  return out << "Solution(" << (self.status ? "sat" : "unsat") << ", " << self.subst << ")";
+  // return out;
+}
+
 }
 
 #endif

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -915,7 +915,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
     // measure time of the overall processing
     auto it4 = getTimeCountedIterator(it3,TC_THEORY_INST_SIMP);
 
-    return getPersistentIterator(it4);
+    return getPersistentIterator(it4); // we need immediate evaluation, so that premiseRedundant is set just after the call!
   }
 }
 

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -38,9 +38,10 @@ using namespace Kernel;
 using namespace Saturation;
 
 struct Solution{
-  Solution(bool s) : status(s) {}
+  explicit Solution(bool s) : status(s) {}
   const bool status;
   Substitution subst;
+  friend std::ostream& operator<<(std::ostream& out, Solution const&);
 };
 
 

--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -769,4 +769,15 @@ bool Clause::contains(Literal* lit)
   return false;
 }
 
+std::ostream& operator<<(std::ostream& out, Clause::Store const& store) 
+{
+  switch (store) {
+    case Clause::PASSIVE:     return out << "PASSIVE";
+    case Clause::ACTIVE:      return out << "ACTIVE";
+    case Clause::UNPROCESSED: return out << "UNPROCESSED";
+    case Clause::NONE:        return out << "NONE";
+    case Clause::SELECTED:    return out << "SELECTED";
+  }
+}
+
 }

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -397,6 +397,7 @@ protected:
   Literal* _literals[1];
 }; // class Clause
 
+std::ostream& operator<<(std::ostream& out, Clause::Store const& clause);
 }
 
 #endif

--- a/Kernel/Substitution.cpp
+++ b/Kernel/Substitution.cpp
@@ -116,19 +116,27 @@ bool Substitution::findBinding(int var, TermList& res) const
 #if VDEBUG
  vstring Substitution::toString() const
  {
-   vstring result("[");
-   VirtualIterator<std::pair<unsigned,TermList>> items = _map.items();
-   bool first=true;
-   while(items.hasNext()){
-     std::pair<unsigned,TermList> item = items.next();
-     if(!first){result+=",";}
-     first=false;
-     result += Lib::Int::toString(item.first) + " -> " + item.second.toString(); 
-   }
-   result += ']';
-   return result;
+   vstringstream out;
+   out << *this;
+   return out.str();
  } // Substitution::toString()
 #endif
 
+
+std::ostream& operator<<(std::ostream& out, Substitution const& self)
+{
+   out << "[";
+   auto items = self._map.items();
+   bool first=true;
+   while(items.hasNext()){
+     std::pair<unsigned,TermList> item = items.next();
+     if(!first){out << ",";}
+     first=false;
+     out  <<  item.first << " -> " << item.second;
+   }
+   out << ']';
+   return out;
 }
+
+} // namespace Kernel
 

--- a/Kernel/Substitution.hpp
+++ b/Kernel/Substitution.hpp
@@ -66,6 +66,7 @@ public:
 #if VDEBUG
   vstring toString() const;
 #endif
+  friend std::ostream& operator<<(std::ostream& out, Substitution const&);
 private:
   DHMap<unsigned,TermList> _map;
 }; // class Substitution

--- a/Lib/StringUtils.hpp
+++ b/Lib/StringUtils.hpp
@@ -26,10 +26,13 @@
 
 #include "VString.hpp"
 #include "DHMap.hpp"
+#include <cstdlib>
 
 namespace Lib {
 
 using namespace std;
+
+template<class A> struct StringParser;
 
 class StringUtils {
 public:
@@ -41,7 +44,25 @@ public:
   static void splitStr(const char* str, char delimiter, Stack<vstring>& strings);
   static bool readEquality(const char* str, char eqChar, vstring& lhs, vstring& rhs);
   static bool readEqualities(const char* str, char delimiter, char eqChar, DHMap<vstring,vstring>& pairs);
+  template<class A>
+  static A parse(vstring const& str) 
+  { return StringParser<A>{}(str); }
 };
+
+template<> struct StringParser<int> 
+{
+  int operator()(vstring const& str)
+  { return atoi(str.c_str()); }
+};
+
+
+template<> struct StringParser<float> 
+{
+  float operator()(vstring const& str)
+  { return atof(str.c_str()); }
+};
+
+
 
 }
 

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1113,8 +1113,8 @@ bool SaturationAlgorithm::activate(Clause* cl)
     instances = _theoryInstSimp->generateClauses(cl,redundant);
   }
 #endif
+
   if(redundant){ 
-    removeActiveOrPassiveClause(cl);
     return false; 
   }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3273,9 +3273,12 @@ Lib::vvector<int> Options::theorySplitQueueRatios() const
   CALL("Options::theorySplitQueueRatios");
   vstringstream inputRatiosStream(_theorySplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
+  {
+    BYPASSING_ALLOCATOR
+    std::string currentRatio;
+    while (std::getline(inputRatiosStream, currentRatio, ',')) {
+      inputRatios.push_back(std::stoi(currentRatio));
+    }
   }
 
   // sanity checks
@@ -3306,10 +3309,13 @@ Lib::vvector<float> Options::theorySplitQueueCutoffs() const
   } else {
     // if custom cutoffs are set, parse them and add float-max as last value
     vstringstream cutoffsStream(_theorySplitQueueCutoffs.actualValue);
-    std::string currentCutoff;
-    while (std::getline(cutoffsStream, currentCutoff, ','))
     {
-      cutoffs.push_back(std::stof(currentCutoff));
+      BYPASSING_ALLOCATOR
+      std::string currentCutoff;
+      while (std::getline(cutoffsStream, currentCutoff, ','))
+      {
+        cutoffs.push_back(std::stof(currentCutoff));
+      }
     }
     cutoffs.push_back(std::numeric_limits<float>::max());
   }
@@ -3333,9 +3339,12 @@ Lib::vvector<int> Options::avatarSplitQueueRatios() const
   CALL("Options::avatarSplitQueueRatios");
   vstringstream inputRatiosStream(_avatarSplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
+  {
+    BYPASSING_ALLOCATOR
+    std::string currentRatio;
+    while (std::getline(inputRatiosStream, currentRatio, ',')) {
+      inputRatios.push_back(std::stoi(currentRatio));
+    }
   }
 
   // sanity checks
@@ -3357,10 +3366,13 @@ Lib::vvector<float> Options::avatarSplitQueueCutoffs() const
   // initialize cutoffs and add float-max as last value
   Lib::vvector<float> cutoffs;
   vstringstream cutoffsStream(_avatarSplitQueueCutoffs.actualValue);
-  std::string currentCutoff;
-  while (std::getline(cutoffsStream, currentCutoff, ','))
   {
-    cutoffs.push_back(std::stof(currentCutoff));
+    BYPASSING_ALLOCATOR
+    std::string currentCutoff;
+    while (std::getline(cutoffsStream, currentCutoff, ','))
+    {
+      cutoffs.push_back(std::stof(currentCutoff));
+    }
   }
   cutoffs.push_back(std::numeric_limits<float>::max());
 
@@ -3383,9 +3395,12 @@ Lib::vvector<int> Options::sineLevelSplitQueueRatios() const
   CALL("Options::sineLevelSplitQueueRatios");
   vstringstream inputRatiosStream(_sineLevelSplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
+  {
+    BYPASSING_ALLOCATOR
+    std::string currentRatio;
+    while (std::getline(inputRatiosStream, currentRatio, ',')) {
+      inputRatios.push_back(std::stoi(currentRatio));
+    }
   }
 
   // sanity checks
@@ -3407,10 +3422,13 @@ Lib::vvector<float> Options::sineLevelSplitQueueCutoffs() const
   // initialize cutoffs and add float-max as last value
   Lib::vvector<float> cutoffs;
   vstringstream cutoffsStream(_sineLevelSplitQueueCutoffs.actualValue);
-  std::string currentCutoff;
-  while (std::getline(cutoffsStream, currentCutoff, ','))
   {
-    cutoffs.push_back(std::stof(currentCutoff));
+    BYPASSING_ALLOCATOR
+    std::string currentCutoff;
+    while (std::getline(cutoffsStream, currentCutoff, ','))
+    {
+      cutoffs.push_back(std::stof(currentCutoff));
+    }
   }
   cutoffs.push_back(std::numeric_limits<float>::max());
 
@@ -3433,9 +3451,12 @@ Lib::vvector<int> Options::positiveLiteralSplitQueueRatios() const
   CALL("Options::positiveLiteralSplitQueueRatios");
   vstringstream inputRatiosStream(_positiveLiteralSplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
+  {
+    BYPASSING_ALLOCATOR
+    std::string currentRatio;
+    while (std::getline(inputRatiosStream, currentRatio, ',')) {
+      inputRatios.push_back(std::stoi(currentRatio));
+    }
   }
 
   // sanity checks
@@ -3457,10 +3478,13 @@ Lib::vvector<float> Options::positiveLiteralSplitQueueCutoffs() const
   // initialize cutoffs and add float-max as last value
   Lib::vvector<float> cutoffs;
   vstringstream cutoffsStream(_positiveLiteralSplitQueueCutoffs.actualValue);
-  std::string currentCutoff;
-  while (std::getline(cutoffsStream, currentCutoff, ','))
   {
-    cutoffs.push_back(std::stof(currentCutoff));
+    BYPASSING_ALLOCATOR
+    std::string currentCutoff;
+    while (std::getline(cutoffsStream, currentCutoff, ','))
+    {
+      cutoffs.push_back(std::stof(currentCutoff));
+    }
   }
   cutoffs.push_back(std::numeric_limits<float>::max());
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3273,12 +3273,9 @@ Lib::vvector<int> Options::theorySplitQueueRatios() const
   CALL("Options::theorySplitQueueRatios");
   vstringstream inputRatiosStream(_theorySplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  {
-    BYPASSING_ALLOCATOR
-    std::string currentRatio;
-    while (std::getline(inputRatiosStream, currentRatio, ',')) {
-      inputRatios.push_back(std::stoi(currentRatio));
-    }
+  std::string currentRatio;
+  while (std::getline(inputRatiosStream, currentRatio, ',')) {
+    inputRatios.push_back(std::stoi(currentRatio));
   }
 
   // sanity checks
@@ -3309,13 +3306,10 @@ Lib::vvector<float> Options::theorySplitQueueCutoffs() const
   } else {
     // if custom cutoffs are set, parse them and add float-max as last value
     vstringstream cutoffsStream(_theorySplitQueueCutoffs.actualValue);
+    std::string currentCutoff;
+    while (std::getline(cutoffsStream, currentCutoff, ','))
     {
-      BYPASSING_ALLOCATOR
-      std::string currentCutoff;
-      while (std::getline(cutoffsStream, currentCutoff, ','))
-      {
-        cutoffs.push_back(std::stof(currentCutoff));
-      }
+      cutoffs.push_back(std::stof(currentCutoff));
     }
     cutoffs.push_back(std::numeric_limits<float>::max());
   }
@@ -3339,12 +3333,9 @@ Lib::vvector<int> Options::avatarSplitQueueRatios() const
   CALL("Options::avatarSplitQueueRatios");
   vstringstream inputRatiosStream(_avatarSplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  {
-    BYPASSING_ALLOCATOR
-    std::string currentRatio;
-    while (std::getline(inputRatiosStream, currentRatio, ',')) {
-      inputRatios.push_back(std::stoi(currentRatio));
-    }
+  std::string currentRatio;
+  while (std::getline(inputRatiosStream, currentRatio, ',')) {
+    inputRatios.push_back(std::stoi(currentRatio));
   }
 
   // sanity checks
@@ -3366,13 +3357,10 @@ Lib::vvector<float> Options::avatarSplitQueueCutoffs() const
   // initialize cutoffs and add float-max as last value
   Lib::vvector<float> cutoffs;
   vstringstream cutoffsStream(_avatarSplitQueueCutoffs.actualValue);
+  std::string currentCutoff;
+  while (std::getline(cutoffsStream, currentCutoff, ','))
   {
-    BYPASSING_ALLOCATOR
-    std::string currentCutoff;
-    while (std::getline(cutoffsStream, currentCutoff, ','))
-    {
-      cutoffs.push_back(std::stof(currentCutoff));
-    }
+    cutoffs.push_back(std::stof(currentCutoff));
   }
   cutoffs.push_back(std::numeric_limits<float>::max());
 
@@ -3395,12 +3383,9 @@ Lib::vvector<int> Options::sineLevelSplitQueueRatios() const
   CALL("Options::sineLevelSplitQueueRatios");
   vstringstream inputRatiosStream(_sineLevelSplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  {
-    BYPASSING_ALLOCATOR
-    std::string currentRatio;
-    while (std::getline(inputRatiosStream, currentRatio, ',')) {
-      inputRatios.push_back(std::stoi(currentRatio));
-    }
+  std::string currentRatio;
+  while (std::getline(inputRatiosStream, currentRatio, ',')) {
+    inputRatios.push_back(std::stoi(currentRatio));
   }
 
   // sanity checks
@@ -3422,13 +3407,10 @@ Lib::vvector<float> Options::sineLevelSplitQueueCutoffs() const
   // initialize cutoffs and add float-max as last value
   Lib::vvector<float> cutoffs;
   vstringstream cutoffsStream(_sineLevelSplitQueueCutoffs.actualValue);
+  std::string currentCutoff;
+  while (std::getline(cutoffsStream, currentCutoff, ','))
   {
-    BYPASSING_ALLOCATOR
-    std::string currentCutoff;
-    while (std::getline(cutoffsStream, currentCutoff, ','))
-    {
-      cutoffs.push_back(std::stof(currentCutoff));
-    }
+    cutoffs.push_back(std::stof(currentCutoff));
   }
   cutoffs.push_back(std::numeric_limits<float>::max());
 
@@ -3451,12 +3433,9 @@ Lib::vvector<int> Options::positiveLiteralSplitQueueRatios() const
   CALL("Options::positiveLiteralSplitQueueRatios");
   vstringstream inputRatiosStream(_positiveLiteralSplitQueueRatios.actualValue);
   Lib::vvector<int> inputRatios;
-  {
-    BYPASSING_ALLOCATOR
-    std::string currentRatio;
-    while (std::getline(inputRatiosStream, currentRatio, ',')) {
-      inputRatios.push_back(std::stoi(currentRatio));
-    }
+  std::string currentRatio;
+  while (std::getline(inputRatiosStream, currentRatio, ',')) {
+    inputRatios.push_back(std::stoi(currentRatio));
   }
 
   // sanity checks
@@ -3478,13 +3457,10 @@ Lib::vvector<float> Options::positiveLiteralSplitQueueCutoffs() const
   // initialize cutoffs and add float-max as last value
   Lib::vvector<float> cutoffs;
   vstringstream cutoffsStream(_positiveLiteralSplitQueueCutoffs.actualValue);
+  std::string currentCutoff;
+  while (std::getline(cutoffsStream, currentCutoff, ','))
   {
-    BYPASSING_ALLOCATOR
-    std::string currentCutoff;
-    while (std::getline(cutoffsStream, currentCutoff, ','))
-    {
-      cutoffs.push_back(std::stof(currentCutoff));
-    }
+    cutoffs.push_back(std::stof(currentCutoff));
   }
   cutoffs.push_back(std::numeric_limits<float>::max());
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -37,6 +37,7 @@
 #include "Debug/Assertion.hpp"
 
 #include "Lib/VString.hpp"
+#include "Lib/StringUtils.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Timer.hpp"
 #include "Lib/Exception.hpp"
@@ -3268,15 +3269,24 @@ bool Options::checkProblemOptionConstraints(Property* prop,bool fail_early)
   return result;
 }
 
+template<class A>
+Lib::vvector<A> parseCommaSeparatedList(vstring const& str) 
+{
+  vstringstream stream(str);
+  Lib::vvector<A> parsed;
+  vstring cur;
+  while (std::getline(stream, cur, ',')) {
+    parsed.push_back(StringUtils::parse<A>(cur));
+  }
+  return parsed;
+}
+
 Lib::vvector<int> Options::theorySplitQueueRatios() const
 {
   CALL("Options::theorySplitQueueRatios");
-  vstringstream inputRatiosStream(_theorySplitQueueRatios.actualValue);
-  Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
-  }
+
+
+  auto inputRatios = parseCommaSeparatedList<int>(_theorySplitQueueRatios.actualValue);
 
   // sanity checks
   if (inputRatios.size() < 2) {
@@ -3305,12 +3315,7 @@ Lib::vvector<float> Options::theorySplitQueueCutoffs() const
     cutoffs.push_back(std::numeric_limits<float>::max());
   } else {
     // if custom cutoffs are set, parse them and add float-max as last value
-    vstringstream cutoffsStream(_theorySplitQueueCutoffs.actualValue);
-    std::string currentCutoff;
-    while (std::getline(cutoffsStream, currentCutoff, ','))
-    {
-      cutoffs.push_back(std::stof(currentCutoff));
-    }
+    cutoffs = parseCommaSeparatedList<float>(_theorySplitQueueCutoffs.actualValue);
     cutoffs.push_back(std::numeric_limits<float>::max());
   }
 
@@ -3331,12 +3336,7 @@ Lib::vvector<float> Options::theorySplitQueueCutoffs() const
 Lib::vvector<int> Options::avatarSplitQueueRatios() const
 {
   CALL("Options::avatarSplitQueueRatios");
-  vstringstream inputRatiosStream(_avatarSplitQueueRatios.actualValue);
-  Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
-  }
+  Lib::vvector<int> inputRatios = parseCommaSeparatedList<int>(_avatarSplitQueueRatios.actualValue);
 
   // sanity checks
   if (inputRatios.size() < 2) {
@@ -3355,13 +3355,7 @@ Lib::vvector<float> Options::avatarSplitQueueCutoffs() const
 {
   CALL("Options::avatarSplitQueueCutoffs");
   // initialize cutoffs and add float-max as last value
-  Lib::vvector<float> cutoffs;
-  vstringstream cutoffsStream(_avatarSplitQueueCutoffs.actualValue);
-  std::string currentCutoff;
-  while (std::getline(cutoffsStream, currentCutoff, ','))
-  {
-    cutoffs.push_back(std::stof(currentCutoff));
-  }
+  auto cutoffs = parseCommaSeparatedList<float>(_avatarSplitQueueCutoffs.actualValue);
   cutoffs.push_back(std::numeric_limits<float>::max());
 
   // sanity checks
@@ -3381,12 +3375,7 @@ Lib::vvector<float> Options::avatarSplitQueueCutoffs() const
 Lib::vvector<int> Options::sineLevelSplitQueueRatios() const
 {
   CALL("Options::sineLevelSplitQueueRatios");
-  vstringstream inputRatiosStream(_sineLevelSplitQueueRatios.actualValue);
-  Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
-  }
+  auto inputRatios = parseCommaSeparatedList<int>(_sineLevelSplitQueueRatios.actualValue);
 
   // sanity checks
   if (inputRatios.size() < 2) {
@@ -3405,13 +3394,7 @@ Lib::vvector<float> Options::sineLevelSplitQueueCutoffs() const
 {
   CALL("Options::sineLevelSplitQueueCutoffs");
   // initialize cutoffs and add float-max as last value
-  Lib::vvector<float> cutoffs;
-  vstringstream cutoffsStream(_sineLevelSplitQueueCutoffs.actualValue);
-  std::string currentCutoff;
-  while (std::getline(cutoffsStream, currentCutoff, ','))
-  {
-    cutoffs.push_back(std::stof(currentCutoff));
-  }
+  auto cutoffs = parseCommaSeparatedList<float>(_sineLevelSplitQueueCutoffs.actualValue);
   cutoffs.push_back(std::numeric_limits<float>::max());
 
   // sanity checks
@@ -3431,12 +3414,7 @@ Lib::vvector<float> Options::sineLevelSplitQueueCutoffs() const
 Lib::vvector<int> Options::positiveLiteralSplitQueueRatios() const
 {
   CALL("Options::positiveLiteralSplitQueueRatios");
-  vstringstream inputRatiosStream(_positiveLiteralSplitQueueRatios.actualValue);
-  Lib::vvector<int> inputRatios;
-  std::string currentRatio;
-  while (std::getline(inputRatiosStream, currentRatio, ',')) {
-    inputRatios.push_back(std::stoi(currentRatio));
-  }
+  auto inputRatios = parseCommaSeparatedList<int>(_positiveLiteralSplitQueueRatios.actualValue);
 
   // sanity checks
   if (inputRatios.size() < 2) {
@@ -3455,13 +3433,7 @@ Lib::vvector<float> Options::positiveLiteralSplitQueueCutoffs() const
 {
   CALL("Options::positiveLiteralSplitQueueCutoffs");
   // initialize cutoffs and add float-max as last value
-  Lib::vvector<float> cutoffs;
-  vstringstream cutoffsStream(_positiveLiteralSplitQueueCutoffs.actualValue);
-  std::string currentCutoff;
-  while (std::getline(cutoffsStream, currentCutoff, ','))
-  {
-    cutoffs.push_back(std::stof(currentCutoff));
-  }
+  auto cutoffs = parseCommaSeparatedList<float>(_positiveLiteralSplitQueueCutoffs.actualValue);
   cutoffs.push_back(std::numeric_limits<float>::max());
 
   // sanity checks

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1045,6 +1045,13 @@ void Options::Options::init()
            _theoryInstAndSimp.description = ""; 
            _theoryInstAndSimp.tag(OptionTag::INFERENCES);
            _lookup.insert(&_theoryInstAndSimp);
+
+           _thiTautologyDeletion = BoolOptionValue("theory_instantiation_tautology_deletion", "thitd", false);
+           _thiTautologyDeletion.description = "Enable deletion of tautology theory subclauses detected via theory instantiation."; 
+           _thiTautologyDeletion.tag(OptionTag::INFERENCES);
+           _lookup.insert(&_thiTautologyDeletion);
+           _thiTautologyDeletion.setExperimental();
+
 #endif
            _unificationWithAbstraction = ChoiceOptionValue<UnificationWithAbstraction>("unification_with_abstraction","uwa",
                                              UnificationWithAbstraction::OFF,

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1051,8 +1051,9 @@ void Options::Options::init()
            _thiTautologyDeletion.tag(OptionTag::INFERENCES);
            _lookup.insert(&_thiTautologyDeletion);
            _thiTautologyDeletion.setExperimental();
-
+           _thiTautologyDeletion.reliesOn(_theoryInstAndSimp.is(notEqual(TheoryInstSimp::OFF)));
 #endif
+
            _unificationWithAbstraction = ChoiceOptionValue<UnificationWithAbstraction>("unification_with_abstraction","uwa",
                                              UnificationWithAbstraction::OFF,
                                              {"off","interpreted_only","one_side_interpreted","one_side_constant","all","ground"});

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2037,6 +2037,7 @@ public:
   bool satFallbackForSMT() const { return _satFallbackForSMT.actualValue; }
   bool smtForGround() const { return _smtForGround.actualValue; }
   TheoryInstSimp theoryInstAndSimp() const { return _theoryInstAndSimp.actualValue; }
+  bool thiTautologyDeletion() const { return _thiTautologyDeletion.actualValue; }
 #endif
   UnificationWithAbstraction unificationWithAbstraction() const { return _unificationWithAbstraction.actualValue; }
   void setUWA(UnificationWithAbstraction value){ _unificationWithAbstraction.actualValue = value; } 
@@ -2611,6 +2612,7 @@ private:
   BoolOptionValue _satFallbackForSMT;
   BoolOptionValue _smtForGround;
   ChoiceOptionValue<TheoryInstSimp> _theoryInstAndSimp;
+  BoolOptionValue _thiTautologyDeletion;
 #endif
   ChoiceOptionValue<UnificationWithAbstraction> _unificationWithAbstraction; 
   BoolOptionValue _fixUWA;


### PR DESCRIPTION
Fixes a subtle bug that potentially has big impacts on the performance of theory instantiation.

When the generating inference rule `TheoryInstAndGen` is called in `SaturationAlgorithm::activate`, it shall set the flag `redundant` in order to signal whether the premise clause can be deleted from the search space. This does never happen right now. 
The issue is that the flag redundant is set in the mapping function `InstanceFn::operator()` in the iterator returned by `TheoryInstAndSimpl::generateClauses`. But this function will only be called when `next`/`hasNext` is called on the returned iterator. This means the flag will only be set after line 1137 in `SaturationAlgorithm.cpp`, but is read in line 1116. Therefore the deletion of the redundant clause will never be performed. 

I tested this hypothesis by adding an assertion `ASS(!redundant)`  before line 1116, and ran vampire over 56000 smtlib arithmetic examples (`-t 0 -sched casc -thi full -uwa one_side_interpreted`, debug build), and the assertion is never triggerd. After applying the fix that is in this pull request the assertion is triggered. (Of course this assertion was removed before making the pull request).