### PR TITLE
Silence warnings for default builds.

### DIFF
--- a/Debug/Assertion.hpp
+++ b/Debug/Assertion.hpp
@@ -225,6 +225,15 @@ private:
 
 #else // ! VDEBUG
 
+/* this point in the code is statically unreachable */
+#ifdef __GNU_C__
+// builtin if the GNU C dialect is availble: GCC, Clang, ICC
+#define __UNREACHABLE { __builtin_unreachable(); }
+#else // !__GNU_C__
+// otherwise, infinite loop - UB post-C++11 and should be optimised out
+#define __UNREACHABLE while(true) {}
+#endif
+
 #define DEBUG_CODE(X)
 
 #define __IGNORE_WUNUSED(...) __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wreturn-type\"", __VA_ARGS__)
@@ -248,7 +257,7 @@ private:
 #define ASS_ALLOC_TYPE(PTR,TYPE)
 #define ASS_METHOD(OBJ,METHOD)
 
-#define ASSERTION_VIOLATION 
+#define ASSERTION_VIOLATION __UNREACHABLE
 #define ASSERTION_VIOLATION_REP(Val) ASSERTION_VIOLATION
 #define ASSERTION_VIOLATION_REP2(Val1,Val2)  ASSERTION_VIOLATION
 

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -68,12 +68,9 @@ bool EqHelper::hasGreaterEqualitySide(Literal* eq, const Ordering& ord, TermList
       lhs = *eq->nthArgument(1);
       rhs = *eq->nthArgument(0);
       return true;
-#if VDEBUG
+    //there should be no equality literals of equal terms
     case Ordering::EQUAL:
-      //there should be no equality literals of equal terms
-    default:
       ASSERTION_VIOLATION;
-#endif
   }
 }
 
@@ -240,12 +237,9 @@ TermIterator EqHelper::getLHSIterator(Literal* lit, const Ordering& ord)
     case Ordering::LESS:
     case Ordering::LESS_EQ:
       return pvi( getSingletonIterator(t1) );
-#if VDEBUG
+    //there should be no equality literals of equal terms
     case Ordering::EQUAL:
-      //there should be no equality literals of equal terms
-    default:
       ASSERTION_VIOLATION;
-#endif
     }
     return TermIterator::getEmpty();
   } else {
@@ -323,12 +317,9 @@ TermIterator EqHelper::getDemodulationLHSIterator(Literal* lit, bool forward, co
     case Ordering::LESS_EQ:
       ASS(t1.containsAllVariablesOf(t0));
       return pvi( getSingletonIterator(t1) );
-#if VDEBUG
+    //there should be no equality literals of equal terms
     case Ordering::EQUAL:
-      //there should be no equality literals of equal terms
-    default:
       ASSERTION_VIOLATION;
-#endif
     }
     return TermIterator::getEmpty();
   } else {

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -137,11 +137,8 @@ void Formula::destroy ()
     delete static_cast<NamedFormula*>(this);
     return;
 
-#if VDEBUG
-  default:
+  case NOCONN:
     ASSERTION_VIOLATION;
-    return;
-#endif
   }
 } // Formula::Data::deref ()
 
@@ -389,12 +386,10 @@ vstring Formula::toString(const Formula* formula)
     case TRUE:
     case FALSE:
       res += toString(c);
-
       continue;
-  #if VDEBUG
-    default:
+
+    case NOCONN:
       ASSERTION_VIOLATION;
-  #endif
   }
   }
 
@@ -445,11 +440,8 @@ bool Formula::parenthesesRequired (Connective outer) const
     case XOR:
       return true;
 
-#if VDEBUG
-    default:
+    case NOCONN:
       ASSERTION_VIOLATION;
-      return false;
-#endif
     }
 } // Formula::parenthesesRequired
 
@@ -675,11 +667,9 @@ void Formula::collectPredicatesWithPolarity(Stack<pair<unsigned,int> >& acc, int
     case FALSE:
       return;
 
-#if VDEBUG
-    default:
+    case NAME:
+    case NOCONN:
       ASSERTION_VIOLATION;
-      return;
-#endif
   }
 }
 

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -89,10 +89,9 @@ Formula* FormulaTransformer::apply(Formula* f)
   case FALSE:
     res = applyTrueFalse(f);
     break;
-#if VDEBUG
-  default:
+  case NAME:
+  case NOCONN:
     ASSERTION_VIOLATION;
-#endif
   }
   postApply(f, res);
   return res;

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -973,11 +973,9 @@ public:
       //undo the previous match
       backtrack();
       _state=FINISHED;
-#if VDEBUG
       break;
-    default:
+    case FINISHED:
       ASSERTION_VIOLATION;
-#endif
     }
     ASS(_state!=FINISHED || _bdata.isEmpty());
     return _state!=FINISHED;

--- a/Kernel/SubformulaIterator.cpp
+++ b/Kernel/SubformulaIterator.cpp
@@ -310,11 +310,8 @@ Formula* SubformulaIterator::next (int& resultPolarity)
     }
     break;
   }
-
-#if VDEBUG
-  default:
+  case NOCONN:
     ASSERTION_VIOLATION;
-#endif
   }
 
   return result;

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -242,7 +242,10 @@ SATSolver::VarAssignment Z3Interfacing::getAssignment(unsigned var)
 
   // with model_completion true (see above), there should be no don't-knows
 
-  ASSERTION_VIOLATION_REP(assignment); // This is actually not a problem for AVATAR in release (see recomputeModel in Splitter.cpp)
+#ifdef VDEBUG
+  // This is actually not a problem for AVATAR in release (see recomputeModel in Splitter.cpp)
+  ASSERTION_VIOLATION_REP(assignment);
+#endif
   return NOT_KNOWN;
 }
 

--- a/SAT/lglib.c
+++ b/SAT/lglib.c
@@ -1162,7 +1162,8 @@ static Flt lglmulflt (Flt a, Flt b) {
   ma = lglmnt (a); mb = lglmnt (b);
   ma >>= 1; mb >>= 1;
   m = ma * mb;
-  assert (3ull << 62);
+  // following always true according to Clang 10
+  // assert (3ull << 62);
   m >>= 30;
   return lglflt (e, m);
 }
@@ -2564,7 +2565,9 @@ static void lglddown (LGL * lgl, int lit) {
     }
     if (lgldcmp (lgl, child, lit) <= 0) break;
     cposptr = lgldpos (lgl, child);
-    assert (*cposptr = cpos);
+    // FIXME this is terrifying but left as found upstream
+    // double parens silence warning
+    assert ((*cposptr = cpos));
     p[ppos] = child;
     *cposptr = ppos;
     LOGDSCHED (5, child, "up from %d", cpos);
@@ -3935,7 +3938,9 @@ static void lgledown (LGL * lgl, int lit) {
     }
     if (lglecmp (lgl, child, lit) <= 0) break;
     cposptr = lglepos (lgl, child);
-    assert (*cposptr = cpos);
+    // FIXME this is terrifying but left as found upstream
+    // double parens silence warning
+    assert ((*cposptr = cpos));
     p[ppos] = child;
     *cposptr = ppos;
     LOGESCHED (5, child, "up from %d", cpos);
@@ -18633,7 +18638,9 @@ static int lglunhideglue (LGL * lgl, const DFPR * dfpr, int glue, int irronly) {
     ndfl = posdfl + negdfl;	// number of literals in BIG
     if (hastobesatisfied) assert (satisfied);
     if (satisfied || ndfl < 2) goto NEXT;
-    assert (nonfalse = eoc - c);
+    // FIXME dubious, left as found upstream
+    // double parens silence warning
+    assert ((nonfalse = eoc - c));
     assert (nonfalse >= negdfl);
 //FAILED: find root implying all negated literals
     if (nonfalse != negdfl) goto HTE;	// not enough complement lits in BIG

--- a/Saturation/PredicateSplitPassiveClauseContainer.cpp
+++ b/Saturation/PredicateSplitPassiveClauseContainer.cpp
@@ -89,7 +89,8 @@ unsigned PredicateSplitPassiveClauseContainer::bestQueue(float featureValue) con
       return i;
     }
   }
-  ASS(false); // unreachable
+  // unreachable
+  ASSERTION_VIOLATION;
 }
 
 void PredicateSplitPassiveClauseContainer::add(Clause* cl)

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -829,14 +829,14 @@ void SaturationAlgorithm::newClausesToUnprocessed()
     case Clause::NONE:
       addUnprocessedClause(cl);
       break;
-#if VDEBUG
     case Clause::SELECTED:
     case Clause::ACTIVE:
+#if VDEBUG
       cout << "FAIL: " << cl->toString() << endl;
       //such clauses should not appear as new ones
       cout << cl->toString() << endl;
-      ASSERTION_VIOLATION_REP(cl->store());
 #endif
+      ASSERTION_VIOLATION_REP(cl->store());
     }
     cl->decRefCnt(); //belongs to _newClauses.popWithoutDec()
   }

--- a/Shell/CNF.cpp
+++ b/Shell/CNF.cpp
@@ -136,10 +136,8 @@ void CNF::clausify (Formula* f)
     clausify(f->qarg());
     return;
 
-#if VDEBUG
   default:
     ASSERTION_VIOLATION;
-#endif
   }
 } // CNF::clausify
 

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -302,10 +302,9 @@ Formula* FOOLElimination::process(Formula* formula) {
     case FALSE:
       return formula;
 
-#if VDEBUG
-    default:
+    case NAME:
+    case NOCONN:
       ASSERTION_VIOLATION;
-#endif
   }
 }
 

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -211,10 +211,9 @@ Formula* Flattening::flatten (Formula* f)
 				   arg->qarg());
     }
 
-#if VDEBUG
-  default:
+  case NAME:
+  case NOCONN:
     ASSERTION_VIOLATION;
-#endif
   }
 
 } // Flattening::flatten ()

--- a/Shell/LaTeX.cpp
+++ b/Shell/LaTeX.cpp
@@ -276,10 +276,8 @@ vstring LaTeX::toString (Formula* f) const
   case NAME:
     return replaceNeg(static_cast<const NamedFormula*>(f)->name());
 
-#if VDEBUG
-  default:
+  case NOCONN:
     ASSERTION_VIOLATION_REP(c);
-#endif
   }
 } // LaTeX::toString (const Formula&)
 

--- a/Shell/LispParser.cpp
+++ b/Shell/LispParser.cpp
@@ -156,10 +156,8 @@ void LispParser::parse(List** expr0)
           return;
         }
         throw Exception("unmatched left parenthesis",t);
-  #if VDEBUG
       default:
         ASSERTION_VIOLATION;
-  #endif
       }
     }
 

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -205,10 +205,8 @@ Formula* NNF::ennf (Formula* f, bool polarity)
 	return Formula::trueFormula();
       }
     }
-#if VDEBUG
   default:
     ASSERTION_VIOLATION;
-#endif
   }
 } // NNF::ennf(Formula&);
 
@@ -513,10 +511,10 @@ Formula* NNF::nnf (Formula* f, bool polarity)
   case TRUE:
   case FALSE:
     return f;
-#if VDEBUG
-  default:
+
+  case NAME:
+  case NOCONN:
     ASSERTION_VIOLATION;
-#endif
   }
 } // NNF::nnf(Formula*);
 

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -247,12 +247,8 @@ Formula* Naming::apply_iter(Formula* top_f) {
           todo_stack.push(t_new);
         }
       } break;
-
-#if VDEBUG
       default:
-        ASSERTION_VIOLATION_REP(*tas.f)
-        ;
-#endif
+        ASSERTION_VIOLATION_REP(*tas.f);
       }
     } break;
 
@@ -1079,11 +1075,8 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
     return f;
   }
 
-#if VDEBUG
   default:
-    ASSERTION_VIOLATION_REP(*f)
-    ;
-#endif
+    ASSERTION_VIOLATION_REP(*f);
   }
 } // Naming::apply
 

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -867,11 +867,9 @@ void PredicateDefinition::count (Formula* f,int polarity,int add, Unit* unit)
       count (f->getBooleanTerm(), add, unit);
       return;
 
-#if VDEBUG
-    default:
+    case NAME:
+    case NOCONN:
       ASSERTION_VIOLATION;
-      return;
-#endif
   }
 } // PredicateDefinition::count (Formula* f,...)
 

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -959,10 +959,9 @@ bool Property::hasXEqualsY(const Formula* f)
     case BOOL_TERM:
       return true;
 
-#if VDEBUG
-    default:
+    case NAME:
+    case NOCONN:
       ASSERTION_VIOLATION;
-#endif
     }
   }
   return false;

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -447,10 +447,9 @@ Formula* Rectify::rectify (Formula* f)
   case BOOL_TERM:
      return new BoolTermFormula(rectify(f->getBooleanTerm()));
 
-#if VDEBUG
-  default:
+  case NAME:
+  case NOCONN:
     ASSERTION_VIOLATION;
-#endif
   }
 } // Rectify::rectify (Formula*)
 

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -323,10 +323,9 @@ Formula* SimplifyFalseTrue::simplify (Formula* f)
       }
     }
 
-#if VDEBUG
-  default:
+  case NAME:
+  case NOCONN:
     ASSERTION_VIOLATION;
-#endif
   }
 } // SimplifyFalseTrue::simplify ()
 

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -214,11 +214,9 @@ void SineSymbolExtractor::extractFormulaSymbols(Formula* f,Stack<SymId>& itms)
     case TRUE:
     case FALSE:
       break;
-#if VDEBUG
-    default:
+    case NAME:
+    case NOCONN:
       ASSERTION_VIOLATION;
-      return;
-#endif
     }
   }
 } // SineSymbolExtractor::extractFormulaSymbols

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -304,10 +304,8 @@ void Skolem::preskolemise (Formula* f)
   case FALSE:
     return;
 
-#if VDEBUG
   default:
     ASSERTION_VIOLATION_REP(f->connective());
-#endif
   }
 }
 
@@ -468,10 +466,8 @@ Formula* Skolem::skolemise (Formula* f)
   case FALSE:
     return f;
 
-#if VDEBUG
   default:
     ASSERTION_VIOLATION;
-#endif
   }
 } // Skolem::skolemise
 

--- a/Shell/SymCounter.cpp
+++ b/Shell/SymCounter.cpp
@@ -174,11 +174,9 @@ void SymCounter::count (Formula* f,int polarity,int add)
   case FALSE:
     return;
 
-#if VDEBUG
-    default:
+  case NAME:
+  case NOCONN:
       ASSERTION_VIOLATION;
-      return;
-#endif
   }
 } // SymCounter::count (Formula* f,...)
 

--- a/Shell/SymbolOccurrenceReplacement.cpp
+++ b/Shell/SymbolOccurrenceReplacement.cpp
@@ -156,10 +156,9 @@ Formula* SymbolOccurrenceReplacement::process(Formula* formula) {
     case FALSE:
       return formula;
 
-#if VDEBUG
-    default:
+    case NAME:
+    case NOCONN:
       ASSERTION_VIOLATION;
-#endif
     }
 }
 

--- a/Shell/TheoryFinder.cpp
+++ b/Shell/TheoryFinder.cpp
@@ -701,10 +701,8 @@ bool TheoryFinder::matchCode(const void* obj,
     goto match;
   }
 
-#if VDEBUG
   default:
     ASSERTION_VIOLATION;
-#endif
   }
 } // TheoryFinder::MatcherState::match
 

--- a/Shell/Token.cpp
+++ b/Shell/Token.cpp
@@ -72,6 +72,8 @@ Lib::vstring Token::toString (TokenType tt)
     return "<=>";
   case TT_IMP:
     return "=>";
+  case TT_REVERSE_IMP:
+    return "<=";
   case TT_XOR:
     return "<~>";
   case TT_FORALL:
@@ -86,6 +88,8 @@ Lib::vstring Token::toString (TokenType tt)
     return "=";
   case TT_NAME:
     return "<name>";
+  case TT_VAMPIRE:
+    return "vampire(...)";
   case TT_VAR:
     return "<variable>";
   case TT_INPUT_FORMULA: 
@@ -228,11 +232,6 @@ Lib::vstring Token::toString (TokenType tt)
     return "<arith>";
   case TT_USER:
     return "<user value>";
-    
-#if VDEBUG
-  default:
-    ASSERTION_VIOLATION;
-#endif
   }
 } // Token::toString
 

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -263,10 +263,9 @@ void outputResult(ostream& out) {
   case Statistics::REFUTATION:
     cout<<"unsat"<<endl;
     break;
-#if VDEBUG
   default:
-    ASSERTION_VIOLATION; //these outcomes are not reachable with the current implementation
-#endif
+    //these outcomes are not reachable with the current implementation
+    ASSERTION_VIOLATION;
   }
   if(env.options->mode()!=Options::Mode::SPIDER){
     env.statistics->print(env.out());


### PR DESCRIPTION
Currently there are some warnings in both release and debug builds, which can make it hard to see the bugs you just created. This PR silences warnings from release and debug builds with the default configuration. In principle there should be no change in runtime behaviour that wasn't already a bug.

The major change is changing the definition of `ASSERTION_VIOLATION` in release mode from no-op to either:
1. `__builtin_unreachable` on compilers that support it (GCC, Clang, ICC). This should allow for further optimisation.
2. `while(true) {}` otherwise. This is undefined behaviour and conforming compilers can in principle optimise this into whatever is fastest based on context. Open to suggestions for better ideas.

@joe-hauns - there's some history of you changing `Assertion.hpp` but it doesn't seem to work out?