### PR TITLE
add clang-format config and README exhortations

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,13 @@
+---
+Language: Cpp
+
+Standard: c++11
+SortIncludes: false
+
+AlignOperands: false
+BreakBeforeBraces: Stroustrup
+ColumnLimit: 0
+DerivePointerAlignment: true
+FixNamespaceComments: true
+IndentCaseLabels: true
+...

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ There are some other top-level files that are left over from previous use cases.
 
 Note that Forwards.hpp contains a lot of forward declarations of things.
 
+When making a pull request, please try to:
+ - add Doxygen comments to new items (bonus points for adding or improving existing comments)
+ - add unit tests for new or related/untested functionality
+ - consider running `clang-format` on code in the vicinity of your change as a companion pull request - this allows incremental automatic formatting of the codebase without breaking everything
+
 ### Namespaces
 
 The code is organised into a number of namespaces. Here is a brief overview.
@@ -59,7 +64,6 @@ Other namespaces have specific purposes that you will find out by looking at the
 ### Documentation
 
 Running make doc makes documentation using doxygen; this has not been fully maintained but ideally each function and class would have an appropriate comment to be parsed by doxygen. 
-
 
 ### Scripts
 


### PR DESCRIPTION
Add some requests for developers to follow when creating new PRs so that documentation, testing, and formatting improve incrementally.

I've also added a configuration file for [clang-format](//clang.llvm.org/docs/ClangFormat.html). Automatic formatting saves you time and aids readability: the point is not to enforce a certain style but to be (more) consistent.

The configuration file says:
- parse C++ sources as C++11
- do not sort `#include`s - this is neat but can (rarely) break things, any other formatting should not change semantics
- do not align binary/ternary operations - causes big diffs for little gain
- use the "stroustrup" brace style - this is more-or-less what Vampire does, albeit inconsistently
- no limit on line length - I'd argue for an 80-character limit, but this can cause a very large diff in some cases
- infer whether to format pointer/reference-to-type decls as `T<SPACE>*` or `T*<SPACE>` from the file - different people do different things so this matches sources better.
- fix namespace comments: add `} //namespace foo` to match other namespaces where this is done (for better or worse)
- indent `case` statements to match Vampire style

If people want to adopt a more draconian style that's great and I'd like to hear about it, this one aims to minimise changes when applied to existing Vampire sources.