### PR TITLE
fix warnings from static analysis, possible bugs in some cases

### DIFF
--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -100,11 +100,11 @@ private:
   /** Equality between two constants */
   struct CEq
   {
-    CEq() : c1(0), c2(0) {}
+    CEq() : c1(0), c2(0), foOrigin(false), foPremise(nullptr) {}
     CEq(unsigned c1, unsigned c2, Literal* lit)
      : c1(c1), c2(c2), foOrigin(true), foPremise(lit) {}
     CEq(unsigned c1, unsigned c2)
-     : c1(c1), c2(c2), foOrigin(false) {}
+     : c1(c1), c2(c2), foOrigin(false), foPremise(nullptr) {}
 
     bool isInvalid() const { ASS_EQ(c1==0, c2==0); return c1==0; }
     vstring toString() const;

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -2588,8 +2588,6 @@ bool FiniteModelBuilder::SmtBasedDSAE::increaseModelSizes(DArray<unsigned>& newS
       }
       _smtSolver.add(sum == _context.int_val(_lastWeight));
 
-      result = _smtSolver.check();
-
       if (_smtSolver.check() == z3::check_result::sat) {
         loadSizesFromSmt(newSortSizes);
         // cout << "\nFound "; output_sizes(_distinctSortSizes); cout << endl;

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -836,7 +836,7 @@ void CodeTree::compileTerm(Term* trm, CodeStack& code, CompileContext& cctx, boo
 	  sti.right();
 	}
 	else {
-	  code.push(CodeOp::getTermOp(CHECK_FUN, s.term()->functor()));
+	  code.push(CodeOp::getTermOp(CHECK_FUN, t->functor()));
 	}
       }
     }
@@ -1325,7 +1325,6 @@ bool CodeTree::RemovingMatcher::next()
       if(!backtrack()) {
 	return false;
       }
-      shouldBacktrack=false;
     }
     else {
       //the SEARCH_STRUCT operation does not appear in CodeBlocks

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -1323,8 +1323,10 @@ bool CodeTree::RemovingMatcher::next()
     }
     if(shouldBacktrack) {
       if(!backtrack()) {
-	return false;
+        return false;
       }
+      // dead store, left here in case it should have been a static?
+      // shouldBacktrack = false;
     }
     else {
       //the SEARCH_STRUCT operation does not appear in CodeBlocks

--- a/Indexing/Index.hpp
+++ b/Indexing/Index.hpp
@@ -76,7 +76,7 @@ struct SLQueryResult
  */
 struct TermQueryResult
 {
-  TermQueryResult() {}
+  TermQueryResult() : literal(nullptr), clause(nullptr) {}
   TermQueryResult(TermList t, Literal* l, Clause* c, ResultSubstitutionSP s)
   : term(t), literal(l), clause(c), substitution(s) {}
   TermQueryResult(TermList t, Literal* l, Clause* c)

--- a/Indexing/SubstitutionTree.cpp
+++ b/Indexing/SubstitutionTree.cpp
@@ -259,9 +259,10 @@ start:
     BindingMap::Iterator svit(svBindings);
     BinaryHeap<Binding, BindingComparator> remainingBindings;
     while (svit.hasNext()) {
-      Binding b;
-      svit.next(b.var, b.term);
-      remainingBindings.insert(b);
+      unsigned var;
+      TermList term;
+      svit.next(var, term);
+      remainingBindings.insert(Binding(var, term));
     }
     while (!remainingBindings.isEmpty()) {
       Binding b=remainingBindings.pop();

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -652,8 +652,6 @@ public:
     TermList term;
     /** Create new binding */
     Binding(int v,TermList t) : var(v), term(t) {}
-    /** Create uninitialised binding */
-    Binding() {}
 
     struct Comparator
     {

--- a/Indexing/SubstitutionTree_FastInst.cpp
+++ b/Indexing/SubstitutionTree_FastInst.cpp
@@ -53,7 +53,7 @@ public:
 
   struct TermSpec
   {
-    TermSpec() {
+    TermSpec() : q(false) {
     #if VDEBUG
       t.makeEmpty();
     #endif

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -630,6 +630,7 @@ void InductionClauseIterator::performStructInductionThree(Clause* premise, Liter
       while(vtit.hasNext()){
         smallers = new FormulaList(new AtomicFormula(Literal::create1(sty,true,TermList(vtit.next(),false))),smallers);
       }
+      ASS(smallers);
       Formula* ax = Formula::quantify(new BinaryFormula(Connective::IMP,smaller_coni, 
                      (FormulaList::length(smallers) > 1) ? new JunctionFormula(Connective::AND,smallers)
                                             : smallers->head()

--- a/Kernel/RCClauseStack.hpp
+++ b/Kernel/RCClauseStack.hpp
@@ -108,7 +108,7 @@ public:
   public:
     DECL_ELEMENT_TYPE(Clause*);
 
-    DelIterator(RCClauseStack& s) : _inner(s._s) {}
+    DelIterator(RCClauseStack& s) : _inner(s._s), curr(nullptr) {}
 
     bool hasNext() { return _inner.hasNext(); }
     Clause* next() {

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -148,7 +148,7 @@ public:
   struct TermSpec
   {
     /** Create a new TermSpec struct */
-    TermSpec() {}
+    TermSpec() : index(0) {}
     /** Create a new TermSpec struct */
     TermSpec(TermList term, int index) : term(term), index(index) {}
     /** Create a new TermSpec struct from a VarSpec*/

--- a/Kernel/SpassLiteralSelector.cpp
+++ b/Kernel/SpassLiteralSelector.cpp
@@ -76,8 +76,8 @@ void SpassLiteralSelector::doSelection(Clause* c, unsigned eligible)
     }
   }
 
-  LiteralList* sel = LiteralList::empty();
-
+  // sel always initialised below
+  LiteralList* sel;
   if(singleSel) {
     LiteralList::destroy(maximals);
     sel = LiteralList::empty();

--- a/Kernel/TermIterators.hpp
+++ b/Kernel/TermIterators.hpp
@@ -283,7 +283,7 @@ public:
     CALL("NonVariableIterator::NonVariableIterator");
     _stack.push(term);
     if (!includeSelf) {
-      next();
+      NonVariableIterator::next();
     }
   }
   // NonVariableIterator(TermList ts);

--- a/Lib/DHMap.hpp
+++ b/Lib/DHMap.hpp
@@ -877,7 +877,7 @@ public:
   class DelIterator {
   public:
     /** Create a new iterator */
-    inline DelIterator(DHMap& map) : _base(map), _map(map) {}
+    inline DelIterator(DHMap& map) : _base(map), _map(map), _curr(nullptr) {}
 
     /** True if there exists next element */
     bool hasNext() { return _base.hasNext(); }

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -369,7 +369,7 @@ public:
   DECL_ELEMENT_TYPE(ELEMENT_TYPE(Inner));
 
   FilteredIterator(Inner inn, Functor func)
-  : _func(func), _inn(inn), _nextStored(false) {}
+  : _func(func), _inn(inn), _next(), _nextStored(false) {}
   bool hasNext()
   {
     if(_nextStored) {

--- a/Lib/MultiCounter.hpp
+++ b/Lib/MultiCounter.hpp
@@ -56,6 +56,7 @@ public:
     if (v >= _top) { // not enough capacity
       expandToFit(v);
     }
+    ASS(_counts);
     _counts[v]++;
   } // MultiCount::inc
 
@@ -68,6 +69,7 @@ public:
     if (v >= _top) { // not enough capacity
       expandToFit(v);
     }
+    ASS(_counts);
     _counts[v]--;
   } // MultiCount::dec
 
@@ -80,6 +82,7 @@ public:
     if (v >= _top) { // not enough capacity
       expandToFit(v);
     }
+    ASS(_counts);
     _counts[v] = c;
   } // MultiCounter::set
 
@@ -121,5 +124,3 @@ private:
 }
 
 #endif // __MultiCounter__
-
-

--- a/Lib/SmartPtr.hpp
+++ b/Lib/SmartPtr.hpp
@@ -63,6 +63,7 @@ public:
   SmartPtr(const SmartPtr& ptr) : _obj(ptr._obj), _refCnt(ptr._refCnt)
   {
     if(_obj && _refCnt) {
+      ASS(_refCnt->_val > 0);
       (_refCnt->_val)++;
     }
   }

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -223,21 +223,13 @@ void Lib::Timer::syncClock()
 {
   if(s_initGuarantedMiliseconds==-1) {
     //we're unable to sync clock as we weren't able to obtain number of ticks in the beginning
-    bool reportedProblem = false;
-    if(!reportedProblem) {
-      reportedProblem = true;
-      cerr << "cannot syncronize clock as times() initially returned -1" << endl;
-    }
+    cerr << "cannot synchronize clock as times() initially returned -1" << endl;
     return;
   }
   int newMilliseconds = guaranteedMilliseconds();
   if(newMilliseconds==-1) {
     //we're unable to sync clock as we cannot get the current time
-    bool reportedProblem = false;
-    if(!reportedProblem) {
-      reportedProblem = true;
-      cerr << "could not syncronize clock as times() returned -1" << endl;
-    }
+    cerr << "could not synchronize clock as times() returned -1" << endl;
     return;
   }
 

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -221,15 +221,22 @@ void Lib::Timer::deinitializeTimer()
 
 void Lib::Timer::syncClock()
 {
+  static bool reportedProblem = false;
   if(s_initGuarantedMiliseconds==-1) {
     //we're unable to sync clock as we weren't able to obtain number of ticks in the beginning
-    cerr << "cannot synchronize clock as times() initially returned -1" << endl;
+    if(!reportedProblem) {
+      reportedProblem = true;
+      cerr << "cannot syncronize clock as times() initially returned -1" << endl;
+    }
     return;
   }
   int newMilliseconds = guaranteedMilliseconds();
   if(newMilliseconds==-1) {
     //we're unable to sync clock as we cannot get the current time
-    cerr << "could not synchronize clock as times() returned -1" << endl;
+    if(!reportedProblem) {
+      reportedProblem = true;
+      cerr << "could not syncronize clock as times() returned -1" << endl;
+    }
     return;
   }
 

--- a/SAT/Preprocess.cpp
+++ b/SAT/Preprocess.cpp
@@ -221,11 +221,16 @@ propagation_start:
     bool del=false;
     removedLitIndexes.reset();
     SATLiteral kept;
+#ifdef VDEBUG
+    // set to true when kept is assigned something
+    bool kept_assigned = false;
+#endif
     for(unsigned i=0;i<clen;i++) {
       SATLiteral lit=(*cl)[i];
       bool posUnit;
       if(!unitBindings.find(lit.var(), posUnit)) {
 	kept=lit;
+	kept_assigned = true;
 	continue;
       }
       if(posUnit==lit.isPositive()) {
@@ -245,6 +250,7 @@ propagation_start:
     unsigned newLen=clen-removedLitIndexes.length();
 
     if(newLen==1) {
+      ASS(kept_assigned);
       SATClause* unit=new(1) SATClause(1, true);
       (*unit)[0]=kept;
       SATClauseList::push(unit, units);

--- a/SAT/Preprocess.cpp
+++ b/SAT/Preprocess.cpp
@@ -230,7 +230,9 @@ propagation_start:
       bool posUnit;
       if(!unitBindings.find(lit.var(), posUnit)) {
 	kept=lit;
+#ifdef VDEBUG
 	kept_assigned = true;
+#endif
 	continue;
       }
       if(posUnit==lit.isPositive()) {

--- a/SAT/RestartStrategy.hpp
+++ b/SAT/RestartStrategy.hpp
@@ -118,7 +118,7 @@ public:
    * According to "Armin Biere, PicoSAT Essentials" paper.
    */
   MinisatRestartStrategy(size_t initCnt = 100, float increase=1.1f)
-  : _initConflictCnt(initCnt), _increase(increase) { reset(); }
+  : _initConflictCnt(initCnt), _increase(increase) { MinisatRestartStrategy::reset(); }
 
   virtual size_t getNextConflictCount();
   virtual void reset() { _innerCnt = _outerCnt = _initConflictCnt; }

--- a/SAT/VariableSelector.cpp
+++ b/SAT/VariableSelector.cpp
@@ -177,7 +177,11 @@ for(const TermList* t = _stack.pop(); !t->isEmpty(); t = t->next()){
       }
       RSTAT_MCTR_INC("nscore",level_sum);
       // if we want average, we set divid=true earlier
-      if(divide){ level_sum = (level_sum/count);}//This division will truncate
+      if(divide) {
+        ASS_NEQ(count, 0);
+        //This division will truncate
+        level_sum = (level_sum/count);
+      }
       return level_sum;
     default: ASSERTION_VIOLATION_REP2("Invalid niceness option: ",static_cast<int>(_niceness_option));
   }

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -496,11 +496,11 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         Formula* condition = process(sd->getCondition());
 
         TermList thenBranch;
-        Formula* thenBranchFormula;
+        Formula* thenBranchFormula {};
         process(*term->nthArgument(0), context, thenBranch, thenBranchFormula);
 
         TermList elseBranch;
-        Formula* elseBranchFormula;
+        Formula* elseBranchFormula {};
         process(*term->nthArgument(1), context, elseBranch, elseBranchFormula);
 
         // the sort of the term is the sort of the then branch

--- a/Shell/InterpolantMinimizer.hpp
+++ b/Shell/InterpolantMinimizer.hpp
@@ -79,7 +79,8 @@ private:
 
   struct UnitInfo
   {
-    UnitInfo() : state(TRANSPARENT_PARENTS), isRefutation(false),
+    UnitInfo() : color(COLOR_INVALID), inputInheritedColor(COLOR_INVALID),
+        state(TRANSPARENT_PARENTS), isRefutation(false),
 	isParentOfLeft(false), isParentOfRight(false), leadsToColor(false),
 	leftSuccessors(0), rightSuccessors(0), transparentSuccessors(0) {}
 

--- a/Shell/Interpolants.cpp
+++ b/Shell/Interpolants.cpp
@@ -91,7 +91,7 @@ VirtualIterator<Unit*> Interpolants::getParents(Unit* u)
 
 struct Interpolants::ItemState
 {
-  ItemState() {}
+  ItemState() : parCnt(0), inheritedColor(COLOR_INVALID), interpolant(0), leftInts(0), rightInts(0), processed(false), _us(nullptr), _usColor(COLOR_INVALID) {}
 
   ItemState(Unit* us) : parCnt(0), inheritedColor(COLOR_TRANSPARENT), interpolant(0),
       leftInts(0), rightInts(0), processed(false), _us(us)

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1086,12 +1086,9 @@ void NewCNF::processBoolterm(TermList ts, Occurrences &occurrences)
     case Term::SF_ITE: {
       Formula* condition = sd->getCondition();
 
-      Formula* branch[2];
-      for (SIDE side : { LEFT, RIGHT }) {
-        branch[side] = BoolTermFormula::create(*term->nthArgument(side));
-      }
-
-      processITE(condition, branch[LEFT], branch[RIGHT], occurrences);
+      Formula* left = BoolTermFormula::create(*term->nthArgument(LEFT));
+      Formula* right = BoolTermFormula::create(*term->nthArgument(RIGHT));
+      processITE(condition, left, right, occurrences);
       break;
     }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2587,7 +2587,7 @@ bool Options::RatioOptionValue::readRatio(const char* val, char separator)
       return false;
     }
     char copy[128];
-    strcpy(copy,val);
+    strncpy(copy,val,128);
     copy[colonIndex] = 0;
     int age;
     if (! Int::stringToInt(copy,age)) {
@@ -2738,7 +2738,7 @@ bool Options::TimeLimitOptionValue::setValue(const vstring& value)
   }
 
   char copy[128];
-  strcpy(copy,value.c_str());
+  strncpy(copy,value.c_str(),128);
   char* end = copy;
   // search for the end of the string for
   while (*end) {

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -57,6 +57,8 @@
 using namespace Lib;
 using namespace Shell;
 
+static const int COPY_SIZE = 128;
+
 /**
  * Initialize options to the default values.
  *
@@ -2583,11 +2585,11 @@ bool Options::RatioOptionValue::readRatio(const char* val, char separator)
   }
 
   if (found) {
-    if (strlen(val) > 127) {
+    if (strlen(val) >= COPY_SIZE) {
       return false;
     }
-    char copy[128];
-    strncpy(copy,val,128);
+    char copy[COPY_SIZE];
+    strncpy(copy,val,COPY_SIZE);
     copy[colonIndex] = 0;
     int age;
     if (! Int::stringToInt(copy,age)) {
@@ -2733,12 +2735,12 @@ bool Options::TimeLimitOptionValue::setValue(const vstring& value)
   CALL("Options::readTimeLimit");
 
   int length = value.size();
-  if (length == 0 || length > 127) {
+  if (length == 0 || length >= COPY_SIZE) {
     USER_ERROR((vstring)"wrong value for time limit: " + value);
   }
 
-  char copy[128];
-  strncpy(copy,value.c_str(),128);
+  char copy[COPY_SIZE];
+  strncpy(copy,value.c_str(),COPY_SIZE);
   char* end = copy;
   // search for the end of the string for
   while (*end) {

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -371,12 +371,12 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         #define THEN 0u
         #define ELSE 1u
 
-        TermList branches[2];
-        bool isTrue[2];
-        bool isFalse[2];
-        for (BRANCH branch : {THEN, ELSE }) {
-          branches[branch] = simplify(*term->nthArgument(branch));
-        }
+        TermList branches[2] = {
+          simplify(*term->nthArgument(THEN)),
+          simplify(*term->nthArgument(ELSE)),
+        };
+        bool isTrue[2] {};
+        bool isFalse[2] {};
 
         switch (condition->connective()) {
           case TRUE:

--- a/Shell/SimplifyProver.cpp
+++ b/Shell/SimplifyProver.cpp
@@ -325,7 +325,7 @@ void SimplifyProver::unbindVar(const vstring& varName)
   CALL("SimplifyProver::unbindVar");
 
   IntList* bindings = 0;
-  _variables.find(varName,bindings);
+  ALWAYS(_variables.find(varName,bindings));
   IntList* tl = bindings->tail();
   delete bindings;
   bindings = tl;
@@ -1501,7 +1501,7 @@ void SimplifyProver::undoLet()
     case K_FORMULA:
       {
 	Lib::List<Formula*>* binding;
-	_formulaLet.find(symb,binding);
+	ALWAYS(_formulaLet.find(symb,binding));
 	_formulaLet.replace(symb,binding->tail());
 	delete binding;
       }
@@ -1509,7 +1509,7 @@ void SimplifyProver::undoLet()
     case K_TERM:
       {
 	Lib::List<TermList>* binding;
-	_termLet.find(symb,binding);
+	ALWAYS(_termLet.find(symb,binding));
 	_termLet.replace(symb,binding->tail());
 	delete binding;
       }

--- a/Shell/TheoryFinder.cpp
+++ b/Shell/TheoryFinder.cpp
@@ -164,10 +164,10 @@ class TheoryFinder::Backtrack
 public:
   /** code pointer */
   unsigned cp;
-  /** object on which the instruction should be executed */
-  const void* obj;
   /** position in the object stack */
   unsigned objPos;
+  /** object on which the instruction should be executed */
+  const void* obj;
 }; // TheoryFinder::Backtrack
 
 bool TheoryFinder::matchCode(const void* obj,
@@ -217,6 +217,9 @@ bool TheoryFinder::matchCode(const void* obj,
   const Clause* clause;
   // the length of this clause
   int clength;
+#ifdef VDEBUG
+  bool clength_assigned = false;
+#endif
   // literal numbers to be matched by LIT i commands
   int literals[4];
 
@@ -407,6 +410,9 @@ bool TheoryFinder::matchCode(const void* obj,
     cout << "M: CLS: " << clause->toString() << endl;
 #endif
     clength = clause->length();
+#ifdef VDEBUG
+    clength_assigned = true;
+#endif
     cp++;
     goto match;
   }
@@ -418,6 +424,7 @@ bool TheoryFinder::matchCode(const void* obj,
 #endif
     unsigned l = code[cp+1];
     // bit field of choices for this literal
+    ASS(clength_assigned);
     unsigned choice = (1u << clength) - 1;
     for (int i = l-1;i >= 0;i--) {
       // remove from the choice literals already used


### PR DESCRIPTION
I ran the `clang-tidy` tool over Vampire. It discovered some false-positives, some fishy code, and some that look like bugs. This patches all of these: see comments in-line. The tree now compiles cleanly under `clang-tidy`, except for third-party code (minisat).