### PR TITLE
swap deprecated C-compatible headers for C++ equivalent

### DIFF
--- a/Debug/Assertion.cpp
+++ b/Debug/Assertion.cpp
@@ -21,7 +21,7 @@
  * Implements assertions.
  */
 
-#include <string.h>
+#include <cstring>
 
 #include "Assertion.hpp"
 #include "Tracer.hpp"

--- a/FMB/FiniteModel.cpp
+++ b/FMB/FiniteModel.cpp
@@ -24,7 +24,7 @@
  * @author Giles
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "Kernel/Term.hpp"
 #include "Kernel/Unit.hpp"

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -25,7 +25,7 @@
  *       so array[arity] is return and array[i] is the ith argument of the function
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "Kernel/Ordering.hpp"
 #include "Kernel/Inference.hpp"

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -24,7 +24,7 @@
  * @author Giles
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "Kernel/Term.hpp"
 #include "Kernel/Unit.hpp"

--- a/Kernel/FlatTerm.cpp
+++ b/Kernel/FlatTerm.cpp
@@ -22,7 +22,7 @@
  * Implements class FlatTerm.
  */
 
-#include <string.h>
+#include <cstring>
 
 #include "Lib/Allocator.hpp"
 #include "Lib/DArray.hpp"

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -21,7 +21,7 @@
  * Implements class Theory.
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "Debug/Assertion.hpp"
 #include "Debug/Tracer.hpp"

--- a/Lib/Exception.cpp
+++ b/Lib/Exception.cpp
@@ -22,7 +22,7 @@
  * @since 03/12/2003, Manchester
  */
 
-#include <string.h>
+#include <cstring>
 
 #include "Int.hpp"
 

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -7,7 +7,7 @@
 
 #include "Lib/Portability.hpp"
 
-#include <signal.h>
+#include <csignal>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/Lib/Sys/Semaphore.cpp
+++ b/Lib/Sys/Semaphore.cpp
@@ -6,7 +6,7 @@
 #include "Lib/Portability.hpp"
 
 #include <cerrno>
-#include <stdlib.h>
+#include <cstdlib>
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/ipc.h>

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -24,7 +24,7 @@
 
 #include "Portability.hpp"
 
-#include <stdlib.h>
+#include <cstdlib>
 #  include <unistd.h>
 #  if !__APPLE__ && !__CYGWIN__
 #    include <sys/prctl.h>

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -51,8 +51,8 @@ bool Timer::s_timeLimitEnforcement = true;
 
 #include <cerrno>
 #include <unistd.h>
-#include <stdlib.h>
-#include <signal.h>
+#include <cstdlib>
+#include <csignal>
 #include <sys/time.h>
 #include <sys/times.h>
 

--- a/Minisat/core/Solver.cc
+++ b/Minisat/core/Solver.cc
@@ -23,7 +23,7 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#include <math.h>
+#include <cmath>
 
 #include "Minisat/mtl/Alg.h"
 #include "Minisat/mtl/Sort.h"

--- a/Minisat/utils/System.cc
+++ b/Minisat/utils/System.cc
@@ -23,14 +23,14 @@ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 **************************************************************************************************/
 
-#include <signal.h>
-#include <stdio.h>
+#include <csignal>
+#include <cstdio>
 
 #include "Minisat/utils/System.h"
 
 #if defined(__linux__)
 
-#include <stdlib.h>
+#include <cstdlib>
 
 using namespace Minisat;
 

--- a/SAT/RestartStrategy.cpp
+++ b/SAT/RestartStrategy.cpp
@@ -21,7 +21,7 @@
  * Implements class RestartStrategy.
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "Debug/Assertion.hpp"
 #include "Debug/Tracer.hpp"

--- a/Saturation/AWPassiveClauseContainer.cpp
+++ b/Saturation/AWPassiveClauseContainer.cpp
@@ -22,7 +22,7 @@
  * @since 30/12/2007 Manchester
  */
 
-#include <math.h>
+#include <cmath>
 
 #include "Debug/RuntimeStatistics.hpp"
 

--- a/Shell/CommandLine.cpp
+++ b/Shell/CommandLine.cpp
@@ -23,8 +23,8 @@
  * @since 14/11/2004 Manchester
  */
 
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 
 #include "Debug/Assertion.hpp"
 #include "Debug/Tracer.hpp"

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -23,7 +23,7 @@
 
 #include <fstream>
 
-#include <stdlib.h>
+#include <cstdlib>
 #include <sys/types.h>
 #include <unistd.h>
 #include <iostream>


### PR DESCRIPTION
As of C++14, C-compatible headers (e.g. `<string.h>`) are deprecated in favour of their C++ equivalents (e.g. `<cstring>`). This replaces these. Very low-risk change.