### PR TITLE
add -Wall to CMake

### DIFF
--- a/CASC/CLTBMode.cpp
+++ b/CASC/CLTBMode.cpp
@@ -212,8 +212,9 @@ void CLTBMode::solveBatch(istream& batchFile, bool first,vstring inputDirectory)
     int resValue;
     // wait until the child terminates
     try {
-      pid_t finishedChild = Multiprocessing::instance()->waitForChildTermination(resValue);
-      ASS_EQ(finishedChild, child);
+      ALWAYS(
+        Multiprocessing::instance()->waitForChildTermination(resValue) == child
+      );
     }
     catch(SystemFailException& ex) {
       cerr << "% SystemFailException at batch level" << endl;

--- a/CASC/CLTBModeLearning.cpp
+++ b/CASC/CLTBModeLearning.cpp
@@ -227,8 +227,9 @@ void CLTBModeLearning::solveBatch(istream& batchFile, bool first,vstring inputDi
     int resValue;
     // wait until the child terminates
     try {
-      pid_t finishedChild = Multiprocessing::instance()->waitForChildTermination(resValue);
-      ASS_EQ(finishedChild, child);
+      ALWAYS(
+        Multiprocessing::instance()->waitForChildTermination(resValue) == child
+      );
     }
     catch(SystemFailException& ex) {
       cerr << "% SystemFailException at batch level" << endl;
@@ -360,8 +361,9 @@ void CLTBModeLearning::doTraining(int time, bool startup)
     }
     int resValue;
     try {
-      pid_t finishedChild = Multiprocessing::instance()->waitForChildTermination(resValue);
-      ASS_EQ(finishedChild, child);
+      ALWAYS(
+        Multiprocessing::instance()->waitForChildTermination(resValue) == child
+      );
     }
     catch(SystemFailException& ex) {
       cerr << "% SystemFailException at batch level" << endl;

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -417,10 +417,8 @@ bool PortfolioMode::waitForChildAndCheckIfProofFound()
   ASS(!childIds.isEmpty());
 
   int resValue;
-#if VDEBUG
-  pid_t finishedChild =
-#endif
-  Multiprocessing::instance()->waitForChildTermination(resValue);
+  DEBUG_CODE(pid_t finishedChild =)
+    Multiprocessing::instance()->waitForChildTermination(resValue);
   ASS(childIds.remove(finishedChild));
   if (!resValue) {
     // we have found the proof. It has been already written down by the writer child,

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -417,10 +417,11 @@ bool PortfolioMode::waitForChildAndCheckIfProofFound()
   ASS(!childIds.isEmpty());
 
   int resValue;
-  pid_t finishedChild = Multiprocessing::instance()->waitForChildTermination(resValue);
 #if VDEBUG
-  ALWAYS(childIds.remove(finishedChild));
+  pid_t finishedChild =
 #endif
+  Multiprocessing::instance()->waitForChildTermination(resValue);
+  ASS(childIds.remove(finishedChild));
   if (!resValue) {
     // we have found the proof. It has been already written down by the writer child,
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -760,7 +760,7 @@ endif()
 
 # configure warning flags
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
-#  target_compile_options(vampire PRIVATE -Wall)
+  target_compile_options(vampire PRIVATE -Wall)
 endif()
 
 ################################################################

--- a/DP/SimpleCongruenceClosure.cpp
+++ b/DP/SimpleCongruenceClosure.cpp
@@ -128,7 +128,7 @@ void SimpleCongruenceClosure::ConstInfo::resetEquivalences(SimpleCongruenceClosu
   }
 }
 
-#ifdef VDEBUG
+#if VDEBUG
 
 void SimpleCongruenceClosure::ConstInfo::assertValid(SimpleCongruenceClosure& parent, unsigned selfIndex) const
 {
@@ -1105,7 +1105,7 @@ void SimpleCongruenceClosure::getModel(LiteralStack& model)
   DEBUG_CODE( assertModelInfoClean(); );  
 }
 
-#ifdef VDEBUG
+#if VDEBUG
 void SimpleCongruenceClosure::assertModelInfoClean() const
 {
   CALL("SimpleCongruenceClosure::assertModelInfoClean");

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -183,7 +183,7 @@ private:
     void init();
     void resetEquivalences(SimpleCongruenceClosure& parent, unsigned selfIndex);
 
-#ifdef VDEBUG
+#if VDEBUG
     void assertValid(SimpleCongruenceClosure& parent, unsigned selfIndex) const;
 #endif
 
@@ -254,7 +254,7 @@ private:
   typedef DHMap<unsigned,TermList> NFMap;
   void computeConstsNormalForm(unsigned c, NFMap& normalForms);
   
-#ifdef VDEBUG
+#if VDEBUG
   void assertModelInfoClean() const;
 #endif  
   

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1491,9 +1491,9 @@ SATLiteral FiniteModelBuilder::getSATLiteral(unsigned f, const DArray<unsigned>&
   // cannot have predicate 0 here (it's equality)
   ASS(f>0 || isFunction);
 
-#if VDEBUG
-  unsigned arity = isFunction ? env.signature->functionArity(f) : env.signature->predicateArity(f);
-#endif
+  DEBUG_CODE(
+    unsigned arity = isFunction ? env.signature->functionArity(f) : env.signature->predicateArity(f)
+  );
   ASS((isFunction && arity==grounding.size()-1) || (!isFunction && arity==grounding.size()));
 
   unsigned offset = isFunction ? f_offsets[f] : p_offsets[f];

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1491,7 +1491,9 @@ SATLiteral FiniteModelBuilder::getSATLiteral(unsigned f, const DArray<unsigned>&
   // cannot have predicate 0 here (it's equality)
   ASS(f>0 || isFunction);
 
+#if VDEBUG
   unsigned arity = isFunction ? env.signature->functionArity(f) : env.signature->predicateArity(f);
+#endif
   ASS((isFunction && arity==grounding.size()-1) || (!isFunction && arity==grounding.size()));
 
   unsigned offset = isFunction ? f_offsets[f] : p_offsets[f];

--- a/Indexing/AcyclicityIndex.cpp
+++ b/Indexing/AcyclicityIndex.cpp
@@ -208,7 +208,6 @@ namespace Indexing
                         AcyclicityIndex& aindex)
       :
       _queryLit(queryLit),
-      _queryClause(queryClause),
       _nextResult(nullptr),
       _stack(0),
       _subst(new RobSubstitution()),
@@ -395,7 +394,6 @@ namespace Indexing
     }
   private:
     Literal *_queryLit;
-    Clause *_queryClause;
     SIndex *_index;
     TermIndexingStructure *_tis;    
     CycleQueryResult *_nextResult;

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -798,12 +798,14 @@ public:
     InstMatcher* _subst;
 
     Renaming _resultDenormalizer;
-    SubstitutionTree* _tree;
     Node* _root;
 
     Stack<void*> _alternatives;
     Stack<unsigned> _specVarNumbers;
     Stack<NodeAlgorithm> _nodeTypes;
+#if VDEBUG
+    SubstitutionTree* _tree;
+#endif
   };
 
 class SubstitutionTreeMismatchHandler : public UWAMismatchHandler 

--- a/Indexing/SubstitutionTree_FastInst.cpp
+++ b/Indexing/SubstitutionTree_FastInst.cpp
@@ -553,8 +553,11 @@ finish:
 SubstitutionTree::FastInstancesIterator::FastInstancesIterator(SubstitutionTree* parent, Node* root,
 	Term* query, bool retrieveSubstitution, bool reversed, bool withoutTop, bool useC)
 : _literalRetrieval(query->isLiteral()), _retrieveSubstitution(retrieveSubstitution),
-  _inLeaf(false), _ldIterator(LDIterator::getEmpty()), _tree(parent),  _root(root),
+  _inLeaf(false), _ldIterator(LDIterator::getEmpty()),  _root(root),
   _alternatives(64), _specVarNumbers(64), _nodeTypes(64)
+#if VDEBUG
+  , _tree(parent)
+#endif 
 {
   CALL("SubstitutionTree::FastInstancesIterator::FastGeneralizationsIterator");
   ASS(root);

--- a/Indexing/TermSubstitutionTree.cpp
+++ b/Indexing/TermSubstitutionTree.cpp
@@ -294,7 +294,11 @@ struct TermSubstitutionTree::LeafToLDIteratorFn
 struct TermSubstitutionTree::UnifyingContext
 {
   UnifyingContext(TermList queryTerm,bool withConstraints)
-  : _queryTerm(queryTerm),_withConstraints(withConstraints) {}
+  : _queryTerm(queryTerm)
+#if VDEBUG
+    , _withConstraints(withConstraints)
+#endif
+  {}
   bool enter(TermQueryResult qr)
   {
     //if(_withConstraints){ cout << "enter " << qr.term << endl; }
@@ -360,7 +364,9 @@ struct TermSubstitutionTree::UnifyingContext
   }
 private:
   TermList _queryTerm;
+#if VDEBUG
   bool _withConstraints;
+#endif
 };
 
 template<class LDIt>

--- a/Inferences/ForwardSubsumptionAndResolution.cpp
+++ b/Inferences/ForwardSubsumptionAndResolution.cpp
@@ -293,8 +293,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
 	//we've already checked this clause
 	continue;
       }
-      unsigned mlen=mcl->length();
-      ASS_G(mlen,1);
+      ASS_G(mcl->length(),1);
 
       ClauseMatches* cms=new ClauseMatches(mcl);
       mcl->setAux(cms);

--- a/Inferences/InterpretedEvaluation.cpp
+++ b/Inferences/InterpretedEvaluation.cpp
@@ -51,8 +51,10 @@ using namespace Kernel;
 
 
 InterpretedEvaluation::InterpretedEvaluation(bool doNormalize, Ordering& ordering) :
-  _simpl(new InterpretedLiteralEvaluator(doNormalize)),
-  _ordering(ordering)
+  _simpl(new InterpretedLiteralEvaluator(doNormalize))
+#if VDEBUG
+  , _ordering(ordering)
+#endif
 {
   CALL("InterpretedEvaluation::InterpretedEvaluation");
 }

--- a/Inferences/InterpretedEvaluation.hpp
+++ b/Inferences/InterpretedEvaluation.hpp
@@ -51,7 +51,9 @@ private:
   bool simplifyLiteral(Literal* lit, bool& constant, Literal*& res, bool& constantTrue,Stack<Literal*>& sideConditions);
 
   InterpretedLiteralEvaluator* _simpl;
+#if VDEBUG
   Ordering& _ordering;
+#endif
 };
 
 };

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -336,8 +336,10 @@ void TheoryInstAndSimp::selectTheoryLiterals(Clause* cl, Stack<Literal*>& theory
   cout << "selectTheoryLiterals in " << cl->toString() << endl;
 #endif
 
-  static Shell::Options::TheoryInstSimp selection = env.options->theoryInstAndSimp();
-  ASS(selection!=Shell::Options::TheoryInstSimp::OFF);
+  ASS_NEQ(
+    env.options->theoryInstAndSimp(),
+    Shell::Options::TheoryInstSimp::OFF
+  );
 
   //  Stack<Literal*> pure_lits;
   Stack<Literal*> trivial_lits;

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -731,10 +731,10 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*>& theor
 
 struct InstanceFn
 {
-  InstanceFn(Clause* premise,Clause* cl, Stack<Literal*>& tl,Splitter* splitter,
-             SaturationAlgorithm* salg, TheoryInstAndSimp* parent,bool& red) :
-         _premise(premise),  _cl(cl), _theoryLits(tl), _splitter(splitter),
-         _salg(salg), _parent(parent), _red(red) {}
+  InstanceFn(Clause* cl, Stack<Literal*>& tl,Splitter* splitter,
+             TheoryInstAndSimp* parent,bool& red) :
+          _cl(cl), _theoryLits(tl), _splitter(splitter),
+         _parent(parent), _red(red) {}
 
   DECL_RETURN_TYPE(Clause*);
   OWN_RETURN_TYPE operator()(Solution sol)
@@ -826,11 +826,9 @@ partial_check_end:
   }
 
 private:
-  Clause* _premise;
   Clause* _cl;
   Stack<Literal*>& _theoryLits;
   Splitter* _splitter;
-  SaturationAlgorithm* _salg;
   TheoryInstAndSimp* _parent;
   bool& _red;
 };
@@ -907,7 +905,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
     auto it1 = getSolutions(selectedLiterals);
 
     auto it2 = getMappingIterator(it1,
-               InstanceFn(premise,flattened,selectedLiterals,_splitter,_salg,this,premiseRedundant));
+               InstanceFn(flattened,selectedLiterals,_splitter,this,premiseRedundant));
 
     // filter out only non-zero results
     auto it3 = getFilteredIterator(it2, NonzeroFn());

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -702,10 +702,8 @@ void MLMatcher::Impl::getBindings(vunordered_map<unsigned, TermList>& outBinding
       // md->boundVarNums[bi] contains the corresponding variable indices.
       unsigned var = md->boundVarNums[bi][vi];
       TermList trm = md->altBindings[bi][alti][vi];
-#if VDEBUG
-      auto res =
-#endif
-      outBindings.insert({var, trm});
+
+      DEBUG_CODE(auto res =) outBindings.insert({var, trm});
 #if VDEBUG
       auto it = res.first;
       bool inserted = res.second;

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -702,12 +702,17 @@ void MLMatcher::Impl::getBindings(vunordered_map<unsigned, TermList>& outBinding
       // md->boundVarNums[bi] contains the corresponding variable indices.
       unsigned var = md->boundVarNums[bi][vi];
       TermList trm = md->altBindings[bi][alti][vi];
-      auto res = outBindings.insert({var, trm});
+#if VDEBUG
+      auto res =
+#endif
+      outBindings.insert({var, trm});
+#if VDEBUG
       auto it = res.first;
       bool inserted = res.second;
       if (!inserted) {
         ASS_EQ(it->second, trm);
       }
+#endif
     }
   }
 }

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -1149,12 +1149,17 @@ void MLMatcherSD::Impl::getBindings(vunordered_map<unsigned, TermList>& outBindi
         // md->boundVarNums[bi] contains the corresponding variable indices.
         unsigned var = md->boundVarNums[bi][vi];
         TermList trm = md->altBindings[bi][alti][vi];
-        auto res = outBindings.insert({var, trm});
+#if VDEBUG
+	auto res =
+#endif 
+        outBindings.insert({var, trm});
+#if VDEBUG
         auto it = res.first;
         bool inserted = res.second;
         if (!inserted) {
           ASS_EQ(it->second, trm);
         }
+#endif
       }
     }
   }

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -1149,10 +1149,8 @@ void MLMatcherSD::Impl::getBindings(vunordered_map<unsigned, TermList>& outBindi
         // md->boundVarNums[bi] contains the corresponding variable indices.
         unsigned var = md->boundVarNums[bi][vi];
         TermList trm = md->altBindings[bi][alti][vi];
-#if VDEBUG
-	auto res =
-#endif 
-        outBindings.insert({var, trm});
+
+	DEBUG_CODE(auto res =) outBindings.insert({var, trm});
 #if VDEBUG
         auto it = res.first;
         bool inserted = res.second;

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -435,10 +435,10 @@ void Problem::collectPredicates(Stack<unsigned>& acc) const
   }
 }
 
+#if VDEBUG
 ///////////////////////
 // debugging
 //
-
 void Problem::assertValid()
 {
   CALL("Problem::assertValid");
@@ -449,3 +449,4 @@ void Problem::assertValid()
     ASSERT_VALID(*u);
   }
 }
+#endif

--- a/Kernel/Problem.hpp
+++ b/Kernel/Problem.hpp
@@ -194,9 +194,10 @@ public:
   void collectPredicates(Stack<unsigned>& acc) const;
 
 
+#if VDEBUG
   //debugging functions
-
   void assertValid();
+#endif
 
 private:
 

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1267,8 +1267,7 @@ void SMTLIB2::parseLetBegin(LExpr* exp)
   LispListReader lRdr(exp->list);
 
   // the let atom
-  const vstring& theLetAtom = lRdr.readAtom();
-  ASS_EQ(theLetAtom,LET);
+  ALWAYS(lRdr.readAtom() == LET);
 
   // now, there should be a list of bindings
   LExprList* bindings = lRdr.readList();
@@ -1315,8 +1314,7 @@ void SMTLIB2::parseLetPrepareLookup(LExpr* exp)
   // so we know it is let
   ASS(exp->isList());
   LispListReader lRdr(exp->list);
-  const vstring& theLetAtom = lRdr.readAtom();
-  ASS_EQ(theLetAtom,LET);
+  ALWAYS(lRdr.readAtom() == LET);
 
   // with a list of bindings
   LispListReader bindRdr(lRdr.readList());
@@ -1365,7 +1363,10 @@ void SMTLIB2::parseLetEnd(LExpr* exp)
   // so we know it is let
   ASS(exp->isList());
   LispListReader lRdr(exp->list);
-  const vstring& theLetAtom = lRdr.readAtom();
+#if VDEBUG
+  const vstring& theLetAtom =
+#endif
+  lRdr.readAtom();
   ASS_EQ(getBuiltInTermSymbol(theLetAtom),TS_LET);
 
   // with a list of bindings
@@ -1418,7 +1419,10 @@ void SMTLIB2::parseQuantBegin(LExpr* exp)
   LispListReader lRdr(exp->list);
 
   // the quant atom
-  const vstring& theQuantAtom = lRdr.readAtom();
+#if VDEBUG
+  const vstring& theQuantAtom =
+#endif
+  lRdr.readAtom();
   ASS(theQuantAtom == FORALL || theQuantAtom == EXISTS);
 
   // there should next be a list of sorted variables
@@ -1457,8 +1461,7 @@ void SMTLIB2::parseAnnotatedTerm(LExpr* exp)
   LispListReader lRdr(exp->list);
 
   // the exclamation atom
-  const vstring& theExclAtom = lRdr.readAtom();
-  ASS_EQ(theExclAtom,EXCLAMATION);
+  ALWAYS(lRdr.readAtom() == EXCLAMATION)
 
   LExpr* toParse = 0;
   if(lRdr.peekAtNext()->isAtom()){ 

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1363,10 +1363,8 @@ void SMTLIB2::parseLetEnd(LExpr* exp)
   // so we know it is let
   ASS(exp->isList());
   LispListReader lRdr(exp->list);
-#if VDEBUG
-  const vstring& theLetAtom =
-#endif
-  lRdr.readAtom();
+  DEBUG_CODE(const vstring& theLetAtom =)
+    lRdr.readAtom();
   ASS_EQ(getBuiltInTermSymbol(theLetAtom),TS_LET);
 
   // with a list of bindings
@@ -1419,10 +1417,8 @@ void SMTLIB2::parseQuantBegin(LExpr* exp)
   LispListReader lRdr(exp->list);
 
   // the quant atom
-#if VDEBUG
-  const vstring& theQuantAtom =
-#endif
-  lRdr.readAtom();
+  DEBUG_CODE(const vstring& theQuantAtom =)
+    lRdr.readAtom();
   ASS(theQuantAtom == FORALL || theQuantAtom == EXISTS);
 
   // there should next be a list of sorted variables

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -71,9 +71,7 @@ public:
 
   virtual unsigned newVar() override {
     CALL("MinimizingSolver::newVar");
-#if VDEBUG
-    unsigned oldVC = _varCnt;
-#endif
+    DEBUG_CODE(unsigned oldVC = _varCnt);
     ensureVarCount(_varCnt+1);
     ASS_EQ(_varCnt,oldVC+1);
     return _varCnt;

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -71,7 +71,9 @@ public:
 
   virtual unsigned newVar() override {
     CALL("MinimizingSolver::newVar");
+#if VDEBUG
     unsigned oldVC = _varCnt;
+#endif
     ensureVarCount(_varCnt+1);
     ASS_EQ(_varCnt,oldVC+1);
     return _varCnt;

--- a/SAT/TWLSolver.cpp
+++ b/SAT/TWLSolver.cpp
@@ -1154,10 +1154,8 @@ void TWLSolver::assertValid()
 
   Stack<USRec>::Iterator uit(_unitStack);
   while(uit.hasNext()) {
-#if VDEBUG
-    USRec rec =
-#endif
-    uit.next();
+    DEBUG_CODE(USRec rec =)
+      uit.next();
     ASS_NEQ(_assignment[rec.var], AS_UNDEFINED);
   }
 }

--- a/SAT/TWLSolver.cpp
+++ b/SAT/TWLSolver.cpp
@@ -1154,7 +1154,10 @@ void TWLSolver::assertValid()
 
   Stack<USRec>::Iterator uit(_unitStack);
   while(uit.hasNext()) {
-    USRec rec=uit.next();
+#if VDEBUG
+    USRec rec =
+#endif
+    uit.next();
     ASS_NEQ(_assignment[rec.var], AS_UNDEFINED);
   }
 }

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -242,7 +242,7 @@ SATSolver::VarAssignment Z3Interfacing::getAssignment(unsigned var)
 
   // with model_completion true (see above), there should be no don't-knows
 
-#ifdef VDEBUG
+#if VDEBUG
   // This is actually not a problem for AVATAR in release (see recomputeModel in Splitter.cpp)
   ASSERTION_VIOLATION_REP(assignment);
 #endif
@@ -861,10 +861,10 @@ SATClause* Z3Interfacing::getRefutation() {
       solver.add(z3clause,p.c_str());
       lookup.insert(p,cl);
     }
-  
-    z3::check_result result = solver.check();
-    ASS_EQ(result,z3::check_result::unsat);   // the new version of Z3 does not suppot unsat-cores?
-  
+
+    // the new version of Z3 does not suppot unsat-cores?
+    ALWAYS(solver.check() == z3::check_result::unsat);
+
     SATClauseList* prems = 0;
 
     z3::expr_vector  core = solver.unsat_core();

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -453,7 +453,7 @@ SATSolver::Status SplittingBranchSelector::processDPConflicts()
   if (_ccModel) {
     TimeCounter tc(TC_CCMODEL);
 
-#ifdef VDEBUG
+#if VDEBUG
     // to keep track of SAT variables introduce just for the sake of the latest call to _ccModel
     lastCheckedVar = _parent.maxSatVar();
 #endif

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -120,7 +120,7 @@ private:
    */
   ArraySet _trueInCCModel;
 
-#ifdef VDEBUG
+#if VDEBUG
   unsigned lastCheckedVar;
 #endif
 };

--- a/Shell/Interpolants.cpp
+++ b/Shell/Interpolants.cpp
@@ -506,8 +506,7 @@ void Interpolants::generateInterpolant(ItemState& st)
 
   TRACE(cout << "GenerateInterpolant for " << u->toString() << endl);
 
-  Color color=st.usColor();
-  ASS_EQ(color, COLOR_TRANSPARENT);
+  ASS_EQ(st.usColor(), COLOR_TRANSPARENT);
 
   Formula* interpolant;
   Formula* unitFormula=u->getFormula();//st.us().prop());

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2125,8 +2125,7 @@ void Options::copyValuesFrom(const Options& that)
     if(opt->shouldCopy()){
       AbstractOptionValue* other = that.getOptionValueByName(opt->longName);
       ASS(opt!=other);
-      bool status = opt -> set(other->getStringOfActual());
-      ASS(status);
+      ALWAYS(opt->set(other->getStringOfActual()));
     }
   }
 }


### PR DESCRIPTION
Add "all warnings" in GCC/Clang and compile cleanly with them. Bonus: remove some unused private member variables.