### PR TITLE
fix deprecated C-compatible system headers in Vampire headers

### DIFF
--- a/Debug/RuntimeStatistics.hpp
+++ b/Debug/RuntimeStatistics.hpp
@@ -89,7 +89,7 @@ square's last digit:
 */
 
 
-#include <string.h>
+#include <cstring>
 #include <ostream>
 
 #include "Lib/Array.hpp"

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -24,7 +24,7 @@
 #ifndef __Induction__
 #define __Induction__
 
-#include <math.h>
+#include <cmath>
 
 #include "Forwards.hpp"
 

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -24,7 +24,7 @@
 #ifndef __Theory__
 #define __Theory__
 
-#include <math.h>
+#include <cmath>
 
 #include "Forwards.hpp"
 

--- a/Lib/BitUtils.hpp
+++ b/Lib/BitUtils.hpp
@@ -25,7 +25,7 @@
 #ifndef __BitUtils__
 #define __BitUtils__
 
-#include <string.h>
+#include <cstring>
 
 #include "Lib/Portability.hpp"
 

--- a/Minisat/core/SolverTypes.h
+++ b/Minisat/core/SolverTypes.h
@@ -27,7 +27,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_SolverTypes_h
 #define Minisat_SolverTypes_h
 
-#include <assert.h>
+#include <cassert>
 
 #include "Minisat/mtl/IntTypes.h"
 #include "Minisat/mtl/Alg.h"

--- a/Minisat/mtl/IntTypes.h
+++ b/Minisat/mtl/IntTypes.h
@@ -35,12 +35,12 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 #else
 
-#   include <stdint.h>
-#   include <inttypes.h>
+#   include <cstdint>
+#   include <cinttypes>
 
 #endif
 
-#include <limits.h>
+#include <climits>
 
 //=================================================================================================
 

--- a/Minisat/mtl/Vec.h
+++ b/Minisat/mtl/Vec.h
@@ -26,7 +26,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_Vec_h
 #define Minisat_Vec_h
 
-#include <assert.h>
+#include <cassert>
 #include <limits>
 #include <new>
 

--- a/Minisat/mtl/XAlloc.h
+++ b/Minisat/mtl/XAlloc.h
@@ -26,8 +26,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_XAlloc_h
 #define Minisat_XAlloc_h
 
-#include <errno.h>
-#include <stdlib.h>
+#include <cerrno>
+#include <cstdlib>
 
 #include "Lib/Allocator.hpp"
 

--- a/Minisat/utils/Options.h
+++ b/Minisat/utils/Options.h
@@ -25,10 +25,10 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_Options_h
 #define Minisat_Options_h
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cmath>
+#include <cstring>
 
 #include "Minisat/mtl/IntTypes.h"
 #include "Minisat/mtl/Vec.h"

--- a/Minisat/utils/ParseUtils.h
+++ b/Minisat/utils/ParseUtils.h
@@ -26,8 +26,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_ParseUtils_h
 #define Minisat_ParseUtils_h
 
-#include <stdlib.h>
-#include <stdio.h>
+#include <cstdlib>
+#include <cstdio>
 
 #include "Minisat/mtl/XAlloc.h"
 

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -24,7 +24,7 @@
 #define __MinisatInterfacingNewSimp__
 
 // For limitMemory
-#include <signal.h>
+#include <csignal>
 #include <sys/time.h>
 #include <sys/resource.h>
 


### PR DESCRIPTION
Seems in #162 I forgot to change the includes within Vampire's header files as well.