### PR TITLE
Run CI automatically when a pull request is created or updated.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,8 @@
 name: CI
-on: [workflow_dispatch]
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:
@@ -10,7 +13,7 @@ jobs:
       run: mkdir ${{runner.workspace}}/build
     - name: Configure Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug
       env:
         CXX: clang++
     - name: Build

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: debug-build
+name: CI
 on: [workflow_dispatch]
 
 jobs:
@@ -10,7 +10,9 @@ jobs:
       run: mkdir ${{runner.workspace}}/build
     - name: Configure Build
       working-directory: ${{runner.workspace}}/build
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Debug
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=Release
+      env:
+        CXX: clang++
     - name: Build
       working-directory: ${{runner.workspace}}/build
-      run: make
+      run: make -j8


### PR DESCRIPTION
This PR runs a build whenever a new pull request is made, an old one is reopened, or new code is pushed. The build can still be scheduled manually.