### PR TITLE
silence static analysis warnings in Minisat

### DIFF
--- a/Minisat/core/Solver.cc
+++ b/Minisat/core/Solver.cc
@@ -924,6 +924,8 @@ bool Solver::implies(const vec<Lit>& assumps, vec<Lit>& out)
 
 static Var mapVar(Var x, vec<Var>& map, Var& max)
 {
+    // bug here on overflow - should be unlikely
+    assert(x + 1 > 0);
     if (map.size() <= x || map[x] == -1){
         map.growTo(x+1, -1);
         map[x] = max++;

--- a/Minisat/core/Solver.h
+++ b/Minisat/core/Solver.h
@@ -39,6 +39,8 @@ namespace Minisat {
 //=================================================================================================
 // Solver -- the main class:
 
+// field layout is pretty bad here, but it doesn't really matter
+// NOLINTNEXTLINE(clang-analyzer-optin.performance.Padding)
 class Solver {
 public:
 

--- a/Minisat/mtl/Queue.h
+++ b/Minisat/mtl/Queue.h
@@ -55,7 +55,9 @@ public:
         buf[end++] = elem;
         if (end == buf.size()) end = 0;
         if (first == end){  // Resize:
-            vec<T>  tmp((buf.size()*3 + 1) >> 1);
+            int tmp_size = (buf.size()*3 + 1) >> 1;
+            assert(tmp_size > 0);
+            vec<T> tmp(tmp_size);
             //**/printf("queue alloc: %d elems (%.1f MB)\n", tmp.size(), tmp.size() * sizeof(T) / 1000000.0);
             int     i = 0;
             for (int j = first; j < buf.size(); j++) tmp[i++] = buf[j];

--- a/Minisat/simp/SimpSolver.cc
+++ b/Minisat/simp/SimpSolver.cc
@@ -371,7 +371,7 @@ void SimpSolver::gatherTouchedClauses()
     if (n_touched == 0) return;
 
     int i,j;
-    for (i = j = 0; i < subsumption_queue.size(); i++)
+    for (i = 0; i < subsumption_queue.size(); i++)
         if (ca[subsumption_queue[i]].mark() == 0)
             ca[subsumption_queue[i]].mark(2);
 


### PR DESCRIPTION
Following on from #160, this fixes some warnings in Minisat since we have our own version of this now. There's one dead-store and two instances where an edge case would cause a null dereference (although I don't think the edge case is ever triggered).