### PR TITLE
add experimental LTO support to the CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,19 @@ endif()
 # statically link libraries
 option(BUILD_SHARED_LIBS "Build an executable dynamically linking to libraries instead of a statically-linked one (static not working on Mac)" ON)
 if (NOT BUILD_SHARED_LIBS)
-  SET(CMAKE_FIND_LIBRARY_SUFFIXES .a)
-  SET(CMAKE_EXE_LINKER_FLAGS -static)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a)
+  set(CMAKE_EXE_LINKER_FLAGS -static)
   set(VAMPIRE_BINARY_STATIC _static)
+endif()
+
+option(LTO "If supported, build with link-time optimisation." OFF)
+# check whether LTO is available
+include(CheckIPOSupported)
+check_ipo_supported(RESULT LTO_SUPPORTED OUTPUT LTO_ERROR)
+if (LTO_SUPPORTED)
+  message(STATUS "LTO supported")
+else()
+  message(STATUS "LTO not supported: ${LTO_ERROR}")
 endif()
 
 ################################################################
@@ -902,6 +912,14 @@ else()
 endif()
 set(VAMPIRE_BINARY "vampire${VAMPIRE_BINARY_Z3}${VAMPIRE_BINARY_BUILD}${VAMPIRE_BINARY_STATIC}${VAMPIRE_BINARY_BRANCH}${VAMPIRE_BINARY_REV_COUNT}")
 message(STATUS "Setting binary name to '${VAMPIRE_BINARY}'")
+
+################################################################
+# link-time optimisation
+################################################################
+if(CMAKE_BUILD_TYPE STREQUAL Release AND LTO)
+  message(STATUS "compiling with LTO")
+  set_property(TARGET vampire PROPERTY INTERPROCEDURAL_OPTIMIZATION true)
+endif()
 
 ################################################################
 # epilogue

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,14 @@ if (NOT BUILD_SHARED_LIBS)
   set(VAMPIRE_BINARY_STATIC _static)
 endif()
 
-option(LTO "If supported, build with link-time optimisation." OFF)
-# check whether LTO is available
+option(IPO "If supported, build with link-time optimisation." OFF)
+# check whether IPO is available
 include(CheckIPOSupported)
-check_ipo_supported(RESULT LTO_SUPPORTED OUTPUT LTO_ERROR)
-if (LTO_SUPPORTED)
-  message(STATUS "LTO supported")
+check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
+if (IPO_SUPPORTED)
+  message(STATUS "IPO supported")
 else()
-  message(STATUS "LTO not supported: ${LTO_ERROR}")
+  message(STATUS "IPO not supported: ${IPO_ERROR}")
 endif()
 
 ################################################################
@@ -916,8 +916,8 @@ message(STATUS "Setting binary name to '${VAMPIRE_BINARY}'")
 ################################################################
 # link-time optimisation
 ################################################################
-if(CMAKE_BUILD_TYPE STREQUAL Release AND LTO)
-  message(STATUS "compiling with LTO")
+if(CMAKE_BUILD_TYPE STREQUAL Release AND IPO)
+  message(STATUS "compiling with IPO")
   set_property(TARGET vampire PROPERTY INTERPROCEDURAL_OPTIMIZATION true)
 endif()
 


### PR DESCRIPTION
Link-time optimisation ought to make a difference to Vampire's overall performance, but this is an unknown quantity and needs tweaking and testing. This adds a flag to the CMake build to allow experimentation with LTO. The build seems to work, but takes around a minute to link.