### PR TITLE
stop suppressing compiler warnings about exceptions

### DIFF
--- a/Debug/Assertion.hpp
+++ b/Debug/Assertion.hpp
@@ -25,25 +25,6 @@
 #ifndef __Assertion__
 #define __Assertion__
 
-#define __PUSH_DIAGNOSTICS(diag, ...) \
-    _Pragma("GCC diagnostic push") \
-    _Pragma(diag) \
-    __VA_ARGS__ \
-    _Pragma("GCC diagnostic pop") \
-
-#ifdef __clang__
-#  define __IGNORE_ASSERTION_WARNINGS(...) __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wexceptions\"", __VA_ARGS__)
-#else // __clang__
-//#  define __IGNORE_ASSERTION_WARNINGS(...)   __VA_ARGS__
-#  define __IGNORE_ASSERTION_WARNINGS(...)   \
-    __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wterminate\"", \
-    __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wterminate\"", \
-    __VA_ARGS__ \
-    ))
-#endif // __clang__
-
-//#undef CONCAT
-
 #if VDEBUG
 
 #include <iostream>
@@ -129,21 +110,20 @@ private:
 #define ASS(Cond)                                               \
   if (! (Cond)) {                                               \
     Debug::Assertion::violated(__FILE__,__LINE__,#Cond);		\
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   }
 
 #define ASS_REP(Cond, ReportedVal)                                      \
   if (! (Cond)) {                                               \
     Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   }
 
 #define ASS_REP2(Cond, ReportedVal, ReportedVal2)               \
   if (! (Cond)) {                                               \
     Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal,ReportedVal2,#ReportedVal2); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   }
-
 
 #define ALWAYS(Cond) ASS(Cond)
 #define NEVER(Cond) ASS(!(Cond))
@@ -152,44 +132,44 @@ private:
 #define ASS_EQ(VAL1,VAL2)                                               \
   if (! ((VAL1)==(VAL2)) ) {                                               \
     Debug::Assertion::violatedEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2); \
-    __IGNORE_ASSERTION_WARNINGS( throw Debug::AssertionViolationException(__FILE__,__LINE__);)  \
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);  \
   } \
 
 #define ASS_NEQ(VAL1,VAL2)                                               \
   if (! ((VAL1)!=(VAL2)) ) {                                               \
     Debug::Assertion::violatedNonequality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   } \
 
 #define ASS_STR_EQ(VAL1,VAL2)                                               \
   if (strcmp((VAL1),(VAL2)) ) {                                               \
     Debug::Assertion::violatedStrEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);	)\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   } \
 
 
 #define ASS_G(VAL1,VAL2)                                               \
   if (! ((VAL1)>(VAL2)) ) {                                               \
     Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,true); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   } \
 
 #define ASS_L(VAL1,VAL2)                                               \
   if (! ((VAL1)<(VAL2)) ) {                                               \
     Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,false); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   } \
 
 #define ASS_GE(VAL1,VAL2)                                               \
   if (! ((VAL1)>=(VAL2)) ) {                                               \
     Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,true); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   } \
 
 #define ASS_LE(VAL1,VAL2)                                               \
   if (! ((VAL1)<=(VAL2)) ) {                                               \
     Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,false); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   } \
 
 #define ASS_ALLOC_TYPE(PTR,TYPE)						\
@@ -198,16 +178,16 @@ private:
 #define ASS_METHOD(OBJ,METHOD)							\
   if (! ((OBJ).METHOD) ) {							\
     Debug::Assertion::violatedMethod(__FILE__,__LINE__,(OBJ), #OBJ, #METHOD,"");\
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
+    throw Debug::AssertionViolationException(__FILE__,__LINE__);	\
   }
 
 #define ASSERT_VALID(obj) try { (obj).assertValid(); } catch(...) \
   { Debug::Assertion::reportAssertValidException(__FILE__,__LINE__,#obj); \
-    __IGNORE_ASSERTION_WARNINGS(throw;) }
+    throw; }
 
 #define ASSERTION_VIOLATION \
   Debug::Assertion::violated(__FILE__,__LINE__,"true");		\
-  __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);) \
+  throw Debug::AssertionViolationException(__FILE__,__LINE__); \
 
 #define ASSERTION_VIOLATION_REP(Val) \
   ASS_REP(false, Val)
@@ -230,8 +210,6 @@ private:
 #endif
 
 #define DEBUG_CODE(X)
-
-#define __IGNORE_WUNUSED(...) __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wreturn-type\"", __VA_ARGS__)
 
 #define ASS(Cond) 
 #define ALWAYS(Cond) (void) ( Cond );
@@ -403,4 +381,3 @@ void Debug::Assertion::violatedMethod(const char* file,int line,const T& obj,
 #endif
 
 #endif // __Assertion__
-

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -657,7 +657,6 @@ CodeTree::~CodeTree()
       }
       
       FixedSearchStruct* ss = static_cast<FixedSearchStruct*> (top_op->getSearchStruct());
-      ASS(ss->isFixedSearchStruct());      
       for (size_t i = 0; i < ss->length; i++) {
         if (ss->targets[i]!=0) { // zeros are allowed as targets (they are holes after removals)
           top_ops.push(ss->targets[i]);
@@ -668,7 +667,6 @@ CodeTree::~CodeTree()
       CodeBlock* cb=firstOpToCodeBlock(top_op);
 
       CodeOp* op=&(*cb)[0];
-      ASS_EQ(top_op,op);
       for(size_t rem=cb->length(); rem; rem--,op++) {
         if (_onCodeOpDestroying) {
           (*_onCodeOpDestroying)(op); 

--- a/Indexing/Index.cpp
+++ b/Indexing/Index.cpp
@@ -35,7 +35,6 @@ using namespace Saturation;
 Index::~Index()
 {
   if(!_addedSD.isEmpty()) {
-    ASS(!_removedSD.isEmpty());
     _addedSD->unsubscribe();
     _removedSD->unsubscribe();
   }

--- a/Indexing/SubstitutionTree.cpp
+++ b/Indexing/SubstitutionTree.cpp
@@ -78,7 +78,6 @@ SubstitutionTree::SubstitutionTree(int nodes,bool useC)
 SubstitutionTree::~SubstitutionTree()
 {
   CALL("SubstitutionTree::~SubstitutionTree");
-  ASS_EQ(_iteratorCnt,0);
 
   for (unsigned i = 0; i<_nodes.size(); i++) {
     if(_nodes[i]!=0) {

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -56,11 +56,7 @@ public:
   USE_ALLOCATOR(InferenceEngine);
 
   InferenceEngine() : _salg(0) {}
-  virtual ~InferenceEngine()
-  {
-    //the object has to be detached before destruction
-    ASS(!_salg);
-  }
+  virtual ~InferenceEngine() {}
   virtual void attach(SaturationAlgorithm* salg)
   {
     CALL("InferenceEngine::attach");

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -56,11 +56,6 @@ using namespace Lib;
 class Clause
   : public Unit
 {
-private:
-  /** Should never be used, declared just to get rid of compiler warning */
-  ~Clause() { ASSERTION_VIOLATION; }
-  /** Should never be used, just that compiler requires it */
-  void operator delete(void* ptr) { ASSERTION_VIOLATION; }
 public:
   typedef ArrayishObjectIterator<const Clause> Iterator;
 

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -427,7 +427,6 @@ public:
     if(_state!=FINISHED && _state!=FIRST) {
 	backtrack();
     }
-    ASS(_bdata.isEmpty());
   }
   bool hasNext()
   {

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -927,7 +927,6 @@ public:
     if(_state!=FINISHED && _state!=FIRST) {
 	backtrack();
     }
-    ASS(_bdata.isEmpty());
   }
   bool hasNext()
   {

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1356,7 +1356,6 @@ Term::Term(const Term& t) throw()
     _vars(0)
 {
   CALL("Term::Term/1");
-  ASS(!isSpecial()); //we do not copy special terms
 
   _args[0] = t._args[0];
   _args[0]._info.shared = 0u;

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -1117,9 +1117,18 @@ void* operator new[](size_t sz) {
   return res;
 }
 
-void operator delete(void* obj) throw() {  
-  ASS_REP(Allocator::_tolerantZone > 0,"Custom operator new matched by global delete!");
-  // Please read: https://github.com/easychair/vampire/wiki/Attempted-to-use-global-new-operator,-thus-bypassing-Allocator!
+void operator delete(void* obj) noexcept {  
+#if VDEBUG
+  if(Allocator::_tolerantZone > 0) {
+    // Please read: https://github.com/easychair/vampire/wiki/Attempted-to-use-global-new-operator,-thus-bypassing-Allocator!
+    Debug::Assertion::violated(
+      __FILE__,
+      __LINE__,
+      "Custom operator new matched by global delete!"
+    );
+    std::terminate();
+  }
+#endif
 
   static Allocator::Initialiser i; // to initialize Allocator even for other libraries
 
@@ -1128,9 +1137,18 @@ void operator delete(void* obj) throw() {
   }
 }
 
-void operator delete[](void* obj) throw() {  
-  ASS_REP(Allocator::_tolerantZone > 0,"Custom operator new[] matched by global delete[]!");
-  // Please read: https://github.com/easychair/vampire/wiki/Attempted-to-use-global-new-operator,-thus-bypassing-Allocator!
+void operator delete[](void* obj) noexcept {  
+#if VDEBUG
+  if(Allocator::_tolerantZone > 0) {
+    // Please read: https://github.com/easychair/vampire/wiki/Attempted-to-use-global-new-operator,-thus-bypassing-Allocator!
+    Debug::Assertion::violated(
+      __FILE__,
+      __LINE__,
+      "Custom operator new matched by global delete!"
+    );
+    std::terminate();
+  }
+#endif
 
   static Allocator::Initialiser i; // to initialize Allocator even for other libraries
 

--- a/Lib/Backtrackable.hpp
+++ b/Lib/Backtrackable.hpp
@@ -268,7 +268,7 @@ public:
    * Ensures that calls to @b bdRecord / @b bdDoNotRecord and
    * @b bdDone were properly paired.
    */
-  ~Backtrackable() { ASS_EQ(_bdStack,0); }
+  ~Backtrackable() {}
 #endif
   /**
    * Start recording object changes into the @b bd object

--- a/Lib/DHMap.hpp
+++ b/Lib/DHMap.hpp
@@ -151,7 +151,6 @@ public:
   ~DHMap()
   {
     if(_entries) {
-      ASS_EQ(_afterLast-_entries,_capacity);
       array_delete(_entries, _capacity);
       DEALLOC_KNOWN(_entries,_capacity*sizeof(Entry),"DHMap::Entry");
 //      DEALLOC_KNOWN(_entries,_capacity*sizeof(Entry),typeid(Entry).name());

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -89,7 +89,6 @@ public:
   {
     if(_lcw.isLast()) {
       s_exceptionCounter--;
-      ASS_GE(s_exceptionCounter,0);
     }
   }
 

--- a/Lib/SmartPtr.hpp
+++ b/Lib/SmartPtr.hpp
@@ -74,7 +74,6 @@ public:
       return;
     }
     (_refCnt->_val)--;
-    ASS(_refCnt->_val >= 0);
     if(! _refCnt->_val) {
       checked_delete(_obj);
       delete _refCnt;

--- a/Lib/Stack.hpp
+++ b/Lib/Stack.hpp
@@ -135,9 +135,6 @@ public:
     if(_stack) {
       DEALLOC_KNOWN(_stack,_capacity*sizeof(C),className());
     }
-    else {
-      ASS_EQ(_capacity,0);
-    }
   }
 
   Stack& operator=(const Stack& s)

--- a/Lib/Sys/SyncPipe.cpp
+++ b/Lib/Sys/SyncPipe.cpp
@@ -63,7 +63,6 @@ SyncPipe::~SyncPipe()
   CALL("SyncPipe::~SyncPipe");
 
   releasePrivileges();
-  ASS(PipeList::member(this, s_instances));
   s_instances = PipeList::remove(this, s_instances);
 
   if(canRead()) {

--- a/Lib/VirtualIterator.hpp
+++ b/Lib/VirtualIterator.hpp
@@ -68,7 +68,7 @@ public:
   /** Create new IteratorCore object */
   IteratorCore() : _refCnt(0) {}
   /** Destroy IteratorCore object */
-  virtual ~IteratorCore() { ASS(_refCnt==0); }
+  virtual ~IteratorCore() {}
   /** Return true if there is a next element */
   virtual bool hasNext() = 0;
   /**

--- a/Saturation/AWPassiveClauseContainer.cpp
+++ b/Saturation/AWPassiveClauseContainer.cpp
@@ -86,7 +86,6 @@ AWPassiveClauseContainer::~AWPassiveClauseContainer()
   while (cit.hasNext()) 
   {
     Clause* cl=cit.next();
-    ASS(!_isOutermost || cl->store()==Clause::PASSIVE);
     cl->setStore(Clause::NONE);
   }
 }

--- a/Saturation/ClauseContainer.cpp
+++ b/Saturation/ClauseContainer.cpp
@@ -104,7 +104,6 @@ UnprocessedClauseContainer::~UnprocessedClauseContainer()
 
   while (!_data.isEmpty()) {
     Clause* cl=_data.pop_back();
-    ASS_EQ(cl->store(), Clause::UNPROCESSED);
     cl->setStore(Clause::NONE);
   }
 }

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -270,7 +270,6 @@ SaturationAlgorithm::SaturationAlgorithm(Problem& prb, const Options& opt)
 SaturationAlgorithm::~SaturationAlgorithm()
 {
   CALL("SaturationAlgorithm::~SaturationAlgorithm");
-  ASS_EQ(s_instance,this);
 
   s_instance=0;
 


### PR DESCRIPTION
`Debug/Assertion` has some code to suppress warnings about throwing exceptions where you shouldn't throw exceptions. This is hiding bugs: for example, in C++11 destructors are implicitly `noexcept` so failing an assertion doesn't throw the exception, but calls `std::terminate`.

This removes the code to suppress warnings. Cue warnings! In most cases these related to testing assertions in destructors, which as mentioned does not have the intended effect and so are just removed. If reviewers feel them critical we can discuss the best path to replacing them with something functional.