### PR TITLE
stop suppressing compiler warnings about exceptions, redux

### DIFF
--- a/Debug/Assertion.cpp
+++ b/Debug/Assertion.cpp
@@ -28,10 +28,11 @@ using namespace Shell;
 using namespace Debug;
 
 namespace Shell {
-  void reportSpiderFail();
+void reportSpiderFail();
 }
 
-[[ noreturn ]] void Assertion::abortAfterViolation() {
+[[noreturn]] void Assertion::abortAfterViolation()
+{
   Shell::reportSpiderFail();
 #if CHECK_LEAKS
   MemoryLeak::cancelReport();
@@ -43,62 +44,69 @@ namespace Shell {
  * Called when an assertion is violated. Simply print the stack and
  * throw an assertion violation exception.
  */
-void Assertion::violated (const char* file,int line,const char* cond)
+void Assertion::violated(const char* file, int line, const char* cond)
 {
-  if(outputAllowed(true)) {
+  if (outputAllowed(true)) {
     cout << "Condition in file " << file << ", line " << line
-	<< " violated:\n" << cond << "\n"
-	<< "----- stack dump -----\n";
+         << " violated:\n"
+         << cond << "\n"
+         << "----- stack dump -----\n";
     Tracer::printStack(cout);
     cout << "----- end of stack dump -----" << endl;
   }
   abortAfterViolation();
 } // Assertion::violated
 
-
-void Assertion::violatedStrEquality(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const char* val1, const char* val2)
+void Assertion::violatedStrEquality(const char* file, int line, const char* val1Str,
+                                    const char* val2Str, const char* val1, const char* val2)
 {
-  if(outputAllowed(true)) {
-    std::cout << "Condition for string equality "<<val1Str<<" == "<<val2Str
-	<< " in file " << file << ", line " << line
-	<< " was violated, as:\n" << val1Str<<" == \""<<val1 <<"\"\n"
-	<< val2Str<<" == \""<<val2 << "\"\n"
-	<< "----- stack dump -----\n";
+  if (outputAllowed(true)) {
+    std::cout << "Condition for string equality " << val1Str << " == " << val2Str
+              << " in file " << file << ", line " << line
+              << " was violated, as:\n"
+              << val1Str << " == \"" << val1 << "\"\n"
+              << val2Str << " == \"" << val2 << "\"\n"
+              << "----- stack dump -----\n";
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 }
 
-void Assertion::checkType(const char* file,int line,const void* ptr, const char* assumed,
-	const char* ptrStr)
+void Assertion::checkType(const char* file, int line, const void* ptr, const char* assumed,
+                          const char* ptrStr)
 {
   Allocator::Descriptor* desc = Allocator::Descriptor::find(ptr);
 
-  if(!desc) {
-    if(outputAllowed(true)) {
+  if (!desc) {
+    if (outputAllowed(true)) {
       cout << "Type condition in file " << file << ", line " << line
-	  << " violated:\n" << ptrStr << " was not allocated by Lib::Allocator.\n";
+           << " violated:\n"
+           << ptrStr << " was not allocated by Lib::Allocator.\n";
     }
-  } else if( !USE_PRECISE_CLASS_NAMES && strcmp(assumed, desc->cls) ) {
+  }
+  else if (!USE_PRECISE_CLASS_NAMES && strcmp(assumed, desc->cls)) {
     //TODO: the use of precise class names disrupts the check, fix it in the future!
-    if(outputAllowed(true)) {
+    if (outputAllowed(true)) {
       cout << "Type condition in file " << file << ", line " << line
-	   << " violated:\n" << ptrStr << " was allocated as \"" << desc->cls
-	   << "\" instead of \"" << assumed <<"\".\n";
+           << " violated:\n"
+           << ptrStr << " was allocated as \"" << desc->cls
+           << "\" instead of \"" << assumed << "\".\n";
     }
-  } else if( !desc->allocated ) {
-    if(outputAllowed(true)) {
+  }
+  else if (!desc->allocated) {
+    if (outputAllowed(true)) {
       cout << "Type condition in file " << file << ", line " << line
-	   << " violated:\n" << ptrStr << " was allocated as \"" << desc->cls
-	   << "\", but no longer is.\n";
+           << " violated:\n"
+           << ptrStr << " was allocated as \"" << desc->cls
+           << "\", but no longer is.\n";
     }
-  } else {
+  }
+  else {
     return;
   }
 
-  if(outputAllowed(true)) {
+  if (outputAllowed(true)) {
     cout << "----- stack dump -----\n";
     Tracer::printStack(cout);
     cout << "----- end of stack dump -----\n";
@@ -110,11 +118,11 @@ void Assertion::checkType(const char* file,int line,const void* ptr, const char*
  * Called when an exception is thrown as part of the ASSERT_VALID call.
  * Simply print the location and argument of the ASSERT_VALID statement.
  */
-void Assertion::reportAssertValidException (const char* file,int line,const char* obj)
+void Assertion::reportAssertValidException(const char* file, int line, const char* obj)
 {
-  if(outputAllowed(true)) {
+  if (outputAllowed(true)) {
     cout << "An exception was thrown by ASSERT_VALID on object " << obj
-	<< " in file " << file << ", line " << line << ".\n";
+         << " in file " << file << ", line " << line << ".\n";
   }
   abortAfterViolation();
 } // Assertion::violated

--- a/Debug/Assertion.hpp
+++ b/Debug/Assertion.hpp
@@ -22,132 +22,148 @@
 #include "Tracer.hpp"
 
 namespace Shell {
-  bool outputAllowed(bool debug);
+bool outputAllowed(bool debug);
 }
 
 namespace Debug {
 namespace Assertion {
-  [[ noreturn ]] void abortAfterViolation();
-  [[ noreturn ]] void violated(const char* file,int line,const char* condition);
+[[noreturn]] void abortAfterViolation();
+[[noreturn]] void violated(const char* file, int line, const char* condition);
 
-  template<typename T>
-  [[ noreturn ]] void violated(const char* file,int line,const char* condition,
-	  const T& rep, const char* repStr);
+template <typename T>
+[[noreturn]] void violated(const char* file, int line, const char* condition,
+                           const T& rep, const char* repStr);
 
-  template<typename T, typename U>
-  [[ noreturn ]] void violated(const char* file,int line,const char* condition,
-	  const T& rep, const char* repStr,const U& rep2, const char* repStr2);
+template <typename T, typename U>
+[[noreturn]] void violated(const char* file, int line, const char* condition,
+                           const T& rep, const char* repStr, const U& rep2, const char* repStr2);
 
-  void checkType(const char* file,int line,const void* ptr,
-	  const char* assumed, const char* ptrStr);
+void checkType(const char* file, int line, const void* ptr,
+               const char* assumed, const char* ptrStr);
 
-  template<typename T,typename U>
-  [[ noreturn ]] void violatedEquality(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2);
+template <typename T, typename U>
+[[noreturn]] void violatedEquality(const char* file, int line, const char* val1Str,
+                                   const char* val2Str, const T& val1, const U& val2);
 
-  template<typename T,typename U>
-  [[ noreturn ]] void violatedNonequality(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2);
+template <typename T, typename U>
+[[noreturn]] void violatedNonequality(const char* file, int line, const char* val1Str,
+                                      const char* val2Str, const T& val1, const U& val2);
 
-  template<typename T,typename U>
-  [[ noreturn ]] void violatedComparison(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2, bool strict, bool greater);
+template <typename T, typename U>
+[[noreturn]] void violatedComparison(const char* file, int line, const char* val1Str,
+                                     const char* val2Str, const T& val1, const U& val2, bool strict, bool greater);
 
-  template<typename T>
-  [[ noreturn ]] void violatedMethod(const char* file,int line,const T& obj,
-	  const char* objStr, const char* methodStr, const char* prefix);
+template <typename T>
+[[noreturn]] void violatedMethod(const char* file, int line, const T& obj,
+                                 const char* objStr, const char* methodStr, const char* prefix);
 
-  [[ noreturn ]] void violatedStrEquality(const char* file,int line,const char* val1Str,
-  	  const char* val2Str, const char* val1, const char* val2);
+[[noreturn]] void violatedStrEquality(const char* file, int line, const char* val1Str,
+                                      const char* val2Str, const char* val1, const char* val2);
 
-  [[ noreturn ]] void reportAssertValidException(const char* file,int line,const char* obj);
-}
-}
+[[noreturn]] void reportAssertValidException(const char* file, int line, const char* obj);
+} // namespace Assertion
+} // namespace Debug
 
-#define ASS(Cond) {\
-  if(!(Cond)) {\
-    Debug::Assertion::violated(__FILE__,__LINE__,#Cond);\
-  }\
-}
+#define ASS(Cond)                                            \
+  {                                                          \
+    if (!(Cond)) {                                           \
+      Debug::Assertion::violated(__FILE__, __LINE__, #Cond); \
+    }                                                        \
+  }
 
-#define ASS_REP(Cond, ReportedVal) {\
-  if(!(Cond)) {\
-    Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal);\
-  }\
-}
+#define ASS_REP(Cond, ReportedVal)                                                      \
+  {                                                                                     \
+    if (!(Cond)) {                                                                      \
+      Debug::Assertion::violated(__FILE__, __LINE__, #Cond, ReportedVal, #ReportedVal); \
+    }                                                                                   \
+  }
 
-#define ASS_REP2(Cond, ReportedVal, ReportedVal2) {\
-  if(!(Cond)) {\
-    Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal,ReportedVal2,#ReportedVal2);\
-  }\
-}
+#define ASS_REP2(Cond, ReportedVal, ReportedVal2)                                                                    \
+  {                                                                                                                  \
+    if (!(Cond)) {                                                                                                   \
+      Debug::Assertion::violated(__FILE__, __LINE__, #Cond, ReportedVal, #ReportedVal, ReportedVal2, #ReportedVal2); \
+    }                                                                                                                \
+  }
 
-#define ASS_EQ(VAL1,VAL2) {\
-  if(!((VAL1)==(VAL2))) {\
-    Debug::Assertion::violatedEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2);\
-  }\
-}
+#define ASS_EQ(VAL1, VAL2)                                                              \
+  {                                                                                     \
+    if (!((VAL1) == (VAL2))) {                                                          \
+      Debug::Assertion::violatedEquality(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2); \
+    }                                                                                   \
+  }
 
-#define ASS_NEQ(VAL1,VAL2) {\
-  if(!((VAL1)!=(VAL2))) {\
-    Debug::Assertion::violatedNonequality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2);\
-  }\
-}
+#define ASS_NEQ(VAL1, VAL2)                                                                \
+  {                                                                                        \
+    if (!((VAL1) != (VAL2))) {                                                             \
+      Debug::Assertion::violatedNonequality(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2); \
+    }                                                                                      \
+  }
 
-#define ASS_STR_EQ(VAL1,VAL2) {\
-  if(strcmp((VAL1),(VAL2))) {\
-    Debug::Assertion::violatedStrEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2);\
-  }\
-}
+#define ASS_STR_EQ(VAL1, VAL2)                                                             \
+  {                                                                                        \
+    if (strcmp((VAL1), (VAL2))) {                                                          \
+      Debug::Assertion::violatedStrEquality(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2); \
+    }                                                                                      \
+  }
 
-#define ASS_G(VAL1,VAL2) {\
-  if(!((VAL1)>(VAL2))) {\
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,true);\
-  }\
-}
+#define ASS_G(VAL1, VAL2)                                                                             \
+  {                                                                                                   \
+    if (!((VAL1) > (VAL2))) {                                                                         \
+      Debug::Assertion::violatedComparison(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2, true, true); \
+    }                                                                                                 \
+  }
 
-#define ASS_L(VAL1,VAL2) {\
-  if (!((VAL1)<(VAL2))) {\
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,false);\
-  }\
-}
+#define ASS_L(VAL1, VAL2)                                                                              \
+  {                                                                                                    \
+    if (!((VAL1) < (VAL2))) {                                                                          \
+      Debug::Assertion::violatedComparison(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2, true, false); \
+    }                                                                                                  \
+  }
 
-#define ASS_GE(VAL1,VAL2) {\
-  if (!((VAL1)>=(VAL2))) {\
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,true);\
-  }\
-}
+#define ASS_GE(VAL1, VAL2)                                                                             \
+  {                                                                                                    \
+    if (!((VAL1) >= (VAL2))) {                                                                         \
+      Debug::Assertion::violatedComparison(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2, false, true); \
+    }                                                                                                  \
+  }
 
-#define ASS_LE(VAL1,VAL2) {\
-  if (!((VAL1)<=(VAL2))) {\
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,false);\
-  }\
-}
+#define ASS_LE(VAL1, VAL2)                                                                              \
+  {                                                                                                     \
+    if (!((VAL1) <= (VAL2))) {                                                                          \
+      Debug::Assertion::violatedComparison(__FILE__, __LINE__, #VAL1, #VAL2, VAL1, VAL2, false, false); \
+    }                                                                                                   \
+  }
 
-#define ASS_ALLOC_TYPE(PTR,TYPE) {\
-  Debug::Assertion::checkType(__FILE__,__LINE__,(PTR),(TYPE), #PTR);\
-}
+#define ASS_ALLOC_TYPE(PTR, TYPE)                                         \
+  {                                                                       \
+    Debug::Assertion::checkType(__FILE__, __LINE__, (PTR), (TYPE), #PTR); \
+  }
 
-#define ASS_METHOD(OBJ,METHOD) {\
-  if (!((OBJ).METHOD)) {\
-    Debug::Assertion::violatedMethod(__FILE__,__LINE__,(OBJ), #OBJ, #METHOD,"");\
-  }\
-}
+#define ASS_METHOD(OBJ, METHOD)                                                       \
+  {                                                                                   \
+    if (!((OBJ).METHOD)) {                                                            \
+      Debug::Assertion::violatedMethod(__FILE__, __LINE__, (OBJ), #OBJ, #METHOD, ""); \
+    }                                                                                 \
+  }
 
-#define ASSERT_VALID(obj) {\
-  try { (obj).assertValid(); }\
-  catch(...) {\
-    Debug::Assertion::reportAssertValidException(__FILE__,__LINE__,#obj);\
-  }\
-}
+#define ASSERT_VALID(obj)                                                     \
+  {                                                                           \
+    try {                                                                     \
+      (obj).assertValid();                                                    \
+    }                                                                         \
+    catch (...) {                                                             \
+      Debug::Assertion::reportAssertValidException(__FILE__, __LINE__, #obj); \
+    }                                                                         \
+  }
 
-#define ASSERTION_VIOLATION {\
-  Debug::Assertion::violated(__FILE__,__LINE__,"true");\
-}
+#define ASSERTION_VIOLATION                                 \
+  {                                                         \
+    Debug::Assertion::violated(__FILE__, __LINE__, "true"); \
+  }
 
 #define ASSERTION_VIOLATION_REP(Val) ASS_REP(false, Val)
 
-#define ASSERTION_VIOLATION_REP2(Val1,Val2) ASS_REP2(false, Val1, Val2)
+#define ASSERTION_VIOLATION_REP2(Val1, Val2) ASS_REP2(false, Val1, Val2)
 
 #define DEBUG_CODE(X) X
 #define ALWAYS(Cond) ASS(Cond)
@@ -157,113 +173,126 @@ namespace Assertion {
 /* __UNREACHABLE: this point in the code is statically unreachable */
 #if defined(__GNUC__)
 // __builtin_unreachable if the GNU dialect is availble: GCC, Clang, ICC
-#define __UNREACHABLE { __builtin_unreachable(); }
+#define __UNREACHABLE        \
+  {                          \
+    __builtin_unreachable(); \
+  }
 #elif defined(_MSC_VER)
 // __assume(0) if Microsoft-y
-#define __UNREACHABLE { __assume(0); }
+#define __UNREACHABLE \
+  {                   \
+    __assume(0);      \
+  }
 #endif
 #ifndef __UNREACHABLE
 // otherwise, infinite loop - UB and should be optimised out
-#define __UNREACHABLE { while(true) {} }
+#define __UNREACHABLE \
+  {                   \
+    while (true) {    \
+    }                 \
+  }
 #endif
 
-#define ASS(Cond) 
+#define ASS(Cond)
 #define ASS_REP(Cond, ReportedVal)
 #define ASS_REP2(Cond, ReportedVal, ReportedVal2)
-#define ASS_EQ(VAL1,VAL2)
-#define ASS_NEQ(VAL1,VAL2)
-#define ASS_STR_EQ(VAL1,VAL2)
-#define ASS_G(VAL1,VAL2)
-#define ASS_L(VAL1,VAL2)
-#define ASS_GE(VAL1,VAL2)
-#define ASS_LE(VAL1,VAL2)
-#define ASS_ALLOC_TYPE(PTR,TYPE)
-#define ASS_METHOD(OBJ,METHOD)
+#define ASS_EQ(VAL1, VAL2)
+#define ASS_NEQ(VAL1, VAL2)
+#define ASS_STR_EQ(VAL1, VAL2)
+#define ASS_G(VAL1, VAL2)
+#define ASS_L(VAL1, VAL2)
+#define ASS_GE(VAL1, VAL2)
+#define ASS_LE(VAL1, VAL2)
+#define ASS_ALLOC_TYPE(PTR, TYPE)
+#define ASS_METHOD(OBJ, METHOD)
 #define ASSERTION_VIOLATION __UNREACHABLE
 #define ASSERTION_VIOLATION_REP(Val) ASSERTION_VIOLATION
-#define ASSERTION_VIOLATION_REP2(Val1,Val2)  ASSERTION_VIOLATION
+#define ASSERTION_VIOLATION_REP2(Val1, Val2) ASSERTION_VIOLATION
 #define ASSERT_VALID(obj)
 #define DEBUG_CODE(X)
-#define ALWAYS(Cond) (void) ( Cond );
-#define NEVER(Cond) (void) ( Cond );
+#define ALWAYS(Cond) (void)(Cond);
+#define NEVER(Cond) (void)(Cond);
 #endif // VDEBUG
 
 #if VDEBUG
 
-template<typename T>
-void Debug::Assertion::violated (const char* file,int line,const char* cond,
-	const T& rep, const char* repStr)
+template <typename T>
+void Debug::Assertion::violated(const char* file, int line, const char* cond,
+                                const T& rep, const char* repStr)
 {
   if (Shell::outputAllowed(true)) {
     cout << "Condition in file " << file << ", line " << line
-	 << " violated:\n" << cond << "\n"
-	 << "Value of " << repStr << " is: " << rep
-	 << "\n----- stack dump -----\n";
+         << " violated:\n"
+         << cond << "\n"
+         << "Value of " << repStr << " is: " << rep
+         << "\n----- stack dump -----\n";
     Tracer::printStack(cout);
     cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violated
 
-template<typename T,typename U>
-void Debug::Assertion::violated (const char* file,int line,const char* cond,
-	const T& rep, const char* repStr, const U& rep2, const char* repStr2)
+template <typename T, typename U>
+void Debug::Assertion::violated(const char* file, int line, const char* cond,
+                                const T& rep, const char* repStr, const U& rep2, const char* repStr2)
 {
   if (Shell::outputAllowed(true)) {
     cout << "Condition in file " << file << ", line " << line
-	<< " violated:\n" << cond << "\n"
-	<< "Value of " << repStr << " is: " << rep << "\n"
-	<< "Value of " << repStr2 << " is: " << rep2
-	<< "\n----- stack dump -----\n";
+         << " violated:\n"
+         << cond << "\n"
+         << "Value of " << repStr << " is: " << rep << "\n"
+         << "Value of " << repStr2 << " is: " << rep2
+         << "\n----- stack dump -----\n";
     Tracer::printStack(cout);
     cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violated
 
-template<typename T,typename U>
-void Debug::Assertion::violatedEquality(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2)
+template <typename T, typename U>
+void Debug::Assertion::violatedEquality(const char* file, int line, const char* val1Str,
+                                        const char* val2Str, const T& val1, const U& val2)
 {
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << val1Str << " == " << val2Str << " in file " << file << ", line " << line
-	      << " was violated, as:\n" << val1Str << " == " << val1 << "\n"
-	      << val2Str << " == " << val2 << "\n"
-	      << "----- stack dump -----\n";
+              << " was violated, as:\n"
+              << val1Str << " == " << val1 << "\n"
+              << val2Str << " == " << val2 << "\n"
+              << "----- stack dump -----\n";
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violatedEquality
 
-
-template<typename T,typename U>
-void Debug::Assertion::violatedNonequality(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2)
+template <typename T, typename U>
+void Debug::Assertion::violatedNonequality(const char* file, int line, const char* val1Str,
+                                           const char* val2Str, const T& val1, const U& val2)
 {
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << val1Str << " != " << val2Str << " in file " << file << ", line " << line
-	      << " was violated, as:\n" << val1Str << " == " << val1 <<"\n" << val2Str << " == " << val2 << "\n"
-	      << "----- stack dump -----\n";
+              << " was violated, as:\n"
+              << val1Str << " == " << val1 << "\n"
+              << val2Str << " == " << val2 << "\n"
+              << "----- stack dump -----\n";
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violatedNonequality
 
-
-template<typename T,typename U>
-void Debug::Assertion::violatedComparison(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2, bool strict, bool greater)
+template <typename T, typename U>
+void Debug::Assertion::violatedComparison(const char* file, int line, const char* val1Str,
+                                          const char* val2Str, const T& val1, const U& val2, bool strict, bool greater)
 {
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << val1Str;
     if (strict) {
       if (greater) {
-	std::cout << " > ";
+        std::cout << " > ";
       }
       else {
-	std::cout << " < ";
+        std::cout << " < ";
       }
     }
     else if (greater) {
@@ -274,24 +303,25 @@ void Debug::Assertion::violatedComparison(const char* file,int line,const char* 
     }
 
     std::cout << val2Str << " in file " << file << ", line " << line
-	      << " was violated, as:\n" << val1Str<<" == " << val1 << "\n"
-	      << val2Str <<" == " << val2 << "\n"
-	      << "----- stack dump -----\n";
+              << " was violated, as:\n"
+              << val1Str << " == " << val1 << "\n"
+              << val2Str << " == " << val2 << "\n"
+              << "----- stack dump -----\n";
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violatedComparison
 
-template<typename T>
-void Debug::Assertion::violatedMethod(const char* file,int line,const T& obj,
-	  const char* objStr, const char* methodStr, const char* prefix)
+template <typename T>
+void Debug::Assertion::violatedMethod(const char* file, int line, const T& obj,
+                                      const char* objStr, const char* methodStr, const char* prefix)
 {
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << prefix << "(" << objStr << ")." << methodStr << " in file "
-	      << file << ", line " << line << " was violated for:\n"
-	      << objStr << " == " << obj << "\n"
-	      << "----- stack dump -----\n";
+              << file << ", line " << line << " was violated for:\n"
+              << objStr << " == " << obj << "\n"
+              << "----- stack dump -----\n";
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }

--- a/Debug/Assertion.hpp
+++ b/Debug/Assertion.hpp
@@ -16,198 +16,145 @@
 #ifndef __Assertion__
 #define __Assertion__
 
-#define __PUSH_DIAGNOSTICS(diag, ...) \
-    _Pragma("GCC diagnostic push") \
-    _Pragma(diag) \
-    __VA_ARGS__ \
-    _Pragma("GCC diagnostic pop") \
-
-#ifdef __clang__
-#  define __IGNORE_ASSERTION_WARNINGS(...) __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wexceptions\"", __VA_ARGS__)
-#else // __clang__
-//#  define __IGNORE_ASSERTION_WARNINGS(...)   __VA_ARGS__
-#  define __IGNORE_ASSERTION_WARNINGS(...)   \
-    __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wterminate\"", \
-    __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wterminate\"", \
-    __VA_ARGS__ \
-    ))
-#endif // __clang__
-
-//#undef CONCAT
-
 #if VDEBUG
-
 #include <iostream>
 #include <ostream>
-
 #include "Tracer.hpp"
 
 namespace Shell {
   bool outputAllowed(bool debug);
-  void reportSpiderFail();
 }
 
 namespace Debug {
-
-// any function. It can be declared in one module and called in
-// another
-extern void debug(void*);
-
-class Assertion
-{
-public:
-  static void violated(const char* file,int line,const char* condition);
+namespace Assertion {
+  [[ noreturn ]] void abortAfterViolation();
+  [[ noreturn ]] void violated(const char* file,int line,const char* condition);
 
   template<typename T>
-  static void violated(const char* file,int line,const char* condition,
+  [[ noreturn ]] void violated(const char* file,int line,const char* condition,
 	  const T& rep, const char* repStr);
 
   template<typename T, typename U>
-  static void violated(const char* file,int line,const char* condition,
+  [[ noreturn ]] void violated(const char* file,int line,const char* condition,
 	  const T& rep, const char* repStr,const U& rep2, const char* repStr2);
 
-
-  static void checkType(const char* file,int line,const void* ptr,
+  void checkType(const char* file,int line,const void* ptr,
 	  const char* assumed, const char* ptrStr);
 
   template<typename T,typename U>
-  static void violatedEquality(const char* file,int line,const char* val1Str,
-	  const char* val2Str, const T& val1, const U& val2);
-  template<typename T,typename U>
-  static void violatedNonequality(const char* file,int line,const char* val1Str,
+  [[ noreturn ]] void violatedEquality(const char* file,int line,const char* val1Str,
 	  const char* val2Str, const T& val1, const U& val2);
 
   template<typename T,typename U>
-  static void violatedComparison(const char* file,int line,const char* val1Str,
+  [[ noreturn ]] void violatedNonequality(const char* file,int line,const char* val1Str,
+	  const char* val2Str, const T& val1, const U& val2);
+
+  template<typename T,typename U>
+  [[ noreturn ]] void violatedComparison(const char* file,int line,const char* val1Str,
 	  const char* val2Str, const T& val1, const U& val2, bool strict, bool greater);
 
   template<typename T>
-  static void violatedMethod(const char* file,int line,const T& obj,
+  [[ noreturn ]] void violatedMethod(const char* file,int line,const T& obj,
 	  const char* objStr, const char* methodStr, const char* prefix);
 
-
-  static void violatedStrEquality(const char* file,int line,const char* val1Str,
+  [[ noreturn ]] void violatedStrEquality(const char* file,int line,const char* val1Str,
   	  const char* val2Str, const char* val1, const char* val2);
 
+  [[ noreturn ]] void reportAssertValidException(const char* file,int line,const char* obj);
+}
+}
 
-  static void reportAssertValidException(const char* file,int line,const char* obj);
-private:
-  static bool _violated;
-};
+#define ASS(Cond) {\
+  if(!(Cond)) {\
+    Debug::Assertion::violated(__FILE__,__LINE__,#Cond);\
+  }\
+}
 
-/**
- * Class AssertionViolationException. It is thrown when any assertion
- * is violated.
- */
-class AssertionViolationException
-{
-public:
-  AssertionViolationException (const char* file, int line);
-  ~AssertionViolationException () {}
-  void cry (std::ostream&);
-private:
-  void outputFileAndLine (std::ostream&) const;
-  /** file in which violation occurred */
-  const char* _file;
-  /** line number in the file */
-  int _line;
-}; // AssertionViolationException
+#define ASS_REP(Cond, ReportedVal) {\
+  if(!(Cond)) {\
+    Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal);\
+  }\
+}
 
-} // namespace Debug
+#define ASS_REP2(Cond, ReportedVal, ReportedVal2) {\
+  if(!(Cond)) {\
+    Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal,ReportedVal2,#ReportedVal2);\
+  }\
+}
 
-#define DEBUG_CODE(X)  X
+#define ASS_EQ(VAL1,VAL2) {\
+  if(!((VAL1)==(VAL2))) {\
+    Debug::Assertion::violatedEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2);\
+  }\
+}
 
-#define ASS(Cond)                                               \
-  if (! (Cond)) {                                               \
-    Debug::Assertion::violated(__FILE__,__LINE__,#Cond);		\
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  }
+#define ASS_NEQ(VAL1,VAL2) {\
+  if(!((VAL1)!=(VAL2))) {\
+    Debug::Assertion::violatedNonequality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2);\
+  }\
+}
 
-#define ASS_REP(Cond, ReportedVal)                                      \
-  if (! (Cond)) {                                               \
-    Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  }
+#define ASS_STR_EQ(VAL1,VAL2) {\
+  if(strcmp((VAL1),(VAL2))) {\
+    Debug::Assertion::violatedStrEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2);\
+  }\
+}
 
-#define ASS_REP2(Cond, ReportedVal, ReportedVal2)               \
-  if (! (Cond)) {                                               \
-    Debug::Assertion::violated(__FILE__,__LINE__,#Cond,ReportedVal,#ReportedVal,ReportedVal2,#ReportedVal2); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  }
+#define ASS_G(VAL1,VAL2) {\
+  if(!((VAL1)>(VAL2))) {\
+    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,true);\
+  }\
+}
 
+#define ASS_L(VAL1,VAL2) {\
+  if (!((VAL1)<(VAL2))) {\
+    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,false);\
+  }\
+}
 
+#define ASS_GE(VAL1,VAL2) {\
+  if (!((VAL1)>=(VAL2))) {\
+    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,true);\
+  }\
+}
+
+#define ASS_LE(VAL1,VAL2) {\
+  if (!((VAL1)<=(VAL2))) {\
+    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,false);\
+  }\
+}
+
+#define ASS_ALLOC_TYPE(PTR,TYPE) {\
+  Debug::Assertion::checkType(__FILE__,__LINE__,(PTR),(TYPE), #PTR);\
+}
+
+#define ASS_METHOD(OBJ,METHOD) {\
+  if (!((OBJ).METHOD)) {\
+    Debug::Assertion::violatedMethod(__FILE__,__LINE__,(OBJ), #OBJ, #METHOD,"");\
+  }\
+}
+
+#define ASSERT_VALID(obj) {\
+  try { (obj).assertValid(); }\
+  catch(...) {\
+    Debug::Assertion::reportAssertValidException(__FILE__,__LINE__,#obj);\
+  }\
+}
+
+#define ASSERTION_VIOLATION {\
+  Debug::Assertion::violated(__FILE__,__LINE__,"true");\
+}
+
+#define ASSERTION_VIOLATION_REP(Val) ASS_REP(false, Val)
+
+#define ASSERTION_VIOLATION_REP2(Val1,Val2) ASS_REP2(false, Val1, Val2)
+
+#define DEBUG_CODE(X) X
 #define ALWAYS(Cond) ASS(Cond)
 #define NEVER(Cond) ASS(!(Cond))
-
-
-#define ASS_EQ(VAL1,VAL2)                                               \
-  if (! ((VAL1)==(VAL2)) ) {                                               \
-    Debug::Assertion::violatedEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2); \
-    __IGNORE_ASSERTION_WARNINGS( throw Debug::AssertionViolationException(__FILE__,__LINE__);)  \
-  } \
-
-#define ASS_NEQ(VAL1,VAL2)                                               \
-  if (! ((VAL1)!=(VAL2)) ) {                                               \
-    Debug::Assertion::violatedNonequality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  } \
-
-#define ASS_STR_EQ(VAL1,VAL2)                                               \
-  if (strcmp((VAL1),(VAL2)) ) {                                               \
-    Debug::Assertion::violatedStrEquality(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);	)\
-  } \
-
-
-#define ASS_G(VAL1,VAL2)                                               \
-  if (! ((VAL1)>(VAL2)) ) {                                               \
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,true); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  } \
-
-#define ASS_L(VAL1,VAL2)                                               \
-  if (! ((VAL1)<(VAL2)) ) {                                               \
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,true,false); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  } \
-
-#define ASS_GE(VAL1,VAL2)                                               \
-  if (! ((VAL1)>=(VAL2)) ) {                                               \
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,true); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  } \
-
-#define ASS_LE(VAL1,VAL2)                                               \
-  if (! ((VAL1)<=(VAL2)) ) {                                               \
-    Debug::Assertion::violatedComparison(__FILE__,__LINE__,#VAL1,#VAL2,VAL1,VAL2,false,false); \
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  } \
-
-#define ASS_ALLOC_TYPE(PTR,TYPE)						\
-  Debug::Assertion::checkType(__FILE__,__LINE__,(PTR),(TYPE), #PTR)
-
-#define ASS_METHOD(OBJ,METHOD)							\
-  if (! ((OBJ).METHOD) ) {							\
-    Debug::Assertion::violatedMethod(__FILE__,__LINE__,(OBJ), #OBJ, #METHOD,"");\
-    __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);)	\
-  }
-
-#define ASSERT_VALID(obj) try { (obj).assertValid(); } catch(...) \
-  { Debug::Assertion::reportAssertValidException(__FILE__,__LINE__,#obj); \
-    __IGNORE_ASSERTION_WARNINGS(throw;) }
-
-#define ASSERTION_VIOLATION \
-  Debug::Assertion::violated(__FILE__,__LINE__,"true");		\
-  __IGNORE_ASSERTION_WARNINGS(throw Debug::AssertionViolationException(__FILE__,__LINE__);) \
-
-#define ASSERTION_VIOLATION_REP(Val) \
-  ASS_REP(false, Val)
-#define ASSERTION_VIOLATION_REP2(Val1,Val2) \
-  ASS_REP2(false, Val1, Val2)
-
 #else // ! VDEBUG
 
-/* this point in the code is statically unreachable */
+/* __UNREACHABLE: this point in the code is statically unreachable */
 #if defined(__GNUC__)
 // __builtin_unreachable if the GNU dialect is availble: GCC, Clang, ICC
 #define __UNREACHABLE { __builtin_unreachable(); }
@@ -220,35 +167,25 @@ private:
 #define __UNREACHABLE { while(true) {} }
 #endif
 
-#define DEBUG_CODE(X)
-
-#define __IGNORE_WUNUSED(...) __PUSH_DIAGNOSTICS("GCC diagnostic ignored \"-Wreturn-type\"", __VA_ARGS__)
-
 #define ASS(Cond) 
-#define ALWAYS(Cond) (void) ( Cond );
-#define NEVER(Cond) (void) ( Cond );
-
 #define ASS_REP(Cond, ReportedVal)
 #define ASS_REP2(Cond, ReportedVal, ReportedVal2)
-
 #define ASS_EQ(VAL1,VAL2)
 #define ASS_NEQ(VAL1,VAL2)
 #define ASS_STR_EQ(VAL1,VAL2)
-
 #define ASS_G(VAL1,VAL2)
 #define ASS_L(VAL1,VAL2)
 #define ASS_GE(VAL1,VAL2)
 #define ASS_LE(VAL1,VAL2)
-
 #define ASS_ALLOC_TYPE(PTR,TYPE)
 #define ASS_METHOD(OBJ,METHOD)
-
 #define ASSERTION_VIOLATION __UNREACHABLE
 #define ASSERTION_VIOLATION_REP(Val) ASSERTION_VIOLATION
 #define ASSERTION_VIOLATION_REP2(Val1,Val2)  ASSERTION_VIOLATION
-
 #define ASSERT_VALID(obj)
-
+#define DEBUG_CODE(X)
+#define ALWAYS(Cond) (void) ( Cond );
+#define NEVER(Cond) (void) ( Cond );
 #endif // VDEBUG
 
 #if VDEBUG
@@ -257,12 +194,6 @@ template<typename T>
 void Debug::Assertion::violated (const char* file,int line,const char* cond,
 	const T& rep, const char* repStr)
 {
-  if (_violated) {
-    return;
-  }
-
-  _violated = true;
-  Shell::reportSpiderFail();
   if (Shell::outputAllowed(true)) {
     cout << "Condition in file " << file << ", line " << line
 	 << " violated:\n" << cond << "\n"
@@ -271,18 +202,13 @@ void Debug::Assertion::violated (const char* file,int line,const char* cond,
     Tracer::printStack(cout);
     cout << "----- end of stack dump -----\n";
   }
+  abortAfterViolation();
 } // Assertion::violated
 
 template<typename T,typename U>
 void Debug::Assertion::violated (const char* file,int line,const char* cond,
 	const T& rep, const char* repStr, const U& rep2, const char* repStr2)
 {
-  if (_violated) {
-    return;
-  }
-
-  _violated = true;
-  Shell::reportSpiderFail();
   if (Shell::outputAllowed(true)) {
     cout << "Condition in file " << file << ", line " << line
 	<< " violated:\n" << cond << "\n"
@@ -292,18 +218,13 @@ void Debug::Assertion::violated (const char* file,int line,const char* cond,
     Tracer::printStack(cout);
     cout << "----- end of stack dump -----\n";
   }
+  abortAfterViolation();
 } // Assertion::violated
 
 template<typename T,typename U>
 void Debug::Assertion::violatedEquality(const char* file,int line,const char* val1Str,
 	  const char* val2Str, const T& val1, const U& val2)
 {
-  if (_violated) {
-    return;
-  }
-
-  _violated = true;
-  Shell::reportSpiderFail();
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << val1Str << " == " << val2Str << " in file " << file << ", line " << line
 	      << " was violated, as:\n" << val1Str << " == " << val1 << "\n"
@@ -312,6 +233,7 @@ void Debug::Assertion::violatedEquality(const char* file,int line,const char* va
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
+  abortAfterViolation();
 } // Assertion::violatedEquality
 
 
@@ -319,12 +241,6 @@ template<typename T,typename U>
 void Debug::Assertion::violatedNonequality(const char* file,int line,const char* val1Str,
 	  const char* val2Str, const T& val1, const U& val2)
 {
-  if (_violated) {
-    return;
-  }
-
-  _violated = true;
-  Shell::reportSpiderFail();
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << val1Str << " != " << val2Str << " in file " << file << ", line " << line
 	      << " was violated, as:\n" << val1Str << " == " << val1 <<"\n" << val2Str << " == " << val2 << "\n"
@@ -332,6 +248,7 @@ void Debug::Assertion::violatedNonequality(const char* file,int line,const char*
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
+  abortAfterViolation();
 } // Assertion::violatedNonequality
 
 
@@ -339,12 +256,6 @@ template<typename T,typename U>
 void Debug::Assertion::violatedComparison(const char* file,int line,const char* val1Str,
 	  const char* val2Str, const T& val1, const U& val2, bool strict, bool greater)
 {
-  if (_violated) {
-    return;
-  }
-
-  _violated = true;
-  Shell::reportSpiderFail();
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << val1Str;
     if (strict) {
@@ -369,18 +280,13 @@ void Debug::Assertion::violatedComparison(const char* file,int line,const char* 
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
+  abortAfterViolation();
 } // Assertion::violatedComparison
 
 template<typename T>
 void Debug::Assertion::violatedMethod(const char* file,int line,const T& obj,
 	  const char* objStr, const char* methodStr, const char* prefix)
 {
-  if (_violated) {
-    return;
-  }
-
-  _violated = true;
-  Shell::reportSpiderFail();
   if (Shell::outputAllowed(true)) {
     std::cout << "Condition " << prefix << "(" << objStr << ")." << methodStr << " in file "
 	      << file << ", line " << line << " was violated for:\n"
@@ -389,9 +295,9 @@ void Debug::Assertion::violatedMethod(const char* file,int line,const T& obj,
     Tracer::printStack(cout);
     std::cout << "----- end of stack dump -----\n";
   }
+  abortAfterViolation();
 } // Assertion::violatedMethod
 
-#endif
+#endif //VDEBUG
 
 #endif // __Assertion__
-

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -926,15 +926,6 @@ int main(int argc, char* argv[])
     env.signature = 0;
 #endif
   }
-#if VDEBUG
-  catch (Debug::AssertionViolationException& exception) {
-    vampireReturnValue = VAMP_RESULT_STATUS_UNHANDLED_EXCEPTION;
-    reportSpiderFail();
-#if CHECK_LEAKS
-    MemoryLeak::cancelReport();
-#endif
-  }
-#endif
 #if VZ3
   catch(z3::exception& exception){
     BYPASSING_ALLOCATOR;


### PR DESCRIPTION
As discussed for #179, when an assertion is violated, this calls `System::terminateImmediately` and some other cleanup functions, then terminates, instead of raising an exception which may not be permitted in all contexts.