### PR TITLE
C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,8 @@
 cmake_minimum_required (VERSION 3.12.0)
 project(Vampire)
 
-# require the compiler to use C++11
-set(CMAKE_CXX_STANDARD 11)
+# require the compiler to use C++14
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/Indexing/RequestedIndex.hpp
+++ b/Indexing/RequestedIndex.hpp
@@ -37,9 +37,9 @@ class RequestedIndex final
 
     // Moving transfers ownership of the index
     RequestedIndex(RequestedIndex&& other) noexcept
-      : _index{exchange(other._index, nullptr)}
+      : _index{std::exchange(other._index, nullptr)}
       , _type{other._type}
-      , _indexManager{exchange(other._indexManager, nullptr)}
+      , _indexManager{std::exchange(other._indexManager, nullptr)}
     { }
 
     // Moving transfers ownership of the index

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -716,7 +716,7 @@ MLMatcher::MLMatcher()
 void MLMatcher::init(Literal** baseLits, unsigned baseLen, Clause* instance, LiteralList const* const* alts, Literal* resolvedLit, bool multiset)
 {
   if (!m_impl) {
-    m_impl = make_unique<MLMatcher::Impl>();
+    m_impl = std::make_unique<MLMatcher::Impl>();
   }
   m_impl->init(baseLits, baseLen, instance, alts, resolvedLit, multiset);
 }

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -1164,7 +1164,7 @@ MLMatcherSD::MLMatcherSD()
 void MLMatcherSD::init(Literal** baseLits, unsigned baseLen, Clause* instance, LiteralList const* const* alts)
 {
   if (!m_impl) {
-    m_impl = make_unique<MLMatcherSD::Impl>();
+    m_impl = std::make_unique<MLMatcherSD::Impl>();
   }
   m_impl->init(baseLits, baseLen, instance, alts);
 }

--- a/Lib/STL.hpp
+++ b/Lib/STL.hpp
@@ -58,37 +58,6 @@ using vunordered_set = std::unordered_set<Key, Hash, KeyEqual, STLAllocator<Key>
 template< typename T >
 using vvector = std::vector<T, STLAllocator<T>>;
 
-
-/** See https://en.cppreference.com/w/cpp/memory/unique_ptr/make_unique
- *
- * Helper function that does not exist in C++11 yet.
- * Replace with std::make_unique once we switch to C++14 or later.
- */
-template< typename T
-        , typename... Args
-        , // make_unique should only be defined for non-array types, according to the C++14 standard
-          typename std::enable_if<!std::is_array<T>::value, int>::type = 0
-        >
-std::unique_ptr<T> make_unique(Args&&... args)
-{
-    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
-}
-
-
-/** See https://en.cppreference.com/w/cpp/utility/exchange
- *
- * Helper function that does not exist in C++11 yet.
- * Replace with std::exchange once we switch to C++14 or later.
- */
-template<class T, class U = T>
-T exchange(T& obj, U&& new_value)
-{
-    T old_value = std::move(obj);
-    obj = std::forward<U>(new_value);
-    return old_value;
-}
-
-
 }  // namespace Lib
 
 #endif /* !STL_HPP */

--- a/Lib/ScopeGuard.hpp
+++ b/Lib/ScopeGuard.hpp
@@ -39,7 +39,7 @@ class ScopeGuard final
     ScopeGuard& operator=(ScopeGuard const&) = delete;
 
     ScopeGuard(ScopeGuard&& other)
-      : active{exchange(other.active, false)}
+      : active{std::exchange(other.active, false)}
       , f(std::move(other.f))
     { }
 

--- a/Lib/ScopeGuard.hpp
+++ b/Lib/ScopeGuard.hpp
@@ -115,7 +115,8 @@ ScopeGuard<Callable> make_scope_guard(Callable&& f)
 #define ON_SCOPE_EXIT(stmt) \
   auto ON_SCOPE_EXIT_CONCAT(on_scope_exit_guard_on_line_,__LINE__) = make_scope_guard([&]() { stmt; });
 
-// We don't need make_scope_guard in C++14 or later:
+// We don't need make_scope_guard in C++17 or later:
+// feature is called "class template argument deduction"
 /*
 #define ON_SCOPE_EXIT(stmt) \
   ScopeGuard ON_SCOPE_EXIT_CONCAT(on_scope_exit_guard_on_line_,__LINE__){[&]() { stmt; }};

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 ################################################################
 
 CXX = g++
-CXXFLAGS = $(XFLAGS) -Wall -std=c++11  $(INCLUDES) # -Wno-unknown-warning-option for clang
+CXXFLAGS = $(XFLAGS) -Wall -std=c++14  $(INCLUDES) # -Wno-unknown-warning-option for clang
 
 CC = gcc 
 CCFLAGS = -Wall -O3 -DNDBLSCR -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLPICOSAT 

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -113,7 +113,7 @@ SaturationAlgorithm* SaturationAlgorithm::s_instance = 0;
 
 std::unique_ptr<PassiveClauseContainer> makeLevel0(bool isOutermost, const Options& opt, vstring name)
 {
-  return Lib::make_unique<AWPassiveClauseContainer>(isOutermost, opt, name + "AWQ");
+  return std::make_unique<AWPassiveClauseContainer>(isOutermost, opt, name + "AWQ");
 }
 
 std::unique_ptr<PassiveClauseContainer> makeLevel1(bool isOutermost, const Options& opt, vstring name)
@@ -127,7 +127,7 @@ std::unique_ptr<PassiveClauseContainer> makeLevel1(bool isOutermost, const Optio
       auto queueName = name + "ThSQ" + Int::toString(cutoffs[i]) + ":";
       queues.push_back(makeLevel0(false, opt, queueName));
     }
-    return Lib::make_unique<TheoryMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "ThSQ", std::move(queues));
+    return std::make_unique<TheoryMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "ThSQ", std::move(queues));
   }
   else
   {
@@ -146,7 +146,7 @@ std::unique_ptr<PassiveClauseContainer> makeLevel2(bool isOutermost, const Optio
       auto queueName = name + "AvSQ" + Int::toString(cutoffs[i]) + ":";
       queues.push_back(makeLevel1(false, opt, queueName));
     }
-    return Lib::make_unique<AvatarMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "AvSQ", std::move(queues));
+    return std::make_unique<AvatarMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "AvSQ", std::move(queues));
   }
   else
   {
@@ -165,7 +165,7 @@ std::unique_ptr<PassiveClauseContainer> makeLevel3(bool isOutermost, const Optio
       auto queueName = name + "SLSQ" + Int::toString(cutoffs[i]) + ":";
       queues.push_back(makeLevel2(false, opt, queueName));
     }
-    return Lib::make_unique<SineLevelMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "SLSQ", std::move(queues));
+    return std::make_unique<SineLevelMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "SLSQ", std::move(queues));
   }
   else
   {
@@ -184,7 +184,7 @@ std::unique_ptr<PassiveClauseContainer> makeLevel4(bool isOutermost, const Optio
       auto queueName = name + "PLSQ" + Int::toString(cutoffs[i]) + ":";
       queues.push_back(makeLevel3(false, opt, queueName));
     }
-    return Lib::make_unique<PositiveLiteralMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "PLSQ", std::move(queues));
+    return std::make_unique<PositiveLiteralMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "PLSQ", std::move(queues));
   }
   else
   {
@@ -228,7 +228,7 @@ SaturationAlgorithm::SaturationAlgorithm(Problem& prb, const Options& opt)
 
   if (opt.useManualClauseSelection())
   {
-    _passive = Lib::make_unique<ManCSPassiveClauseContainer>(true, opt);
+    _passive = std::make_unique<ManCSPassiveClauseContainer>(true, opt);
   }
   else
   {


### PR DESCRIPTION
This makes the necessary changes to compile with the C++14 standard. No obvious damage is done: the compile takes around the same time on my machine (GCC and Clang), unit tests pass and running a few random problems doesn't crash Vampire.

Pros:
* all the work the standards people do to make our lives easier and our binaries faster
* working toward more recent standards like C++17 or even '20?!
* I get new toys for the CAPS project, notably `std::shared_timed_mutex`
* modern tooling can work better on modern standards
* it's possible that the standard library now provides things we implement ourselves so Vampire can shrink a little

Cons:
* may inadvertently introduce obscure bugs
* people with older build machines may find it difficult to build Vampire.
  * partial rebuttal: cross-compiling is possible