### PR TITLE
fix bug introduced in #195

### DIFF
--- a/Indexing/GroundingIndex.cpp
+++ b/Indexing/GroundingIndex.cpp
@@ -34,6 +34,10 @@ GroundingIndex::GroundingIndex(const Options& opt)
   CALL("GroundingIndex::GroundingIndex");
 
   switch(opt.satSolver()){
+#if VZ3
+    case Options::SatSolver::Z3:
+      //cout << "Warning, Z3 not curently used for Global Subsumption" << endl;
+#endif
     case Options::SatSolver::MINISAT:
       _solver = new MinisatInterfacing(opt,true);
       break;


### PR DESCRIPTION
While removing `TWLSolver` in #195 I introduced an unintended behaviour change when using Z3 in `GroundingIndex`. Good catch @ibnyusuf!