### PR TITLE
Fingerprint indices experiment.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,7 @@ set(VAMPIRE_INDEXING_SOURCES
     Indexing/CodeTree.cpp
     Indexing/CodeTreeInterfaces.cpp
 #    Indexing/FormulaIndex.cpp
+    Indexing/FingerprintIndex.cpp
     Indexing/GroundingIndex.cpp
     Indexing/Index.cpp
     Indexing/IndexManager.cpp
@@ -331,6 +332,7 @@ set(VAMPIRE_INDEXING_SOURCES
     Indexing/ClauseVariantIndex.hpp
     Indexing/CodeTree.hpp
     Indexing/CodeTreeInterfaces.hpp
+    Indexing/FingerprintIndex.hpp
     Indexing/FormulaIndex.hpp
     Indexing/GroundingIndex.hpp
     Indexing/Index.hpp

--- a/Indexing/FingerprintIndex.cpp
+++ b/Indexing/FingerprintIndex.cpp
@@ -1,0 +1,236 @@
+#include "Kernel/RobSubstitution.hpp"
+#include "Lib/Metaiterators.hpp"
+#include "TermIndexingStructure.hpp"
+#include "FingerprintIndex.hpp"
+#include <iostream>
+
+static const signed A = -1, B = -2, N = -4;
+
+namespace Indexing {
+std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> FingerprintIndex::fingerprint(TermList p)
+{
+  CALL("FingerprintIndex::fingerprint");
+  std::array<signed, FINGERPRINT_SIZE> result{N};
+  if (p.isVar()) {
+    result[0] = A;
+    result[1] = B;
+    return result;
+  }
+  Term *t = p.term();
+  result[0] = t->functor();
+
+  if (t->arity() == 0) {
+    result[1] = N;
+    return result;
+  }
+  TermList *p1 = t->nthArgument(0);
+  if (p1->isVar()) {
+    result[1] = A;
+    return result;
+  }
+
+  Term *t1 = p1->term();
+  result[1] = t1->functor();
+  return result;
+}
+
+FingerprintIndex::FingerprintIndex() : _root(new Branch()), _fresh_bucket(0) {}
+FingerprintIndex::~FingerprintIndex()
+{
+  CALL("FingerprintIndex::~FingerprintIndex()");
+  delete _root;
+}
+
+unsigned FingerprintIndex::makeBucket(TermList t)
+{
+  CALL("FingerprintIndex::make");
+  auto fp = fingerprint(t);
+  return _root->makeBucket(fp, _fresh_bucket, 0);
+}
+
+void FingerprintIndex::getUnifications(Stack<unsigned> &results, TermList t)
+{
+  CALL("FingerprintIndex::insert");
+  auto fp = fingerprint(t);
+  _root->getUnifications(results, fp, 0);
+}
+
+FingerprintIndex::Branch::~Branch()
+{
+  CALL("FingerprintIndex::Branch::~Branch");
+  _children.deleteAll();
+}
+
+FingerprintIndex::Leaf::Leaf(unsigned bucket) : _bucket(bucket) {}
+
+unsigned FingerprintIndex::Leaf::makeBucket(const std::array<signed, FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index)
+{
+  CALL("FingerprintIndex::Leaf::makeBucket");
+  return _bucket;
+}
+
+void FingerprintIndex::Leaf::getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index)
+{
+  CALL("FingerprintIndex::Leaf::getUnifications");
+  results.push(_bucket);
+}
+
+unsigned FingerprintIndex::Branch::makeBucket(const std::array<signed, FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index)
+{
+  CALL("FingerprintIndex::Branch::makeBucket");
+  Node *next;
+  Node **next_ptr = _children.getPtr(fingerprint[index]);
+  if (next_ptr) {
+    next = *next_ptr;
+  }
+  else {
+    if (index + 1 == FINGERPRINT_SIZE) {
+      next = new Leaf(fresh++);
+    }
+    else {
+      next = new Branch();
+    }
+    _children.insert(fingerprint[index], next);
+  }
+  return next->makeBucket(fingerprint, fresh, index + 1);
+}
+
+void FingerprintIndex::Branch::getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index)
+{
+  CALL("FingerprintIndex::Branch::getUnifications");
+  signed value = fingerprint[index];
+
+  auto node = [&](signed n) {
+    if (Node **next_ptr = _children.getPtr(n)) {
+      (*next_ptr)->getUnifications(results, fingerprint, index + 1);
+    }
+  };
+  auto nodes_if = [&](bool (*condition)(signed)) {
+    decltype(_children)::Iterator it(_children);
+    signed key;
+    Node *next;
+    while (it.hasNext()) {
+      it.next(key, next);
+      if (condition(key)) {
+        next->getUnifications(results, fingerprint, index + 1);
+      }
+    }
+  };
+  switch (value) {
+    case N:
+      node(B);
+      node(N);
+      break;
+    case B:
+      nodes_if([](signed key) { return true; });
+      break;
+    case A:
+      nodes_if([](signed key) { return key != N; });
+      break;
+    default:
+      ASS_GE(value, 0);
+      node(value);
+      node(A);
+      node(B);
+      break;
+  }
+}
+
+bool TermFingerprintIndex::Entry::operator==(const Entry &other) const {
+  return cls == other.cls && lit == other.lit && term == other.term;
+}
+
+bool TermFingerprintIndex::Entry::operator!=(const Entry &other) const {
+  return cls != other.cls || lit != other.lit || term != other.term;
+}
+
+TermFingerprintIndex::ResultIterator::ResultIterator(
+  TermFingerprintIndex *index,
+  Stack<unsigned> &&buckets
+) :
+  _index(index),
+  _buckets(buckets),
+  _entryIt()
+{}
+
+bool TermFingerprintIndex::ResultIterator::hasNext() {
+  CALL("TermFingerprintIndex::ResultIterator::hasNext");
+  while(!_entryIt.hasNext()) {
+    if(_buckets.isEmpty()) {
+      return false;
+    }
+    unsigned bucket = _buckets.pop();
+    _entryIt = Set<Entry>::Iterator(_index->_buckets[bucket]);
+  }
+  return true;
+}
+
+TermQueryResult TermFingerprintIndex::ResultIterator::next() {
+  CALL("TermFingerprintIndex::ResultIterator::next");
+  Entry entry = _entryIt.next();
+  return TermQueryResult(entry.term, entry.lit, entry.cls);
+}
+
+TermFingerprintIndex::UnificationIterator::UnificationIterator(
+  ResultIterator it,
+  TermList query
+) :
+  _it(it),
+  _query(query),
+  _subst(new RobSubstitution()),
+  _next(),
+  _hasNext(false)
+{}
+
+bool TermFingerprintIndex::UnificationIterator::hasNext() {
+  CALL("TermFingerprintIndex::UnificationIterator::hasNext");
+  if(_hasNext) {
+    return true;
+  }
+  //std::cout << "candidates for " << _query << std::endl;
+  while(_it.hasNext()) {
+    _next = _it.next();
+    //std::cout << _next.term << std::endl;
+    _subst->reset();
+    if(_subst->unify(_query, 0, _next.term, 1)) {
+      _next.substitution =
+        ResultSubstitution::fromSubstitution(_subst.ptr(), 0, 1);
+      _hasNext = true;
+      return true;
+    }
+  }
+  //std::cout << "done" << std::endl;
+  return false;
+}
+
+TermQueryResult TermFingerprintIndex::UnificationIterator::next() {
+  CALL("TermFingerprintIndex::UnificationIterator::next");
+  //std::cout << _query << " unifies with " << _next.term << std::endl;
+  //std::cout << _subst->toString() << std::endl;
+  _hasNext = false;
+  return _next;
+}
+
+void TermFingerprintIndex::insert(TermList trm, Literal *lit, Clause *cls)
+{
+  CALL("TermFingerprintIndex::insert");
+  //std::cout << "insert: " << trm << " in " << *lit << std::endl;
+  _buckets[_index.makeBucket(trm)].insert(Entry{cls, lit, trm});
+}
+
+void TermFingerprintIndex::remove(TermList trm, Literal *lit, Clause *cls)
+{
+  CALL("TermFingerprintIndex::remove");
+  //std::cout << "remove: " << trm << " in " << *lit << std::endl;
+  _buckets[_index.makeBucket(trm)].remove(Entry{cls, lit, trm});
+}
+
+TermQueryResultIterator TermFingerprintIndex::getUnifications(TermList t, bool retrieveSubstitutions)
+{
+  CALL("TermFingerprintIndex::getUnifications");
+  Stack<unsigned> buckets;
+  _index.getUnifications(buckets, t);
+  return
+    pvi(UnificationIterator(ResultIterator(this, std::move(buckets)), t));
+}
+} // namespace Indexing

--- a/Indexing/FingerprintIndex.cpp
+++ b/Indexing/FingerprintIndex.cpp
@@ -1,3 +1,12 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
 #include "Kernel/RobSubstitution.hpp"
 #include "Lib/Metaiterators.hpp"
 #include "TermIndexingStructure.hpp"

--- a/Indexing/FingerprintIndex.cpp
+++ b/Indexing/FingerprintIndex.cpp
@@ -20,26 +20,45 @@ std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> FingerprintIndex::fingerp
 {
   CALL("FingerprintIndex::fingerprint");
   std::array<signed, FINGERPRINT_SIZE> result{N};
-  if (p.isVar()) {
-    result[0] = A;
-    result[1] = B;
-    return result;
-  }
+  ASS(!p.isVar());
+
   Term *t = p.term();
   result[0] = t->functor();
-
   if (t->arity() == 0) {
-    result[1] = N;
     return result;
   }
+
   TermList *p1 = t->nthArgument(0);
   if (p1->isVar()) {
     result[1] = A;
-    return result;
+    result[4] = B;
+    result[5] = B;
+  }
+  else {
+    Term *t1 = p1->term();
+    result[1] = t1->functor();
+    if(t1->arity() > 0) {
+      TermList *p11 = t1->nthArgument(0);
+      result[4] = p11->isVar() ? A : p11->term()->functor();
+    }
+    if(t1->arity() > 1) {
+      TermList *p12 = t1->nthArgument(1);
+      result[5] = p12->isVar() ? A : p12->term()->functor();
+    }
   }
 
-  Term *t1 = p1->term();
-  result[1] = t1->functor();
+  if(t->arity() == 1) {
+    return result;
+  }
+  TermList *p2 = t->nthArgument(1);
+  result[2] = p2->isVar() ? A : p2->term()->functor();
+
+  if(t->arity() == 2) {
+    return result;
+  }
+  TermList *p3 = t->nthArgument(2);
+  result[3] = p3->isVar() ? A : p3->term()->functor();
+
   return result;
 }
 

--- a/Indexing/FingerprintIndex.hpp
+++ b/Indexing/FingerprintIndex.hpp
@@ -1,0 +1,112 @@
+#ifndef __FingerprintIndex__
+#define __FingerprintIndex__
+
+#include "Lib/Array.hpp"
+#include "Lib/Set.hpp"
+#include "Lib/Stack.hpp"
+
+namespace Indexing {
+class FingerprintIndex {
+public:
+  CLASS_NAME(FingerprintIndex);
+  USE_ALLOCATOR(FingerprintIndex);
+
+  static const unsigned FINGERPRINT_SIZE = 2;
+  static std::array<signed, FINGERPRINT_SIZE> fingerprint(TermList ts);
+  FingerprintIndex();
+  ~FingerprintIndex();
+  unsigned makeBucket(TermList ts);
+  void getUnifications(Stack<unsigned> &results, TermList ts);
+
+private:
+  class Node {
+  public:
+    virtual ~Node() = default;
+    virtual unsigned makeBucket(const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index) = 0;
+    virtual void getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index) = 0;
+  };
+
+  class Leaf final : public Node {
+  public:
+    CLASS_NAME(FingerprintIndex::Leaf);
+    USE_ALLOCATOR(FingerprintIndex::Leaf);
+    Leaf(unsigned);
+    unsigned makeBucket(const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index);
+    void getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index);
+  private:
+    unsigned _bucket;
+  };
+
+  class Branch final : public Node {
+  public:
+    CLASS_NAME(FingerprintIndex::Branch);
+    USE_ALLOCATOR(FingerprintIndex::Branch);
+    ~Branch();
+    unsigned makeBucket(const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index);
+    void getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index);
+  private:
+    Map<signed, Node *> _children;
+  };
+
+  Node *_root;
+  unsigned _fresh_bucket;
+}; // class FingerprintIndex
+
+class TermFingerprintIndex final : public TermIndexingStructure {
+public:
+  CLASS_NAME(TermFingerprintIndex);
+  USE_ALLOCATOR(TermFingerprintIndex);
+  void insert(TermList t, Literal *lit, Clause *cls) override;
+  void remove(TermList t, Literal *lit, Clause *cls) override;
+
+  TermQueryResultIterator getUnifications(TermList t, bool retrieveSubstitutions = true) override;
+  TermQueryResultIterator getUnificationsWithConstraints(TermList t, bool retrieveSubstitutions = true) override { NOT_IMPLEMENTED; }
+  TermQueryResultIterator getGeneralizations(TermList t, bool retrieveSubstitutions = true) override { NOT_IMPLEMENTED; }
+  TermQueryResultIterator getInstances(TermList t, bool retrieveSubstitutions = true) override { NOT_IMPLEMENTED; }
+
+  bool generalizationExists(TermList t) override { NOT_IMPLEMENTED; }
+#if VDEBUG
+  void markTagged() override {};
+#endif
+private:
+  struct Entry {
+    Clause *cls;
+    Literal *lit;
+    TermList term;
+    bool operator==(const Entry &other) const;
+    bool operator!=(const Entry &other) const;
+  };
+
+  class ResultIterator {
+  public:
+    ResultIterator(TermFingerprintIndex *index, Stack<unsigned> &&buckets);
+    DECL_ELEMENT_TYPE(TermQueryResult);
+    bool hasNext();
+    OWN_ELEMENT_TYPE next();
+  private:
+    TermFingerprintIndex *_index;
+    Stack<unsigned> _buckets;
+    Set<Entry>::Iterator _entryIt;
+  };
+
+  class UnificationIterator {
+  public:
+    UnificationIterator(ResultIterator results, TermList query);
+    DECL_ELEMENT_TYPE(TermQueryResult);
+    bool hasNext();
+    OWN_ELEMENT_TYPE next();
+  private:
+    ResultIterator _it;
+    TermList _query;
+    RobSubstitutionSP _subst;
+    TermQueryResult _next;
+    bool _hasNext;
+  };
+
+  friend class ResultIterator;
+  FingerprintIndex _index;
+  Array<Set<Entry>> _buckets;
+}; // class TermFingerprintIndex
+} //namespace Indexing
+
+#endif // __FingerprintIndex__

--- a/Indexing/FingerprintIndex.hpp
+++ b/Indexing/FingerprintIndex.hpp
@@ -20,7 +20,7 @@ public:
   CLASS_NAME(FingerprintIndex);
   USE_ALLOCATOR(FingerprintIndex);
 
-  static const unsigned FINGERPRINT_SIZE = 2;
+  static const unsigned FINGERPRINT_SIZE = 6;
   static std::array<signed, FINGERPRINT_SIZE> fingerprint(TermList ts);
   FingerprintIndex();
   unsigned getBucket(TermList ts);

--- a/Indexing/FingerprintIndex.hpp
+++ b/Indexing/FingerprintIndex.hpp
@@ -11,8 +11,8 @@
 #define __FingerprintIndex__
 
 #include "Lib/Array.hpp"
-#include "Lib/Set.hpp"
 #include "Lib/Stack.hpp"
+#include "Lib/STL.hpp"
 
 namespace Indexing {
 class FingerprintIndex {
@@ -88,14 +88,16 @@ private:
 
   class ResultIterator {
   public:
-    ResultIterator(TermFingerprintIndex *index, Stack<unsigned> &&buckets);
+    ResultIterator(const TermFingerprintIndex &index, Stack<unsigned> &&buckets);
     DECL_ELEMENT_TYPE(TermQueryResult);
     bool hasNext();
+    void nextBucket();
     OWN_ELEMENT_TYPE next();
   private:
-    TermFingerprintIndex *_index;
+    const TermFingerprintIndex &_index;
     Stack<unsigned> _buckets;
-    Set<Entry>::Iterator _entryIt;
+    vvector<Entry>::const_iterator _entry;
+    vvector<Entry>::const_iterator _end;
   };
 
   class UnificationIterator {
@@ -114,7 +116,7 @@ private:
 
   friend class ResultIterator;
   FingerprintIndex _index;
-  Array<Set<Entry>> _buckets;
+  Array<vvector<Entry>> _buckets;
 }; // class TermFingerprintIndex
 } //namespace Indexing
 

--- a/Indexing/FingerprintIndex.hpp
+++ b/Indexing/FingerprintIndex.hpp
@@ -23,41 +23,12 @@ public:
   static const unsigned FINGERPRINT_SIZE = 2;
   static std::array<signed, FINGERPRINT_SIZE> fingerprint(TermList ts);
   FingerprintIndex();
-  ~FingerprintIndex();
-  unsigned makeBucket(TermList ts);
+  unsigned getBucket(TermList ts);
   void getUnifications(Stack<unsigned> &results, TermList ts);
 
 private:
-  class Node {
-  public:
-    virtual ~Node() = default;
-    virtual unsigned makeBucket(const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index) = 0;
-    virtual void getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index) = 0;
-  };
-
-  class Leaf final : public Node {
-  public:
-    CLASS_NAME(FingerprintIndex::Leaf);
-    USE_ALLOCATOR(FingerprintIndex::Leaf);
-    Leaf(unsigned);
-    unsigned makeBucket(const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index);
-    void getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index);
-  private:
-    unsigned _bucket;
-  };
-
-  class Branch final : public Node {
-  public:
-    CLASS_NAME(FingerprintIndex::Branch);
-    USE_ALLOCATOR(FingerprintIndex::Branch);
-    ~Branch();
-    unsigned makeBucket(const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned &fresh, unsigned index);
-    void getUnifications(Stack<unsigned> &results, const std::array<signed, FingerprintIndex::FINGERPRINT_SIZE> &fingerprint, unsigned index);
-  private:
-    Map<signed, Node *> _children;
-  };
-
-  Node *_root;
+  vmap<std::pair<unsigned, signed>, unsigned> _edges;
+  unsigned _fresh_node;
   unsigned _fresh_bucket;
 }; // class FingerprintIndex
 

--- a/Indexing/FingerprintIndex.hpp
+++ b/Indexing/FingerprintIndex.hpp
@@ -1,3 +1,12 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
 #ifndef __FingerprintIndex__
 #define __FingerprintIndex__
 

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -20,6 +20,7 @@
 
 #include "AcyclicityIndex.hpp"
 #include "CodeTreeInterfaces.hpp"
+#include "FingerprintIndex.hpp"
 #include "GroundingIndex.hpp"
 #include "LiteralIndex.hpp"
 #include "LiteralSubstitutionTree.hpp"
@@ -176,7 +177,8 @@ Index* IndexManager::create(IndexType t)
     break;
 
   case SUPERPOSITION_SUBTERM_SUBST_TREE:
-    tis=new TermSubstitutionTree(useConstraints);
+    tis=new TermFingerprintIndex();
+    //tis=new TermSubstitutionTree(useConstraints);
 #if VDEBUG
     //tis->markTagged();
 #endif

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -177,8 +177,12 @@ Index* IndexManager::create(IndexType t)
     break;
 
   case SUPERPOSITION_SUBTERM_SUBST_TREE:
-    tis=new TermFingerprintIndex();
-    //tis=new TermSubstitutionTree(useConstraints);
+    if(useConstraints) {
+      tis=new TermSubstitutionTree(useConstraints);
+    }
+    else {
+      tis=new TermFingerprintIndex();
+    }
 #if VDEBUG
     //tis->markTagged();
 #endif
@@ -186,19 +190,24 @@ Index* IndexManager::create(IndexType t)
     isGenerating = true;
     break;
   case SUPERPOSITION_LHS_SUBST_TREE:
-    tis=new TermSubstitutionTree(useConstraints);
+    if(useConstraints) {
+      tis=new TermSubstitutionTree(useConstraints);
+    }
+    else {
+      tis=new TermFingerprintIndex();
+    }
     res=new SuperpositionLHSIndex(tis, _alg->getOrdering(), _alg->getOptions());
     isGenerating = true;
     break;
 
   case ACYCLICITY_INDEX:
-    tis = new TermSubstitutionTree();
+    tis=new TermFingerprintIndex();
     res = new AcyclicityIndex(tis);
     isGenerating = true;
     break;
 
   case DEMODULATION_SUBTERM_SUBST_TREE:
-    tis=new TermSubstitutionTree();
+    tis=new TermFingerprintIndex();
     res=new DemodulationSubtermIndex(tis);
     isGenerating = false;
     break;


### PR DESCRIPTION
This branch implements the _fingerprint indexing_ technique described in [_Fingerprint Indexing for Paramodulation and Rewriting_](http://wwwlehre.dhbw-stuttgart.de/~sschulz/PAPERS/schulz_fp-index.pdf). Fingerprint indexing is a simple imperfect indexing technique for first-order unification and matching.

It's possible that Vampire could benefit from this technique, alongside or in place of existing index structures. A quick hack is promising: replacing a single substitution-tree index with a fingerprint index gives a slight performance win, even though the fingerprint index is not well-tuned.

This should not be merged and is here to gauge interest and solicit feedback from more experienced team members. There are at least some bugs. TODO:
- [x] implement instances and generalisations as well as unification
- [ ] implement literal indexing
- [ ] guard against, or implement support for, theories/HOL
- [ ] test on problems
- [ ] cleanup, format, test, document etc.