### PR TITLE
Initial Attempt at Auto-detecting Input langauge

### DIFF
--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -343,9 +343,9 @@ void Options::init()
 
     _inputSyntax= ChoiceOptionValue<InputSyntax>("input_syntax","",
                                                  //in case we compile vampire with bpa, then the default input syntax is smtlib
-                                                 InputSyntax::TPTP,
+                                                 InputSyntax::AUTO,
                                                  //{"simplify","smtlib","smtlib2","tptp"});//,"xhuman","xmps","xnetlib"});
-                                                 {"smtlib2","tptp"});//,"xhuman","xmps","xnetlib"});
+                                                 {"smtlib2","tptp","auto"});//,"xhuman","xmps","xnetlib"});
     _inputSyntax.description=
     "Input syntax. Historic input syntaxes have been removed as they are not actively maintained. Contact developers for help with these.";
     _lookup.insert(&_inputSyntax);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -384,6 +384,7 @@ public:
     SMTLIB2 = 0,
     /** syntax of the TPTP prover */
     TPTP = 1, 
+    AUTO = 2
     //HUMAN = 4, 
     //MPS = 5, 
     //NETLIB = 6

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -281,6 +281,11 @@ Problem* UIHelper::getInputProblem(const Options& opts)
            exception.cry(env.out());
            env.out() << "Trying TPTP\n";
            env.endOutput();
+           {
+             BYPASSING_ALLOCATOR;
+             delete static_cast<ifstream*>(input);
+             input=new ifstream(inputFile.c_str());
+           }
            units = tryParseTPTP(input);
          }
 
@@ -298,6 +303,11 @@ Problem* UIHelper::getInputProblem(const Options& opts)
            exception.cry(env.out());
            env.out() << "Trying SMTLIB2\n";
            env.endOutput();
+           {
+             BYPASSING_ALLOCATOR;
+             delete static_cast<ifstream*>(input);
+             input=new ifstream(inputFile.c_str());
+           }
            units = tryParseSMTLIB2(opts,input,smtLibLogic); 
          }
        }
@@ -311,7 +321,6 @@ Problem* UIHelper::getInputProblem(const Options& opts)
     units = tryParseSMTLIB2(opts,input,smtLibLogic);
     break;
   }
-
   if (inputFile!="") {
     BYPASSING_ALLOCATOR;
     

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -188,6 +188,49 @@ void UIHelper::outputSaturatedSet(ostream& out, UnitIterator uit)
 
 UnitList* parsedUnits;
 
+
+// String utility function that probably belongs elsewhere
+static bool hasEnding (vstring const &fullString, vstring const &ending) {
+    if (fullString.length() >= ending.length()) {
+        return (0 == fullString.compare (fullString.length() - ending.length(), ending.length(), ending));
+    } else {
+        return false;
+    }
+}
+
+UnitList* UIHelper::tryParseTPTP(istream* input)
+{
+      Parse::TPTP parser(*input);
+      try{
+        parser.parse();
+      }
+      catch (UserErrorException& exception) {
+        vstring msg = exception.msg();
+        throw Parse::TPTP::ParseErrorException(msg,parser.lineNumber());
+      }
+      s_haveConjecture=parser.containsConjecture();
+      return parser.units();
+}
+UnitList* UIHelper::tryParseSMTLIB2(const Options& opts,istream* input,SMTLIBLogic& smtLibLogic)
+{
+          Parse::SMTLIB2 parser(opts);
+          parser.parse(*input);
+          Unit::onParsingEnd();
+
+          smtLibLogic = parser.getLogic();
+          s_haveConjecture=false;
+
+#if VDEBUG
+          const vstring& expected_status = parser.getStatus();
+          if (expected_status == "sat") {
+            s_expecting_sat = true;
+          } else if (expected_status == "unsat") {
+            s_expecting_unsat = true;
+          }
+#endif
+          return parser.getFormulas();
+}
+
 /**
  * Return problem object with units obtained according to the content of
  * @b env.options
@@ -218,53 +261,55 @@ Problem* UIHelper::getInputProblem(const Options& opts)
     }
   }
 
-  UnitList* units;
+  UnitList* units = nullptr;
   switch (opts.inputSyntax()) {
-  case Options::InputSyntax::TPTP:
+  case Options::InputSyntax::AUTO:
     {
-      Parse::TPTP parser(*input);
-      try{
-        parser.parse();
-      }
-      catch (UserErrorException& exception) {
-        vstring msg = exception.msg();
-        throw Parse::TPTP::ParseErrorException(msg,parser.lineNumber());
-      }
-      units = parser.units();
-      s_haveConjecture=parser.containsConjecture();
+       // First lets pick a place to start based on the input file name
+       bool smtlib = hasEnding(inputFile,"smt") || hasEnding(inputFile,"smt2");
+
+       if(smtlib){
+         env.beginOutput();
+         env.out() << "Running in auto input_syntax mode. Trying SMTLIB2\n";
+         env.endOutput();
+         try{
+           units = tryParseSMTLIB2(opts,input,smtLibLogic);
+         }
+         catch (UserErrorException& exception) {
+           env.beginOutput();
+           env.out() << "Failed with\n";
+           exception.cry(env.out());
+           env.out() << "Trying TPTP\n";
+           env.endOutput();
+           units = tryParseTPTP(input);
+         }
+
+       }
+       else{
+         env.beginOutput();
+         env.out() << "Running in auto input_syntax mode. Trying TPTP\n";
+         env.endOutput();
+         try{
+           units = tryParseTPTP(input); 
+         }
+         catch (UserErrorException& exception) {
+           env.beginOutput();
+           env.out() << "Failed with\n";
+           exception.cry(env.out());
+           env.out() << "Trying SMTLIB2\n";
+           env.endOutput();
+           units = tryParseSMTLIB2(opts,input,smtLibLogic); 
+         }
+       }
+       
     }
     break;
+  case Options::InputSyntax::TPTP:
+    units = tryParseTPTP(input);
+    break;
   case Options::InputSyntax::SMTLIB2:
-  {
-	  Parse::SMTLIB2 parser(opts);
-	  parser.parse(*input);
-          Unit::onParsingEnd();
-
-	  units = parser.getFormulas();
-    smtLibLogic = parser.getLogic();
-	  s_haveConjecture=false;
-
-#if VDEBUG
-	  const vstring& expected_status = parser.getStatus();
-	  if (expected_status == "sat") {
-	    s_expecting_sat = true;
-	  } else if (expected_status == "unsat") {
-	    s_expecting_unsat = true;
-	  }
-#endif
-
-	  break;
-  }
-/*
-  case Options::InputSyntax::MPS:
-  case Options::InputSyntax::NETLIB:
-  case Options::InputSyntax::HUMAN:
-  {
-    cout << "This is not supported yet";
-    NOT_IMPLEMENTED;
-   }
-*/
-   break;
+    units = tryParseSMTLIB2(opts,input,smtLibLogic);
+    break;
   }
 
   if (inputFile!="") {

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -33,6 +33,8 @@ bool outputAllowed(bool debug=false);
 
 class UIHelper {
 public:
+  static UnitList* tryParseTPTP(istream* input);
+  static UnitList* tryParseSMTLIB2(const Options& opts,istream* input,SMTLIBLogic& logic);
   static Problem* getInputProblem(const Options& opts);
   static void outputResult(ostream& out);
 


### PR DESCRIPTION
In issue [198](https://github.com/vprover/vampire/issues/198) Bernhard made the very sensible suggestion to have an auto-detect mode for the input syntax.

The proposal was to do this solely based on filename. This will probably cover 99% of the use cases as it is a defacto standard in SMT to use smt or smt2 as file extensions. 

However, there was the counterproposal to look inside the file to see how we should parse it.

This pull request is an initial attempt to combine the two. We first check the filename to work out which way to parse the file initially but then fallback to the other parser (we now only have two) if this fails.

This PR is not ready to merge as I haven't tested on more than a few examples. 

It currently (perhaps naively) assumes that all parser errors are being raised as ParseExceptions and this needs to be checked.

The code in UIHelper could probably be refactored a little. I welcome initial thoughts.