### PR TITLE
Experimental multi-threaded Vampire.

### DIFF
--- a/Api/FormulaBuilder.cpp
+++ b/Api/FormulaBuilder.cpp
@@ -66,7 +66,7 @@ Sort FormulaBuilder::sort(const vstring& sortName)
 {
   CALL("FormulaBuilder::sort");
 
-  unsigned res = env.sorts->addSort(sortName);
+  unsigned res = env->sorts->addSort(sortName);
   return Sort(res);
 }
 
@@ -103,7 +103,7 @@ vstring FormulaBuilder::getSortName(Sort s)
 {
   CALL("FormulaBuilder::getSortName");
 
-  return env.sorts->sortName(s);
+  return env->sorts->sortName(s);
 }
 
 vstring FormulaBuilder::getPredicateName(Predicate p)
@@ -170,8 +170,8 @@ Function FormulaBuilder::function(const vstring& funName, unsigned arity, Sort r
   }
 
   bool added;
-  unsigned res = env.signature->addFunction(funName, arity, added);
-  Kernel::Signature::Symbol* sym = env.signature->getFunction(res);
+  unsigned res = env->signature->addFunction(funName, arity, added);
+  Kernel::Signature::Symbol* sym = env->signature->getFunction(res);
 
   static DArray<unsigned> nativeSorts;
   nativeSorts.initFromArray(arity, domainSorts);
@@ -198,7 +198,7 @@ Function FormulaBuilder::integerConstant(int i)
 {
   CALL("FormulaBuilder::integerConstant");
 
-  unsigned fun = env.signature->addIntegerConstant(IntegerConstantType(i));
+  unsigned fun = env->signature->addIntegerConstant(IntegerConstantType(i));
   return Function(fun);
 }
 
@@ -208,7 +208,7 @@ Function FormulaBuilder::integerConstant(vstring i)
 
   unsigned fun;
   try {
-    fun = env.signature->addIntegerConstant(IntegerConstantType(i));
+    fun = env->signature->addIntegerConstant(IntegerConstantType(i));
   }
   catch (ArithmeticException) {
     throw FormulaBuilderException("Constant value invalid or does not fit into internal representation: " + i);
@@ -238,9 +238,9 @@ Predicate FormulaBuilder::predicate(const vstring& predName, unsigned arity, Sor
   }
 
   bool added;
-  unsigned res = env.signature->addPredicate(predName, arity, added);
+  unsigned res = env->signature->addPredicate(predName, arity, added);
 
-  Kernel::Signature::Symbol* sym = env.signature->getPredicate(res);
+  Kernel::Signature::Symbol* sym = env->signature->getPredicate(res);
 
   static DArray<unsigned> nativeSorts;
   nativeSorts.initFromArray(arity, domainSorts);
@@ -283,7 +283,7 @@ Predicate FormulaBuilder::interpretedPredicate(InterpretedPredicate symbol)
     break;
   }
 
-  unsigned res = env.signature->getInterpretingSymbol(itp);
+  unsigned res = env->signature->getInterpretingSymbol(itp);
 
   return Predicate(res);
 }
@@ -446,14 +446,14 @@ Term FormulaBuilder::term(const Function& f,const Term* args)
 {
   CALL("FormulaBuilder::term");
 
-  return _aux->term(f,args,env.signature->functionArity(f));
+  return _aux->term(f,args,env->signature->functionArity(f));
 }
 
 Formula FormulaBuilder::atom(const Predicate& p, const Term* args, bool positive)
 {
   CALL("FormulaBuilder::atom");
 
-  return _aux->atom(p,positive, args,env.signature->predicateArity(p));
+  return _aux->atom(p,positive, args,env->signature->predicateArity(p));
 }
 
 Formula FormulaBuilder::equality(const Term& lhs,const Term& rhs, Sort sort, bool positive)
@@ -1217,7 +1217,7 @@ void OutputOptions::setAssignFormulaNames(bool newVal)
   CALL("OutputOptions::setAssignFormulaNames");
 
   _assignFormulaNames = newVal;
-  env.options->setOutputAxiomNames(newVal);
+  env->options->setOutputAxiomNames(newVal);
 }
 
 
@@ -1303,7 +1303,7 @@ vstring StringIterator::next()
 std::ostream& operator<< (std::ostream& str,const Api::Sort& sort)
 {
   CALL("operator<< (ostream&,const Api::Sort&)");
-  return str<<env.sorts->sortName(sort);
+  return str<<env->sorts->sortName(sort);
 }
 
 ostream& operator<< (ostream& str,const Api::Formula& f)

--- a/Api/Helper.cpp
+++ b/Api/Helper.cpp
@@ -60,12 +60,12 @@ vstring DefaultHelperCore::getDummyName(bool pred, unsigned functor)
   CALL("DefaultHelperCore::getDummyName/2");
 
   Signature::Symbol* sym = pred ?
-      env.signature->getPredicate(functor) :
-      env.signature->getFunction(functor);
+      env->signature->getPredicate(functor) :
+      env->signature->getFunction(functor);
 
   if(sym->interpreted()) {
-    return pred ? env.signature->predicateName(functor) :
-	env.signature->functionName(functor);
+    return pred ? env->signature->predicateName(functor) :
+	env->signature->functionName(functor);
   }
 
   if(pred) {
@@ -91,10 +91,10 @@ vstring DefaultHelperCore::getSymbolName(bool pred, unsigned functor) const
   }
   else {
     if(pred) {
-      return env.signature->predicateName(functor);
+      return env->signature->predicateName(functor);
     }
     else {
-      return env.signature->functionName(functor);
+      return env->signature->functionName(functor);
     }
   }
 }
@@ -122,7 +122,7 @@ vstring DefaultHelperCore::toString(const Kernel::Term* t0) const
 	unsigned sort = SortHelper::getEqualityArgumentSort(l);
 	res=(l->isPositive() ? "" : "~");
 	res+="$$equality_sorted(";
-	res+=env.sorts->sortName(sort)+",";
+	res+=env->sorts->sortName(sort)+",";
 	res+=toString(*l->nthArgument(0))+",";
 	res+=toString(*l->nthArgument(1))+")";
 	return res;
@@ -256,7 +256,7 @@ vstring DefaultHelperCore::toString(const Kernel::Formula* f0) const
 	    sort = Sorts::SRT_DEFAULT;
 	  }
 	}
-	result += env.sorts->sortName(sort);
+	result += env->sorts->sortName(sort);
       }
       if(vit.hasNext()) {
 	result += ',';
@@ -424,13 +424,13 @@ Term FBHelperCore::term(const Function& f,const Term* args, unsigned arity)
 {
   CALL("FBHelperCore::term");
 
-  if(f>=static_cast<unsigned>(env.signature->functions())) {
+  if(f>=static_cast<unsigned>(env->signature->functions())) {
     throw FormulaBuilderException("Function does not exist");
   }
-  if(arity!=env.signature->functionArity(f)) {
-    throw FormulaBuilderException("Invalid function arity: "+env.signature->functionName(f));
+  if(arity!=env->signature->functionArity(f)) {
+    throw FormulaBuilderException("Invalid function arity: "+env->signature->functionName(f));
   }
-  ensureArgumentsSortsMatch(env.signature->getFunction(f)->fnType(), args);
+  ensureArgumentsSortsMatch(env->signature->getFunction(f)->fnType(), args);
 
   DArray<TermList> argArr;
   argArr.initFromArray(arity, args);
@@ -445,13 +445,13 @@ Formula FBHelperCore::atom(const Predicate& p, bool positive, const Term* args, 
 {
   CALL("FBHelperCore::atom");
 
-  if(p>=static_cast<unsigned>(env.signature->predicates())) {
+  if(p>=static_cast<unsigned>(env->signature->predicates())) {
     throw FormulaBuilderException("Predicate does not exist");
   }
-  if(arity!=env.signature->predicateArity(p)) {
-    throw FormulaBuilderException("Invalid predicate arity: "+env.signature->predicateName(p));
+  if(arity!=env->signature->predicateArity(p)) {
+    throw FormulaBuilderException("Invalid predicate arity: "+env->signature->predicateName(p));
   }
-  ensureArgumentsSortsMatch(env.signature->getPredicate(p)->predType(), args);
+  ensureArgumentsSortsMatch(env->signature->getPredicate(p)->predType(), args);
 
   DArray<TermList> argArr;
   argArr.initFromArray(arity, args);
@@ -471,7 +471,7 @@ unsigned FBHelperCore::getUnaryPredicate()
     return _unaryPredicate;
   }
 
-  Kernel::Signature& sig = *env.signature;
+  Kernel::Signature& sig = *env->signature;
   unsigned cnt = sig.predicates();
   for(unsigned i=1; i<cnt; i++) {
     if(sig.predicateArity(i)==1 && !sig.getPredicate(i)->interpreted()) {
@@ -493,7 +493,7 @@ Sort FBHelperCore::getSort(const Api::Term t)
   }
   else {
     unsigned fun = t.functor();
-    return Sort(env.signature->getFunction(fun)->fnType()->result());
+    return Sort(env->signature->getFunction(fun)->fnType()->result());
   }
 }
 

--- a/Api/Problem.cpp
+++ b/Api/Problem.cpp
@@ -469,8 +469,8 @@ void Problem::addFromStream(istream& s, vstring includeDirectory, bool simplifyS
 
   using namespace Shell;
 
-  vstring originalInclude=env.options->include();
-  env.options->setInclude(includeDirectory);
+  vstring originalInclude=env->options->include();
+  env->options->setInclude(includeDirectory);
 
   Kernel::UnitList* units;
   if(simplifySyntax) {
@@ -484,7 +484,7 @@ void Problem::addFromStream(istream& s, vstring includeDirectory, bool simplifyS
     units = Parse::TPTP::parse(s);
   }
 
-  env.options->setInclude(originalInclude);
+  env->options->setInclude(originalInclude);
   while(units) {
     Kernel::Unit* u=Kernel::UnitList::pop(units);
     addFormula(AnnotatedFormula(u));
@@ -975,10 +975,10 @@ protected:
     static DHSet<Kernel::Unit*> defs;
     defs.reset();
 
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] api: started def inlining" << std::endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] api: started def inlining" << std::endl;
+      env->endOutput();
     }    
 
     AnnotatedFormulaIterator fit;
@@ -990,10 +990,10 @@ protected:
 	  AnnotatedFormula f=fit.next();
 	  _pdInliner.updatePredOccCounts(f.unit);
 	}
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] api: non-growing counting finished" << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] api: non-growing counting finished" << std::endl;
+    env->endOutput();
   }
       }
 
@@ -1008,10 +1008,10 @@ protected:
 	  defs.insert(fu);
 	}
       }
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] api: predicate equivalence scan finished" << std::endl;
-        env.endOutput();
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "[PP] api: predicate equivalence scan finished" << std::endl;
+        env->endOutput();
       }
 
       if(_mode!=INL_PREDICATE_EQUIVALENCES_ONLY) {
@@ -1026,10 +1026,10 @@ protected:
 	    defs.insert(fu);
 	  }
 	}
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] api: other definition scan finished" << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] api: other definition scan finished" << std::endl;
+    env->endOutput();
   }
       }
     }
@@ -1616,12 +1616,12 @@ inlining:
     return res;
   }
 
-  bool oldTraceVal = env.options->showNonconstantSkolemFunctionTrace();
-  env.options->setShowNonconstantSkolemFunctionTrace(options.showNonConstantSkolemFunctionTrace);
+  bool oldTraceVal = env->options->showNonconstantSkolemFunctionTrace();
+  env->options->setShowNonconstantSkolemFunctionTrace(options.showNonConstantSkolemFunctionTrace);
 
   res = Clausifier(options.namingThreshold, options.preserveEpr, options.mode==PM_SKOLEMIZE).transform(res);
 
-  env.options->setShowNonconstantSkolemFunctionTrace(oldTraceVal);
+  env->options->setShowNonconstantSkolemFunctionTrace(oldTraceVal);
   return res;
 }
 
@@ -1711,7 +1711,7 @@ void outputSymbolTypeDefinitions(ostream& out, unsigned symNumber, bool function
   CALL("outputSymbolTypeDefinitions");
 
   Signature::Symbol* sym = function ?
-      env.signature->getFunction(symNumber) : env.signature->getPredicate(symNumber);
+      env->signature->getFunction(symNumber) : env->signature->getPredicate(symNumber);
 
   if(sym->interpreted()) {
     //there is no need to output type definitions for interpreted symbols
@@ -1732,7 +1732,7 @@ void outputSymbolTypeDefinitions(ostream& out, unsigned symNumber, bool function
   unsigned arity = sym->arity();
   if(arity>0) {
     if(arity==1) {
-      out << env.sorts->sortName(type->arg(0));
+      out << env->sorts->sortName(type->arg(0));
     }
     else {
       out << "(";
@@ -1740,14 +1740,14 @@ void outputSymbolTypeDefinitions(ostream& out, unsigned symNumber, bool function
 	if(i>0) {
 	  out << " * ";
 	}
-	out << env.sorts->sortName(type->arg(i));
+	out << env->sorts->sortName(type->arg(i));
       }
       out << ")";
     }
     out << " > ";
   }
   if(function) {
-    out << env.sorts->sortName(sym->fnType()->result());
+    out << env->sorts->sortName(sym->fnType()->result());
   }
   else {
     out << "$o";
@@ -1764,20 +1764,20 @@ void Problem::outputTypeDefinitions(ostream& out, bool outputAllTypeDefs)
   DefaultHelperCore* core0 = _data->getCore();
   bool dummyNames = core0 && core0->outputDummyNames();
   FBHelperCore* core = (core0 && core0->isFBHelper()) ? static_cast<FBHelperCore*>(core0) : 0;
-  unsigned sorts = env.sorts->count();
+  unsigned sorts = env->sorts->count();
   for(unsigned i=Sorts::FIRST_USER_SORT; i<sorts; i++) {
-    out << "tff(sort_def_" << i << ",type, " << env.sorts->sortName(i) << ": $tType";
+    out << "tff(sort_def_" << i << ",type, " << env->sorts->sortName(i) << ": $tType";
     if(core) { outputAttributes(out, &core->getSortAttributes(i)); }
     out << " )." << endl;
   }
 
 
-  unsigned funs = env.signature->functions();
+  unsigned funs = env->signature->functions();
   for(unsigned i=0; i<funs; i++) {
     outputSymbolTypeDefinitions(out, i, true, outputAllTypeDefs,
 	core ? &core->getFunctionAttributes(i) : 0, dummyNames);
   }
-  unsigned preds = env.signature->predicates();
+  unsigned preds = env->signature->predicates();
   for(unsigned i=1; i<preds; i++) {
     outputSymbolTypeDefinitions(out, i, false, outputAllTypeDefs,
 	core ? &core->getPredicateAttributes(i) : 0, dummyNames);
@@ -1801,7 +1801,7 @@ void Problem::outputStatistics(ostream& out)
 {
   CALL("Problem::outputStatictics");
 
-  env.statistics->print(out);
+  env->statistics->print(out);
 }
 
 ///////////////////////////////////////

--- a/Api/ResourceLimits.cpp
+++ b/Api/ResourceLimits.cpp
@@ -38,7 +38,7 @@ struct __InitHelper
   {
     ResourceLimits::disableLimits();
 
-    env.options->setOutputAxiomNames(true);
+    env->options->setOutputAxiomNames(true);
   }
 
   __InitHelper()
@@ -55,10 +55,10 @@ void ResourceLimits::setLimits(size_t memoryInBytes, int timeInDeciseconds)
 {
   CALL("ResourceLimits::setLimits");
 
-  env.options->setMemoryLimit(memoryInBytes);
+  env->options->setMemoryLimit(memoryInBytes);
   Allocator::setMemoryLimit(memoryInBytes);
 
-  env.options->setTimeLimitInDeciseconds(timeInDeciseconds);
+  env->options->setTimeLimitInDeciseconds(timeInDeciseconds);
 }
 
 }

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -643,8 +643,16 @@ void PortfolioMode::runSlice(Options& strategyOpt)
 #if VTHREADED
   if(env->options->mode() == Options::Mode::THREADED) {
     if(!resultValue) {
+      // gross: copied from elsewhere
+      // we need to exit immediately, not really a "nice" way to do this :-(
+      ifstream input(_tmpFileNameForProof);
+      if (input) {
+        env->beginOutput();
+        env->out() << input.rdbuf();
+        env->endOutput();
+      }
+
       // TODO: other threads are still running while global destructors run
-      // Allocator::lockPermanently();
       quick_exit(resultValue);
     }
     // allow other threads to fight the good fight, don't exit() the process
@@ -724,4 +732,3 @@ bool CASCMode::runSlice(Options& opt)
 }
 
 */
-

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -552,7 +552,14 @@ void PortfolioMode::runSlice(Options *strategyOpt)
     env.endOutput();
   }
 
-  Saturation::ProvingHelper::runVampire(*_prb, *opt);
+#if VTHREADED
+  if(env.options->mode() == Options::Mode::THREADED) {
+    ScopedPtr<Problem> problem(_prb->copy(true));
+    Saturation::ProvingHelper::runVampire(*problem, *opt);
+  }
+  else
+#endif
+    Saturation::ProvingHelper::runVampire(*_prb, *opt);
 
   //set return value to zero if we were successful
   if (env.statistics->terminationReason == Statistics::REFUTATION ||

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -122,10 +122,7 @@ bool PortfolioMode::searchForProof()
 {
   CALL("PortfolioMode::searchForProof");
 
-#if VTHREADED
-  if(env.options->mode() != Options::Mode::THREADED)
-#endif
-    env.timer->makeChildrenIncluded();
+  env.timer->makeChildrenIncluded();
   TimeCounter::reinitialize();
 
   _prb = UIHelper::getInputProblem(*env.options);

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -79,7 +79,7 @@ private:
   bool runSchedule(Schedule& schedule);
   bool waitForChildAndCheckIfProofFound();
   void runSlice(vstring slice, unsigned timeLimitInDeciseconds);
-  void runSlice(Options *strategyOpt);
+  void runSlice(Options &strategyOpt);
 
 #if VDEBUG
   DHSet<pid_t> childIds;

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -39,7 +39,7 @@ using namespace Shell;
 class PortfolioMode;
 
 // Simple one-after-the-other priority.
-class PortfolioProcessPriorityPolicy : public ProcessPriorityPolicy
+class PortfolioPriorityPolicy : public StrategyPriorityPolicy
 {
 public:
   float staticPriority(vstring sliceCode) override;
@@ -78,8 +78,8 @@ private:
   void getExtraSchedules(Property& prop, Schedule& old, Schedule& extra, bool add_extra, int time_multiplier); 
   bool runSchedule(Schedule& schedule);
   bool waitForChildAndCheckIfProofFound();
-  void runSlice(vstring slice, unsigned timeLimitInDeciseconds) NO_RETURN;
-  void runSlice(Options& strategyOpt) NO_RETURN;
+  void runSlice(vstring slice, unsigned timeLimitInDeciseconds);
+  void runSlice(Options *strategyOpt);
 
 #if VDEBUG
   DHSet<pid_t> childIds;

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -79,7 +79,7 @@ private:
   bool runSchedule(Schedule& schedule);
   bool waitForChildAndCheckIfProofFound();
   void runSlice(vstring slice, unsigned timeLimitInDeciseconds);
-  void runSlice(Options &strategyOpt);
+  void runSlice(Options& strategyOpt);
 
 #if VDEBUG
   DHSet<pid_t> childIds;

--- a/CASC/ProcessScheduleExecutor.cpp
+++ b/CASC/ProcessScheduleExecutor.cpp
@@ -67,7 +67,7 @@ bool ProcessScheduleExecutor::run(const Schedule &schedule)
 
   bool success = false;
   int remainingTime;
-  while(Timer::syncClock(), remainingTime = DECI(env.remainingTime()), remainingTime > 0)
+  while(Timer::syncClock(), remainingTime = DECI(env->remainingTime()), remainingTime > 0)
   {
     unsigned poolSize = pool ? Pool::length(pool) : 0;
 
@@ -121,10 +121,10 @@ bool ProcessScheduleExecutor::run(const Schedule &schedule)
       queue.insert(priority, Item(process));
     } else if (signalled) {
       // killed by an external agency (could be e.g. a slurm cluster killing for too much memory allocated)
-      env.beginOutput();
-      Shell::addCommentSignForSZS(env.out());
-      env.out()<<"Child killed by signal " << code << endl;
-      env.endOutput();
+      env->beginOutput();
+      Shell::addCommentSignForSZS(env->out());
+      env->out()<<"Child killed by signal " << code << endl;
+      env->endOutput();
       pool = Pool::remove(process, pool);
     }
 

--- a/CASC/ProcessScheduleExecutor.cpp
+++ b/CASC/ProcessScheduleExecutor.cpp
@@ -1,0 +1,168 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#include "ProcessScheduleExecutor.hpp"
+
+#include "Lib/Environment.hpp"
+#include "Lib/List.hpp"
+#include "Lib/PriorityQueue.hpp"
+#include "Lib/System.hpp"
+#include "Lib/Sys/Multiprocessing.hpp"
+#include "Lib/Timer.hpp"
+#include "Shell/UIHelper.hpp"
+
+#define DECI(milli) (milli/100)
+
+class Item
+{
+public:
+  Item() : _started(true), _process(-1), _code("") {}
+  Item(vstring code)
+    : _started(false), _process(-1), _code(code) {}
+  Item(pid_t process)
+    : _started(true), _process(process), _code("") {}
+
+  bool started() const {return _started;}
+  vstring code() const
+  {
+    ASS(!started());
+    return _code;
+  }
+  pid_t process() const
+  {
+    ASS(started());
+    return _process;
+  }
+
+private:
+  bool _started;
+  pid_t _process;
+  vstring _code;
+};
+
+namespace CASC {
+bool ProcessScheduleExecutor::run(const Schedule &schedule)
+{
+  CALL("ProcessScheduleExecutor::run");
+
+  PriorityQueue<Item> queue;
+  Schedule::BottomFirstIterator it(schedule);
+
+  // insert all strategies into the queue
+  while(it.hasNext())
+  {
+    vstring code = it.next();
+    float priority = _policy->staticPriority(code);
+    queue.insert(priority, code);
+  }
+
+  typedef List<pid_t> Pool;
+  Pool *pool = Pool::empty();
+
+  bool success = false;
+  int remainingTime;
+  while(Timer::syncClock(), remainingTime = DECI(env.remainingTime()), remainingTime > 0)
+  {
+    unsigned poolSize = pool ? Pool::length(pool) : 0;
+
+    // running under capacity, wake up more tasks
+    while(poolSize < _numWorkers && !queue.isEmpty())
+    {
+      Item item = queue.pop();
+      pid_t process;
+      if(!item.started())
+      {
+        // DBG("spawning schedule ", item.code())
+        process = spawn(item.code(), remainingTime);
+      }
+      else
+      {
+        process = item.process();
+        Multiprocessing::instance()->kill(process, SIGCONT);
+      }
+      Pool::push(process, pool);
+      poolSize++;
+    }
+
+    bool stopped, exited, signalled;
+    int code;
+    // sleep until process changes state
+    pid_t process = Multiprocessing::instance()
+      ->poll_children(stopped, exited, signalled, code);
+
+    /*
+    cout << "Child " << process
+        << " stop " << stopped
+        << " exit " << exited
+        << " sig " << signalled << " code " << code << endl;
+        */
+
+    // child died, remove it from the pool and check if succeeded
+    if(exited)
+    {
+      pool = Pool::remove(process, pool);
+      if(!code)
+      {
+        success = true;
+        goto exit;
+      }
+    }
+    // child stopped, re-insert it in the queue
+    else if(stopped)
+    {
+      pool = Pool::remove(process, pool);
+      float priority = _policy->dynamicPriority(process);
+      queue.insert(priority, Item(process));
+    } else if (signalled) {
+      // killed by an external agency (could be e.g. a slurm cluster killing for too much memory allocated)
+      env.beginOutput();
+      Shell::addCommentSignForSZS(env.out());
+      env.out()<<"Child killed by signal " << code << endl;
+      env.endOutput();
+      pool = Pool::remove(process, pool);
+    }
+
+    // pool empty and queue exhausted - we failed
+    if(!pool && queue.isEmpty())
+    {
+      goto exit;
+    }
+  }
+
+exit:
+  // kill all running processes first
+  Pool::DestructiveIterator killIt(pool);
+  while(killIt.hasNext())
+  {
+    pid_t process = killIt.next();
+    Multiprocessing::instance()->killNoCheck(process, SIGKILL);
+  }
+  return success;
+}
+
+pid_t ProcessScheduleExecutor::spawn(vstring code, int remainingTime)
+{
+  CALL("ProcessScheduleExecutor::spawn");
+
+  pid_t pid = Multiprocessing::instance()->fork();
+  ASS_NEQ(pid, -1);
+
+  // parent
+  if(pid)
+  {
+    return pid;
+  }
+  // child
+  else
+  {
+    _executor->runSlice(code, remainingTime);
+    ASSERTION_VIOLATION; // should not return
+  }
+}
+} //namespace CASC

--- a/CASC/ProcessScheduleExecutor.hpp
+++ b/CASC/ProcessScheduleExecutor.hpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#ifndef __ProcessScheduleExecutor__
+#define __ProcessScheduleExecutor__
+
+#include "ScheduleExecutor.hpp"
+
+namespace CASC
+{
+
+class ProcessScheduleExecutor final : public ScheduleExecutor
+{
+public:
+  CLASS_NAME(ProcessScheduleExecutor);
+  USE_ALLOCATOR(ProcessScheduleExecutor);
+  using ScheduleExecutor::ScheduleExecutor;
+  bool run(const Schedule &schedule) override;
+
+private:
+  pid_t spawn(Lib::vstring code, int remaminingTime);
+};
+}
+
+#endif

--- a/CASC/ScheduleExecutor.cpp
+++ b/CASC/ScheduleExecutor.cpp
@@ -9,156 +9,12 @@
  */
 #include "ScheduleExecutor.hpp"
 
-#include "Lib/Array.hpp"
-#include "Lib/Environment.hpp"
-#include "Lib/List.hpp"
-#include "Lib/PriorityQueue.hpp"
 #include "Lib/System.hpp"
 #include "Lib/Sys/Multiprocessing.hpp"
-#include "Lib/Timer.hpp"
+#include "Lib/Environment.hpp"
 #include "Shell/Options.hpp"
-#include "Shell/UIHelper.hpp"
 
-using namespace CASC;
-using namespace Lib;
-using namespace Lib::Sys;
-
-#define DECI(milli) (milli/100)
-
-ScheduleExecutor::ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor)
-  : _policy(policy), _executor(executor)
-{
-  CALL("ScheduleExecutor::ScheduleExecutor");
-  _numWorkers = getNumWorkers();
-}
-
-class Item
-{
-public:
-  Item() : _started(true), _process(-1), _code("") {}
-  Item(vstring code)
-    : _started(false), _process(-1), _code(code) {}
-  Item(pid_t process)
-    : _started(true), _process(process), _code("") {}
-
-  bool started() const {return _started;}
-  vstring code() const
-  {
-    ASS(!started());
-    return _code;
-  }
-  pid_t process() const
-  {
-    ASS(started());
-    return _process;
-  }
-
-private:
-  bool _started;
-  pid_t _process;
-  vstring _code;
-};
-
-bool ScheduleExecutor::run(const Schedule &schedule)
-{
-  CALL("ScheduleExecutor::run");
-
-  PriorityQueue<Item> queue;
-  Schedule::BottomFirstIterator it(schedule);
-
-  // insert all strategies into the queue
-  while(it.hasNext())
-  {
-    vstring code = it.next();
-    float priority = _policy->staticPriority(code);
-    queue.insert(priority, code);
-  }
-
-  typedef List<pid_t> Pool;
-  Pool *pool = Pool::empty();
-
-  bool success = false;
-  int remainingTime;
-  while(Timer::syncClock(), remainingTime = DECI(env.remainingTime()), remainingTime > 0)
-  {
-    unsigned poolSize = pool ? Pool::length(pool) : 0;
-
-    // running under capacity, wake up more tasks
-    while(poolSize < _numWorkers && !queue.isEmpty())
-    {
-      Item item = queue.pop();
-      pid_t process;
-      if(!item.started())
-      {
-        // DBG("spawning schedule ", item.code())
-        process = spawn(item.code(), remainingTime);
-      }
-      else
-      {
-        process = item.process();
-        Multiprocessing::instance()->kill(process, SIGCONT);
-      }
-      Pool::push(process, pool);
-      poolSize++;
-    }
-
-    bool stopped, exited, signalled;
-    int code;
-    // sleep until process changes state
-    pid_t process = Multiprocessing::instance()
-      ->poll_children(stopped, exited, signalled, code);
-
-    /*
-    cout << "Child " << process
-        << " stop " << stopped
-        << " exit " << exited
-        << " sig " << signalled << " code " << code << endl;
-        */
-
-    // child died, remove it from the pool and check if succeeded
-    if(exited)
-    {
-      pool = Pool::remove(process, pool);
-      if(!code)
-      {
-        success = true;
-        goto exit;
-      }
-    }
-    // child stopped, re-insert it in the queue
-    else if(stopped)
-    {
-      pool = Pool::remove(process, pool);
-      float priority = _policy->dynamicPriority(process);
-      queue.insert(priority, Item(process));
-    } else if (signalled) {
-      // killed by an external agency (could be e.g. a slurm cluster killing for too much memory allocated)
-      env.beginOutput();
-      Shell::addCommentSignForSZS(env.out());
-      env.out()<<"Child killed by signal " << code << endl;
-      env.endOutput();
-      pool = Pool::remove(process, pool);
-    }
-
-    // pool empty and queue exhausted - we failed
-    if(!pool && queue.isEmpty())
-    {
-      goto exit;
-    }
-  }
-
-exit:
-  // kill all running processes first
-  Pool::DestructiveIterator killIt(pool);
-  while(killIt.hasNext())
-  {
-    pid_t process = killIt.next();
-    Multiprocessing::instance()->killNoCheck(process, SIGKILL);
-  }
-  return success;
-}
-
-unsigned ScheduleExecutor::getNumWorkers()
+static unsigned getNumWorkers()
 {
   CALL("ScheduleExecutor::getNumWorkers");
 
@@ -172,22 +28,15 @@ unsigned ScheduleExecutor::getNumWorkers()
   return workers;
 }
 
-pid_t ScheduleExecutor::spawn(vstring code, int remainingTime)
+namespace CASC {
+ScheduleExecutor::ScheduleExecutor(
+  StrategyPriorityPolicy *policy,
+  SliceExecutor *executor
+) :
+  _policy(policy),
+  _executor(executor)
 {
-  CALL("ScheduleExecutor::spawn");
-
-  pid_t pid = Multiprocessing::instance()->fork();
-  ASS_NEQ(pid, -1);
-
-  // parent
-  if(pid)
-  {
-    return pid;
-  }
-  // child
-  else
-  {
-    _executor->runSlice(code, remainingTime);
-    ASSERTION_VIOLATION; // should not return
-  }
+  CALL("ScheduleExecutor::ScheduleExecutor");
+  _numWorkers = getNumWorkers();
 }
+} //namespace CASC

--- a/CASC/ScheduleExecutor.cpp
+++ b/CASC/ScheduleExecutor.cpp
@@ -20,7 +20,7 @@ static unsigned getNumWorkers()
 
   unsigned cores = System::getNumberOfCores();
   cores = cores < 1 ? 1 : cores;
-  unsigned workers = min(cores, env.options->multicore());
+  unsigned workers = min(cores, env->options->multicore());
   if(!workers)
   {
     workers = cores >= 8 ? cores - 2 : cores;

--- a/CASC/ScheduleExecutor.hpp
+++ b/CASC/ScheduleExecutor.hpp
@@ -10,13 +10,12 @@
 #ifndef __ScheduleExecutor__
 #define __ScheduleExecutor__
 
-#include <unistd.h>
 #include "Schedules.hpp"
 
 namespace CASC
 {
 
-class ProcessPriorityPolicy
+class StrategyPriorityPolicy
 {
 public:
   virtual float staticPriority(Lib::vstring sliceCode) = 0;
@@ -26,20 +25,18 @@ public:
 class SliceExecutor
 {
 public:
-  virtual void runSlice(Lib::vstring sliceCode, int remaminingTime) NO_RETURN = 0;
+  virtual void runSlice(Lib::vstring sliceCode, int remaminingTime) = 0;
 };
 
 class ScheduleExecutor
 {
 public:
-  ScheduleExecutor(ProcessPriorityPolicy *policy, SliceExecutor *executor);
-  bool run(const Schedule &schedule);
+  ScheduleExecutor(StrategyPriorityPolicy *policy, SliceExecutor *executor);
+  virtual bool run(const Schedule &schedule) = 0;
+  virtual ~ScheduleExecutor() = default;
 
-private:
-  pid_t spawn(Lib::vstring code, int remaminingTime);
-  unsigned getNumWorkers();
-
-  ProcessPriorityPolicy *_policy;
+protected:
+  StrategyPriorityPolicy *_policy;
   SliceExecutor *_executor;
   unsigned _numWorkers;
 };

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -52,13 +52,13 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
 
     // fresh statistics
     env->statistics = new Shell::Statistics();
-    // deep-copy options, signature and term sharing from parent thread
+    // deep-copy options, signature from parent thread
     env->options = new Shell::Options(*penv->options);
     env->signature = new Kernel::Signature(*penv->signature);
-    env->sharing = new Indexing::TermSharing(*penv->sharing);
 
     // shallow-copy sorts, sharing, property
     env->sorts = penv->sorts;
+    env->sharing = penv->sharing;
     env->property = penv->property;
 
     env->timer = Timer::instance();
@@ -69,6 +69,7 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
 
     // unbind stuff we shallow-copied to stop it being deallocated
     env->property = nullptr;
+    env->sharing = nullptr;
     env->sorts = nullptr;
 
     // indicate we're done

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -10,6 +10,7 @@
 #if VTHREADED
 #include "ThreadScheduleExecutor.hpp"
 
+#include "Indexing/TermSharing.hpp"
 #include "Kernel/Signature.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Timer.hpp"
@@ -51,13 +52,13 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
 
     // fresh statistics
     env->statistics = new Shell::Statistics();
-    // deep-copy options and signature from parent thread
+    // deep-copy options, signature and term sharing from parent thread
     env->options = new Shell::Options(*penv->options);
     env->signature = new Kernel::Signature(*penv->signature);
+    env->sharing = new Indexing::TermSharing(*penv->sharing);
 
     // shallow-copy sorts, sharing, property
     env->sorts = penv->sorts;
-    env->sharing = penv->sharing;
     env->property = penv->property;
 
     env->timer = Timer::instance();
@@ -68,11 +69,7 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
 
     // unbind stuff we shallow-copied to stop it being deallocated
     env->property = nullptr;
-    env->sharing = nullptr;
     env->sorts = nullptr;
-
-    //leak signature :-( - currently TermSharing keeps handles to this
-    env->signature = nullptr;
 
     // indicate we're done
     std::lock_guard<std::mutex> task_lock(task_mutex);

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#if VTHREADED
+#include "ThreadScheduleExecutor.hpp"
+
+#include "Lib/Environment.hpp"
+#include "Lib/Timer.hpp"
+#include "Shell/Options.hpp"
+#include "Shell/UIHelper.hpp"
+
+#include <thread>
+
+#define DECI(milli) (milli/100)
+
+namespace CASC {
+bool ThreadScheduleExecutor::run(const Schedule &schedule)
+{
+  CALL("ThreadScheduleExecutor::run");
+  bool success = false;
+  // TODO is this the right way up?
+  // It matches the process executor but looks wrong
+  Schedule::BottomFirstIterator it(schedule);
+
+  int remainingTime;
+  while(
+    Timer::syncClock(),
+    remainingTime = DECI(env.remainingTime()),
+    remainingTime > 0 &&
+    it.hasNext()
+  ) {
+    vstring code = it.next();
+    {
+      BYPASSING_ALLOCATOR;
+      std::thread t([&] {
+        _executor->runSlice(code, remainingTime);
+      });
+      t.join();
+    }
+    Timer::syncClock();
+  }
+
+  return success;
+}
+} //namespace CASC
+#endif

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -36,21 +36,14 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
 
   // this closure is run _by_ a thread...
   auto parent_signature = env.signature;
-  auto parent_sharing = env.sharing;
   auto parent_options = env.options;
   auto task = [&](vstring code, int remainingTime, unsigned i) {
     // copy options from parent thread
     *env.options = *parent_options;
     // also deep-copy the signature
     env.signature->clone_from(parent_signature);
-    // but we can share the term sharing (!)
-    // keep a copy of the original to avoid a double-free though
-    auto sharing = env.sharing;
-    env.sharing = parent_sharing;
     // thread setup done, now do All The Things
     _executor->runSlice(code, remainingTime);
-    // swap the term sharing back in
-    env.sharing = sharing;
     // indicate we're done
     std::lock_guard<std::mutex> task_lock(task_mutex);
     tasks_idle++;

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -17,6 +17,7 @@
 #include "Shell/UIHelper.hpp"
 
 #include <thread>
+#include <condition_variable>
 
 #define DECI(milli) (milli/100)
 
@@ -24,42 +25,85 @@ namespace CASC {
 bool ThreadScheduleExecutor::run(const Schedule &schedule)
 {
   CALL("ThreadScheduleExecutor::run");
-  bool success = false;
-  // TODO is this the right way up?
-  // It matches the process executor but looks wrong
-  Schedule::BottomFirstIterator it(schedule);
 
-  int remainingTime;
+  const int num_threads = 8;
+  std::thread threads[num_threads]{};
+  // if the thread in question is running or not
+  std::atomic<bool> busy[num_threads]{};
+  // basically a nasty counting semaphore, but we don't have one until C++20
+  std::condition_variable task_done;
+  std::mutex task_mutex;
+  int tasks_idle = 0;
+
+  // this closure is run _by_ a thread...
+  auto parent_signature = env.signature;
+  auto parent_sharing = env.sharing;
+  auto parent_options = env.options;
+  auto task = [&](vstring code, int remainingTime, unsigned i) {
+    // copy options from parent thread
+    *env.options = *parent_options;
+    // also deep-copy the signature
+    env.signature->clone_from(parent_signature);
+    // but we can share the term sharing (!)
+    // keep a copy of the original to avoid a double-free though
+    auto sharing = env.sharing;
+    env.sharing = parent_sharing;
+    // thread setup done, now do All The Things
+    _executor->runSlice(code, remainingTime);
+    // swap the term sharing back in
+    env.sharing = sharing;
+    // indicate we're done
+    std::lock_guard<std::mutex> task_lock(task_mutex);
+    tasks_idle++;
+    busy[i] = false;
+    task_done.notify_one();
+    std::cout << "finished" << std::endl;
+  };
+
+  // ...but this closure _starts_ the thread
+  Schedule::BottomFirstIterator it(schedule);
+  int remainingTime = DECI(env.remainingTime());
+  auto launch_task = [&](int i) {
+      vstring code = it.next();
+      busy[i] = true;
+      {
+        BYPASSING_ALLOCATOR;
+        threads[i] = std::thread(task, code, remainingTime, i);
+      }
+  };
+
+  // start some threads so we can wait on them
+  for(int i = 0; i < num_threads && it.hasNext(); i++) {
+    launch_task(i);
+  }
+
+  // while we have time, wait for threads to finish and spawn new ones
   while(
     Timer::syncClock(),
     remainingTime = DECI(env.remainingTime()),
-    remainingTime > 0 &&
-    it.hasNext()
+    remainingTime > 0 && it.hasNext()
   ) {
-    vstring code = it.next();
-    auto parent_signature = env.signature;
-    auto parent_sharing = env.sharing;
-    auto parent_options = env.options;
-    auto task = [&] {
-      *env.options = *parent_options;
-      env.signature->clone_from(parent_signature);
-      auto sharing = env.sharing;
-      env.sharing = parent_sharing;
-      _executor->runSlice(code, remainingTime);
-      env.sharing = sharing;
-    };
-    {
-      BYPASSING_ALLOCATOR;
-      const int num_threads = 8;
-      std::thread threads[num_threads];
-      for(int i = 0; i < num_threads; i++)
-        threads[i] = std::thread(task);
-      for(int i = 0; i < num_threads; i++)
-        threads[i].join();
+    std::unique_lock<std::mutex> task_lock(task_mutex);
+    task_done.wait(task_lock, [&]() { return tasks_idle > 0; });
+    tasks_idle--;
+    for(int i = 0; i < num_threads; i++) {
+      if(!busy[i]) {
+        if(threads[i].joinable())
+          threads[i].join();
+        if(it.hasNext())
+          launch_task(i);
+        break;
+      }
     }
   }
 
-  return success;
+  // cleanup after time runs out
+  for(int i = 0; i < num_threads; i++) {
+    if(threads[i].joinable())
+      threads[i].join();
+  }
+
+  return false;
 }
 } //namespace CASC
 #endif

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -70,6 +70,9 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
     env.sharing = nullptr;
     env.sorts = nullptr;
 
+    //leak signature :-( - currently TermSharing keeps handles to this
+    env.signature = nullptr;
+
     // indicate we're done
     std::lock_guard<std::mutex> task_lock(task_mutex);
     tasks_idle++;

--- a/CASC/ThreadScheduleExecutor.cpp
+++ b/CASC/ThreadScheduleExecutor.cpp
@@ -38,12 +38,23 @@ bool ThreadScheduleExecutor::run(const Schedule &schedule)
     vstring code = it.next();
     {
       BYPASSING_ALLOCATOR;
+      auto parent_options = env.options;
+      auto parent_signature = env.signature;
+      auto parent_sharing = env.sharing;
       std::thread t([&] {
+        auto options = env.options;
+        auto signature = env.signature;
+        auto sharing = env.sharing;
+        env.options = parent_options;
+        env.signature = parent_signature;
+        env.sharing = parent_sharing;
         _executor->runSlice(code, remainingTime);
+        env.sharing = sharing;
+        env.signature = signature;
+        env.options = options;
       });
       t.join();
     }
-    Timer::syncClock();
   }
 
   return success;

--- a/CASC/ThreadScheduleExecutor.hpp
+++ b/CASC/ThreadScheduleExecutor.hpp
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#if VTHREADED
+#ifndef __ThreadScheduleExecutor__
+#define __ThreadScheduleExecutor__
+
+#include "ScheduleExecutor.hpp"
+
+namespace CASC
+{
+
+class ThreadScheduleExecutor final : public ScheduleExecutor
+{
+public:
+  CLASS_NAME(ThreadScheduleExecutor);
+  USE_ALLOCATOR(ThreadScheduleExecutor);
+  using ScheduleExecutor::ScheduleExecutor;
+  bool run(const Schedule &schedule) override;
+};
+}
+
+#endif
+#endif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,25 @@ else()
   endif()
 endif()
 
+# experimental thread-parallel strategy scheduling
+option(THREADING "Build Vampire with experimental threaded mode." OFF)
+if (THREADING)
+  message(STATUS "building with threading enabled: EXPERIMENTAL")
+  add_compile_definitions(VTHREADED=1)
+  find_package(Threads REQUIRED)
+  link_libraries(Threads::Threads)
+else()
+  add_compile_definitions(VTHREADED=0)
+endif()
+
+# ThreadSanitizer tool
+option(TSAN "Build Vampire with ThreadSanitizer." OFF)
+if (TSAN)
+  message(STATUS "building with ThreadSanitizer: EXPERIMENTAL")
+  add_compile_options(-fsanitize=thread)
+  add_link_options(-fsanitize=thread)
+endif()
+
 ################################################################
 # define all vampire sources,
 # generate the main target and 
@@ -197,6 +216,7 @@ set(VAMPIRE_LIB_SOURCES
     Lib/STLAllocator.hpp
     Lib/StringUtils.hpp
     Lib/System.hpp
+    Lib/Threading.hpp
     Lib/TimeCounter.hpp
     Lib/Timer.hpp
     Lib/TriangularArray.hpp
@@ -742,11 +762,15 @@ set(VAMPIRE_CASC_SOURCES
     CASC/PortfolioMode.cpp
     CASC/Schedules.cpp
     CASC/ScheduleExecutor.cpp
+    CASC/ProcessScheduleExecutor.cpp
+    CASC/ThreadScheduleExecutor.cpp
     CASC/CLTBMode.cpp
     CASC/CLTBModeLearning.cpp
     CASC/PortfolioMode.hpp
     CASC/Schedules.hpp
     CASC/ScheduleExecutor.hpp
+    CASC/ProcessScheduleExecutor.hpp
+    CASC/ThreadScheduleExecutor.hpp
     CASC/CLTBMode.hpp
     CASC/CLTBModeLearning.hpp
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -557,6 +557,7 @@ set(VAMPIRE_SATURATION_SOURCES
     Saturation/LabelFinder.cpp
     Saturation/LRS.cpp
     Saturation/Otter.cpp
+    Saturation/PersistentGrounding.cpp
     Saturation/ProvingHelper.cpp
     Saturation/SaturationAlgorithm.cpp
     Saturation/Splitter.cpp
@@ -570,6 +571,7 @@ set(VAMPIRE_SATURATION_SOURCES
     Saturation/LabelFinder.hpp
     Saturation/LRS.hpp
     Saturation/Otter.hpp
+    Saturation/PersistentGrounding.hpp
     Saturation/ProvingHelper.hpp
     Saturation/SaturationAlgorithm.hpp
     Saturation/Splitter.hpp

--- a/DP/ShortConflictMetaDP.cpp
+++ b/DP/ShortConflictMetaDP.cpp
@@ -67,7 +67,7 @@ DecisionProcedure::Status ShortConflictMetaDP::getStatus(bool getMultipleCores)
   unsigned minSz = UINT_MAX;
 
   typedef pair<LiteralStack,unsigned> CoreWithSize;
-  static Stack<CoreWithSize> cores;
+  VTHREAD_LOCAL static Stack<CoreWithSize> cores;
   ASS(cores.isEmpty());
 
   // Record cores with their sizes in cores stack and

--- a/DP/SimpleCongruenceClosure.cpp
+++ b/DP/SimpleCongruenceClosure.cpp
@@ -97,7 +97,7 @@ void SimpleCongruenceClosure::ConstInfo::resetEquivalences(SimpleCongruenceClosu
   predecessorPremise = CEq(0,0);
   classList.reset();
 
-  static ArraySet seen;
+  VTHREAD_LOCAL static ArraySet seen;
   seen.ensure(parent.getMaxConst()+1);
   seen.reset();
 
@@ -583,7 +583,7 @@ bool SimpleCongruenceClosure::checkPositiveDistincts(bool retrieveMultipleCores)
   CALL("SimpleCongruenceClosure::checkPositiveDistincts");
 
   //map from a representative to constant in its class present in the current distinct group
-  static ArrayMap<unsigned> reprs;
+  VTHREAD_LOCAL static ArrayMap<unsigned> reprs;
   reprs.ensure(getMaxConst()+1);
 
   bool foundConflict = false;
@@ -617,7 +617,7 @@ bool SimpleCongruenceClosure::checkPositiveDistincts(bool retrieveMultipleCores)
 DecisionProcedure::Status SimpleCongruenceClosure::checkNegativeDistincts(bool retrieveMultipleCores)
 {
   //map from a representative to constant in its class present in the current distinct group
-  static ArrayMap<unsigned> reprs;
+  VTHREAD_LOCAL static ArrayMap<unsigned> reprs;
   reprs.ensure(getMaxConst()+1);
 
   DistinctStack::BottomFirstIterator distIt(_negDistinctConstraints);
@@ -787,12 +787,12 @@ void SimpleCongruenceClosure::getUnsatCore(LiteralStack& res, unsigned coreIndex
     res.push(unsatEq.foPremise);
   }
 
-  static Stack<CPair> toExplain;
+  VTHREAD_LOCAL static Stack<CPair> toExplain;
   toExplain.push(CPair(unsatEq.c1, unsatEq.c2));
   ASS_EQ(deref(toExplain.top().first), deref(toExplain.top().second));
 
   IntUnionFind explained(getMaxConst()+1);
-  static Stack<unsigned> pathStack;
+  VTHREAD_LOCAL static Stack<unsigned> pathStack;
 
   while(toExplain.isNonEmpty()) {
     CPair curr = toExplain.pop();
@@ -890,7 +890,7 @@ void SimpleCongruenceClosure::computeConstsNormalForm(unsigned c, NFMap& normalF
     unsigned idx = t->arity();
     unsigned d = c;
     
-    static DArray<TermList> args(8);
+    VTHREAD_LOCAL static DArray<TermList> args(8);
     args.ensure(idx);
     while (idx-->0) {
       CPair pair = _cInfos[d].namedPair;
@@ -917,12 +917,12 @@ void SimpleCongruenceClosure::getModel(LiteralStack& model)
   CALL("SimpleCongruenceClosure::getModel");
   
   // a heap of candidate constants to process
-  static DynamicHeap<unsigned, ConstOrderingComparator, ArrayMap<unsigned> >
+  VTHREAD_LOCAL static DynamicHeap<unsigned, ConstOrderingComparator, ArrayMap<unsigned> >
     candidates(ConstOrderingComparator(_cInfos,*_ord));
   ASS(candidates.isEmpty());
   
   // a map of already computed normal forms, indexed by class representatives
-  static NFMap normalForms;
+  VTHREAD_LOCAL static NFMap normalForms;
   normalForms.reset();
   
   unsigned maxConst = getMaxConst();
@@ -1052,7 +1052,7 @@ void SimpleCongruenceClosure::getModel(LiteralStack& model)
     
     //cout << "Outputting for class " << r << " with nf " << nf.toString() << endl;
     
-    static DHSet<TermList> seen;
+    VTHREAD_LOCAL static DHSet<TermList> seen;
     seen.reset();
     seen.insert(nf); // this way we avoid generating the identity equality
     

--- a/Debug/Assertion.cpp
+++ b/Debug/Assertion.cpp
@@ -20,6 +20,7 @@
 #include "Lib/Allocator.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/System.hpp"
+#include "Lib/Threading.hpp"
 #include "Lib/Timer.hpp"
 #include "Shell/Options.hpp"
 
@@ -76,6 +77,7 @@ void Assertion::violatedStrEquality(const char* file, int line, const char* val1
 void Assertion::checkType(const char* file, int line, const void* ptr, const char* assumed,
                           const char* ptrStr)
 {
+#if !TSAN
   Allocator::Descriptor* desc = Allocator::Descriptor::find(ptr);
 
   if (!desc) {
@@ -112,6 +114,7 @@ void Assertion::checkType(const char* file, int line, const void* ptr, const cha
     cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
+#endif
 } // Assertion::violated
 
 /**

--- a/Debug/RuntimeStatistics.cpp
+++ b/Debug/RuntimeStatistics.cpp
@@ -78,7 +78,7 @@ void RSMultiStatistic::print(ostream& out)
 
 RuntimeStatistics* RuntimeStatistics::instance()
 {
-  static RuntimeStatistics inst;
+  VTHREAD_LOCAL static RuntimeStatistics inst;
 
   return &inst;
 }

--- a/Debug/RuntimeStatistics.hpp
+++ b/Debug/RuntimeStatistics.hpp
@@ -14,6 +14,7 @@
 
 #ifndef __RuntimeStatistics__
 #define __RuntimeStatistics__
+#include "Lib/Threading.hpp"
 
 /**
 If RUNTIME_STATS is defined as 0, runtime statistics are not being
@@ -188,10 +189,10 @@ private:
 #define RSTAT_AUX_NAME_(SEED) RSTAT_AUX_NAME__(SEED)
 #define RSTAT_AUX_NAME RSTAT_AUX_NAME_(__LINE__)
 
-#define RSTAT_CTR_INC(stat) if(RSTAT_COLLECTION) { static Debug::RSCounter* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSCounter>(stat); RSTAT_AUX_NAME->inc(); }
-#define RSTAT_CTR_INC_MANY(stat,num) if(RSTAT_COLLECTION) { static Debug::RSCounter* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSCounter>(stat); RSTAT_AUX_NAME->inc(num); }
-#define RSTAT_MCTR_INC(stat, index) if(RSTAT_COLLECTION) { static Debug::RSMultiCounter* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSMultiCounter>(stat); RSTAT_AUX_NAME->inc(index); }
-#define RSTAT_MST_INC(stat, index, val) if(RSTAT_COLLECTION) { static Debug::RSMultiStatistic* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSMultiStatistic>(stat); RSTAT_AUX_NAME->addRecord(index, val); }
+#define RSTAT_CTR_INC(stat) if(RSTAT_COLLECTION) { VTHREAD_LOCAL static Debug::RSCounter* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSCounter>(stat); RSTAT_AUX_NAME->inc(); }
+#define RSTAT_CTR_INC_MANY(stat,num) if(RSTAT_COLLECTION) { VTHREAD_LOCAL static Debug::RSCounter* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSCounter>(stat); RSTAT_AUX_NAME->inc(num); }
+#define RSTAT_MCTR_INC(stat, index) if(RSTAT_COLLECTION) { VTHREAD_LOCAL static Debug::RSMultiCounter* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSMultiCounter>(stat); RSTAT_AUX_NAME->inc(index); }
+#define RSTAT_MST_INC(stat, index, val) if(RSTAT_COLLECTION) { VTHREAD_LOCAL static Debug::RSMultiStatistic* RSTAT_AUX_NAME = Debug::RuntimeStatistics::instance()->get<Debug::RSMultiStatistic>(stat); RSTAT_AUX_NAME->addRecord(index, val); }
 
 #define RSTAT_PRINT(out) Debug::RuntimeStatistics::instance()->print(out)
 

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -53,7 +53,7 @@ VTHREAD_LOCAL bool Tracer::_forced = false;
  *  In order to watch also all changes of the address one should
  *  define WATCH_ADDR in this file. 
  */
-bool Tracer::canWatch = false;
+VTHREAD_LOCAL bool Tracer::canWatch = false;
 
 /** To understand how to use the following variable read documentation
  *  to Tracer::canWatch */

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -37,12 +37,12 @@ extern const char* VERSION_STRING;
 using namespace std;
 using namespace Debug;
 
-const char* Tracer::_lastControlPoint;
-Tracer* Tracer::_current = 0;
-unsigned Tracer::_depth = 0;
-unsigned Tracer::_passedControlPoints = 0L;
-ControlPointKind Tracer::_lastPointKind = CP_MID;
-bool Tracer::_forced = false;
+VTHREAD_LOCAL const char* Tracer::_lastControlPoint;
+VTHREAD_LOCAL Tracer* Tracer::_current = 0;
+VTHREAD_LOCAL unsigned Tracer::_depth = 0;
+VTHREAD_LOCAL unsigned Tracer::_passedControlPoints = 0L;
+VTHREAD_LOCAL ControlPointKind Tracer::_lastPointKind = CP_MID;
+VTHREAD_LOCAL bool Tracer::_forced = false;
 
 /** This variable is needed when all changes in the value of an
  *  an address are traced. To make it work one should define

--- a/Debug/Tracer.hpp
+++ b/Debug/Tracer.hpp
@@ -21,6 +21,9 @@
 #  define __Tracer__
 
 #if VDEBUG
+#if VTHREADED
+#include "Lib/Threading.hpp"
+#endif
 
 #include <iostream>
 
@@ -62,17 +65,17 @@ class Tracer {
   static void spaces(ostream& str,int number);
 
   /** current trace point */
-  static Tracer* _current;
+  VTHREAD_LOCAL static Tracer* _current;
   /** current depth */
-  static unsigned _depth;
+  VTHREAD_LOCAL static unsigned _depth;
   /** description of the last control point (function name) */
-  static const char* _lastControlPoint;
+  VTHREAD_LOCAL static const char* _lastControlPoint;
   /** total number of passed control points */
-  static unsigned _passedControlPoints;
+  VTHREAD_LOCAL static unsigned _passedControlPoints;
   /** kind of the last point */
-  static ControlPointKind _lastPointKind;
+  VTHREAD_LOCAL static ControlPointKind _lastPointKind;
   /** forced by startTrace */
-  static bool _forced;
+  VTHREAD_LOCAL static bool _forced;
   static void controlPoint (const char*, ControlPointKind);
   static void outputLastControlPoint (ostream& str);
 public:

--- a/Debug/Tracer.hpp
+++ b/Debug/Tracer.hpp
@@ -21,9 +21,7 @@
 #  define __Tracer__
 
 #if VDEBUG
-#if VTHREADED
 #include "Lib/Threading.hpp"
-#endif
 
 #include <iostream>
 

--- a/Debug/Tracer.hpp
+++ b/Debug/Tracer.hpp
@@ -54,7 +54,7 @@ class Tracer {
   static void forceOutput() { _forced = true; }
   /** stop outputting forced by startOutput */
   static void stopOutput() { _forced = false; }
-  static bool canWatch;
+  VTHREAD_LOCAL static bool canWatch;
  private:
   const char* _fun;
   Tracer* _previous;

--- a/FMB/DefinitionIntroduction.hpp
+++ b/FMB/DefinitionIntroduction.hpp
@@ -31,7 +31,7 @@ namespace FMB {
 
   public:
     DefinitionIntroduction(ClauseIterator cit) : _cit(cit) {
-      //_ng = env.options->fmbNonGroundDefs();
+      //_ng = env->options->fmbNonGroundDefs();
     }
 
 
@@ -121,9 +121,9 @@ namespace FMB {
         //cout << "Considering " << t->toString() << endl;
         if(t->arity()==0) continue;
         if(!_introduced.find(t)){
-          unsigned newConstant = env.signature->addFreshFunction(0,"fmbdef");
+          unsigned newConstant = env->signature->addFreshFunction(0,"fmbdef");
           TermList srt = SortHelper::getResultSort(t);
-          Signature::Symbol* newConstantSymb = env.signature->getFunction(newConstant);
+          Signature::Symbol* newConstantSymb = env->signature->getFunction(newConstant);
           newConstantSymb->setType(OperatorType::getConstantsType(srt));
           newConstantSymb->incUsageCnt();
           Term* c = Term::createConstant(newConstant); 
@@ -192,7 +192,7 @@ namespace FMB {
         unsigned vars = t->vars();
 
         // then create a fresh function symbol for the definition
-        newf = env.signature->addFreshFunction(vars,"fmbdef");
+        newf = env->signature->addFreshFunction(vars,"fmbdef");
         // and save it
         _introducedNG.insert(t,newf);
         

--- a/FMB/DefinitionIntroduction.hpp
+++ b/FMB/DefinitionIntroduction.hpp
@@ -62,7 +62,7 @@ namespace FMB {
 
       //cout << "Process " << c->toString() << endl;
 
-      static Stack<Literal*> lits; // to rebuild the clause
+      VTHREAD_LOCAL static Stack<Literal*> lits; // to rebuild the clause
       lits.reset();
 
       bool anyUpdated = false;
@@ -149,7 +149,7 @@ namespace FMB {
           }
           TermList sort = SortHelper::getResultSort(t); //TODO set sort of c as this
           Literal* l = Literal::createEquality(true,TermList(t),TermList(c),sort);
-          static Stack<Literal*> lstack;
+          VTHREAD_LOCAL static Stack<Literal*> lstack;
           lstack.reset();
           lstack.push(l);
           Clause* def = Clause::fromStack(lstack,NonspecificInference1(InferenceRule::FMB_DEF_INTRO,from));

--- a/FMB/FiniteModel.cpp
+++ b/FMB/FiniteModel.cpp
@@ -49,16 +49,16 @@ FiniteModel::FiniteModel(unsigned size) : _size(size), _isPartial(false)
 
   (void)_isPartial; // to suppress unused warning
 
-  f_offsets.ensure(env.signature->functions());
-  p_offsets.ensure(env.signature->predicates());
+  f_offsets.ensure(env->signature->functions());
+  p_offsets.ensure(env->signature->predicates());
 
   // generate offsets per function for indexing f_interpreation
   // see addFunctionDefinition for how the offset is used to compute
   // the actual index
   unsigned offsets=1;
-  for(unsigned f=0; f<env.signature->functions(); f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
-    unsigned arity=env.signature->functionArity(f);
+  for(unsigned f=0; f<env->signature->functions(); f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }
+    unsigned arity=env->signature->functionArity(f);
     f_offsets[f]=offsets;
     unsigned add = pow(size,arity+1);
     ASS(UINT_MAX - add > offsets);
@@ -67,8 +67,8 @@ FiniteModel::FiniteModel(unsigned size) : _size(size), _isPartial(false)
   f_interpretation.expand(offsets+1,0);
   // can restart for predicates as indexing p_interepration instead
   offsets=1;
-  for(unsigned p=1; p<env.signature->predicates();p++){
-    unsigned arity=env.signature->predicateArity(p);
+  for(unsigned p=1; p<env->signature->predicates();p++){
+    unsigned arity=env->signature->predicateArity(p);
     p_offsets[p]=offsets;
     unsigned add = pow(size,arity+1);
     ASS(UINT_MAX - add > offsets);
@@ -89,7 +89,7 @@ void FiniteModel::addFunctionDefinition(unsigned f, const DArray<unsigned>& args
 {
   CALL("FiniteModel::addFunctionDefinition");
 
-  ASS_EQ(env.signature->functionArity(f),args.size());
+  ASS_EQ(env->signature->functionArity(f),args.size());
 
   unsigned var = f_offsets[f];
   unsigned mult = 1;
@@ -122,7 +122,7 @@ void FiniteModel::addPredicateDefinition(unsigned p, const DArray<unsigned>& arg
 {
   CALL("FiniteModel::addPredicateDefinition");
 
-  ASS_EQ(env.signature->predicateArity(p),args.size());
+  ASS_EQ(env->signature->predicateArity(p),args.size());
 
   unsigned var = p_offsets[p];
   unsigned mult = 1;
@@ -186,12 +186,12 @@ vstring FiniteModel::toString()
   }
 
   //Constants
-  for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
-    unsigned arity = env.signature->functionArity(f);
+  for(unsigned f=0;f<env->signature->functions();f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }
+    unsigned arity = env->signature->functionArity(f);
     if(arity>0) continue;
-    if(!printIntroduced && env.signature->getFunction(f)->introduced()) continue;
-    vstring name = env.signature->functionName(f);
+    if(!printIntroduced && env->signature->getFunction(f)->introduced()) continue;
+    vstring name = env->signature->functionName(f);
     unsigned res = f_interpretation[f_offsets[f]];
     if(res>0){ 
       modelStm << "fof("<<name<<"_definition,axiom,"<<name<<" = fmb"<< res << ")."<<endl;
@@ -202,12 +202,12 @@ vstring FiniteModel::toString()
   }
 
   //Functions
-  for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
-    unsigned arity = env.signature->functionArity(f);
+  for(unsigned f=0;f<env->signature->functions();f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }
+    unsigned arity = env->signature->functionArity(f);
     if(arity==0) continue;
-    if(!printIntroduced && env.signature->getFunction(f)->introduced()) continue;
-    vstring name = env.signature->functionName(f);
+    if(!printIntroduced && env->signature->getFunction(f)->introduced()) continue;
+    vstring name = env->signature->functionName(f);
     modelStm << "fof(function_"<<name<<",axiom,"<<endl;
 
     unsigned offset = f_offsets[f];
@@ -262,11 +262,11 @@ fModelLabel:
   }
 
   //Propositions
-  for(unsigned f=1;f<env.signature->predicates();f++){
-    unsigned arity = env.signature->predicateArity(f);
+  for(unsigned f=1;f<env->signature->predicates();f++){
+    unsigned arity = env->signature->predicateArity(f);
     if(arity>0) continue;
-    if(!printIntroduced && env.signature->getPredicate(f)->introduced()) continue;
-    vstring name = env.signature->predicateName(f);
+    if(!printIntroduced && env->signature->getPredicate(f)->introduced()) continue;
+    vstring name = env->signature->predicateName(f);
     unsigned res = p_interpretation[p_offsets[f]];
     if(res==2){
       modelStm << "fof("<<name<<"_definition,axiom,"<<name<< ")."<<endl;
@@ -280,11 +280,11 @@ fModelLabel:
   }
 
 //Predicates
-  for(unsigned f=1;f<env.signature->predicates();f++){
-    unsigned arity = env.signature->predicateArity(f);
+  for(unsigned f=1;f<env->signature->predicates();f++){
+    unsigned arity = env->signature->predicateArity(f);
     if(arity==0) continue;
-    if(!printIntroduced && env.signature->getPredicate(f)->introduced()) continue;
-    vstring name = env.signature->predicateName(f);
+    if(!printIntroduced && env->signature->getPredicate(f)->introduced()) continue;
+    vstring name = env->signature->predicateName(f);
     modelStm << "fof(predicate_"<<name<<",axiom,"<<endl;
 
     unsigned offset = p_offsets[f];
@@ -353,7 +353,7 @@ unsigned FiniteModel::evaluateGroundTerm(Term* term)
 #endif  
   if(isDomainConstant(term)) return getDomainConstant(term);
 
-  unsigned arity = env.signature->functionArity(term->functor());
+  unsigned arity = env->signature->functionArity(term->functor());
   DArray<unsigned> args(arity);
   for(unsigned i=0;i<arity;i++){
     args[i] = evaluateGroundTerm(term->nthArgument(i)->term());
@@ -384,7 +384,7 @@ bool FiniteModel::evaluateGroundLiteral(Literal* lit)
 #endif
 
   // evaluate all arguments
-  unsigned arity = env.signature->predicateArity(lit->functor());
+  unsigned arity = env->signature->predicateArity(lit->functor());
   DArray<unsigned> args(arity);
   for(unsigned i=0;i<arity;i++){
     args[i] = evaluateGroundTerm(lit->nthArgument(i)->term());

--- a/FMB/FiniteModel.cpp
+++ b/FMB/FiniteModel.cpp
@@ -212,7 +212,7 @@ vstring FiniteModel::toString()
 
     unsigned offset = f_offsets[f];
 
-    static DArray<unsigned> args;
+    VTHREAD_LOCAL static DArray<unsigned> args;
     args.ensure(arity);
     for(unsigned i=0;i<arity;i++) args[i]=1;
     args[arity-1]=0;
@@ -289,7 +289,7 @@ fModelLabel:
 
     unsigned offset = p_offsets[f];
 
-    static DArray<unsigned> args;
+    VTHREAD_LOCAL static DArray<unsigned> args;
     args.ensure(arity);
     for(unsigned i=0;i<arity;i++) args[i]=1;
     args[arity-1]=0;

--- a/FMB/FiniteModel.hpp
+++ b/FMB/FiniteModel.hpp
@@ -84,7 +84,7 @@ public:
    Term* t;
    if(_domainConstants.find(c,t)) return t;
    vstring name = "domainConstant";//+Lib::Int::toString(c);
-   unsigned f = env.signature->addFreshFunction(0,name.c_str()); 
+   unsigned f = env->signature->addFreshFunction(0,name.c_str()); 
    t = Term::createConstant(f);
    _domainConstants.insert(c,t);
    _domainConstantsRev.insert(t,c);

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -163,7 +163,7 @@ bool FiniteModelBuilder::reset(){
   // This has been refined after adding multiple sorts i.e. no general 'size'
   // We now need the current size of the sort of each position to compute the offsets
 
-  static const unsigned VAR_MAX = MinisatInterfacingNewSimp::VAR_MAX;
+  const unsigned VAR_MAX = MinisatInterfacingNewSimp::VAR_MAX;
 
   // Start from 1 as SAT solver variables are 1-based
   unsigned offsets=1;
@@ -826,7 +826,7 @@ void FiniteModelBuilder::init()
       DArray<unsigned>* csig = new DArray<unsigned>(c->varCnt()); 
       DArray<bool> csig_set(c->varCnt());
       for(unsigned i=0;i<c->varCnt();i++) csig_set[i]=false;
-      static Stack<Literal*> twoVarEqualities;
+      VTHREAD_LOCAL static Stack<Literal*> twoVarEqualities;
       twoVarEqualities.reset();
       for(unsigned i=0;i<c->length();i++){
         Literal* lit = (*c)[i];
@@ -933,7 +933,7 @@ void FiniteModelBuilder::addGroundClauses()
       Clause* c = cit.next();
       ASS(c);
 
-      static SATLiteralStack satClauseLits;
+      VTHREAD_LOCAL static SATLiteralStack satClauseLits;
       satClauseLits.reset();
       for(unsigned i=0;i<c->length();i++){
         unsigned f = (*c)[i]->functor();
@@ -987,7 +987,7 @@ void FiniteModelBuilder::addNewInstances()
 
     unsigned vars = c->varCnt();
     const DArray<unsigned>* varSorts = _clauseVariableSorts.get(c) ;
-    static DArray<unsigned> maxVarSize;
+    VTHREAD_LOCAL static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(vars);
 
     if(!varSorts){
@@ -1000,7 +1000,7 @@ void FiniteModelBuilder::addNewInstances()
     }
     ASS(varSorts);
 
-    static ArrayMap<unsigned> varDistinctSortsMaxes(_distinctSortSizes.size());
+    VTHREAD_LOCAL static ArrayMap<unsigned> varDistinctSortsMaxes(_distinctSortSizes.size());
 
     if (!_xmass) {
       varDistinctSortsMaxes.reset();
@@ -1021,7 +1021,7 @@ void FiniteModelBuilder::addNewInstances()
       }
     }
     
-    static DArray<unsigned> grounding;
+    VTHREAD_LOCAL static DArray<unsigned> grounding;
     grounding.ensure(vars);
 
     for(unsigned i=0;i<vars;i++) grounding[i]=1;
@@ -1037,7 +1037,7 @@ instanceLabel:
       else{
         grounding[var]++;
         // Grounding represents a new instance
-        static SATLiteralStack satClauseLits;
+        VTHREAD_LOCAL static SATLiteralStack satClauseLits;
         satClauseLits.reset();
 
         if (_xmass) {
@@ -1104,7 +1104,7 @@ instanceLabel:
             Term* t = lit->nthArgument(0)->term();
             unsigned functor = t->functor();
             unsigned arity = t->arity();
-            static DArray<unsigned> use;
+            VTHREAD_LOCAL static DArray<unsigned> use;
             use.ensure(arity+1);
 
             for(unsigned j=0;j<arity;j++){
@@ -1117,7 +1117,7 @@ instanceLabel:
           }else{
             unsigned functor = lit->functor();
             unsigned arity = lit->arity();
-            static DArray<unsigned> use;
+            VTHREAD_LOCAL static DArray<unsigned> use;
             use.ensure(arity);
 
             for(unsigned j=0;j<arity;j++){
@@ -1186,7 +1186,7 @@ void FiniteModelBuilder::addNewFunctionalDefs()
 #endif
 
     const DArray<unsigned>& f_signature = _sortedSignature->functionSignatures[f];
-    static DArray<unsigned> maxVarSize;
+    VTHREAD_LOCAL static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(arity+2);
 
     // find max size of y and z 
@@ -1200,7 +1200,7 @@ void FiniteModelBuilder::addNewFunctionalDefs()
       maxVarSize[var] = min(_sortedSignature->sortBounds[srt],_sortModelSizes[srt]);
     }
 
-    static DArray<unsigned> grounding;
+    VTHREAD_LOCAL static DArray<unsigned> grounding;
     grounding.ensure(arity+2);
     for(unsigned var=0;var<arity+2;var++){ grounding[var]=1; }
     grounding[arity+1]=0;
@@ -1222,14 +1222,14 @@ newFuncLabel:
             //Skip this instance
             goto newFuncLabel;
           }
-          static SATLiteralStack satClauseLits;
+          VTHREAD_LOCAL static SATLiteralStack satClauseLits;
           satClauseLits.reset();
 
           // grounding is of the form [y,z,x1,x2,...]
           // but use wants to be of the form use[x1,x2,...,y] and use[x1,x2,....,z]
           // so need to do some moving around!
           // btw we put y and z at the front so we can do the symmetry trick above
-          static DArray<unsigned> use;
+          VTHREAD_LOCAL static DArray<unsigned> use;
           use.ensure(arity+1);
           for(unsigned k=0;k<arity;k++) use[k]=grounding[k+2];
           use[arity]=grounding[0];
@@ -1258,13 +1258,13 @@ void FiniteModelBuilder::addNewSymmetryOrderingAxioms(unsigned size,
   GroundedTerm gt = groundedTerms[size-1];
 
   unsigned arity = env.signature->functionArity(gt.f);
-  static DArray<unsigned> grounding;
+  VTHREAD_LOCAL static DArray<unsigned> grounding;
   grounding.ensure(arity+1);
   for(unsigned i=0;i<arity;i++) grounding[i] = gt.grounding[i];
 
   //cout << "Add symmetry ordering for " << gt.toString() << endl;
 
-  static SATLiteralStack satClauseLits;
+  VTHREAD_LOCAL static SATLiteralStack satClauseLits;
   satClauseLits.reset(); 
   for(unsigned i=1;i<=size;i++){
     grounding[arity]=i;
@@ -1290,7 +1290,7 @@ void FiniteModelBuilder::addNewSymmetryCanonicityAxioms(unsigned size,
   }
 
   for(unsigned i=1;i<w;i++){
-      static SATLiteralStack satClauseLits;
+      VTHREAD_LOCAL static SATLiteralStack satClauseLits;
       satClauseLits.reset();
    
       GroundedTerm gti = groundedTerms[i];
@@ -1298,7 +1298,7 @@ void FiniteModelBuilder::addNewSymmetryCanonicityAxioms(unsigned size,
 
       if(arityi>0) return;
 
-      static DArray<unsigned> grounding_i;
+      VTHREAD_LOCAL static DArray<unsigned> grounding_i;
       grounding_i.ensure(arityi+1);
       for(unsigned a=0;a<arityi;a++){ grounding_i[a]=gti.grounding[a];}
       grounding_i[arityi]=size;
@@ -1309,7 +1309,7 @@ void FiniteModelBuilder::addNewSymmetryCanonicityAxioms(unsigned size,
       for(unsigned j=0;j<i;j++){
         GroundedTerm gtj = groundedTerms[j];
         unsigned arityj = env.signature->functionArity(gtj.f);
-        static DArray<unsigned> grounding_j;
+        VTHREAD_LOCAL static DArray<unsigned> grounding_j;
         grounding_j.ensure(arityj+1);
         for(unsigned a=0;a<arityj;a++){ grounding_j[a]=gtj.grounding[a];}
         grounding_j[arityj]=size-1;
@@ -1372,7 +1372,7 @@ void FiniteModelBuilder::addNewTotalityDefs()
       for (unsigned j = 0; j < _distinctSortSizes[i]-1; j++) {
         // for every domain size j have clause: not marker(j+1) | marker(j)
         // which says: "d > j+2" -> "d > j+1"
-        static SATLiteralStack satClauseLits;
+        VTHREAD_LOCAL static SATLiteralStack satClauseLits;
         satClauseLits.reset();
         satClauseLits.push(SATLiteral(marker_offsets[i]+j,1));
         satClauseLits.push(SATLiteral(marker_offsets[i]+j+1,0));
@@ -1401,11 +1401,11 @@ void FiniteModelBuilder::addNewTotalityDefs()
       // cout << "Totality for const " << f << " of sort " << srt << " and max size " << maxSize << endl;
 
       for (unsigned i = (!_xmass || (_sortedSignature->monotonicSorts[dsrt])) ? maxSize : 1; i <= maxSize; i++) { // just the weakest one, if monotonic
-        static SATLiteralStack satClauseLits;
+        VTHREAD_LOCAL static SATLiteralStack satClauseLits;
         satClauseLits.reset();
 
         for(unsigned constant=1;constant<=i;constant++){
-          static DArray<unsigned> use(1);
+          VTHREAD_LOCAL static DArray<unsigned> use(1);
           use[0]=constant;
           SATLiteral slit = getSATLiteral(f,use,true,true);
           satClauseLits.push(slit);
@@ -1426,7 +1426,7 @@ void FiniteModelBuilder::addNewTotalityDefs()
       continue;
     }
 
-    static DArray<unsigned> maxVarSize;
+    VTHREAD_LOCAL static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(arity);
     for(unsigned var=0;var<arity;var++){
       unsigned srt = f_signature[var]; 
@@ -1436,7 +1436,7 @@ void FiniteModelBuilder::addNewTotalityDefs()
     unsigned dRetSrt = _sortedSignature->parents[retSrt];
     unsigned maxRtSrtSize = min(_sortedSignature->sortBounds[retSrt],_sortModelSizes[retSrt]);
 
-    static DArray<unsigned> grounding;
+    VTHREAD_LOCAL static DArray<unsigned> grounding;
     grounding.ensure(arity);
     for(unsigned var=0;var<arity;var++){ grounding[var]=1; }
     grounding[arity-1]=0;
@@ -1454,11 +1454,11 @@ newTotalLabel:
           //cout << endl;
 
           for (unsigned i = (!_xmass || (_sortedSignature->monotonicSorts[dRetSrt])) ? maxRtSrtSize : 1; i <= maxRtSrtSize; i++) {
-            static SATLiteralStack satClauseLits;
+            VTHREAD_LOCAL static SATLiteralStack satClauseLits;
             satClauseLits.reset();
 
             for(unsigned constant=1;constant<=i;constant++) {
-              static DArray<unsigned> use;
+              VTHREAD_LOCAL static DArray<unsigned> use;
               use.ensure(arity+1);
               for(unsigned k=0;k<arity;k++) use[k]=grounding[k];
               use[arity]=constant;
@@ -1640,7 +1640,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
       env.statistics->phase = Statistics::FMB_SOLVING;
       TimeCounter tc(TC_FMB_SAT_SOLVING);
 
-      static SATLiteralStack assumptions(_distinctSortSizes.size());
+      VTHREAD_LOCAL static SATLiteralStack assumptions(_distinctSortSizes.size());
       assumptions.reset();
       if (_xmass) {
         for (unsigned i = 0; i < _distinctSortSizes.size(); i++) {
@@ -1666,7 +1666,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
       return MainLoopResult(Statistics::SATISFIABLE);
     }
 
-    static unsigned numberOfSatCalls = 0;
+    VTHREAD_LOCAL static unsigned numberOfSatCalls = 0;
     numberOfSatCalls++;
     unsigned clauseSetSize = _clausesToBeAdded.size();
     unsigned weight = clauseSetSize;
@@ -1687,7 +1687,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
         unsigned domToGrow = UINT_MAX;
         unsigned domsWeight = UINT_MAX;
 
-        static unsigned alternator = 0;
+        VTHREAD_LOCAL static unsigned alternator = 0;
         alternator++;
 
         for (unsigned i = 0; i < failed.size(); i++) {
@@ -1761,7 +1761,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
           return MainLoopResult(Statistics::REFUTATION,empty);
         }
       } else { // i.e. (!_xmass)
-        static Constraint_Generator_Vals nogood;
+        VTHREAD_LOCAL static Constraint_Generator_Vals nogood;
 
         nogood.ensure(_distinctSortSizes.size());
 
@@ -1884,7 +1884,7 @@ void FiniteModelBuilder::onModelFound()
 
     bool found=false;
     for(unsigned c=1;c<=_sortModelSizes[_sortedSignature->functionSignatures[f][0]];c++){
-      static DArray<unsigned> grounding(1);
+      VTHREAD_LOCAL static DArray<unsigned> grounding(1);
       grounding[0]=c;
       SATLiteral slit = getSATLiteral(f,grounding,true,true);
       if(_solver->trueInAssignment(slit)){
@@ -1906,7 +1906,7 @@ void FiniteModelBuilder::onModelFound()
 
     //cout << "For " << env.signature->getFunction(f)->name() << endl;
 
-    static DArray<unsigned> grounding;
+    VTHREAD_LOCAL static DArray<unsigned> grounding;
     grounding.ensure(arity);
     for(unsigned i=0;i<arity;i++){
        grounding[i]=1;
@@ -1914,7 +1914,7 @@ void FiniteModelBuilder::onModelFound()
     grounding[arity-1]=0;
 
     const DArray<unsigned>& f_signature = _sortedSignature->functionSignatures[f];
-    static DArray<unsigned> maxVarSize;
+    VTHREAD_LOCAL static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(arity);
     for(unsigned var=0;var<arity;var++){ 
       unsigned srt = f_signature[var];
@@ -1932,7 +1932,7 @@ fModelLabel:
         else{
           grounding[var]++;
 
-          static DArray<unsigned> use;
+          VTHREAD_LOCAL static DArray<unsigned> use;
           use.ensure(arity+1);
           for(unsigned k=0;k<arity;k++) use[k]=grounding[k];
 
@@ -1985,8 +1985,8 @@ fModelLabel:
 
     //cout << "Record for " << env.signature->getPredicate(f)->name() << endl;
 
-    static DArray<unsigned> grounding;
-    static DArray<unsigned> args;
+    VTHREAD_LOCAL static DArray<unsigned> grounding;
+    VTHREAD_LOCAL static DArray<unsigned> args;
     grounding.ensure(arity);
     args.ensure(arity);
     for(unsigned i=0;i<arity-1;i++){grounding[i]=1;args[1]=1;}
@@ -1994,7 +1994,7 @@ fModelLabel:
     args[arity-1]=0;
 
     const DArray<unsigned>& f_signature = _sortedSignature->predicateSignatures[f];
-    static DArray<unsigned> maxVarSize;
+    VTHREAD_LOCAL static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(arity);
     for(unsigned var=0;var<arity;var++){
       unsigned srt = f_signature[var];
@@ -2072,8 +2072,8 @@ pModelLabel:
     }
 
     if(arity>0){
-      static DArray<unsigned> grounding;
-      static DArray<unsigned> f_signature_distinct(arity);
+      VTHREAD_LOCAL static DArray<unsigned> grounding;
+      VTHREAD_LOCAL static DArray<unsigned> f_signature_distinct(arity);
       grounding.ensure(arity);
       f_signature_distinct.ensure(arity);
       for(unsigned i=0;i<arity-1;i++){
@@ -2210,8 +2210,8 @@ ffModelLabel:
       }
     }
 
-    static DArray<unsigned> grounding;
-    static DArray<unsigned> p_signature_distinct;
+    VTHREAD_LOCAL static DArray<unsigned> grounding;
+    VTHREAD_LOCAL static DArray<unsigned> p_signature_distinct;
     grounding.ensure(arity);
     p_signature_distinct.ensure(arity);
     for(unsigned i=0;i<arity;i++){

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -147,7 +147,7 @@ private:
   void addSATClause(SATClause* cl);
   // Add a singleton SATClause in the form of a SATLiteral to the SAT solver
   void addSATClause(SATLiteral lit){
-    static SATLiteralStack satClauseLits;
+    VTHREAD_LOCAL static SATLiteralStack satClauseLits;
     satClauseLits.reset();
     satClauseLits.push(lit);
     addSATClause(SATClause::fromStack(satClauseLits));

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -152,7 +152,7 @@ void FiniteModelMultiSorted::addPropositionalDefinition(unsigned p, bool res)
 {
   CALL("FiniteModelMultiSorted::addPropositionalDefinition");
   
-  static const DArray<unsigned> empty(0);
+  VTHREAD_LOCAL static const DArray<unsigned> empty(0);
   addPredicateDefinition(p,empty,res);
 }
 
@@ -196,7 +196,7 @@ vstring FiniteModelMultiSorted::toString()
 
   bool printIntroduced = false;
 
-  static DArray<DArray<vstring>> cnames;
+  VTHREAD_LOCAL static DArray<DArray<vstring>> cnames;
   cnames.ensure(env.sorts->count());
 
   //Output sorts and their sizes 
@@ -303,7 +303,7 @@ vstring FiniteModelMultiSorted::toString()
 
     unsigned offset = f_offsets[f];
 
-    static DArray<unsigned> args;
+    VTHREAD_LOCAL static DArray<unsigned> args;
     args.ensure(arity);
     for(unsigned i=0;i<arity;i++) args[i]=1;
     args[arity-1]=0;
@@ -399,7 +399,7 @@ fModelLabel:
 
     unsigned offset = p_offsets[f];
 
-    static DArray<unsigned> args;
+    VTHREAD_LOCAL static DArray<unsigned> args;
     args.ensure(arity);
     for(unsigned i=0;i<arity;i++) args[i]=1;
     args[arity-1]=0;

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -89,10 +89,10 @@ public:
    Term* t;
    pair<unsigned,unsigned> pair = make_pair(c,srt);
    if(_domainConstants.find(pair,t)) return t;
-   vstring name = "domCon_"+env.sorts->sortName(srt)+"_"+Lib::Int::toString(c);
-   unsigned f = env.signature->addFreshFunction(0,name.c_str()); 
+   vstring name = "domCon_"+env->sorts->sortName(srt)+"_"+Lib::Int::toString(c);
+   unsigned f = env->signature->addFreshFunction(0,name.c_str()); 
    TermList srtT = SortHelper::sortTerm(srt);
-   env.signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
+   env->signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
    t = Term::createConstant(f);
    _domainConstants.insert(pair,t);
    _domainConstantsRev.insert(t,pair);

--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -57,7 +57,7 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
                  DHSet<std::pair<unsigned,unsigned>>& strict_cons)
 {
   CALL("FunctionRelationshipInference::findFunctionRelationships");
-  bool print = env.options->showFMBsortInfo();
+  bool print = env->options->showFMBsortInfo();
 
   ClauseList* checkingClauses = getCheckingClauses();
 
@@ -67,10 +67,10 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
   Options opt; // default saturation algorithm options
 
   // because of bad things the time limit is actually taken from env!
-  int oldTimeLimit = env.options->timeLimitInDeciseconds();
-  Property* oldProperty = env.property;
-  unsigned useTimeLimit = env.options->fmbDetectSortBoundsTimeLimit();
-  env.options->setTimeLimitInSeconds(useTimeLimit);
+  int oldTimeLimit = env->options->timeLimitInDeciseconds();
+  Property* oldProperty = env->property;
+  unsigned useTimeLimit = env->options->fmbDetectSortBoundsTimeLimit();
+  env->options->setTimeLimitInSeconds(useTimeLimit);
   opt.setSplitting(false);
   Timer::setTimeLimitEnforcement(false);
 
@@ -86,8 +86,8 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
   }
 
   Timer::setTimeLimitEnforcement(true);
-  env.options->setTimeLimitInDeciseconds(oldTimeLimit);
-  env.property = oldProperty;
+  env->options->setTimeLimitInDeciseconds(oldTimeLimit);
+  env->property = oldProperty;
 
   Stack<unsigned> foundLabels = labelFinder->getFoundLabels();
 
@@ -114,7 +114,7 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
 /*
   Stop this for now... broken (need to check no strict) and very uncommon 
 
-  IntUnionFind uf(env.sorts->sorts());
+  IntUnionFind uf(env->sorts->sorts());
   {
     DHSet<std::pair<unsigned,unsigned>>::Iterator it1(nonstrict_constraints);
     while(it1.hasNext()){
@@ -133,9 +133,9 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
 
   bool header_printed = false;
   {
-    for(unsigned s=0;s<env.sorts->sorts();s++){
+    for(unsigned s=0;s<env->sorts->sorts();s++){
       DHSet<unsigned>* cls = new DHSet<unsigned>();
-      for(unsigned t=0;t<env.sorts->sorts();t++){
+      for(unsigned t=0;t<env->sorts->sorts();t++){
         if(uf.root(t)==s) cls->insert(t);
       }
       if(cls->size()>1){
@@ -205,13 +205,13 @@ ClauseList* FunctionRelationshipInference::getCheckingClauses()
 
   ClauseList* newClauses = 0;
 
-  unsigned initial_functions = env.signature->functions();
+  unsigned initial_functions = env->signature->functions();
   for(unsigned f=0; f < initial_functions; f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
+    if(env->signature->isTypeConOrSup(f)){ continue; }
 
-    OperatorType* ftype = env.signature->getFunction(f)->fnType();
+    OperatorType* ftype = env->signature->getFunction(f)->fnType();
     TermList ret_srt = ftype->result();
-    unsigned arity = env.signature->functionArity(f);
+    unsigned arity = env->signature->functionArity(f);
 
     bool different_sorted=false;
     for(unsigned i=0;i<arity;i++){
@@ -346,8 +346,8 @@ Formula* FunctionRelationshipInference::getName(TermList fromSrt, TermList toSrt
 {
     CALL("FunctionRelationshipInference::getName");
 
-    unsigned label= env.signature->addFreshPredicate(0,"label");
-    env.signature->getPredicate(label)->markLabel();
+    unsigned label= env->signature->addFreshPredicate(0,"label");
+    env->signature->getPredicate(label)->markLabel();
 
     unsigned fsT = SortHelper::sortNum(fromSrt);
     unsigned tsT = SortHelper::sortNum(toSrt);

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -184,7 +184,7 @@ static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domain
             // store and check the ground constant used
             Term* constant = right->term();
             unsigned f = constant->functor();
-            if(env.signature->functionArity(f)!=0) USER_ERROR("finite_domain is not a domain axiom");
+            if(env->signature->functionArity(f)!=0) USER_ERROR("finite_domain is not a domain axiom");
             if(domainConstants.contains(constant)) USER_ERROR("finite_domain is not a domain axiom");
 
             domainConstants.insert(constant);
@@ -213,7 +213,7 @@ static void addDefinition(FiniteModel& model,Literal* lit,bool negated,
           if(left->isVar()) USER_ERROR("Expect term on left of definition");
           Term* fun = left->term();
           unsigned f = fun->functor();
-          unsigned arity = env.signature->functionArity(f);
+          unsigned arity = env->signature->functionArity(f);
           if(arity==0) model.addConstantDefinition(f,res);
           else{
             DArray<unsigned> args(arity);
@@ -230,7 +230,7 @@ static void addDefinition(FiniteModel& model,Literal* lit,bool negated,
           if(!lit->polarity()) negated=!negated;
           // Defining a predicate or proposition
           unsigned p = lit->functor();
-          unsigned arity = env.signature->predicateArity(p);
+          unsigned arity = env->signature->predicateArity(p);
           if(arity==0) model.addPropositionalDefinition(p,!negated);
           else{
             DArray<unsigned> args(arity);

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -215,7 +215,7 @@ void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, DArray<
         continue;
 
       unsigned arity = env.signature->functionArity(f);
-      static Stack<TermList> vars;
+      VTHREAD_LOCAL static Stack<TermList> vars;
       vars.reset();
       for(unsigned x=0;x<arity;x++) vars.push(TermList(x,false)); 
 
@@ -246,7 +246,7 @@ void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, DArray<
    while(it.hasNext()){
      Clause* cl = it.next();
      // pair(variable,variableSort)
-     static Stack<std::pair<unsigned,unsigned>> sortedVariables;
+     VTHREAD_LOCAL static Stack<std::pair<unsigned,unsigned>> sortedVariables;
      sortedVariables.reset();
 
      DHMap<unsigned,TermList> varSorts;

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -50,7 +50,7 @@ namespace FMB
 void SortInference::doInference()
 {
   CALL("SortInference::doInference");
-  bool _print = env.options->showFMBsortInfo();
+  bool _print = env->options->showFMBsortInfo();
 
   if(_ignoreInference){
 #if DEBUG_SORT_INFERENCE
@@ -67,8 +67,8 @@ void SortInference::doInference()
       _sig->distinctToVampire.insert(dsorts,stack);
     }
 
-    for(unsigned s=0;s<env.sorts->count();s++){
-      if(env.property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
+    for(unsigned s=0;s<env->sorts->count();s++){
+      if(env->property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
         if(_assumeMonotonic){
           _sig->distinctToVampire.get(dsorts)->push(s);
           Stack<unsigned>* stack = new Stack<unsigned>();
@@ -105,16 +105,16 @@ void SortInference::doInference()
       _sig->varEqSorts[i]=i;
     }
 
-    for(unsigned f=0;f<env.signature->functions();f++){
-      if(env.signature->isTypeConOrSup(f)){ continue; }
+    for(unsigned f=0;f<env->signature->functions();f++){
+      if(env->signature->isTypeConOrSup(f)){ continue; }
       if(_del_f[f]) continue;
-      unsigned arity = env.signature->functionArity(f);
-      OperatorType* ftype = env.signature->getFunction(f)->fnType();
-      //cout << env.signature->functionName(f) << " : " << env.sorts->sortName(ftype->result()) << endl;;
+      unsigned arity = env->signature->functionArity(f);
+      OperatorType* ftype = env->signature->getFunction(f)->fnType();
+      //cout << env->signature->functionName(f) << " : " << env->sorts->sortName(ftype->result()) << endl;;
       TermList resTypeT = ftype->result();
       unsigned resType = SortHelper::sortNum(resTypeT);
       unsigned dsort = (*_sig->vampireToDistinct.get(resType))[0];
-      //cout << env.signature->functionName(f) << " : " << dsort << endl;
+      //cout << env->signature->functionName(f) << " : " << dsort << endl;
       if(arity==0){
         _sig->sortedConstants[dsort].push(f);
       }else{
@@ -123,25 +123,25 @@ void SortInference::doInference()
     }
 
     // we need at least one constant for symmetry breaking
-    for(unsigned s=0;s<env.sorts->count();s++){
-      if(env.property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
+    for(unsigned s=0;s<env->sorts->count();s++){
+      if(env->property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
         unsigned dsort = (*_sig->vampireToDistinct.get(s))[0];
         if(_sig->sortedConstants[dsort].isEmpty()){
-          unsigned fresh = env.signature->addFreshFunction(0,"fmbFreshConstant");
+          unsigned fresh = env->signature->addFreshFunction(0,"fmbFreshConstant");
           TermList sT = SortHelper::sortTerm(s);
-          env.signature->getFunction(fresh)->setType(OperatorType::getConstantsType(sT));
+          env->signature->getFunction(fresh)->setType(OperatorType::getConstantsType(sT));
           _sig->sortedConstants[dsort].push(fresh);
         }
       }
     }
-    _sig->functionSignatures.ensure(env.signature->functions());
-    _sig->predicateSignatures.ensure(env.signature->predicates());
+    _sig->functionSignatures.ensure(env->signature->functions());
+    _sig->predicateSignatures.ensure(env->signature->predicates());
 
-    for(unsigned f=0;f<env.signature->functions();f++){
-      if(env.signature->isTypeConOrSup(f)){ continue; }
+    for(unsigned f=0;f<env->signature->functions();f++){
+      if(env->signature->isTypeConOrSup(f)){ continue; }
       if(f < _del_f.size() && _del_f[f]) continue;
-      unsigned arity = env.signature->functionArity(f);
-      OperatorType* ftype = env.signature->getFunction(f)->fnType();
+      unsigned arity = env->signature->functionArity(f);
+      OperatorType* ftype = env->signature->getFunction(f)->fnType();
       _sig->functionSignatures[f].ensure(arity+1);
       for(unsigned i=0;i<arity;i++){ 
         TermList argTypeT = ftype->arg(i);
@@ -153,10 +153,10 @@ void SortInference::doInference()
       _sig->functionSignatures[f][arity]=(*_sig->vampireToDistinct.get(resType))[0];
     }
 
-    for(unsigned p=1;p<env.signature->predicates();p++){
+    for(unsigned p=1;p<env->signature->predicates();p++){
       if(_del_p[p]) continue;
-      unsigned arity = env.signature->predicateArity(p);
-      OperatorType* ptype = env.signature->getPredicate(p)->predType();
+      unsigned arity = env->signature->predicateArity(p);
+      OperatorType* ptype = env->signature->getPredicate(p)->predType();
       _sig->predicateSignatures[p].ensure(arity);
       for(unsigned i=0;i<arity;i++){ 
         TermList argTypeT = ptype->arg(i);
@@ -187,8 +187,8 @@ void SortInference::doInference()
       cout << "Monotonicity information:" << endl;
       if(_assumeMonotonic){ cout << "Assuming all sorts monotonic due to translation" << endl; }
     }
-    for(unsigned s=0;s<env.sorts->count();s++){
-      if(env.property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
+    for(unsigned s=0;s<env->sorts->count();s++){
+      if(env->property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
         bool monotonic = _assumeMonotonic;
         if(!monotonic){
           Monotonicity m(_clauses,s);
@@ -199,22 +199,22 @@ void SortInference::doInference()
         }
         if(_print){
           if(monotonic && !_assumeMonotonic){
-            cout << "Input sort " << env.sorts->sortName(s) << " is monotonic" << endl;
+            cout << "Input sort " << env->sorts->sortName(s) << " is monotonic" << endl;
           }
         }
       }
     }
   }
 
-  Array<unsigned> offset_f(env.signature->functions());
-  Array<unsigned> offset_p(env.signature->predicates());
+  Array<unsigned> offset_f(env->signature->functions());
+  Array<unsigned> offset_p(env->signature->predicates());
 
   unsigned count = 0;
-  for(unsigned f=0; f < env.signature->functions();f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
+  for(unsigned f=0; f < env->signature->functions();f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }
     if(_del_f[f]) continue;
     offset_f[f] = count;
-    count += (1+env.signature->getFunction(f)->arity());
+    count += (1+env->signature->getFunction(f)->arity());
   }
 
 #if DEBUG_SORT_INFERENCE
@@ -222,10 +222,10 @@ void SortInference::doInference()
 #endif
 
   // skip 0 because it is always equality
-  for(unsigned p=1; p < env.signature->predicates();p++){
+  for(unsigned p=1; p < env->signature->predicates();p++){
     if(_del_p[p]) continue;
     offset_p[p] = count;
-    count += (env.signature->getPredicate(p)->arity());
+    count += (env->signature->getPredicate(p)->arity());
   }
 
 #if DEBUG_SORT_INFERENCE
@@ -350,10 +350,10 @@ void SortInference::doInference()
   // Later we will use this to promote sorts if _expandSubsorts is true
 
   // First check all of the predicate positions
-  for(unsigned p=0;p<env.signature->predicates();p++){
+  for(unsigned p=0;p<env->signature->predicates();p++){
     if(p < _del_p.size() && _del_p[p]) continue;
     unsigned offset = offset_p[p];
-    unsigned arity = env.signature->predicateArity(p);
+    unsigned arity = env->signature->predicateArity(p);
     for(unsigned i=0;i<arity;i++){
       unsigned arg_offset = offset+i;
       int argRoot = unionFind.root(arg_offset);
@@ -370,12 +370,12 @@ void SortInference::doInference()
 
   // Next check function positions for positive equalities
   // Also recorded the functions/constants for each sort
-  for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
+  for(unsigned f=0;f<env->signature->functions();f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }
     if(f < _del_f.size() && _del_f[f]) continue;
 
     unsigned offset = offset_f[f];
-    unsigned arity = env.signature->functionArity(f); 
+    unsigned arity = env->signature->functionArity(f); 
     int root = unionFind.root(offset);
     unsigned rangeSort;
     if(!translate.find(root,rangeSort)){
@@ -400,14 +400,14 @@ void SortInference::doInference()
     }
     if(arity==0){
 #if DEBUG_SORT_INFERENCE
-    cout << "adding " << env.signature->functionName(f) << " as constant for " << rangeSort << endl;
+    cout << "adding " << env->signature->functionName(f) << " as constant for " << rangeSort << endl;
     //cout << "it is " << Term::createConstant(f)->toString() << endl;
 #endif
        _sig->sortedConstants[rangeSort].push(f);
     }
     else{
 #if DEBUG_SORT_INFERENCE
-      cout << "recording " << env.signature->functionName(f) << " as function for " << rangeSort << endl;
+      cout << "recording " << env->signature->functionName(f) << " as function for " << rangeSort << endl;
 #endif
        _sig->sortedFunctions[rangeSort].push(f);
     }
@@ -427,7 +427,7 @@ void SortInference::doInference()
       if(!posEqualitiesOnSort[s]){ cout << "No positive equalities for subsort " << s << endl; }
 #endif
     if(_sig->sortedConstants[s].size()==0 && _sig->sortedFunctions[s].size()>0){
-      unsigned fresh = env.signature->addFreshFunction(0,"fmbFreshConstant");
+      unsigned fresh = env->signature->addFreshFunction(0,"fmbFreshConstant");
       _sig->sortedConstants[s].push(fresh);
       freshMap.insert(fresh,s);
       if(firstFreshConstant==UINT_MAX) firstFreshConstant=fresh;
@@ -472,8 +472,8 @@ void SortInference::doInference()
   for(unsigned i=0;i<comps;i++) parentSet[i]=false;
 
   _sig->parents.ensure(comps);
-  _sig->functionSignatures.ensure(env.signature->functions());
-  _sig->predicateSignatures.ensure(env.signature->predicates());
+  _sig->functionSignatures.ensure(env->signature->functions());
+  _sig->predicateSignatures.ensure(env->signature->predicates());
 
 
 #if DEBUG_SORT_INFERENCE
@@ -481,11 +481,11 @@ void SortInference::doInference()
 #endif
 
   // Now record the _signatures for functions
-  for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }   
+  for(unsigned f=0;f<env->signature->functions();f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }   
     if(f < _del_f.size() && _del_f[f]) continue;
 #if DEBUG_SORT_INFERENCE
-    cout << env.signature->functionName(f) << " : ";
+    cout << env->signature->functionName(f) << " : ";
 #endif
     // fresh constants are introduced for sorts with no constants
     // but that have function symbols, therefore these sorts cannot
@@ -502,7 +502,7 @@ void SortInference::doInference()
       continue;
     }
 
-    unsigned arity = env.signature->functionArity(f);
+    unsigned arity = env->signature->functionArity(f);
     _sig->functionSignatures[f].ensure(arity+1);
     int root = unionFind.root(offset_f[f]);
     unsigned rangeSort = translate.get(root);
@@ -511,11 +511,11 @@ void SortInference::doInference()
 #endif
     _sig->functionSignatures[f][arity] = rangeSort;
 
-    Signature::Symbol* fnSym = env.signature->getFunction(f);
+    Signature::Symbol* fnSym = env->signature->getFunction(f);
     OperatorType* fnType = fnSym->fnType();
     if(parentSet[rangeSort]){
 #if VDEBUG
-      //cout << "FUNCTION " << env.signature->functionName(f) << endl;
+      //cout << "FUNCTION " << env->signature->functionName(f) << endl;
       TermList vs = fnType->result();
       unsigned vampireSort = SortHelper::sortNum(vs);
       unsigned ourSort = getDistinctSort(rangeSort,vampireSort,false);
@@ -525,7 +525,7 @@ void SortInference::doInference()
       bool found=false;
       //cout << "<<<<" << rangeSort << endl;
       while(it.hasNext()){ unsigned vs = it.next(); if(vs==vampireSort) found=true;  }
-      ASS_REP(found,Lib::Int::toString(rangeSort)+","+env.sorts->sortName(vampireSort));
+      ASS_REP(found,Lib::Int::toString(rangeSort)+","+env->sorts->sortName(vampireSort));
 #endif
     }
     else{
@@ -553,7 +553,7 @@ void SortInference::doInference()
       Stack<unsigned>::Iterator it(* _sig->distinctToVampire.get(ourSort));
       bool found=false;
       while(it.hasNext()){ unsigned vs = it.next(); if(vs==vampireSort) found=true; }
-      ASS_REP(found,Lib::Int::toString(argSort)+","+env.sorts->sortName(vampireSort));
+      ASS_REP(found,Lib::Int::toString(argSort)+","+env->sorts->sortName(vampireSort));
 #endif
       }
       else{
@@ -571,14 +571,14 @@ void SortInference::doInference()
   cout << "Setting up fresh constant info" << endl;
 #endif
   // Setting types for fresh constants
-  for(unsigned f=firstFreshConstant;f<env.signature->functions();f++){
-    if(env.signature->isTypeConOrSup(f)){ continue; }
+  for(unsigned f=firstFreshConstant;f<env->signature->functions();f++){
+    if(env->signature->isTypeConOrSup(f)){ continue; }
     unsigned srt = freshMap.get(f);
     unsigned dsrt = _sig->parents[srt];
     unsigned vsrt = (*_sig->distinctToVampire.get(dsrt))[0];
     TermList vsrtT = SortHelper::sortTerm(vsrt);
-    env.signature->getFunction(f)->setType(OperatorType::getConstantsType(vsrtT));
-    env.signature->getFunction(f)->markIntroduced();
+    env->signature->getFunction(f)->setType(OperatorType::getConstantsType(vsrtT));
+    env->signature->getFunction(f)->markIntroduced();
   }
 
 #if DEBUG_SORT_INFERENCE
@@ -586,17 +586,17 @@ void SortInference::doInference()
 #endif
 
   // Remember to skip 0 as it is =
-  for(unsigned p=1;p<env.signature->predicates();p++){
+  for(unsigned p=1;p<env->signature->predicates();p++){
     if(p < _del_p.size() && _del_p[p]) continue;
 #if DEBUG_SORT_INFERENCE
-    cout << env.signature->predicateName(p) << " : ";
+    cout << env->signature->predicateName(p) << " : ";
 #endif
-    //cout << env.signature->predicateName(p) <<" : "; 
-    unsigned arity = env.signature->predicateArity(p);
+    //cout << env->signature->predicateName(p) <<" : "; 
+    unsigned arity = env->signature->predicateArity(p);
     // Now set _signatures 
     _sig->predicateSignatures[p].ensure(arity);
 
-    Signature::Symbol* prSym = env.signature->getPredicate(p);
+    Signature::Symbol* prSym = env->signature->getPredicate(p);
     OperatorType* prType = prSym->predType();
 
     for(unsigned i=0;i<arity;i++){
@@ -613,7 +613,7 @@ void SortInference::doInference()
       Stack<unsigned>::Iterator it(* _sig->distinctToVampire.get(ourSort));
       bool found=false;
       while(it.hasNext()){ unsigned vs = it.next(); if(vs==vampireSort) found=true; }
-      ASS_REP(found,Lib::Int::toString(argSort)+","+env.sorts->sortName(vampireSort));
+      ASS_REP(found,Lib::Int::toString(argSort)+","+env->sorts->sortName(vampireSort));
 #endif
       }
       else{
@@ -683,16 +683,16 @@ void SortInference::doInference()
     for(unsigned i=0;i<_sig->distinctSorts;i++){
 
       Stack<unsigned>* vs = _sig->distinctToVampire.get(i);
-      if(vs->size()==1) cout << env.sorts->sortName((*vs)[0]);
-      else cout << env.sorts->sortName((*vs)[0]) << "(+)";
+      if(vs->size()==1) cout << env->sorts->sortName((*vs)[0]);
+      else cout << env->sorts->sortName((*vs)[0]) << "(+)";
 
       if(i==_sig->distinctSorts-1) cout << "]" << endl;
       else cout << ",";
     }
   }
 
-  for(unsigned s=0;s<env.sorts->count();s++){
-    if(env.property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
+  for(unsigned s=0;s<env->sorts->count();s++){
+    if(env->property->usesSort(s) || SortHelper::isNotDefaultSort(s)){
       // if sort is not here then it does not appear in signature (check)
       if(!_sig->vampireToDistinct.find(s)){ continue; }
 
@@ -708,14 +708,14 @@ void SortInference::doInference()
       // add those constraints between children and parent
       unsigned parent = _sig->vampireToDistinctParent.get(s);
 #if DEBUG_SORT_INFERENCE 
-      cout << "Parent " << parent << " for " << env.sorts->sortName(s) << endl;
+      cout << "Parent " << parent << " for " << env->sorts->sortName(s) << endl;
 #endif
       Stack<unsigned>::Iterator children(*_sig->vampireToDistinct.get(s));
       while(children.hasNext()){
         unsigned child = children.next();
         if(child==parent) continue;
 #if DEBUG_SORT_INFERENCE 
-        cout << "Child " << child << " for " << env.sorts->sortName(s) << endl;
+        cout << "Child " << child << " for " << env->sorts->sortName(s) << endl;
 #endif
         _sort_constraints.push(make_pair(parent,child));
       }
@@ -735,7 +735,7 @@ unsigned SortInference::getDistinctSort(unsigned subsort, unsigned realVampireSo
   unsigned vampireSort = realVampireSort;
   if(_expandSubsorts){
     if(!posEqualitiesOnSort[subsort]){
-      vampireSort = env.sorts->count()+subsort+1;
+      vampireSort = env->sorts->count()+subsort+1;
     }
   }
 
@@ -743,7 +743,7 @@ unsigned SortInference::getDistinctSort(unsigned subsort, unsigned realVampireSo
     if(ourDistinctSorts.find(vampireSort,ourSort)){
       return ourSort;
     }
-    //cout << "CREATE " << subsort << "," << env.sorts->sortName(realVampireSort) << endl;
+    //cout << "CREATE " << subsort << "," << env->sorts->sortName(realVampireSort) << endl;
     ASS(createNew);
 
     if(monotonicVampireSorts.contains(vampireSort)){

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -728,9 +728,9 @@ unsigned SortInference::getDistinctSort(unsigned subsort, unsigned realVampireSo
 {
   CALL("SortInference::getDistinctSort");
 
-  static bool firstMonotonicSortSeen = false;
-  static unsigned firstMonotonicSort = 0;
-  static DHMap<unsigned,unsigned> ourDistinctSorts;
+  VTHREAD_LOCAL static bool firstMonotonicSortSeen = false;
+  VTHREAD_LOCAL static unsigned firstMonotonicSort = 0;
+  VTHREAD_LOCAL static DHMap<unsigned,unsigned> ourDistinctSorts;
 
   unsigned vampireSort = realVampireSort;
   if(_expandSubsorts){

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -87,21 +87,21 @@ public:
                 Stack<DHSet<unsigned>*> equiv_v_sorts,
                 Stack<std::pair<unsigned,unsigned>>& cons) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
-                _equiv_v_sorts(equiv_v_sorts), _equiv_vs(env.sorts->count()),
+                _equiv_v_sorts(equiv_v_sorts), _equiv_vs(env->sorts->count()),
                 _sort_constraints(cons) {
 
                   _sig = new SortedSignature();
-                  _print = env.options->showFMBsortInfo();
+                  _print = env->options->showFMBsortInfo();
 
                    // ignore inference if there are no clauses
                   _ignoreInference = !clauses; 
-                  _expandSubsorts = env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::EXPAND;
+                  _expandSubsorts = env->options->fmbAdjustSorts() == Options::FMBAdjustSorts::EXPAND;
 
                   _usingMonotonicity = true;
-                  _collapsingMonotonicSorts = (env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::OFF && 
-                                               env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::EXPAND);
+                  _collapsingMonotonicSorts = (env->options->fmbAdjustSorts() != Options::FMBAdjustSorts::OFF && 
+                                               env->options->fmbAdjustSorts() != Options::FMBAdjustSorts::EXPAND);
                   _assumeMonotonic = _collapsingMonotonicSorts && 
-                                     env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::GROUP;
+                                     env->options->fmbAdjustSorts() != Options::FMBAdjustSorts::GROUP;
 
                   _distinctSorts=0;
                   _collapsed=0;

--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -319,6 +319,9 @@ typedef Lib::SmartPtr<PassiveClauseContainer> PassiveClauseContainerSP;
 class ActiveClauseContainer;
 
 class Splitter;
+#if VTHREADED
+class PersistentGrounding;
+#endif
 class ConsequenceFinder;
 class LabelFinder;
 class SymElOutput;

--- a/Indexing/AcyclicityIndex.cpp
+++ b/Indexing/AcyclicityIndex.cpp
@@ -62,7 +62,7 @@ namespace Indexing
     List<TermList>* res = List<TermList>::empty();
     
     TermList sort = SortHelper::getResultSort(t);
-    ASS(env.signature->isTermAlgebraSort(sort));
+    ASS(env->signature->isTermAlgebraSort(sort));
 
     for (unsigned i = 0; i < t->arity(); i++) {
       if (SortHelper::getArgSort(t, i) == sort) {
@@ -76,7 +76,7 @@ namespace Indexing
 
     while (toVisit.isNonEmpty()) {
       Term *u = toVisit.pop();
-      if (env.signature->getFunction(u->functor())->termAlgebraCons()) {
+      if (env->signature->getFunction(u->functor())->termAlgebraCons()) {
         for (unsigned i = 0; i < u->arity(); i++) {
           if (SortHelper::getArgSort(u, i) == sort) {
             TermList *s = u->nthArgument(i);
@@ -101,15 +101,15 @@ namespace Indexing
     }
 
     *sort = SortHelper::getEqualityArgumentSort(lit);
-    if (!env.signature->isTermAlgebraSort(*sort) || env.signature->getTermAlgebraOfSort(*sort)->allowsCyclicTerms()) {
+    if (!env->signature->isTermAlgebraSort(*sort) || env->signature->getTermAlgebraOfSort(*sort)->allowsCyclicTerms()) {
       return false;
     }
 
     TermList *l = lit->nthArgument(0);
     TermList *r = lit->nthArgument(1);
     
-    bool termAlgebraConsL = l->isTerm() && env.signature->getFunction(l->term()->functor())->termAlgebraCons();
-    bool termAlgebraConsR = r->isTerm() && env.signature->getFunction(r->term()->functor())->termAlgebraCons();
+    bool termAlgebraConsL = l->isTerm() && env->signature->getFunction(l->term()->functor())->termAlgebraCons();
+    bool termAlgebraConsR = r->isTerm() && env->signature->getFunction(r->term()->functor())->termAlgebraCons();
     
     if (!termAlgebraConsL && termAlgebraConsR) {
       t = l;

--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -65,15 +65,15 @@ void ClauseCodeTree::insert(Clause* cl)
   CALL("ClauseCodeTree::insert");
 
   unsigned clen=cl->length();
-  static DArray<Literal*> lits;
+  VTHREAD_LOCAL static DArray<Literal*> lits;
   lits.initFromArray(clen, *cl);
 
   optimizeLiteralOrder(lits);
 
-  static CodeStack code;
+  VTHREAD_LOCAL static CodeStack code;
   code.reset();
 
-  static CompileContext cctx;
+  VTHREAD_LOCAL static CompileContext cctx;
   cctx.init();
 
   for(unsigned i=0;i<clen;i++) {
@@ -155,8 +155,8 @@ void ClauseCodeTree::evalSharing(Literal* lit, CodeOp* startOp, size_t& sharedLe
 {
   CALL("ClauseCodeTree::evalSharing");
 
-  static CodeStack code;
-  static CompileContext cctx;
+  VTHREAD_LOCAL static CodeStack code;
+  VTHREAD_LOCAL static CompileContext cctx;
 
   code.reset();
   cctx.init();
@@ -232,9 +232,9 @@ void ClauseCodeTree::remove(Clause* cl)
 {
   CALL("ClauseCodeTree::remove");
 
-  static DArray<LitInfo> lInfos;
-  static Stack<CodeOp*> firstsInBlocks;
-  static Stack<RemovingLiteralMatcher*> rlms;
+  VTHREAD_LOCAL static DArray<LitInfo> lInfos;
+  VTHREAD_LOCAL static Stack<CodeOp*> firstsInBlocks;
+  VTHREAD_LOCAL static Stack<RemovingLiteralMatcher*> rlms;
 
   unsigned clen=cl->length();
   lInfos.ensure(clen);
@@ -431,8 +431,8 @@ bool ClauseCodeTree::LiteralMatcher::doEagerMatching()
   //backup the current op
   CodeOp* currOp=op;
 
-  static Stack<CodeOp*> eagerResultsRevOrder;
-  static Stack<CodeOp*> successes;
+  VTHREAD_LOCAL static Stack<CodeOp*> eagerResultsRevOrder;
+  VTHREAD_LOCAL static Stack<CodeOp*> successes;
   eagerResultsRevOrder.reset();
   successes.reset();
 
@@ -843,7 +843,7 @@ bool ClauseCodeTree::ClauseMatcher::matchGlobalVars(int& resolvedQueryLit)
   //  when we get to binding j-th literal
   //  Matches in ILStruct::matches are reordered, so that we always try
   //  the _first_ remaining[j,j] literals
-  static TriangularArray<int> remaining(10);
+  VTHREAD_LOCAL static TriangularArray<int> remaining(10);
   remaining.setSide(clen);
   for(unsigned j=0;j<clen;j++) {
     ILStruct* ils=lms[j]->getILS();
@@ -864,7 +864,7 @@ bool ClauseCodeTree::ClauseMatcher::matchGlobalVars(int& resolvedQueryLit)
   }
 //  VERB_OUT("secOp:"<<(lms[1]->op-1)->instr()<<" "<<(lms[1]->op-1)->arg());
 
-  static DArray<int> matchIndex;
+  VTHREAD_LOCAL static DArray<int> matchIndex;
   matchIndex.ensure(clen);
   unsigned failLev=0;
   for(unsigned i=0;i<clen;i++) {

--- a/Indexing/ClauseVariantIndex.cpp
+++ b/Indexing/ClauseVariantIndex.cpp
@@ -55,7 +55,7 @@ public:
       return 0;
     }
 
-    static DArray<LiteralList*> alts(32);
+    VTHREAD_LOCAL static DArray<LiteralList*> alts(32);
     alts.init(_length, 0);
 
     for(unsigned i=0;i<_length;i++) {
@@ -200,7 +200,7 @@ Literal* SubstitutionTreeClauseVariantIndex::getMainLiteral(Literal* const * lit
   CALL("SubstitutionTreeClauseVariantIndex::getMainLiteral");
   ASS_G(length,0);
 
-  static LiteralComparators::NormalizedLinearComparatorByWeight<> comp;
+  VTHREAD_LOCAL static LiteralComparators::NormalizedLinearComparatorByWeight<> comp;
 
   Literal* best=lits[0];
   unsigned bestVal=best->weight()-best->getDistinctVars();
@@ -309,7 +309,7 @@ struct HashingClauseVariantIndex::VariableIgnoringComparator {
     CALL("HashingClauseVariantIndex::VariableIgnoringComparator::disagreement");
 
     //now get just some total deterministic order while ignoring variables
-    static DisagreementSetIterator dsit;
+    VTHREAD_LOCAL static DisagreementSetIterator dsit;
     dsit.reset(t1, t2, false);
     while(dsit.hasNext()) {
       pair<TermList, TermList> dis=dsit.next();
@@ -514,13 +514,13 @@ unsigned HashingClauseVariantIndex::computeHash(Literal* const * lits, unsigned 
 
   TimeCounter tc( TC_HCVI_COMPUTE_HASH );
 
-  static Stack<unsigned> litOrder;
+  VTHREAD_LOCAL static Stack<unsigned> litOrder;
   litOrder.reset();
   litOrder.loadFromIterator(getRangeIterator(0u,length));
 
   std::sort(litOrder.begin(), litOrder.end(), VariableIgnoringComparator(lits));
 
-  static VarCounts varCnts;
+  VTHREAD_LOCAL static VarCounts varCnts;
   varCnts.reset();
 
   unsigned hash = 2166136261u;
@@ -530,7 +530,7 @@ unsigned HashingClauseVariantIndex::computeHash(Literal* const * lits, unsigned 
   }
 
   if (varCnts.size() > 0) {
-    static Stack<unsigned char> varCntHistogram;
+    VTHREAD_LOCAL static Stack<unsigned char> varCntHistogram;
     varCntHistogram.reset();
     VarCounts::Iterator it(varCnts);
     while (it.hasNext()) {

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -391,7 +391,7 @@ CodeTree::SearchStruct* CodeTree::CodeOp::getSearchStruct()
   //the following line gives warning for not being according
   //to the standard, so we have to work around
 //  static const size_t opOfs=offsetof(SearchStruct,landingOp);
-  static const size_t opOfs=reinterpret_cast<size_t>(
+  const size_t opOfs=reinterpret_cast<size_t>(
 	&reinterpret_cast<SearchStruct*>(8)->landingOp)-8;
 
   SearchStruct* res=reinterpret_cast<SearchStruct*>(
@@ -684,7 +684,7 @@ CodeTree::CodeBlock* CodeTree::firstOpToCodeBlock(CodeOp* op)
   //the following line gives warning for not being according
   //to the standard, so we have to work around
 //  static const size_t opOfs=offsetof(CodeBlock,_array);
-  static const size_t opOfs=reinterpret_cast<size_t>(
+  const size_t opOfs=reinterpret_cast<size_t>(
 	&reinterpret_cast<CodeBlock*>(8)->_array[0])-8;
 
   CodeBlock* res=reinterpret_cast<CodeBlock*>(
@@ -887,8 +887,8 @@ void CodeTree::incorporate(CodeStack& code)
     return;
   }
 
-  static const unsigned checkFunOpThreshold=5; //must be greater than 1 or it would cause loops
-  static const unsigned checkGroundTermOpThreshold=3; //must be greater than 1 or it would cause loops
+  const unsigned checkFunOpThreshold=5; //must be greater than 1 or it would cause loops
+  const unsigned checkGroundTermOpThreshold=3; //must be greater than 1 or it would cause loops
 
   size_t clen=code.length();
   CodeOp** tailTarget;

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -211,7 +211,7 @@ void CodeTree::ILStruct::putIntoSequence(ILStruct* previous_)
 
   if(!varCnt) { return; }
 
-  static DArray<pair<unsigned,unsigned> > gvArr;
+  VTHREAD_LOCAL static DArray<pair<unsigned,unsigned> > gvArr;
   gvArr.ensure(varCnt);
   for(unsigned i=0;i<varCnt;i++) {
     gvArr[i].first=globalVarNumbers[i];
@@ -632,7 +632,7 @@ CodeTree::~CodeTree()
 {
   CALL("CodeTree::~CodeTree");
       
-  static Stack<CodeOp*> top_ops; 
+  VTHREAD_LOCAL static Stack<CodeOp*> top_ops; 
   // each top_op is either a first op of a Block or a SearchStruct
   // but it cannot be both since SearchStructs don't occur inside blocks
   top_ops.reset();
@@ -699,7 +699,7 @@ void CodeTree::visitAllOps(Visitor visitor)
 {
   CALL("CodeTree::visitAllOps");
 
-  static Stack<CodeOp*> top_ops; 
+  VTHREAD_LOCAL static Stack<CodeOp*> top_ops; 
   // each top_op is either a first op of a Block or a SearchStruct
   // but it cannot be both since SearchStructs don't occur inside blocks
   top_ops.reset();
@@ -779,7 +779,7 @@ void CodeTree::compileTerm(Term* trm, CodeStack& code, CompileContext& cctx, boo
 {
   CALL("CodeTree::compileTerm");
 
-  static Stack<unsigned> globalCounterparts;
+  VTHREAD_LOCAL static Stack<unsigned> globalCounterparts;
   globalCounterparts.reset();
 
   cctx.nextLit();
@@ -1011,9 +1011,9 @@ void CodeTree::compressCheckOps(CodeOp* chainStart, SearchStruct::Kind kind)
   CALL("CodeTree::compressCheckOps");
   ASS(chainStart->alternative());
 
-  static Stack<CodeOp*> toDo;
-  static Stack<CodeOp*> chfOps;
-  static Stack<CodeOp*> otherOps;
+  VTHREAD_LOCAL static Stack<CodeOp*> toDo;
+  VTHREAD_LOCAL static Stack<CodeOp*> chfOps;
+  VTHREAD_LOCAL static Stack<CodeOp*> otherOps;
   toDo.reset();
   chfOps.reset();
   otherOps.reset();

--- a/Indexing/CodeTreeInterfaces.cpp
+++ b/Indexing/CodeTreeInterfaces.cpp
@@ -215,7 +215,7 @@ bool CodeTreeTIS::generalizationExists(TermList t)
     return false;
   }
 
-  static TermCodeTree::TermMatcher tm;
+  VTHREAD_LOCAL static TermCodeTree::TermMatcher tm;
   
   tm.init(&_ct, t);
   bool res=tm.next();

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -143,10 +143,9 @@ Index* IndexManager::create(IndexType t)
   TermIndexingStructure* tis;
 
   bool isGenerating;
-  static bool const useConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
-  static bool const extByAbs = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) &&
+  VTHREAD_LOCAL static bool const useConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
+  VTHREAD_LOCAL static bool const extByAbs = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) &&
                     env.statistics->higherOrder;
-                    
   switch(t) {
   case GENERATING_SUBST_TREE:
     is=new LiteralSubstitutionTree(useConstraints);

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -143,9 +143,9 @@ Index* IndexManager::create(IndexType t)
   TermIndexingStructure* tis;
 
   bool isGenerating;
-  VTHREAD_LOCAL static bool const useConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
-  VTHREAD_LOCAL static bool const extByAbs = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) &&
-                    env.statistics->higherOrder;
+  VTHREAD_LOCAL static bool const useConstraints = env->options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
+  VTHREAD_LOCAL static bool const extByAbs = (env->options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) &&
+                    env->statistics->higherOrder;
   switch(t) {
   case GENERATING_SUBST_TREE:
     is=new LiteralSubstitutionTree(useConstraints);
@@ -240,7 +240,7 @@ Index* IndexManager::create(IndexType t)
 
   case DEMODULATION_SUBTERM_SUBST_TREE:
     tis=new TermSubstitutionTree();
-    if (env.options->combinatorySup()) {
+    if (env->options->combinatorySup()) {
       res=new DemodulationSubtermIndexImpl<true>(tis);
     } else {
       res=new DemodulationSubtermIndexImpl<false>(tis);

--- a/Indexing/LiteralIndex.cpp
+++ b/Indexing/LiteralIndex.cpp
@@ -208,7 +208,7 @@ Literal* RewriteRuleIndex::getGreater(Clause* c)
   CALL("RewriteRuleIndex::getGreater");
   ASS_EQ(c->length(), 2);
 
-  static LiteralComparators::NormalizedLinearComparatorByWeight<true> comparator;
+  VTHREAD_LOCAL static LiteralComparators::NormalizedLinearComparatorByWeight<true> comparator;
 
   Comparison comp=comparator.compare((*c)[0], (*c)[1]);
 

--- a/Indexing/LiteralSubstitutionTree.cpp
+++ b/Indexing/LiteralSubstitutionTree.cpp
@@ -29,13 +29,13 @@ namespace Indexing
 {
 
 LiteralSubstitutionTree::LiteralSubstitutionTree(bool useC)
-: SubstitutionTree(2*env.signature->predicates(),useC)
+: SubstitutionTree(2*env->signature->predicates(),useC)
 {
   //EqualityProxy transformation can introduce polymorphism in a monomorphic problem
   //However, there is no need to guard aginst it, as equalityProxy removes all
   //equality literals. The flag below is only used during the unification of 
   //equality literals.
-  _polymorphic = env.statistics->polymorphic || env.statistics->higherOrder;
+  _polymorphic = env->statistics->polymorphic || env->statistics->higherOrder;
 }
 
 void LiteralSubstitutionTree::insert(Literal* lit, Clause* cls)

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -93,7 +93,7 @@ private:
         return instantiation ? res.substitution->matchSorts(_queryEqSort, resSort) 
                              : res.substitution->matchSorts(resSort, _queryEqSort); 
       } else {
-        static RobSubstitution subst;
+        VTHREAD_LOCAL static RobSubstitution subst;
         subst.reset();
         return instantiation ? subst.match(_queryEqSort, 0, resSort, 1):
                                subst.match(resSort, 0, _queryEqSort, 1);           
@@ -143,7 +143,7 @@ private:
         }
         return success;
       } else {
-        static RobSubstitution subst;
+        VTHREAD_LOCAL static RobSubstitution subst;
         subst.reset();
         return subst.unify(_queryEqSort, 0, resSort, 1);
       }

--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -77,7 +77,7 @@ ResultSubstitutionSP IdentitySubstitution::instance()
 {
   CALL("IdentitySubstitution::instance");
 
-  static ResultSubstitutionSP inst = ResultSubstitutionSP(new IdentitySubstitution());
+  VTHREAD_LOCAL static ResultSubstitutionSP inst = ResultSubstitutionSP(new IdentitySubstitution());
 
   return inst;
 }

--- a/Indexing/SubstitutionTree.cpp
+++ b/Indexing/SubstitutionTree.cpp
@@ -165,7 +165,7 @@ void SubstitutionTree::insert(Node** pnode,BindingMap& svBindings,LeafData ld)
   }
 
   typedef BinaryHeap<UnresolvedSplitRecord, BindingComparator> SplitRecordHeap;
-  static SplitRecordHeap unresolvedSplits;
+  VTHREAD_LOCAL static SplitRecordHeap unresolvedSplits;
   unresolvedSplits.reset();
 
   ASS((*pnode));
@@ -365,7 +365,7 @@ void SubstitutionTree::remove(Node** pnode,BindingMap& svBindings,LeafData ld)
 
   ASS(*pnode);
 
-  static Stack<Node**> history(1000);
+  VTHREAD_LOCAL static Stack<Node**> history(1000);
   history.reset();
 
   while (! (*pnode)->isLeaf()) {

--- a/Indexing/SubstitutionTree_FastInst.cpp
+++ b/Indexing/SubstitutionTree_FastInst.cpp
@@ -295,7 +295,7 @@ TermList SubstitutionTree::InstMatcher::derefQueryBinding(unsigned var)
       return varBinding.t;
     }
   }
-  static Stack<DerefTask> toDo;
+  VTHREAD_LOCAL static Stack<DerefTask> toDo;
   toDo.reset();
 
   for(;;) {
@@ -476,8 +476,8 @@ bool SubstitutionTree::InstMatcher::matchNextAux(TermList queryTerm, TermList no
     goto finish;
   }
 
-  static Stack<pair<TermSpec,TermSpec> > toDo;
-  static DisagreementSetIterator dsit;
+  VTHREAD_LOCAL static Stack<pair<TermSpec,TermSpec> > toDo;
+  VTHREAD_LOCAL static DisagreementSetIterator dsit;
 
   toDo.reset();
   toDo.push(make_pair(tsBinding, tsNode));

--- a/Indexing/SubstitutionTree_Nodes.cpp
+++ b/Indexing/SubstitutionTree_Nodes.cpp
@@ -144,7 +144,7 @@ SubstitutionTree::IntermediateNode* SubstitutionTree::createIntermediateNode(Ter
 
 void SubstitutionTree::IntermediateNode::destroyChildren()
 {
-  static Stack<Node*> toDelete;
+  VTHREAD_LOCAL static Stack<Node*> toDelete;
   toDelete.reset();
   toDelete.push(this);
   while(toDelete.isNonEmpty()) {

--- a/Indexing/TermCodeTree.cpp
+++ b/Indexing/TermCodeTree.cpp
@@ -52,7 +52,7 @@ void TermCodeTree::insert(TermInfo* ti)
 {
   CALL("TermCodeTree::insert");
   
-  static CodeStack code;
+  VTHREAD_LOCAL static CodeStack code;
   code.reset();
 
 
@@ -63,7 +63,7 @@ void TermCodeTree::insert(TermInfo* ti)
   else {
     ASS(t.isTerm());
     
-    static CompileContext cctx;
+    VTHREAD_LOCAL static CompileContext cctx;
     cctx.init();
     compileTerm(t.term(), code, cctx, false);
     cctx.deinit(this);
@@ -81,8 +81,8 @@ void TermCodeTree::remove(const TermInfo& ti)
 {
   CALL("TermCodeTree::remove");
   
-  static RemovingTermMatcher rtm;
-  static Stack<CodeOp*> firstsInBlocks;
+  VTHREAD_LOCAL static RemovingTermMatcher rtm;
+  VTHREAD_LOCAL static Stack<CodeOp*> firstsInBlocks;
   firstsInBlocks.reset();
   
   FlatTerm* ft=FlatTerm::create(ti.t);

--- a/Indexing/TermIndex.cpp
+++ b/Indexing/TermIndex.cpp
@@ -127,7 +127,7 @@ void DemodulationSubtermIndexImpl<combinatorySupSupport>::handleClause(Clause* c
 
   TimeCounter tc(TC_BACKWARD_DEMODULATION_INDEX_MAINTENANCE);
 
-  static DHSet<TermList> inserted;
+  VTHREAD_LOCAL static DHSet<TermList> inserted;
 
   unsigned cLen=c->length();
   for (unsigned i=0; i<cLen; i++) {

--- a/Indexing/TermIndex.cpp
+++ b/Indexing/TermIndex.cpp
@@ -82,7 +82,7 @@ void SuperpositionSubtermIndex::handleClause(Clause* c, bool adding)
   for (unsigned i=0; i<selCnt; i++) {
     Literal* lit=(*c)[i];
     TermIterator rsti;
-    if(!env.options->combinatorySup()){
+    if(!env->options->combinatorySup()){
       rsti = EqHelper::getSubtermIterator(lit,_ord);
     } else {
       rsti = EqHelper::getFoSubtermIterator(lit,_ord);
@@ -268,7 +268,7 @@ void PrimitiveInstantiationIndex::populateIndex()
 
   typedef ApplicativeHelper AH;
 
-  static Options::PISet set = env.options->piSet();
+  static Options::PISet set = env->options->piSet();
 
   auto srtOf = [] (TermList t) {
     ASS(t.isTerm());
@@ -285,13 +285,13 @@ void PrimitiveInstantiationIndex::populateIndex()
   TermList args1[] = {s1, boolS, boolS};
   TermList args2[] = {s1, s1_bool, s1_bool};
 
-  unsigned k_comb = env.signature->getCombinator(Signature::K_COMB);
-  unsigned b_comb = env.signature->getCombinator(Signature::B_COMB);
-  unsigned v_and = env.signature->getBinaryProxy("vAND");
-  unsigned v_or = env.signature->getBinaryProxy("vOR");
-  unsigned v_imp = env.signature->getBinaryProxy("vIMP");
-  unsigned v_not = env.signature->getNotProxy();
-  unsigned v_equals = env.signature->getEqualityProxy();
+  unsigned k_comb = env->signature->getCombinator(Signature::K_COMB);
+  unsigned b_comb = env->signature->getCombinator(Signature::B_COMB);
+  unsigned v_and = env->signature->getBinaryProxy("vAND");
+  unsigned v_or = env->signature->getBinaryProxy("vOR");
+  unsigned v_imp = env->signature->getBinaryProxy("vIMP");
+  unsigned v_not = env->signature->getNotProxy();
+  unsigned v_equals = env->signature->getEqualityProxy();
 
   TermList kcomb = TermList(Term::create2(k_comb, Term::boolSort(), s1));
   TermList bcomb1 = TermList(Term::create(b_comb, 3, args1));
@@ -349,7 +349,7 @@ void NarrowingIndex::populateIndex()
 
   typedef ApplicativeHelper AH;
 
-  static Options::Narrow set = env.options->narrow();
+  static Options::Narrow set = env->options->narrow();
 
   auto srtOf = [] (TermList t) {
      ASS(t.isTerm());
@@ -364,30 +364,30 @@ void NarrowingIndex::populateIndex()
   TermList z = TermList(5, false);
   TermList args[] = {s1, s2, s3};
 
-  unsigned s_comb = env.signature->getCombinator(Signature::S_COMB);
+  unsigned s_comb = env->signature->getCombinator(Signature::S_COMB);
   TermList constant = TermList(Term::create(s_comb, 3, args));
   TermList lhsS = AH::createAppTerm(srtOf(constant), constant, x, y, z);
   TermList rhsS = AH::createAppTerm3(Term::arrowSort(s1, s2, s3), x, z, AH::createAppTerm(Term::arrowSort(s1, s2), y, z));
   Literal* sLit = Literal::createEquality(true, lhsS, rhsS, s3);
 
-  unsigned c_comb = env.signature->getCombinator(Signature::C_COMB);
+  unsigned c_comb = env->signature->getCombinator(Signature::C_COMB);
   constant = TermList(Term::create(c_comb, 3, args));
   TermList lhsC = AH::createAppTerm(srtOf(constant), constant, x, y, z);
   TermList rhsC = AH::createAppTerm3(Term::arrowSort(s1, s2, s3), x, z, y);
   Literal* cLit = Literal::createEquality(true, lhsC, rhsC, s3);
 
-  unsigned b_comb = env.signature->getCombinator(Signature::B_COMB);
+  unsigned b_comb = env->signature->getCombinator(Signature::B_COMB);
   constant = TermList(Term::create(b_comb, 3, args));
   TermList lhsB = AH::createAppTerm(srtOf(constant), constant, x, y, z);
   TermList rhsB = AH::createAppTerm(Term::arrowSort(s2, s3), x, AH::createAppTerm(Term::arrowSort(s1, s2), y, z));
   Literal* bLit = Literal::createEquality(true, lhsB, rhsB, s3);
 
-  unsigned k_comb = env.signature->getCombinator(Signature::K_COMB);
+  unsigned k_comb = env->signature->getCombinator(Signature::K_COMB);
   constant = TermList(Term::create2(k_comb, s1, s2));
   TermList lhsK = AH::createAppTerm3(srtOf(constant), constant, x, y);
   Literal* kLit = Literal::createEquality(true, lhsK, x, s1);
 
-  unsigned i_comb = env.signature->getCombinator(Signature::I_COMB);
+  unsigned i_comb = env->signature->getCombinator(Signature::I_COMB);
   constant = TermList(Term::create1(i_comb, s1));
   TermList lhsI = AH::createAppTerm(srtOf(constant), constant, x);
   Literal* iLit = Literal::createEquality(true, lhsI, x, s1);
@@ -512,9 +512,9 @@ void RenamingFormulaIndex::handleClause(Clause* c, bool adding)
       if(SortHelper::getResultSort(t) == Term::boolSort() &&
          AH::getProxy(AH::getHead(t)) != Signature::NOT_PROXY){
         if(adding){
-          env.signature->incrementFormulaCount(t);
+          env->signature->incrementFormulaCount(t);
         } else {
-          env.signature->decrementFormulaCount(t);
+          env->signature->decrementFormulaCount(t);
         }
       }
     }

--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -59,6 +59,8 @@ TermSharing::TermSharing(const TermSharing &other)
   , _totalLiterals(other._totalLiterals)
   , _literalInsertions(other._literalInsertions)
   , _termInsertions(other._termInsertions)
+  , _poly(other._poly)
+  , _wellSortednessCheckingDisabled(other._wellSortednessCheckingDisabled)
 {
   CALL("TermSharing::TermSharing(const TermSharing &)");
 

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -40,11 +40,6 @@ public:
   TermSharing();
   ~TermSharing();
 
-// instance-level mutex
-#if VTHREADED
-  std::recursive_mutex _mutex;
-#endif
-
   Term* insert(Term*);
   Term* insertRecurrently(Term*);
 
@@ -94,6 +89,11 @@ public:
 
 private:
   int sumRedLengths(TermStack& args);
+// instance-level mutex
+#if VTHREADED
+  std::recursive_mutex _mutex;
+#endif
+
   bool argNormGt(TermList t1, TermList t2);
 
   /** The set storing all terms */

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -24,6 +24,10 @@
 
 #if VTHREADED
 #include <mutex>
+#define ACQ_TERM_SHARING_LOCK const std::lock_guard<std::recursive_mutex>\
+  __vampire_term_sharing_lock(Indexing::TermSharing::_mutex)
+#else
+#define ACQ_TERM_SHARING_LOCK
 #endif
 
 using namespace Lib;
@@ -49,26 +53,56 @@ public:
   Literal* tryGetOpposite(Literal* l);
 
   void setPoly();
-
-  /** The hash function of this literal */
-  inline static unsigned hash(const Literal* l)
-  { return l->hash(); }
-  /** The hash function of this term */
-  inline static unsigned hash(const Term* t)
-  { return t->hash(); }
-  static bool equals(const Term* t1,const Term* t2);
-
-  static bool equals(const Literal* l1, const Literal* l2, bool opposite=false);
-
   struct OpLitWrapper {
     OpLitWrapper(Literal* l) : l(l) {}
     Literal* l;
   };
+
+#if VTHREADED
+  /** The hash function of this term */
+  inline static unsigned hash(std::pair<Signature*, Term*> item)
+  { return item.second->hashUnderSignature(item.first); }
+
+  /** The hash function of this literal */
+  inline static unsigned hash(std::pair<Signature*, Literal*> item)
+  { return item.second->hashUnderSignature(item.first); }
+
+  inline static unsigned hash(std::pair<Signature*, OpLitWrapper> item)
+  { return item.second.l->oppositeHashUnderSignature(item.first); }
+
+  static bool equals(
+    std::pair<Signature*, Term*> left,
+    std::pair<Signature*, Term*> right
+  );
+  static bool equals(
+    std::pair<Signature*, Literal*> left,
+    std::pair<Signature*, Literal*> right,
+    bool opposite=false
+  );
+  static bool equals(
+    std::pair<Signature*, Literal*> left,
+    std::pair<Signature*, OpLitWrapper> right
+  ) {
+    return equals(left, std::make_pair(right.first, right.second.l), true);
+  }
+#else
+  /** The hash function of this term */
+  inline static unsigned hash(const Term* t)
+  { return t->hash(); }
+
+  /** The hash function of this literal */
+  inline static unsigned hash(const Literal* l)
+  { return l->hash(); }
+
   inline static unsigned hash(const OpLitWrapper& w)
   { return w.l->oppositeHash(); }
+
+  static bool equals(const Term* s,const Term* t);
+  static bool equals(const Literal* l1, const Literal* l2, bool opposite=false);
   static bool equals(const Literal* l1,const OpLitWrapper& w) {
     return equals(l1, w.l, true);
   }
+#endif
 
   friend class WellSortednessCheckingLocalDisabler;
 
@@ -91,15 +125,23 @@ private:
   int sumRedLengths(TermStack& args);
 // instance-level mutex
 #if VTHREADED
-  std::recursive_mutex _mutex;
+  static std::recursive_mutex _mutex;
+  friend class Kernel::Signature;
 #endif
 
   bool argNormGt(TermList t1, TermList t2);
 
+#if VTHREADED
+  /** The set storing all terms */
+  Set<std::pair<Signature*, Term*>,TermSharing> _terms;
+  /** The set storing all literals */
+  Set<std::pair<Signature*, Literal*>,TermSharing> _literals;
+#else
   /** The set storing all terms */
   Set<Term*,TermSharing> _terms;
   /** The set storing all literals */
   Set<Literal*,TermSharing> _literals;
+#endif
   /** Number of terms stored */
   unsigned _totalTerms;
   /** Number of ground terms stored */

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -22,6 +22,10 @@
 
 #include "Lib/Allocator.hpp"
 
+#if VTHREADED
+#include <mutex>
+#endif
+
 using namespace Lib;
 using namespace Kernel;
 
@@ -35,6 +39,11 @@ public:
 
   TermSharing();
   ~TermSharing();
+
+// instance-level mutex
+#if VTHREADED
+  std::recursive_mutex _mutex;
+#endif
 
   Term* insert(Term*);
   Term* insertRecurrently(Term*);

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -17,6 +17,10 @@
 #ifndef __TermSharing__
 #define __TermSharing__
 
+#if VTHREADED
+#include <mutex>
+#endif
+
 #include "Lib/Set.hpp"
 #include "Kernel/Term.hpp"
 
@@ -34,9 +38,6 @@ public:
   USE_ALLOCATOR(TermSharing);
 
   TermSharing();
-#if VTHREADED
-  TermSharing(const TermSharing &other);
-#endif
   ~TermSharing();
 
   Term* insert(Term*);
@@ -89,13 +90,11 @@ public:
 
 private:
   int sumRedLengths(TermStack& args);
-/*
 // instance-level mutex
 #if VTHREADED
-  static std::recursive_mutex _mutex;
+  static std::mutex _term_mutex, _literal_mutex;
   friend class Kernel::Signature;
 #endif
-*/
 
   bool argNormGt(TermList t1, TermList t2);
 
@@ -104,20 +103,20 @@ private:
   /** The set storing all literals */
   Set<Literal*,TermSharing> _literals;
   /** Number of terms stored */
-  unsigned _totalTerms;
+  VATOMIC(unsigned) _totalTerms;
   /** Number of ground terms stored */
   // unsigned _groundTerms; // MS: unused
   /** Number of literals stored */
-  unsigned _totalLiterals;
+  VATOMIC(unsigned) _totalLiterals;
   /** Number of ground literals stored */
   // unsigned _groundLiterals; // MS: unused
   /** Number of literal insertions */
-  unsigned _literalInsertions;
+  VATOMIC(unsigned) _literalInsertions;
   /** Number of term insertions */
-  unsigned _termInsertions;
+  VATOMIC(unsigned) _termInsertions;
 
-  bool _poly;
-  bool _wellSortednessCheckingDisabled;
+  VATOMIC(bool) _poly;
+  VATOMIC(bool) _wellSortednessCheckingDisabled;
 }; // class TermSharing
 
 } // namespace Indexing

--- a/Indexing/TermSubstitutionTree.cpp
+++ b/Indexing/TermSubstitutionTree.cpp
@@ -36,7 +36,7 @@ using namespace Lib;
 using namespace Kernel;
 
 TermSubstitutionTree::TermSubstitutionTree(bool useC, bool rfSubs, bool extra)
-: SubstitutionTree(env.signature->functions(),useC, rfSubs), _extByAbs(rfSubs)
+: SubstitutionTree(env->signature->functions(),useC, rfSubs), _extByAbs(rfSubs)
 {
   _extra = extra;
   if(rfSubs){

--- a/Indexing/TypeSubstitutionTree.cpp
+++ b/Indexing/TypeSubstitutionTree.cpp
@@ -36,7 +36,7 @@ using namespace Lib;
 using namespace Kernel;
 
 TypeSubstitutionTree::TypeSubstitutionTree()
-: SubstitutionTree(env.signature->functions())
+: SubstitutionTree(env->signature->functions())
 {
 }
 

--- a/Inferences/ArgCong.cpp
+++ b/Inferences/ArgCong.cpp
@@ -112,7 +112,7 @@ struct ArgCong::ResultFn
           /*TimeCounter tc(TC_LITERAL_ORDER_AFTERCHECK);
 
           if (i < _cl->numSelected() && _ord->compare(currAfter,newLit) == Ordering::GREATER) {
-            env.statistics->inferencesBlockedForOrderingAftercheck++;
+            env->statistics->inferencesBlockedForOrderingAftercheck++;
             res->destroy();
             return 0;
           }*/ //TODO reintroduce check
@@ -126,7 +126,7 @@ struct ArgCong::ResultFn
       }
     }
 
-    env.statistics->argumentCongruence++;
+    env->statistics->argumentCongruence++;
 
     return res;
   }

--- a/Inferences/ArrayTheoryISE.cpp
+++ b/Inferences/ArrayTheoryISE.cpp
@@ -159,7 +159,7 @@ Clause* ArrayTheoryISE::simplify(Clause* c)
     return c;
   }
   
-  static DArray<Literal*> lits(32);
+  VTHREAD_LOCAL static DArray<Literal*> lits(32);
   int length = c->length();
   lits.ensure(length);
   bool modified = false;

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -203,7 +203,7 @@ struct BackwardDemodulation::ResultFn
 
     Literal* resLit=EqHelper::replace(qr.literal,lhsS,rhsS);
     if(EqHelper::isEqTautology(resLit)) {
-      env.statistics->backwardDemodulationsToEqTaut++;
+      env->statistics->backwardDemodulationsToEqTaut++;
       _removed->insert(qr.clause);
       return BwSimplificationRecord(qr.clause);
     }
@@ -222,7 +222,7 @@ struct BackwardDemodulation::ResultFn
     }
     ASS_EQ(next,cLen);
 
-    env.statistics->backwardDemodulations++;
+    env->statistics->backwardDemodulations++;
     _removed->insert(qr.clause);
     return BwSimplificationRecord(qr.clause,res);
   }

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -151,7 +151,7 @@ void BackwardSubsumptionDemodulation::perform(Clause* sideCl, BwSimplificationRe
   Literal* lmLit1 = best2.first.lit();
   Literal* lmLit2 = best2.second.lit();
 
-  static vvector<BwSimplificationRecord> simplificationsStorage;
+  VTHREAD_LOCAL static vvector<BwSimplificationRecord> simplificationsStorage;
   ASS_EQ(simplificationsStorage.size(), 0);
 
   if (!lmLit1->isEquality() || !lmLit1->isPositive()) {
@@ -296,7 +296,7 @@ void BackwardSubsumptionDemodulation::performWithQueryLit(Clause* sideCl, Litera
 /// Returns true iff the main premise has been simplified.
 bool BackwardSubsumptionDemodulation::simplifyCandidate(Clause* sideCl, Clause* mainCl, vvector<BwSimplificationRecord>& simplifications)
 {
-    static vvector<LiteralList*> alts;
+    VTHREAD_LOCAL static vvector<LiteralList*> alts;
 
     alts.clear();
     alts.resize(sideCl->length(), LiteralList::empty());
@@ -356,10 +356,10 @@ bool BackwardSubsumptionDemodulation::simplifyCandidate(Clause* sideCl, Clause* 
     ASS_LE(baseLitsWithoutAlternatives, 1);
     ASS_EQ(sideCl->length(), alts.size());
 
-    static MLMatcherSD matcher;
+    VTHREAD_LOCAL static MLMatcherSD matcher;
     matcher.init(sideCl, mainCl, alts.data());
 
-    static unsigned const maxMatches =
+    VTHREAD_LOCAL static unsigned const maxMatches =
       getOptions().backwardSubsumptionDemodulationMaxMatches() == 0
       ? std::numeric_limits<decltype(maxMatches)>::max()
       : getOptions().backwardSubsumptionDemodulationMaxMatches();
@@ -419,15 +419,15 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
   }
 
   // isMatched[i] is true iff (*mainCl)[i] is matched by some literal in sideCl (other than eqLit)
-  static vvector<bool> isMatched;
+  VTHREAD_LOCAL static vvector<bool> isMatched;
   matcher.getMatchedAltsBitmap(isMatched);
 
-  static OverlayBinder binder;
+  VTHREAD_LOCAL static OverlayBinder binder;
   binder.clear();
   matcher.getBindings(binder.base());
 
   // NOTE: for explanation see comments in ForwardSubsumptionDemodulation::perform
-  static vvector<TermList> lhsVector;
+  VTHREAD_LOCAL static vvector<TermList> lhsVector;
   lhsVector.clear();
   {
     TermList t0 = *eqLit->nthArgument(0);
@@ -476,7 +476,7 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
 
 
 
-  static DHSet<TermList> attempted;  // Terms we already attempted to demodulate
+  VTHREAD_LOCAL static DHSet<TermList> attempted;  // Terms we already attempted to demodulate
   attempted.reset();
 
   for (unsigned dli = 0; dli < mainCl->length(); ++dli) {

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -404,7 +404,7 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
     }
 #endif
     ASS(replacement == nullptr);
-    env.statistics->backwardSubsumed++;
+    env->statistics->backwardSubsumed++;
     return true;
   }
   ASS(eqLit->isEquality());
@@ -489,7 +489,7 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
 
     // TODO higher-order support not yet implemented; see forward demodulation
     //      (maybe it's enough to just use the different iterator)
-    ASS(!env.options->combinatorySup());
+    ASS(!env->options->combinatorySup());
     NonVariableNonTypeIterator nvi(dlit);
     while (nvi.hasNext()) {
       TermList lhsS = nvi.next();  // named 'lhsS' because it will be matched against 'lhs'
@@ -582,7 +582,7 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
               }
 #endif
               ASS(replacement == nullptr);
-              env.statistics->backwardSubsumed++;
+              env->statistics->backwardSubsumed++;
               return true;
             } else {
               // Here, we have subsumption resolution
@@ -598,7 +598,7 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
                 ASS(SDHelper::clauseIsSmaller(replacement, mainCl, ordering));
               }
 #endif
-              env.statistics->backwardSubsumptionResolution++;
+              env->statistics->backwardSubsumptionResolution++;
               return true;
             }
           }
@@ -656,7 +656,7 @@ isRedundant:
 #endif
 
         if (EqHelper::isEqTautology(newLit)) {
-          env.statistics->backwardSubsumptionDemodulationsToEqTaut++;
+          env->statistics->backwardSubsumptionDemodulationsToEqTaut++;
           ASS(replacement == nullptr);
           return true;
         }
@@ -672,17 +672,17 @@ isRedundant:
           }
         }
 
-        env.statistics->backwardSubsumptionDemodulations++;
+        env->statistics->backwardSubsumptionDemodulations++;
 
         replacement = newCl;
 
 #if BSD_LOG_INFERENCES
-        env.beginOutput();
-        env.out() << "\% Begin Inference \"BSD-" << newCl->number() << "\"\n";
-        env.out() << "\% eqLit: " << eqLit->toString() << "\n";
-        env.out() << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
-        env.out() << "\% dlit: " << dlit->toString() << "\n";
-        // env.out() << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
+        env->beginOutput();
+        env->out() << "\% Begin Inference \"BSD-" << newCl->number() << "\"\n";
+        env->out() << "\% eqLit: " << eqLit->toString() << "\n";
+        env->out() << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
+        env->out() << "\% dlit: " << dlit->toString() << "\n";
+        // env->out() << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
         TPTPPrinter tptp;
         // NOTE: do not output the splitLevels here, because those will be set for newCl only later
         tptp.printWithRole("side_premise", "hypothesis", sideCl, false);
@@ -694,8 +694,8 @@ isRedundant:
         //       Problem: how to detect that situation??
         //       probably if the input only contains FOF and no TFF
         // TODO: Also don't output type defs for $$false and $$true, see problem SYO091^5.p
-        env.out() << "\% End Inference \"BSD-" << newCl->number() << "\"" << std::endl;
-        env.endOutput();
+        env->out() << "\% End Inference \"BSD-" << newCl->number() << "\"" << std::endl;
+        env->endOutput();
 #endif
 
 #if VDEBUG && BSD_VDEBUG_REDUNDANCY_ASSERTIONS

--- a/Inferences/BackwardSubsumptionResolution.cpp
+++ b/Inferences/BackwardSubsumptionResolution.cpp
@@ -123,7 +123,7 @@ void BackwardSubsumptionResolution::perform(Clause* cl,
       Clause* resCl=ForwardSubsumptionAndResolution::generateSubsumptionResolutionClause(qr.clause, qr.literal, cl);
 
       List<BwSimplificationRecord>::push(BwSimplificationRecord(qr.clause,resCl), simplRes);
-      env.statistics->backwardSubsumptionResolution++;
+      env->statistics->backwardSubsumptionResolution++;
       RSTAT_CTR_INC("bsr0 performed (units)");
     }
     if(simplRes) {
@@ -264,7 +264,7 @@ void BackwardSubsumptionResolution::perform(Clause* cl,
       RSTAT_CTR_INC("bsr1 4 performed");
       Clause* resCl=ForwardSubsumptionAndResolution::generateSubsumptionResolutionClause(qr.clause, qr.literal, cl);
       List<BwSimplificationRecord>::push(BwSimplificationRecord(qr.clause,resCl), simplRes);
-      env.statistics->backwardSubsumptionResolution++;      
+      env->statistics->backwardSubsumptionResolution++;      
     }
 
   match_fail:
@@ -410,7 +410,7 @@ void BackwardSubsumptionResolution::perform(Clause* cl,
       RSTAT_CTR_INC("bsr2 5 performed");
       Clause* resCl=ForwardSubsumptionAndResolution::generateSubsumptionResolutionClause(qr.clause, resolvedLit, cl);
       List<BwSimplificationRecord>::push(BwSimplificationRecord(qr.clause,resCl), simplRes);
-      env.statistics->backwardSubsumptionResolution++;
+      env->statistics->backwardSubsumptionResolution++;
     }
 
   match_fail2:

--- a/Inferences/BackwardSubsumptionResolution.cpp
+++ b/Inferences/BackwardSubsumptionResolution.cpp
@@ -106,7 +106,7 @@ void BackwardSubsumptionResolution::perform(Clause* cl,
     return;
   }
 
-  static DHSet<Clause*> checkedClauses;
+  VTHREAD_LOCAL static DHSet<Clause*> checkedClauses;
   checkedClauses.reset();
 
   if(clen==1) {
@@ -149,12 +149,12 @@ void BackwardSubsumptionResolution::perform(Clause* cl,
   unsigned lmPred=lmLit->functor();
   unsigned lmHeader=lmLit->header();
 
-  static DArray<LiteralList*> matchedLits(32);
+  VTHREAD_LOCAL static DArray<LiteralList*> matchedLits(32);
   matchedLits.init(clen, 0);
 
   bool mustPredInit=false;
   unsigned mustPred;
-  static DHSet<unsigned> basePreds;
+  VTHREAD_LOCAL static DHSet<unsigned> basePreds;
   bool basePredsInit=false;
 
   List<BwSimplificationRecord>* simplRes=0;

--- a/Inferences/BinaryResolution.cpp
+++ b/Inferences/BinaryResolution.cpp
@@ -221,7 +221,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
 
       Literal* constraint = Literal::createEquality(false,qT,rT,sort);
 
-      static Options::UnificationWithAbstraction uwa = opts.unificationWithAbstraction();
+      VTHREAD_LOCAL static Options::UnificationWithAbstraction uwa = opts.unificationWithAbstraction();
       if(uwa==Options::UnificationWithAbstraction::GROUND &&
          !constraint->ground() &&
          (!theory->isInterpretedFunction(qT) && !theory->isInterpretedConstant(qT)) && 

--- a/Inferences/BinaryResolution.cpp
+++ b/Inferences/BinaryResolution.cpp
@@ -56,7 +56,7 @@ void BinaryResolution::attach(SaturationAlgorithm* salg)
   _index=static_cast<GeneratingLiteralIndex*> (
 	  _salg->getIndexManager()->request(GENERATING_SUBST_TREE) );
 
-  _unificationWithAbstraction = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
+  _unificationWithAbstraction = env->options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
 }
 
 void BinaryResolution::detach()
@@ -124,11 +124,11 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
   ASS(qr.clause->store()==Clause::ACTIVE);//Added to check that generation only uses active clauses
 
   if(!ColorHelper::compatible(queryCl->color(),qr.clause->color()) ) {
-    env.statistics->inferencesSkippedDueToColors++;
+    env->statistics->inferencesSkippedDueToColors++;
     if(opts.showBlocked()) {
-      env.beginOutput();
-      env.out()<<"Blocked resolution of "<<queryCl->toString()<<" and "<<qr.clause->toString()<<endl;
-      env.endOutput();
+      env->beginOutput();
+      env->out()<<"Blocked resolution of "<<queryCl->toString()<<" and "<<qr.clause->toString()<<endl;
+      env->endOutput();
     }
     if(opts.colorUnblocking()) {
       SaturationAlgorithm* salg = SaturationAlgorithm::tryGetInstance();
@@ -175,7 +175,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
     }
     if(!passiveClauseContainer->fulfilsWeightLimit(wlb, numPositiveLiteralsLowerBound, inf)) {
       RSTAT_CTR_INC("binary resolutions skipped for weight limit before building clause");
-      env.statistics->discardedNonRedundantClauses++;
+      env->statistics->discardedNonRedundantClauses++;
       return 0;
     }
   }
@@ -244,7 +244,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
         wlb+=newLit->weight() - curr->weight();
         if(!passiveClauseContainer->fulfilsWeightLimit(wlb, numPositiveLiteralsLowerBound, res->inference())) {
           RSTAT_CTR_INC("binary resolutions skipped for weight limit while building clause");
-          env.statistics->discardedNonRedundantClauses++;
+          env->statistics->discardedNonRedundantClauses++;
           res->destroy();
           return 0;
         }
@@ -257,7 +257,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
         if (o == Ordering::GREATER ||
             (ls->isPositiveForSelection(newLit)    // strict maximimality for positive literals
                 && (o == Ordering::GREATER_EQ || o == Ordering::EQUAL))) { // where is GREATER_EQ ever coming from?
-          env.statistics->inferencesBlockedForOrderingAftercheck++;
+          env->statistics->inferencesBlockedForOrderingAftercheck++;
           res->destroy();
           return 0;
         }
@@ -282,7 +282,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
         wlb+=newLit->weight() - curr->weight();
         if(!passiveClauseContainer->fulfilsWeightLimit(wlb, numPositiveLiteralsLowerBound, res->inference())) {
           RSTAT_CTR_INC("binary resolutions skipped for weight limit while building clause");
-          env.statistics->discardedNonRedundantClauses++;
+          env->statistics->discardedNonRedundantClauses++;
           res->destroy();
           return 0;
         }
@@ -295,7 +295,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
         if (o == Ordering::GREATER ||
             (ls->isPositiveForSelection(newLit)   // strict maximimality for positive literals
                 && (o == Ordering::GREATER_EQ || o == Ordering::EQUAL))) { // where is GREATER_EQ ever coming from?
-          env.statistics->inferencesBlockedForOrderingAftercheck++;
+          env->statistics->inferencesBlockedForOrderingAftercheck++;
           res->destroy();
           return 0;
         }
@@ -307,10 +307,10 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, SLQ
   }
 
   if(withConstraints){
-    env.statistics->cResolution++;
+    env->statistics->cResolution++;
   }
   else{ 
-    env.statistics->resolution++;
+    env->statistics->resolution++;
   }
 
   //cout << "RESULT " << res->toString() << endl;

--- a/Inferences/BoolEqToDiseq.cpp
+++ b/Inferences/BoolEqToDiseq.cpp
@@ -65,9 +65,9 @@ ClauseIterator BoolEqToDiseq::generateClauses(Clause* cl)
       }
       TermList head = AH::getHead(lhs);
       if(!head.isVar()){
-        Signature::Symbol* sym = env.signature->getFunction(head.term()->functor());
+        Signature::Symbol* sym = env->signature->getFunction(head.term()->functor());
         if(sym->proxy() != Signature::NOT){
-          TermList vNot = TermList(Term::createConstant(env.signature->getNotProxy()));
+          TermList vNot = TermList(Term::createConstant(env->signature->getNotProxy()));
           TermList vNotSort = SortHelper::getResultSort(vNot.term());
           TermList newLhs = AH::createAppTerm(vNotSort, vNot, lhs);
           newLit = Literal::createEquality(false, newLhs, rhs, Term::boolSort());
@@ -76,9 +76,9 @@ ClauseIterator BoolEqToDiseq::generateClauses(Clause* cl)
       }
       head = AH::getHead(rhs);
       if(!head.isVar()){
-        Signature::Symbol* sym = env.signature->getFunction(head.term()->functor());
+        Signature::Symbol* sym = env->signature->getFunction(head.term()->functor());
         if(sym->proxy() != Signature::NOT){
-          TermList vNot = TermList(Term::createConstant(env.signature->getNotProxy()));
+          TermList vNot = TermList(Term::createConstant(env->signature->getNotProxy()));
           TermList vNotSort = SortHelper::getResultSort(vNot.term());
           TermList newRhs = AH::createAppTerm(vNotSort, vNot, rhs);
           newLit = Literal::createEquality(false, lhs, newRhs, Term::boolSort());

--- a/Inferences/BoolSimp.cpp
+++ b/Inferences/BoolSimp.cpp
@@ -62,7 +62,7 @@ substitution:
     (*conclusion)[i] = i == literalPosition ? EqHelper::replace((*premise)[i], subTerm, simpedSubTerm) : (*premise)[i];
   }
 
-  env.statistics->booleanSimps++;
+  env->statistics->booleanSimps++;
   return conclusion;
 }
 
@@ -75,7 +75,7 @@ bool BoolSimp::areComplements(TermList t1, TermList t2){
 
   ApplicativeHelper::getHeadAndArgs(t1, head, args);
   if(!head.isVar()){
-    sym = env.signature->getFunction(head.term()->functor());
+    sym = env->signature->getFunction(head.term()->functor());
     if(sym->proxy() == Signature::NOT){
       ASS(args.size() == 1);
       if(args[0] == t2){ return true;}
@@ -84,7 +84,7 @@ bool BoolSimp::areComplements(TermList t1, TermList t2){
 
   ApplicativeHelper::getHeadAndArgs(t2, head, args);
   if(!head.isVar()){
-    sym = env.signature->getFunction(head.term()->functor());
+    sym = env->signature->getFunction(head.term()->functor());
     if(sym->proxy() == Signature::NOT){
       ASS(args.size() == 1);
       if(args[0] == t1){ return true;}
@@ -100,7 +100,7 @@ TermList BoolSimp::negate(TermList term){
   
   TermList constant, constSort;
 
-  constant = TermList(Term::createConstant(env.signature->getNotProxy()));
+  constant = TermList(Term::createConstant(env->signature->getNotProxy()));
   constSort = SortHelper::getResultSort(constant.term());
   return ApplicativeHelper::createAppTerm(constSort, constant, term);
 }
@@ -117,7 +117,7 @@ TermList BoolSimp::boolSimplify(TermList term){
 
   if(head.isVar()){ return term; }
 
-  Signature::Symbol* sym = env.signature->getFunction(head.term()->functor());
+  Signature::Symbol* sym = env->signature->getFunction(head.term()->functor());
   switch(sym->proxy()){
     case Signature::AND:{
       ASS(args.size() == 2);
@@ -163,7 +163,7 @@ TermList BoolSimp::boolSimplify(TermList term){
       if(args[0] == fols){ return troo; }
       ApplicativeHelper::getHeadAndArgs(args[0], head, args);
       if(!head.isVar()){
-        sym = env.signature->getFunction(head.term()->functor());
+        sym = env->signature->getFunction(head.term()->functor());
         if(sym->proxy() == Signature::NOT){
           ASS(args.size() == 1);
           return args[0];

--- a/Inferences/CNFOnTheFly.cpp
+++ b/Inferences/CNFOnTheFly.cpp
@@ -407,11 +407,11 @@ ClauseIterator produceClauses(Clause* c, bool generating, SkolemisingFormulaInde
 {
   CALL("CNFOnTheFly::produceClauses");
 
-  static bool eager = env.options->cnfOnTheFly() == Options::CNFOnTheFly::EAGER;
-  static bool simp = env.options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_SIMP;
-  static bool gen = env.options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_GEN;
-  static bool simp_except_not_be_off = env.options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_SIMP_NOT_GEN_BOOL_EQ_OFF;
-  static bool simp_except_not_and_be = env.options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_SIMP_NOT_GEN_BOOL_EQ_GEN;
+  static bool eager = env->options->cnfOnTheFly() == Options::CNFOnTheFly::EAGER;
+  static bool simp = env->options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_SIMP;
+  static bool gen = env->options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_GEN;
+  static bool simp_except_not_be_off = env->options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_SIMP_NOT_GEN_BOOL_EQ_OFF;
+  static bool simp_except_not_and_be = env->options->cnfOnTheFly() == Options::CNFOnTheFly::LAZY_SIMP_NOT_GEN_BOOL_EQ_GEN;
   bool not_be = simp_except_not_be_off || (!generating && simp_except_not_and_be);
 
 

--- a/Inferences/CTFwSubsAndRes.cpp
+++ b/Inferences/CTFwSubsAndRes.cpp
@@ -110,10 +110,10 @@ bool CTFwSubsAndRes::perform(Clause* cl, Clause*& replacement, ClauseIterator& p
 
     if(res.resolved) {
       replacement=buildSResClause(cl, res.resolvedQueryLiteralIndex, premise);
-      env.statistics->forwardSubsumptionResolution++;
+      env->statistics->forwardSubsumptionResolution++;
     }
     else {
-      env.statistics->forwardSubsumed++;
+      env->statistics->forwardSubsumed++;
     }
     
     break;

--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -86,7 +86,7 @@ struct Choice::AxiomsIterator
 
     //cout << "the result sort is " + _resultSort.toString() << endl;
 
-    DHSet<unsigned>* ops = env.signature->getChoiceOperators();
+    DHSet<unsigned>* ops = env->signature->getChoiceOperators();
     DHSet<unsigned>::Iterator opsIt(*ops);
     _choiceOps.loadFromIterator(opsIt);
     _inBetweenNextandHasNext = false;
@@ -102,7 +102,7 @@ struct Choice::AxiomsIterator
     while(!_choiceOps.isEmpty()){
       unsigned op = _choiceOps.getOneKey();
       _choiceOps.remove(op);
-      OperatorType* type = env.signature->getFunction(op)->fnType();
+      OperatorType* type = env->signature->getFunction(op)->fnType();
       
       static RobSubstitution subst;
       static TermStack typeArgs;
@@ -132,7 +132,7 @@ struct Choice::AxiomsIterator
     CALL("Choice::AxiomsIterator::next()");
     _inBetweenNextandHasNext = false;
     Clause* c = createChoiceAxiom(_opApplied, _setApplied); 
-    env.statistics->choiceInstances++;
+    env->statistics->choiceInstances++;
     return c;
   }
 
@@ -158,7 +158,7 @@ struct Choice::ResultFn
       return pvi(AxiomsIterator(term));
     } else {
       Clause* axiom = createChoiceAxiom(op, *term.term()->nthArgument(3));
-      env.statistics->choiceInstances++;
+      env->statistics->choiceInstances++;
       return pvi(getSingletonIterator(axiom));
     }
   }
@@ -184,7 +184,7 @@ struct Choice::IsChoiceTerm
     subst.reset();
 
     subst.reset();
-    return ((head.isVar() || env.signature->isChoiceOperator(head.term()->functor())) &&
+    return ((head.isVar() || env->signature->isChoiceOperator(head.term()->functor())) &&
            subst.match(sort,0,headSort,1));
 
   }

--- a/Inferences/CombinatorNormalisationISE.cpp
+++ b/Inferences/CombinatorNormalisationISE.cpp
@@ -191,7 +191,7 @@ bool CombinatorNormalisationISE::replaceWithSmallerCombinator(TermList& t)
                                    AH::getComb(head1) == Signature::S_COMB) &&
              AH::isComb(args1[0]) && AH::getComb(args1[0]) == Signature::K_COMB){
             //S (C K) = I /\ S (S K) = I
-            t =  TermList(Term::create1(env.signature->getCombinator(Signature::I_COMB), AH::getNthArg(sort,1)));
+            t =  TermList(Term::create1(env->signature->getCombinator(Signature::I_COMB), AH::getNthArg(sort,1)));
             return true;
           }
           if(args1.size() == 2 &&
@@ -207,7 +207,7 @@ bool CombinatorNormalisationISE::replaceWithSmallerCombinator(TermList& t)
           TermList arg1 = args[1];
           TermList arg2 = args[0];
           if(AH::isComb(arg1) && AH::getComb(arg1) == Signature::K_COMB){
-            t = TermList(Term::create1(env.signature->getCombinator(Signature::I_COMB), AH::getNthArg(sort,1)));
+            t = TermList(Term::create1(env->signature->getCombinator(Signature::I_COMB), AH::getNthArg(sort,1)));
             return true;
           }
           AH::getHeadAndArgs(arg1, head1, args1);
@@ -250,7 +250,7 @@ bool CombinatorNormalisationISE::replaceWithSmallerCombinator(TermList& t)
       case Signature::B_COMB : {
         if(args.size() == 1){
           if(AH::isComb(args[0]) && AH::getComb(args[0]) == Signature::I_COMB){
-            t =  TermList(Term::create1(env.signature->getCombinator(Signature::I_COMB), AH::getNthArg(sort,1)));
+            t =  TermList(Term::create1(env->signature->getCombinator(Signature::I_COMB), AH::getNthArg(sort,1)));
             return true;
           }
         }
@@ -308,7 +308,7 @@ TermList CombinatorNormalisationISE::createKTerm(TermList s1, TermList s2, TermL
 {
   CALL("CombinatorNormalisationISE::createKTerm");
   
-  unsigned kcomb = env.signature->getCombinator(Signature::K_COMB);
+  unsigned kcomb = env->signature->getCombinator(Signature::K_COMB);
   TermList res = TermList(Term::create2(kcomb, s1, s2));
   res = AH::createAppTerm(SortHelper::getResultSort(res.term()), res, arg1);             
   return res;
@@ -320,7 +320,7 @@ TermList CombinatorNormalisationISE::createSCorBTerm(TermList arg1, TermList arg
   CALL("CombinatorNormalisationISE::createSCorBTerm");
   
   TermList s1, s2, s3;
-  unsigned cb = env.signature->getCombinator(comb);
+  unsigned cb = env->signature->getCombinator(comb);
   
   if(comb == Signature::S_COMB || comb == Signature::C_COMB){
     //cout << "CCOMB arg1 " + arg1.toString() + " of sort " + arg1sort.toString() << endl; 

--- a/Inferences/Condensation.cpp
+++ b/Inferences/Condensation.cpp
@@ -138,7 +138,7 @@ Clause* Condensation::simplify(Clause* cl)
           (*res)[i] = newLits[i];
         }
 
-        env.statistics->condensations++;
+        env->statistics->condensations++;
         return res;
       }
     }

--- a/Inferences/Condensation.cpp
+++ b/Inferences/Condensation.cpp
@@ -52,9 +52,9 @@ Clause* Condensation::simplify(Clause* cl)
   unsigned newLen=clen-1;
 
   // stores newLen new literals
-  static DArray<Literal*> newLits(32);
+  VTHREAD_LOCAL static DArray<Literal*> newLits(32);
   //
-  static DArray<LiteralList*> alts(32);
+  VTHREAD_LOCAL static DArray<LiteralList*> alts(32);
   //static OCMatchIterator matcher;
 
   LiteralMiniIndex cmi(cl);

--- a/Inferences/DistinctEqualitySimplifier.cpp
+++ b/Inferences/DistinctEqualitySimplifier.cpp
@@ -46,7 +46,7 @@ Clause* DistinctEqualitySimplifier::simplify(Clause* cl)
       //we have a clause that is implied by the distinctness constraints
       return 0;
     }
-    Unit* prem = env.signature->getDistinctGroupPremise(grp);
+    Unit* prem = env->signature->getDistinctGroupPremise(grp);
     if(prem) {
       prems.push(prem);
     }
@@ -84,11 +84,11 @@ bool DistinctEqualitySimplifier::mustBeDistinct(TermList t1, TermList t2, unsign
   }
   unsigned fn1 = t1.term()->functor();
   unsigned fn2 = t2.term()->functor();
-  const List<unsigned>* dlst1 = env.signature->getFunction(fn1)->distinctGroups();
+  const List<unsigned>* dlst1 = env->signature->getFunction(fn1)->distinctGroups();
   if(!dlst1) {
     return false;
   }
-  const List<unsigned>* dlst2 = env.signature->getFunction(fn2)->distinctGroups();
+  const List<unsigned>* dlst2 = env->signature->getFunction(fn2)->distinctGroups();
   if(!dlst2) {
     return false;
   }

--- a/Inferences/DistinctEqualitySimplifier.cpp
+++ b/Inferences/DistinctEqualitySimplifier.cpp
@@ -30,8 +30,8 @@ Clause* DistinctEqualitySimplifier::simplify(Clause* cl)
   if(!canSimplify(cl)) {
     return cl;
   }
-  static LiteralStack lits;
-  static Stack<Unit*> prems;
+  VTHREAD_LOCAL static LiteralStack lits;
+  VTHREAD_LOCAL static Stack<Unit*> prems;
   prems.reset();
   lits.reset();
   unsigned clen = cl->length();

--- a/Inferences/ElimLeibniz.cpp
+++ b/Inferences/ElimLeibniz.cpp
@@ -160,7 +160,7 @@ afterLoop:
 
   TermList var = TermList(lerPosLit.var, false);
 
-  TermList vEquals = TermList(Term::create1(env.signature->getEqualityProxy(), argS));
+  TermList vEquals = TermList(Term::create1(env->signature->getEqualityProxy(), argS));
   TermList t1 = AH::createAppTerm(SH::getResultSort(vEquals.term()), vEquals, lerNegLit.arg);
   if(subst.unify(var, 0, t1, 0)){
     Clause* c = createConclusion(premise, newLit, posLit, negLit, subst);
@@ -171,10 +171,10 @@ afterLoop:
   TermList t2 = AH::createAppTerm(SH::getResultSort(vEquals.term()), vEquals, lerPosLit.arg);
   
   TermList typeArgs[] = {argS, Term::boolSort(), Term::boolSort()};
-  unsigned b_comb = env.signature->getCombinator(Signature::B_COMB);
+  unsigned b_comb = env->signature->getCombinator(Signature::B_COMB);
   
   TermList bComb  = TermList(Term::create(b_comb, 3, typeArgs));
-  TermList vNot   = TermList(Term::createConstant(env.signature->getNotProxy()));
+  TermList vNot   = TermList(Term::createConstant(env->signature->getNotProxy()));
   t2 = AH::createAppTerm3(SH::getResultSort(bComb.term()), bComb,vNot,t2);
 
   if(subst.unify(var, 0, t2, 0)){
@@ -182,7 +182,7 @@ afterLoop:
     clauses.push(c);
   }  
 
-  env.statistics->leibnizElims++;
+  env->statistics->leibnizElims++;
   return pvi(getUniquePersistentIterator(ClauseStack::Iterator(clauses)));
 
 }

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -119,8 +119,8 @@ struct EqualityFactoring::ResultFn
     TermList fRHS=EqHelper::getOtherEqualitySide(fLit, fLHS);
     ASS_NEQ(sLit, fLit);
 
-    VTHREAD_LOCAL static Options::FunctionExtensionality ext = env.options->functionExtensionality();
-    bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) && env.statistics->higherOrder;
+    VTHREAD_LOCAL static Options::FunctionExtensionality ext = env->options->functionExtensionality();
+    bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) && env->statistics->higherOrder;
 
     if(use_ho_handler){
       TermList sLHSreplaced = sLHS;
@@ -171,7 +171,7 @@ struct EqualityFactoring::ResultFn
         if (sLitAfter) {
           TimeCounter tc(TC_LITERAL_ORDER_AFTERCHECK);
           if (i < _cl->numSelected() && _ordering.compare(currAfter,sLitAfter) == Ordering::GREATER) {
-            env.statistics->inferencesBlockedForOrderingAftercheck++;
+            env->statistics->inferencesBlockedForOrderingAftercheck++;
             res->destroy();
             return 0;
           }
@@ -192,7 +192,7 @@ struct EqualityFactoring::ResultFn
     }
     ASS_EQ(next,newLen);
 
-    env.statistics->equalityFactoring++;
+    env->statistics->equalityFactoring++;
 
     return res;
   }

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -102,8 +102,8 @@ struct EqualityFactoring::ResultFn
 
     TermList srt = SortHelper::getEqualityArgumentSort(sLit);
 
-    static RobSubstitution subst;
-    static UnificationConstraintStack constraints;
+    VTHREAD_LOCAL static RobSubstitution subst;
+    VTHREAD_LOCAL static UnificationConstraintStack constraints;
     subst.reset();
     constraints.reset();
 
@@ -119,7 +119,7 @@ struct EqualityFactoring::ResultFn
     TermList fRHS=EqHelper::getOtherEqualitySide(fLit, fLHS);
     ASS_NEQ(sLit, fLit);
 
-    static Options::FunctionExtensionality ext = env.options->functionExtensionality();
+    VTHREAD_LOCAL static Options::FunctionExtensionality ext = env.options->functionExtensionality();
     bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) && env.statistics->higherOrder;
 
     if(use_ho_handler){

--- a/Inferences/EqualityResolution.cpp
+++ b/Inferences/EqualityResolution.cpp
@@ -75,11 +75,11 @@ struct EqualityResolution::ResultFn
     TermList arg0 = *lit->nthArgument(0);
     TermList arg1 = *lit->nthArgument(1);
 
-    VTHREAD_LOCAL static Options::UnificationWithAbstraction uwa = env.options->unificationWithAbstraction();
-    VTHREAD_LOCAL static Options::FunctionExtensionality ext = env.options->functionExtensionality();
+    VTHREAD_LOCAL static Options::UnificationWithAbstraction uwa = env->options->unificationWithAbstraction();
+    VTHREAD_LOCAL static Options::FunctionExtensionality ext = env->options->functionExtensionality();
     bool use_uwa_handler = uwa != Options::UnificationWithAbstraction::OFF;
     bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) &&
-                          env.statistics->higherOrder;
+                          env->statistics->higherOrder;
 
     if(use_ho_handler){
       TermList sort = SortHelper::getEqualityArgumentSort(lit);
@@ -149,7 +149,7 @@ struct EqualityResolution::ResultFn
           TimeCounter tc(TC_LITERAL_ORDER_AFTERCHECK);
 
           if (i < _cl->numSelected() && _ord->compare(currAfter,litAfter) == Ordering::GREATER) {
-            env.statistics->inferencesBlockedForOrderingAftercheck++;
+            env->statistics->inferencesBlockedForOrderingAftercheck++;
             res->destroy();
             return 0;
           }
@@ -180,7 +180,7 @@ struct EqualityResolution::ResultFn
     }
     ASS_EQ(next,newLen);
 
-    env.statistics->equalityResolution++;
+    env->statistics->equalityResolution++;
 
     return res;
   }

--- a/Inferences/EqualityResolution.cpp
+++ b/Inferences/EqualityResolution.cpp
@@ -75,8 +75,8 @@ struct EqualityResolution::ResultFn
     TermList arg0 = *lit->nthArgument(0);
     TermList arg1 = *lit->nthArgument(1);
 
-    static Options::UnificationWithAbstraction uwa = env.options->unificationWithAbstraction();
-    static Options::FunctionExtensionality ext = env.options->functionExtensionality();
+    VTHREAD_LOCAL static Options::UnificationWithAbstraction uwa = env.options->unificationWithAbstraction();
+    VTHREAD_LOCAL static Options::FunctionExtensionality ext = env.options->functionExtensionality();
     bool use_uwa_handler = uwa != Options::UnificationWithAbstraction::OFF;
     bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) &&
                           env.statistics->higherOrder;
@@ -100,8 +100,8 @@ struct EqualityResolution::ResultFn
       use_uwa_handler = false;
     }
 
-    static RobSubstitution subst;
-    static UnificationConstraintStack constraints;
+    VTHREAD_LOCAL static RobSubstitution subst;
+    VTHREAD_LOCAL static UnificationConstraintStack constraints;
     subst.reset();
     constraints.reset();
     subst.setMap(&funcSubtermMap);

--- a/Inferences/EquationalTautologyRemoval.cpp
+++ b/Inferences/EquationalTautologyRemoval.cpp
@@ -35,7 +35,7 @@ Clause* EquationalTautologyRemoval::simplify(Clause* cl)
   bool has_pos_eq = false;
   bool has_complement = false;
 
-  static DHSet<int> preds;
+  VTHREAD_LOCAL static DHSet<int> preds;
   preds.reset();
 
   for (unsigned i = 0; i < cl->length(); i++) {

--- a/Inferences/EquationalTautologyRemoval.cpp
+++ b/Inferences/EquationalTautologyRemoval.cpp
@@ -85,7 +85,7 @@ Clause* EquationalTautologyRemoval::simplify(Clause* cl)
   if (_cc.getStatus(false) == DP::DecisionProcedure::UNSATISFIABLE) {
     // cout << "Deep equational: " << cl->toString() << endl;
 
-    env.statistics->deepEquationalTautologies++;
+    env->statistics->deepEquationalTautologies++;
     return 0;
   } else {
     return cl;

--- a/Inferences/ExtensionalityResolution.cpp
+++ b/Inferences/ExtensionalityResolution.cpp
@@ -113,7 +113,7 @@ struct ExtensionalityResolution::ForwardResultFn
     Literal* extLit = arg.first.second.literal;
 
     return performExtensionalityResolution(extCl, extLit, _otherCl, otherLit, subst,
-                                             env.statistics->forwardExtensionalityResolution,
+                                             env->statistics->forwardExtensionalityResolution,
                                              _parent.getOptions());
   }
 private:
@@ -206,7 +206,7 @@ struct ExtensionalityResolution::BackwardResultFn
     Literal* otherLit = arg.first.second;
 
     return performExtensionalityResolution(_extCl, _extLit, otherCl, otherLit, subst,
-                                             env.statistics->backwardExtensionalityResolution,
+                                             env->statistics->backwardExtensionalityResolution,
                                              _parent.getOptions());
   }
 private:
@@ -231,11 +231,11 @@ Clause* ExtensionalityResolution::performExtensionalityResolution(
   CALL("ExtensionalityResolution::performExtensionalityResolution");
   
   if(!ColorHelper::compatible(extCl->color(),otherCl->color()) ) {
-    env.statistics->inferencesSkippedDueToColors++;
+    env->statistics->inferencesSkippedDueToColors++;
     if(opts.showBlocked()) {
-      env.beginOutput();
-      env.out()<<"Blocked extensionality resolution of "<<extCl->toString()<<" and "<<otherCl->toString()<<endl;
-      env.endOutput();
+      env->beginOutput();
+      env->out()<<"Blocked extensionality resolution of "<<extCl->toString()<<" and "<<otherCl->toString()<<endl;
+      env->endOutput();
     }
     return 0;
   }

--- a/Inferences/FOOLParamodulation.cpp
+++ b/Inferences/FOOLParamodulation.cpp
@@ -51,8 +51,8 @@ ClauseIterator FOOLParamodulation::generateClauses(Clause* premise) {
    * C[s] is deleted after the inference is applied.
    */
 
-  static TermList troo(Term::foolTrue());
-  static TermList fols(Term::foolFalse());
+  VTHREAD_LOCAL static TermList troo(Term::foolTrue());
+  VTHREAD_LOCAL static TermList fols(Term::foolFalse());
 
   /**
    * We will be looking for a literal, standing in a `literalPosition` in

--- a/Inferences/FOOLParamodulation.cpp
+++ b/Inferences/FOOLParamodulation.cpp
@@ -77,8 +77,8 @@ ClauseIterator FOOLParamodulation::generateClauses(Clause* premise) {
     if (literal->isEquality() && literal->polarity()) {
       TermList* lhs = literal->nthArgument(0);
       TermList* rhs = literal->nthArgument(1);
-      if ((lhs->isTerm() && env.signature->isFoolConstantSymbol(false,lhs->term()->functor())) ||
-          (rhs->isTerm() && env.signature->isFoolConstantSymbol(false,rhs->term()->functor()))) {
+      if ((lhs->isTerm() && env->signature->isFoolConstantSymbol(false,lhs->term()->functor())) ||
+          (rhs->isTerm() && env->signature->isFoolConstantSymbol(false,rhs->term()->functor()))) {
         literalPosition++;
         continue;
       }
@@ -91,11 +91,11 @@ ClauseIterator FOOLParamodulation::generateClauses(Clause* premise) {
       unsigned functor = subterm.term()->functor();
 
       // we shouldn't replace boolean constants
-      if (env.signature->isFoolConstantSymbol(false,functor) || env.signature->isFoolConstantSymbol(true,functor)) {
+      if (env->signature->isFoolConstantSymbol(false,functor) || env->signature->isFoolConstantSymbol(true,functor)) {
         continue;
       }
 
-      TermList resultType = env.signature->getFunction(functor)->fnType()->result();
+      TermList resultType = env->signature->getFunction(functor)->fnType()->result();
       if (resultType == Term::boolSort()) {
         booleanTerm = subterm;
         goto substitution;

--- a/Inferences/Factoring.cpp
+++ b/Inferences/Factoring.cpp
@@ -133,7 +133,7 @@ public:
           TimeCounter tc(TC_LITERAL_ORDER_AFTERCHECK);
 
           if (i < _cl->numSelected() && _ord.compare(currAfter,skippedAfter) == Ordering::GREATER) {
-            env.statistics->inferencesBlockedForOrderingAftercheck++;
+            env->statistics->inferencesBlockedForOrderingAftercheck++;
             res->destroy();
             return 0;
           }
@@ -144,7 +144,7 @@ public:
     }
     ASS_EQ(next,newLength);
 
-    env.statistics->factoring++;
+    env->statistics->factoring++;
     return res;
   }
 private:

--- a/Inferences/FastCondensation.cpp
+++ b/Inferences/FastCondensation.cpp
@@ -126,7 +126,7 @@ Clause* FastCondensation::simplify(Clause* cl)
         }
         ASS_EQ(ri, newLen);
  
-        env.statistics->condensations++;
+        env->statistics->condensations++;
  
         return res;
       }

--- a/Inferences/FastCondensation.cpp
+++ b/Inferences/FastCondensation.cpp
@@ -80,7 +80,7 @@ Clause* FastCondensation::simplify(Clause* cl)
 
   //if variable is present in only one literal, the map contains its index,
   //otherwise it contains -1
-  static DHMap<unsigned, int> varLits;
+  VTHREAD_LOCAL static DHMap<unsigned, int> varLits;
   varLits.reset();
 
   for(unsigned i=0;i<clen;i++) {
@@ -99,7 +99,7 @@ Clause* FastCondensation::simplify(Clause* cl)
     }
   }
 
-  static CondensationBinder cbinder;
+  VTHREAD_LOCAL static CondensationBinder cbinder;
   cbinder.init(&varLits);
 
   for(unsigned cIndex=0;cIndex<clen;cIndex++) {

--- a/Inferences/ForwardDemodulation.cpp
+++ b/Inferences/ForwardDemodulation.cpp
@@ -82,7 +82,7 @@ bool ForwardDemodulationImpl<combinatorySupSupport>::perform(Clause* cl, Clause*
   //replace subterms in some special order, like
   //the heaviest first...
 
-  static DHSet<TermList> attempted;
+  VTHREAD_LOCAL static DHSet<TermList> attempted;
   attempted.reset();
 
   unsigned cLen=cl->length();

--- a/Inferences/ForwardDemodulation.cpp
+++ b/Inferences/ForwardDemodulation.cpp
@@ -198,7 +198,7 @@ bool ForwardDemodulationImpl<combinatorySupSupport>::perform(Clause* cl, Clause*
 
         Literal* resLit = EqHelper::replace(lit,trm,rhsS);
         if(EqHelper::isEqTautology(resLit)) {
-          env.statistics->forwardDemodulationsToEqTaut++;
+          env->statistics->forwardDemodulationsToEqTaut++;
           premises = pvi( getSingletonIterator(qr.clause));
           return true;
         }
@@ -218,7 +218,7 @@ bool ForwardDemodulationImpl<combinatorySupSupport>::perform(Clause* cl, Clause*
         }
         ASS_EQ(next,cLen);
 
-        env.statistics->forwardDemodulations++;
+        env->statistics->forwardDemodulations++;
 
         premises = pvi( getSingletonIterator(qr.clause));
         replacement = res;

--- a/Inferences/ForwardLiteralRewriting.cpp
+++ b/Inferences/ForwardLiteralRewriting.cpp
@@ -111,7 +111,7 @@ bool ForwardLiteralRewriting::perform(Clause* cl, Clause*& replacement, ClauseIt
       }
       ASS_EQ(next,clen);
 
-      env.statistics->forwardLiteralRewrites++;
+      env->statistics->forwardLiteralRewrites++;
 
       premises = pvi( getSingletonIterator(premise));
       replacement = res;

--- a/Inferences/ForwardSubsumptionAndResolution.cpp
+++ b/Inferences/ForwardSubsumptionAndResolution.cpp
@@ -252,7 +252,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
 
   Clause::requestAux();
 
-  static CMStack cmStore(64);
+  VTHREAD_LOCAL static CMStack cmStore(64);
   ASS(cmStore.isEmpty());
 
   for(unsigned li=0;li<clen;li++) {

--- a/Inferences/ForwardSubsumptionAndResolution.cpp
+++ b/Inferences/ForwardSubsumptionAndResolution.cpp
@@ -265,7 +265,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
       premise->setAux(0);
       if(ColorHelper::compatible(cl->color(), premise->color()) ) {
         premises = pvi( getSingletonIterator(premise) );
-        env.statistics->forwardSubsumed++;
+        env->statistics->forwardSubsumed++;
         result = true;
         goto fin;
       }
@@ -299,7 +299,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
 
       if(MLMatcher::canBeMatched(mcl,cl,cms->_matches,0) && ColorHelper::compatible(cl->color(), mcl->color())) {
         premises = pvi( getSingletonIterator(mcl) );
-        env.statistics->forwardSubsumed++;
+        env->statistics->forwardSubsumed++;
         result = true;
         goto fin;
       }
@@ -322,7 +322,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
 	Clause* mcl=rit.next().clause;
 	if(ColorHelper::compatible(cl->color(), mcl->color())) {
 	  resolutionClause=generateSubsumptionResolutionClause(cl,resLit,mcl);
-	  env.statistics->forwardSubsumptionResolution++;
+	  env->statistics->forwardSubsumptionResolution++;
 	  premises = pvi( getSingletonIterator(mcl) );
 	  replacement = resolutionClause;
 	  result = true;
@@ -339,7 +339,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
 	  Literal* resLit=(*cl)[li];
 	  if(checkForSubsumptionResolution(cl, cms, resLit) && ColorHelper::compatible(cl->color(), cms->_cl->color()) ) {
 	    resolutionClause=generateSubsumptionResolutionClause(cl,resLit,cms->_cl);
-	    env.statistics->forwardSubsumptionResolution++;
+	    env->statistics->forwardSubsumptionResolution++;
 	    premises = pvi( getSingletonIterator(cms->_cl) );
 	    replacement = resolutionClause;
 	    result = true;
@@ -368,7 +368,7 @@ bool ForwardSubsumptionAndResolution::perform(Clause* cl, Clause*& replacement, 
 
 	if(checkForSubsumptionResolution(cl, cms, resLit) && ColorHelper::compatible(cl->color(), cms->_cl->color())) {
 	  resolutionClause=generateSubsumptionResolutionClause(cl,resLit,cms->_cl);
-	  env.statistics->forwardSubsumptionResolution++;
+	  env->statistics->forwardSubsumptionResolution++;
           premises = pvi( getSingletonIterator(cms->_cl) );
           replacement = resolutionClause;
           result = true;

--- a/Inferences/ForwardSubsumptionDemodulation.cpp
+++ b/Inferences/ForwardSubsumptionDemodulation.cpp
@@ -155,7 +155,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
       /**
        * Step 2: choose a positive equality in mcl to use for demodulation and try to instantiate the rest to some subset of cl
        */
-      static vvector<LiteralList*> alts;
+      VTHREAD_LOCAL static vvector<LiteralList*> alts;
       alts.clear();
       alts.reserve(mcl->length());
       ASS_EQ(alts.size(), 0);
@@ -222,10 +222,10 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
 
       ASS_EQ(mcl->length(), alts.size());
 
-      static MLMatcherSD matcher;
+      VTHREAD_LOCAL static MLMatcherSD matcher;
       matcher.init(mcl, cl, alts.data());
 
-      static unsigned const maxMatches =
+      VTHREAD_LOCAL static unsigned const maxMatches =
         getOptions().forwardSubsumptionDemodulationMaxMatches() == 0
         ? std::numeric_limits<decltype(maxMatches)>::max()
         : getOptions().forwardSubsumptionDemodulationMaxMatches();
@@ -267,10 +267,10 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
         }
 
         // isMatched[i] is true iff (*cl)[i] is matched my some literal in mcl (without eqLit)
-        static vvector<bool> isMatched;
+        VTHREAD_LOCAL static vvector<bool> isMatched;
         matcher.getMatchedAltsBitmap(isMatched);
 
-        static OverlayBinder binder;
+        VTHREAD_LOCAL static OverlayBinder binder;
         binder.clear();
         matcher.getBindings(binder.base());
 
@@ -296,7 +296,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
         // 1. No LHS (if INCOMPARABLE and no side contains all variables of the other side)
         // 2. One LHS (oriented, or INCOMPARABLE with exactly one variable-free side)
         // 3. Two LHSs (INCOMPARABLE and same variables)
-        static vvector<TermList> lhsVector;
+        VTHREAD_LOCAL static vvector<TermList> lhsVector;
         lhsVector.clear();
         {
           TermList t0 = *eqLit->nthArgument(0);
@@ -393,7 +393,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
           continue;
         }
 
-        static DHSet<TermList> attempted;  // Terms we already attempted to demodulate
+        VTHREAD_LOCAL static DHSet<TermList> attempted;  // Terms we already attempted to demodulate
         attempted.reset();
 
         for (unsigned dli = 0; dli < cl->length(); ++dli) {

--- a/Inferences/ForwardSubsumptionDemodulation.cpp
+++ b/Inferences/ForwardSubsumptionDemodulation.cpp
@@ -112,7 +112,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
         }
 
         premises = pvi(getSingletonIterator(premise));
-        env.statistics->forwardSubsumed++;
+        env->statistics->forwardSubsumed++;
         return true;
       }
     }
@@ -252,7 +252,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
 #endif
           ASS(replacement == nullptr);
           premises = pvi(getSingletonIterator(mcl));
-          env.statistics->forwardSubsumed++;
+          env->statistics->forwardSubsumed++;
           return true;
         }
         ASS(eqLit->isEquality());
@@ -406,7 +406,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
 
           // TODO higher-order support not yet implemented; see forward demodulation
           //      (maybe it's enough to just use the different iterator)
-          ASS(!env.options->combinatorySup());
+          ASS(!env->options->combinatorySup());
           NonVariableNonTypeIterator nvi(dlit);
           while (nvi.hasNext()) {
             TermList lhsS = nvi.next();  // named 'lhsS' because it will be matched against 'lhs'
@@ -532,7 +532,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
 #endif
                     ASS(replacement == nullptr);
                     premises = pvi(getSingletonIterator(mcl));
-                    env.statistics->forwardSubsumed++;
+                    env->statistics->forwardSubsumed++;
                     return true;
                   } else {
                     // Here, we have subsumption resolution
@@ -549,7 +549,7 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
                     }
 #endif
                     premises = pvi(getSingletonIterator(mcl));
-                    env.statistics->forwardSubsumptionResolution++;
+                    env->statistics->forwardSubsumptionResolution++;
                     return true;
                   }
                 }
@@ -607,7 +607,7 @@ isRedundant:
 #endif
 
               if (EqHelper::isEqTautology(newLit)) {
-                env.statistics->forwardSubsumptionDemodulationsToEqTaut++;
+                env->statistics->forwardSubsumptionDemodulationsToEqTaut++;
                 premises = pvi(getSingletonIterator(mcl));
                 replacement = nullptr;
                 return true;
@@ -624,18 +624,18 @@ isRedundant:
                 }
               }
 
-              env.statistics->forwardSubsumptionDemodulations++;
+              env->statistics->forwardSubsumptionDemodulations++;
 
               premises = pvi(getSingletonIterator(mcl));
               replacement = newCl;
 
 #if FSD_LOG_INFERENCES
-              env.beginOutput();
-              env.out() << "\% Begin Inference \"FSD-" << newCl->number() << "\"\n";
-              env.out() << "\% eqLit: " << eqLit->toString() << "\n";
-              env.out() << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
-              env.out() << "\% dlit: " << dlit->toString() << "\n";
-              env.out() << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
+              env->beginOutput();
+              env->out() << "\% Begin Inference \"FSD-" << newCl->number() << "\"\n";
+              env->out() << "\% eqLit: " << eqLit->toString() << "\n";
+              env->out() << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
+              env->out() << "\% dlit: " << dlit->toString() << "\n";
+              env->out() << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
               TPTPPrinter tptp;
               // NOTE: do not output the splitLevels here, because those will be set for newCl only later
               tptp.printWithRole("side_premise_mcl", "hypothesis", mcl,   false);
@@ -647,8 +647,8 @@ isRedundant:
               //       Problem: how to detect that situation??
               //       probably if the input only contains FOF and no TFF
               // TODO: Also don't output type defs for $$false and $$true, see problem SYO091^5.p
-              env.out() << "\% End Inference \"FSD-" << newCl->number() << "\"" << std::endl;
-              env.endOutput();
+              env->out() << "\% End Inference \"FSD-" << newCl->number() << "\"" << std::endl;
+              env->endOutput();
 #endif
 
               RSTAT_MCTR_INC("FSD, successes by MLMatch", numMatches + 1);  // +1 so it fits with the previous output

--- a/Inferences/GlobalSubsumption.cpp
+++ b/Inferences/GlobalSubsumption.cpp
@@ -238,7 +238,7 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
           UnitList::push(us, premList);
         }
         
-        SATClauseList* satPremises = env.options->minimizeSatProofs() ?
+        SATClauseList* satPremises = env->options->minimizeSatProofs() ?
             solver.getRefutationPremiseList() : nullptr; // getRefutationPremiseList may be nullptr already, if our solver does not support minimization
 
         Inference inf(FromSatRefutation(InferenceRule::GLOBAL_SUBSUMPTION, premList, satPremises, failedFinal));
@@ -251,7 +251,7 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
         
         Clause* replacement = Clause::fromIterator(LiteralStack::BottomFirstIterator(survivors),inf);
 
-        env.statistics->globalSubsumption++;
+        env->statistics->globalSubsumption++;
         ASS_L(replacement->length(), clen);
         
         return replacement;       

--- a/Inferences/GlobalSubsumption.cpp
+++ b/Inferences/GlobalSubsumption.cpp
@@ -98,16 +98,16 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
   Grounder& grounder = _index->getGrounder();
   
   // SAT literals of the prop. abstraction of cl
-  static SATLiteralStack plits;
+  VTHREAD_LOCAL static SATLiteralStack plits;
   plits.reset();
   
   // assumptions corresponding to the negation of the new prop clause
   // (and perhaps additional ones used to "activate" AVATAR-conditional clauses)
-  static SATLiteralStack assumps;
+  VTHREAD_LOCAL static SATLiteralStack assumps;
   assumps.reset();
   
   // lookup to retrieve the FO lits later back
-  static DHMap<SATLiteral,Literal*> lookup;
+  VTHREAD_LOCAL static DHMap<SATLiteral,Literal*> lookup;
   lookup.reset();
     
   // first abstract cl's FO literals using grounder,
@@ -177,10 +177,10 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
       // proper subset sufficed for UNSAT - that's the interesting case
       const SATLiteralStack& failedFinal = _explicitMinim ? solver.explicitlyMinimizedFailedAssumptions(_uprOnly,_randomizeMinim) : failed;
 
-      static LiteralStack survivors;
+      VTHREAD_LOCAL static LiteralStack survivors;
       survivors.reset();
 
-      static Set<SATLiteral> splitAssumps;
+      VTHREAD_LOCAL static Set<SATLiteral> splitAssumps;
       splitAssumps.reset();
 
       for (unsigned i = 0; i < failedFinal.size(); i++) {
@@ -277,7 +277,7 @@ bool GlobalSubsumption::perform(Clause* cl, Clause*& replacement, ClauseIterator
 {
   CALL("GlobalSubsumption::perform/3");
 
-  static Stack<Unit*> prems;
+  VTHREAD_LOCAL static Stack<Unit*> prems;
   
   Clause* newCl = perform(cl,prems);
   if(newCl==cl) {

--- a/Inferences/HyperSuperposition.cpp
+++ b/Inferences/HyperSuperposition.cpp
@@ -227,18 +227,18 @@ void HyperSuperposition::tryUnifyingSuperpositioins(Clause* cl, unsigned literal
 
   Color clauseClr = cl->color();
 
-  static RobSubstitution subst;
+  VTHREAD_LOCAL static RobSubstitution subst;
   subst.reset();
 
   int bank2 = disjointVariables ? 1 : 0;
   int nextAvailBank = bank2+1;
 
-  static ClauseStack premises;
+  VTHREAD_LOCAL static ClauseStack premises;
   premises.reset();
   //the int is a variable bank index
   typedef pair<TermPair, int> RewriterEntry;
   typedef Stack<RewriterEntry> RewriterStack;
-  static RewriterStack rewriters;
+  VTHREAD_LOCAL static RewriterStack rewriters;
   rewriters.reset();
 
   if(!tryGetRewriters(t1, t2, bank2, nextAvailBank, premises, rewriters, subst, clauseClr)) {
@@ -275,13 +275,13 @@ void HyperSuperposition::tryUnifyingSuperpositioins(Clause* cl, unsigned literal
     t1Rwr = EqHelper::replace(t1Rwr, src, tgt);
   }
 
-  static RobSubstitution checkerSubst;
+  VTHREAD_LOCAL static RobSubstitution checkerSubst;
   checkerSubst.reset();
   if(!checkerSubst.unifyArgs(t1Rwr, 0, t2, bank2)) {
     return;
   }
 
-  static LiteralStack resLits;
+  VTHREAD_LOCAL static LiteralStack resLits;
   resLits.reset();
 
   unsigned clen = cl->length();
@@ -333,7 +333,7 @@ void HyperSuperposition::tryUnifyingNonequality(Clause* cl, unsigned literalInde
     return;
   }
 
-  static ClauseStack localRes;
+  VTHREAD_LOCAL static ClauseStack localRes;
   tryUnifyingSuperpositioins(cl, literalIndex, t1.term(), t2.term(), false, localRes);
 
   while(localRes.isNonEmpty()) {
@@ -349,7 +349,7 @@ Literal* HyperSuperposition::getUnifQueryLit(Literal* base)
   CALL("HyperSuperposition::getUnifQueryLit");
 
   unsigned arity = base->arity();
-  static TermStack varArgs;
+  VTHREAD_LOCAL static TermStack varArgs;
   for(unsigned i=varArgs.size(); i<arity; i++) {
     varArgs.push(TermList(i, false));
   }
@@ -382,7 +382,7 @@ void HyperSuperposition::tryUnifyingToResolveWithUnit(Clause* cl, unsigned liter
   Literal* queryLit = getUnifQueryLit(lit);
   SLQueryResultIterator unifIt = _index->getUnifications(queryLit, true, false);
 
-  static ClauseStack localRes;
+  VTHREAD_LOCAL static ClauseStack localRes;
 
   while(unifIt.hasNext()) {
     SLQueryResult unifRes = unifIt.next();
@@ -404,7 +404,7 @@ ClauseIterator HyperSuperposition::generateClauses(Clause* cl)
 
   TimeCounter tc(TC_HYPER_SUPERPOSITION);
 
-  static ClausePairStack res;
+  VTHREAD_LOCAL static ClausePairStack res;
   res.reset();
 
   unsigned clen = cl->length();
@@ -430,13 +430,13 @@ bool HyperSuperposition::tryGetUnifyingPremises(Term* t1, Term* t2, Color clr, b
 
   Color clauseClr = clr;
 
-  static RobSubstitution subst;
+  VTHREAD_LOCAL static RobSubstitution subst;
   subst.reset();
 
   int bank2 = disjointVariables ? 1 : 0;
   int nextAvailBank = bank2+1;
 
-  static RewriterStack rewriters;
+  VTHREAD_LOCAL static RewriterStack rewriters;
   rewriters.reset();
 
   return tryGetRewriters(t1, t2, bank2, nextAvailBank, premises, rewriters, subst, clauseClr);
@@ -512,7 +512,7 @@ bool HyperSuperposition::tryUnifyingNonequalitySimpl(Clause* cl, Clause*& replac
     return false;
   }
 
-  static ClauseStack premStack;
+  VTHREAD_LOCAL static ClauseStack premStack;
   premStack.reset();
 
   return trySimplifyingFromUnification(cl, t1.term(), t2.term(), false, premStack, replacement, premises);
@@ -531,7 +531,7 @@ bool HyperSuperposition::tryUnifyingToResolveSimpl(Clause* cl, Clause*& replacem
   Literal* queryLit = getUnifQueryLit(lit);
   SLQueryResultIterator unifIt = _index->getUnifications(queryLit, true, false);
 
-  static ClauseStack prems;
+  VTHREAD_LOCAL static ClauseStack prems;
 
   while(unifIt.hasNext()) {
     SLQueryResult unifRes = unifIt.next();

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -225,7 +225,7 @@ Literal* LiteralSubsetReplacement::transformSubset(InferenceRule& rule) {
   CALL("LiteralSubsetReplacement::transformSubset");
   // Increment _iteration, since it either is 0, or was already used.
   _iteration++;
-  const unsigned maxSubsetSize = env.options->maxInductionGenSubsetSize();
+  const unsigned maxSubsetSize = env->options->maxInductionGenSubsetSize();
   // Note: __builtin_popcount() is a GCC built-in function.
   unsigned setBits = __builtin_popcount(_iteration);
   // Skip this iteration if not all bits are set, but more than maxSubset are set.
@@ -312,13 +312,13 @@ void InductionClauseIterator::processLiteral(Clause* premise, Literal* lit)
 {
   CALL("Induction::ClauseIterator::processLiteral");
 
-  if(env.options->showInduction()){
-    env.beginOutput();
-    env.out() << "[Induction] process " << lit->toString() << " in " << premise->toString() << endl;
-    env.endOutput();
+  if(env->options->showInduction()){
+    env->beginOutput();
+    env->out() << "[Induction] process " << lit->toString() << " in " << premise->toString() << endl;
+    env->endOutput();
   }
 
-  VTHREAD_LOCAL static bool generalize = env.options->inductionGen();
+  VTHREAD_LOCAL static bool generalize = env->options->inductionGen();
 
   if(InductionHelper::isInductionLiteral(lit)){
       Set<Term*> ta_terms;
@@ -356,12 +356,12 @@ void InductionClauseIterator::processLiteral(Clause* premise, Literal* lit)
       Set<Term*>::Iterator citer2(ta_terms);
       while(citer2.hasNext()){
         Term* t = citer2.next();
-        const bool one = env.options->structInduction() == Options::StructuralInductionKind::ONE ||
-                          env.options->structInduction() == Options::StructuralInductionKind::ALL; 
-        const bool two = env.options->structInduction() == Options::StructuralInductionKind::TWO ||
-                          env.options->structInduction() == Options::StructuralInductionKind::ALL; 
-        const bool three = env.options->structInduction() == Options::StructuralInductionKind::THREE ||
-                          env.options->structInduction() == Options::StructuralInductionKind::ALL;
+        const bool one = env->options->structInduction() == Options::StructuralInductionKind::ONE ||
+                          env->options->structInduction() == Options::StructuralInductionKind::ALL; 
+        const bool two = env->options->structInduction() == Options::StructuralInductionKind::TWO ||
+                          env->options->structInduction() == Options::StructuralInductionKind::ALL; 
+        const bool three = env->options->structInduction() == Options::StructuralInductionKind::THREE ||
+                          env->options->structInduction() == Options::StructuralInductionKind::ALL;
         if(notDone(lit,t)){
           InferenceRule rule = InferenceRule::INDUCTION_AXIOM;
           Term* inductionTerm = generalize ? getPlaceholderForTerm(t) : t;
@@ -405,7 +405,7 @@ void InductionClauseIterator::performIntInductionForEligibleBounds(Clause* premi
       }
     }
   }
-  VTHREAD_LOCAL static bool useDefaultBound = env.options->integerInductionDefaultBound();
+  VTHREAD_LOCAL static bool useDefaultBound = env->options->integerInductionDefaultBound();
   if (useDefaultBound && _helper.isInductionForInfiniteIntervalsOn()) {
     VTHREAD_LOCAL static TermQueryResult defaultBound(TermList(theory->representConstant(IntegerConstantType(0))), nullptr, nullptr);
     if (notDoneInt(origLit, origTerm, increasing, defaultBound.term.term(), /*optionalBound2=*/nullptr, /*fromComparison=*/false)) {
@@ -415,7 +415,7 @@ void InductionClauseIterator::performIntInductionForEligibleBounds(Clause* premi
 }
 
 void InductionClauseIterator::generalizeAndPerformIntInduction(Clause* premise, Literal* origLit, Term* origTerm, List<pair<Literal*, InferenceRule>>*& indLits, Term* indTerm, bool increasing, TermQueryResult& bound1, TermQueryResult* optionalBound2) {
-  VTHREAD_LOCAL static bool generalize = env.options->inductionGen();
+  VTHREAD_LOCAL static bool generalize = env->options->inductionGen();
   // If induction literals were not computed yet, compute them now.
   if (List<pair<Literal*, InferenceRule>>::isEmpty(indLits)) {
     bool finite = ((optionalBound2 != nullptr) && (optionalBound2->literal != nullptr));
@@ -452,7 +452,7 @@ void InductionClauseIterator::processIntegerComparison(Clause* premise, Literal*
   ASS(greaterTL != nullptr);
   Term* lt = lesserTL->term();
   Term* gt = greaterTL->term();
-  VTHREAD_LOCAL static bool generalize = env.options->inductionGen();
+  VTHREAD_LOCAL static bool generalize = env->options->inductionGen();
   DHMap<Term*, TermQueryResult> grBound;
   addToMapFromIterator(grBound, _helper.getGreaterEqual(gt));
   addToMapFromIterator(grBound, _helper.getGreater(gt));
@@ -529,13 +529,13 @@ void InductionClauseIterator::produceClauses(Clause* premise, Literal* origLit, 
           // we apply binary resolution on it.
           _helper.callSplitterOnNewClause(c);
         }
-        c = BinaryResolution::generateClause(c,litAndSLQR.first,litAndSLQR.second,*env.options);
+        c = BinaryResolution::generateClause(c,litAndSLQR.first,litAndSLQR.second,*env->options);
         resolved = true;
       }
     }
     _clauses.push(c);
   }
-  env.statistics->induction++;
+  env->statistics->induction++;
   if (rule == InferenceRule::GEN_INDUCTION_AXIOM ||
       rule == InferenceRule::INT_INF_UP_GEN_INDUCTION_AXIOM ||
       rule == InferenceRule::INT_FIN_UP_GEN_INDUCTION_AXIOM ||
@@ -543,30 +543,30 @@ void InductionClauseIterator::produceClauses(Clause* premise, Literal* origLit, 
       rule == InferenceRule::INT_INF_DOWN_GEN_INDUCTION_AXIOM ||
       rule == InferenceRule::INT_FIN_DOWN_GEN_INDUCTION_AXIOM ||
       rule == InferenceRule::INT_DB_DOWN_GEN_INDUCTION_AXIOM) {
-    env.statistics->generalizedInduction++;
+    env->statistics->generalizedInduction++;
   }
   switch (rule) {
     case InferenceRule::INDUCTION_AXIOM:
     case InferenceRule::GEN_INDUCTION_AXIOM:
-      env.statistics->structInduction++;
+      env->statistics->structInduction++;
       break;
     case InferenceRule::INT_INF_UP_INDUCTION_AXIOM:
     case InferenceRule::INT_INF_UP_GEN_INDUCTION_AXIOM:
     case InferenceRule::INT_INF_DOWN_INDUCTION_AXIOM:
     case InferenceRule::INT_INF_DOWN_GEN_INDUCTION_AXIOM:
-      env.statistics->intInfInduction++;
+      env->statistics->intInfInduction++;
       break;
     case InferenceRule::INT_FIN_UP_INDUCTION_AXIOM:
     case InferenceRule::INT_FIN_UP_GEN_INDUCTION_AXIOM:
     case InferenceRule::INT_FIN_DOWN_INDUCTION_AXIOM:
     case InferenceRule::INT_FIN_DOWN_GEN_INDUCTION_AXIOM:
-      env.statistics->intFinInduction++;
+      env->statistics->intFinInduction++;
       break;
     case InferenceRule::INT_DB_UP_INDUCTION_AXIOM:
     case InferenceRule::INT_DB_UP_GEN_INDUCTION_AXIOM:
     case InferenceRule::INT_DB_DOWN_INDUCTION_AXIOM:
     case InferenceRule::INT_DB_DOWN_GEN_INDUCTION_AXIOM:
-      env.statistics->intDBInduction++;
+      env->statistics->intDBInduction++;
       break;
     default:
       ;
@@ -574,27 +574,27 @@ void InductionClauseIterator::produceClauses(Clause* premise, Literal* origLit, 
   switch (rule) {
     case InferenceRule::INT_INF_UP_INDUCTION_AXIOM:
     case InferenceRule::INT_INF_UP_GEN_INDUCTION_AXIOM:
-      env.statistics->intInfUpInduction++;
+      env->statistics->intInfUpInduction++;
       break;
     case InferenceRule::INT_INF_DOWN_INDUCTION_AXIOM:
     case InferenceRule::INT_INF_DOWN_GEN_INDUCTION_AXIOM:
-      env.statistics->intInfDownInduction++;
+      env->statistics->intInfDownInduction++;
       break;
     case InferenceRule::INT_FIN_UP_INDUCTION_AXIOM:
     case InferenceRule::INT_FIN_UP_GEN_INDUCTION_AXIOM:
-      env.statistics->intFinUpInduction++;
+      env->statistics->intFinUpInduction++;
       break;
     case InferenceRule::INT_FIN_DOWN_INDUCTION_AXIOM:
     case InferenceRule::INT_FIN_DOWN_GEN_INDUCTION_AXIOM:
-      env.statistics->intFinDownInduction++;
+      env->statistics->intFinDownInduction++;
       break;
     case InferenceRule::INT_DB_UP_INDUCTION_AXIOM:
     case InferenceRule::INT_DB_UP_GEN_INDUCTION_AXIOM:
-      env.statistics->intDBUpInduction++;
+      env->statistics->intDBUpInduction++;
       break;
     case InferenceRule::INT_DB_DOWN_INDUCTION_AXIOM:
     case InferenceRule::INT_DB_DOWN_GEN_INDUCTION_AXIOM:
-      env.statistics->intDBDownInduction++;
+      env->statistics->intDBDownInduction++;
       break;
     default:
       ;
@@ -639,11 +639,11 @@ void InductionClauseIterator::performIntInduction(Clause* premise, Literal* orig
   Formula* Ly = new AtomicFormula(cr3.transform(clit));
 
   // create L[X+1] or L[X-1]
-  TermList fpo(Term::create2(env.signature->getInterpretingSymbol(Theory::INT_PLUS),x,one));
+  TermList fpo(Term::create2(env->signature->getInterpretingSymbol(Theory::INT_PLUS),x,one));
   TermReplacement cr4(term,fpo);
   Formula* Lxpo = new AtomicFormula(cr4.transform(clit));
 
-  VTHREAD_LOCAL static unsigned less = env.signature->getInterpretingSymbol(Theory::INT_LESS);
+  VTHREAD_LOCAL static unsigned less = env->signature->getInterpretingSymbol(Theory::INT_LESS);
   // create X>=b1 (which is ~X<b1) or X<=b1 (which is ~b1<X)
   Formula* Lxcompb1 = new AtomicFormula(Literal::create2(less,false,(increasing ? x : b1),(increasing ? b1 : x)));
   // create Y>=b1 (which is ~Y<b1), or Y>b1, or Y<=b1 (which is ~b1<Y), or Y<b1
@@ -729,7 +729,7 @@ void InductionClauseIterator::performStructInductionOne(Clause* premise, Literal
 {
   CALL("InductionClauseIterator::performStructInductionOne"); 
 
-  TermAlgebra* ta = env.signature->getTermAlgebraOfSort(env.signature->getFunction(term->functor())->fnType()->result());
+  TermAlgebra* ta = env->signature->getTermAlgebraOfSort(env->signature->getFunction(term->functor())->fnType()->result());
   TermList ta_sort = ta->sort();
 
   FormulaList* formulas = FormulaList::empty();
@@ -818,7 +818,7 @@ void InductionClauseIterator::performStructInductionTwo(Clause* premise, Literal
 {
   CALL("InductionClauseIterator::performStructInductionTwo"); 
 
-  TermAlgebra* ta = env.signature->getTermAlgebraOfSort(env.signature->getFunction(term->functor())->fnType()->result());
+  TermAlgebra* ta = env->signature->getTermAlgebraOfSort(env->signature->getFunction(term->functor())->fnType()->result());
   TermList ta_sort = ta->sort();
 
   Literal* clit = Literal::complementaryLiteral(lit);
@@ -913,7 +913,7 @@ void InductionClauseIterator::performStructInductionThree(Clause* premise, Liter
 {
   CALL("InductionClauseIterator::performStructInductionThree");
 
-  TermAlgebra* ta = env.signature->getTermAlgebraOfSort(env.signature->getFunction(term->functor())->fnType()->result());
+  TermAlgebra* ta = env->signature->getTermAlgebraOfSort(env->signature->getFunction(term->functor())->fnType()->result());
   TermList ta_sort = ta->sort();
 
   Literal* clit = Literal::complementaryLiteral(lit);
@@ -926,8 +926,8 @@ void InductionClauseIterator::performStructInductionThree(Clause* premise, Liter
   Literal* Ly = cr.transform(lit);
 
   // make smallerThanY
-  unsigned sty = env.signature->addFreshPredicate(1,"smallerThan");
-  env.signature->getPredicate(sty)->setType(OperatorType::getPredicateType({ta_sort}));
+  unsigned sty = env->signature->addFreshPredicate(1,"smallerThan");
+  env->signature->getPredicate(sty)->setType(OperatorType::getPredicateType({ta_sort}));
 
   // make ( y = con_i(..dec(y)..) -> smaller(dec(y)))  for each constructor 
   FormulaList* conjunction = new FormulaList(new AtomicFormula(Ly),0); 
@@ -1031,11 +1031,11 @@ bool InductionClauseIterator::notDone(Literal* lit, Term* term)
 
   VTHREAD_LOCAL static DHSet<Literal*> done;
   VTHREAD_LOCAL static DHMap<TermList,TermList> blanks;
-  TermList srt = env.signature->getFunction(term->functor())->fnType()->result();
+  TermList srt = env->signature->getFunction(term->functor())->fnType()->result();
 
   if(!blanks.find(srt)){
-    unsigned fresh = env.signature->addFreshFunction(0,"blank");
-    env.signature->getFunction(fresh)->setType(OperatorType::getConstantsType(srt));
+    unsigned fresh = env->signature->addFreshFunction(0,"blank");
+    env->signature->getFunction(fresh)->setType(OperatorType::getConstantsType(srt));
     TermList blank = TermList(Term::createConstant(fresh));
     blanks.insert(srt,blank);
   }
@@ -1064,9 +1064,9 @@ bool InductionClauseIterator::notDoneInt(Literal* lit, Term* t, bool increasing,
 
   // Create representation of lit/t combination
   VTHREAD_LOCAL static Term* blank;
-  VTHREAD_LOCAL static unsigned freshInt = env.signature->addFreshFunction(0, "blank");
+  VTHREAD_LOCAL static unsigned freshInt = env->signature->addFreshFunction(0, "blank");
   if (!blank) {
-    env.signature->getFunction(freshInt)->setType(OperatorType::getConstantsType(Term::intSort()));
+    env->signature->getFunction(freshInt)->setType(OperatorType::getConstantsType(Term::intSort()));
     blank = Term::createConstant(freshInt);
   }
   TermReplacement cr(t, TermList(blank));
@@ -1117,11 +1117,11 @@ bool InductionClauseIterator::notDoneInt(Literal* lit, Term* t, bool increasing,
 Term* InductionClauseIterator::getPlaceholderForTerm(Term* t) {
   CALL("InductionClauseIterator::getPlaceholderForTerm");
 
-  OperatorType* ot = env.signature->getFunction(t->functor())->fnType();
+  OperatorType* ot = env->signature->getFunction(t->functor())->fnType();
   bool added; 
-  unsigned placeholderConstNumber = env.signature->addFunction("placeholder_" + ot->toString(), 0, added);
+  unsigned placeholderConstNumber = env->signature->addFunction("placeholder_" + ot->toString(), 0, added);
   if (added) {
-    env.signature->getFunction(placeholderConstNumber)->setType(OperatorType::getConstantsType(ot->result()));
+    env->signature->getFunction(placeholderConstNumber)->setType(OperatorType::getConstantsType(ot->result()));
   }
   return Term::createConstant(placeholderConstNumber);
 }

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -117,10 +117,10 @@ public:
   inline bool hasNext() { return _clauses.isNonEmpty(); }
   inline OWN_ELEMENT_TYPE next() { 
     Clause* c = _clauses.pop();
-    if(env.options->showInduction()){
-      env.beginOutput();
-      env.out() << "[Induction] generate " << c->toString() << endl; 
-      env.endOutput();
+    if(env->options->showInduction()){
+      env->beginOutput();
+      env->out() << "[Induction] generate " << c->toString() << endl; 
+      env->endOutput();
     }
     return c; 
   }

--- a/Inferences/InductionHelper.cpp
+++ b/Inferences/InductionHelper.cpp
@@ -65,8 +65,8 @@ bool isIntegerComparisonLiteral(Literal* lit) {
 
 bool isIntInductionOn() {
   CALL("InductionHelper::isIntInductionOn");
-  static bool intInd = env.options->induction() == Options::Induction::BOTH ||
-                       env.options->induction() == Options::Induction::INTEGER;
+  VTHREAD_LOCAL static bool intInd = env->options->induction() == Options::Induction::BOTH ||
+                       env->options->induction() == Options::Induction::INTEGER;
   return intInd;
 }
 
@@ -76,7 +76,7 @@ TermQueryResultIterator InductionHelper::getComparisonMatch(
     bool polarity, TermList& left, TermList& right, TermList& var) {
   CALL("InductionHelper::getComparisonMatch");
 
-  static unsigned less = env.signature->getInterpretingSymbol(Theory::INT_LESS);
+  VTHREAD_LOCAL static unsigned less = env->signature->getInterpretingSymbol(Theory::INT_LESS);
 
   Literal* pattern = Literal::create2(less, polarity, left, right);
   return pvi(getMappingIterator(_comparisonIndex->getUnifications(pattern, /*complementary=*/ false, /*retrieveSubstitution=*/ true),
@@ -87,7 +87,7 @@ TermQueryResultIterator InductionHelper::getLessEqual(Term* t)
 {
   CALL("InductionHelper::getLessEqual");
 
-  static TermList var(0, false);
+  VTHREAD_LOCAL static TermList var(0, false);
   TermList tl(t);
   // x <= t  iff  ~ t < x
   return getComparisonMatch(/*polarity=*/false, tl, var, var);
@@ -96,7 +96,7 @@ TermQueryResultIterator InductionHelper::getLess(Term* t)
 {
   CALL("InductionHelper::getLess");
 
-  static TermList var(0, false);
+  VTHREAD_LOCAL static TermList var(0, false);
   TermList tl(t);
   // x < t
   return getComparisonMatch(/*polarity=*/true, var, tl, var);
@@ -105,7 +105,7 @@ TermQueryResultIterator InductionHelper::getGreaterEqual(Term* t)
 {
   CALL("InductionHelper::getGreaterEqual");
 
-  static TermList var(0, false);
+  VTHREAD_LOCAL static TermList var(0, false);
   TermList tl(t);
   // x >= t  iff  ~ x < t
   return getComparisonMatch(/*polarity=*/false, var, tl, var);
@@ -114,7 +114,7 @@ TermQueryResultIterator InductionHelper::getGreater(Term* t)
 {
   CALL("InductionHelper::getGreater");
 
-  static TermList var(0, false);
+  VTHREAD_LOCAL static TermList var(0, false);
   TermList tl(t);
   // x > t  iff  t < x
   return getComparisonMatch(/*polarity=*/true, tl, var, var);
@@ -129,7 +129,7 @@ TermQueryResultIterator InductionHelper::getTQRsForInductionTerm(TermList induct
 
 void InductionHelper::callSplitterOnNewClause(Clause* c) {
   CALL("InductionHelper::callSplitterOnNewClause");
-  static bool splitting = env.options->splitting();
+  VTHREAD_LOCAL static bool splitting = env->options->splitting();
   if (splitting) _splitter->onNewClause(c);
 }
 
@@ -141,54 +141,54 @@ bool InductionHelper::isIntegerComparison(Clause* c) {
 
 bool InductionHelper::isIntInductionOn() {
   CALL("InductionHelper::isIntInductionOn");
-  static bool intInd = env.options->induction() == Options::Induction::BOTH ||
-                        env.options->induction() == Options::Induction::INTEGER;
+  VTHREAD_LOCAL static bool intInd = env->options->induction() == Options::Induction::BOTH ||
+                        env->options->induction() == Options::Induction::INTEGER;
   return intInd;
 }
 
 bool InductionHelper::isIntInductionOneOn() {
   CALL("InductionHelper::isIntInductionOneOn");
-  static bool one = env.options->intInduction() == Options::IntInductionKind::ONE ||
-                    env.options->intInduction() == Options::IntInductionKind::ALL;
+  VTHREAD_LOCAL static bool one = env->options->intInduction() == Options::IntInductionKind::ONE ||
+                    env->options->intInduction() == Options::IntInductionKind::ALL;
   return isIntInductionOn() && one;
 }
 
 bool InductionHelper::isIntInductionTwoOn() {
   CALL("InductionHelper::isIntInductionTwoOn");
-  static bool two = env.options->intInduction() == Options::IntInductionKind::TWO ||
-                    env.options->intInduction() == Options::IntInductionKind::ALL;
+  VTHREAD_LOCAL static bool two = env->options->intInduction() == Options::IntInductionKind::TWO ||
+                    env->options->intInduction() == Options::IntInductionKind::ALL;
   return isIntInductionOn() && two;
 }
 
 bool InductionHelper::isInductionForFiniteIntervalsOn() {
   CALL("InductionHelper::isInductionForFiniteIntervalsOn");
-  static bool finite = env.options->integerInductionInterval() == Options::IntegerInductionInterval::FINITE ||
-                       env.options->integerInductionInterval() == Options::IntegerInductionInterval::BOTH;
+  VTHREAD_LOCAL static bool finite = env->options->integerInductionInterval() == Options::IntegerInductionInterval::FINITE ||
+                       env->options->integerInductionInterval() == Options::IntegerInductionInterval::BOTH;
   return isIntInductionOn() && finite;
 }
 
 bool InductionHelper::isInductionForInfiniteIntervalsOn() {
   CALL("InductionHelper::isInductionForInfiniteIntervalsOn");
-  static bool infinite = env.options->integerInductionInterval() == Options::IntegerInductionInterval::INFINITE ||
-                         env.options->integerInductionInterval() == Options::IntegerInductionInterval::BOTH;
+  VTHREAD_LOCAL static bool infinite = env->options->integerInductionInterval() == Options::IntegerInductionInterval::INFINITE ||
+                         env->options->integerInductionInterval() == Options::IntegerInductionInterval::BOTH;
   return isIntInductionOn() && infinite;
 }
 
 bool InductionHelper::isStructInductionOn() {
   CALL("InductionHelper::isStructInductionOn");
-  static bool structInd = env.options->induction() == Options::Induction::BOTH ||
-                          env.options->induction() == Options::Induction::STRUCTURAL;
+  VTHREAD_LOCAL static bool structInd = env->options->induction() == Options::Induction::BOTH ||
+                          env->options->induction() == Options::Induction::STRUCTURAL;
   return structInd;
 }
 
 bool InductionHelper::isInductionClause(Clause* c) {
   CALL("InductionHelper::isInductionClause");
-  static Options::InductionChoice kind = env.options->inductionChoice();
-  static bool all = (kind == Options::InductionChoice::ALL);
-  static bool goal = (kind == Options::InductionChoice::GOAL);
-  static bool goal_plus = (kind == Options::InductionChoice::GOAL_PLUS);
-  static unsigned maxD = env.options->maxInductionDepth();
-  static bool unitOnly = env.options->inductionUnitOnly();
+  VTHREAD_LOCAL static Options::InductionChoice kind = env->options->inductionChoice();
+  VTHREAD_LOCAL static bool all = (kind == Options::InductionChoice::ALL);
+  VTHREAD_LOCAL static bool goal = (kind == Options::InductionChoice::GOAL);
+  VTHREAD_LOCAL static bool goal_plus = (kind == Options::InductionChoice::GOAL_PLUS);
+  VTHREAD_LOCAL static unsigned maxD = env->options->maxInductionDepth();
+  VTHREAD_LOCAL static bool unitOnly = env->options->inductionUnitOnly();
   return ((!unitOnly || c->length()==1) && 
           (all || ( (goal || goal_plus) && c->derivedFromGoal())) &&
                   (maxD == 0 || c->inference().inductionDepth() < maxD)
@@ -197,7 +197,7 @@ bool InductionHelper::isInductionClause(Clause* c) {
 
 bool InductionHelper::isInductionLiteral(Literal* l) {
   CALL("InductionHelper::isInductionLiteral");
-  static bool negOnly = env.options->inductionNegOnly();
+  VTHREAD_LOCAL static bool negOnly = env->options->inductionNegOnly();
   return ((!negOnly || l->isNegative() || 
            (theory->isInterpretedPredicate(l) && theory->isInequality(theory->interpretPredicate(l)))
           ) && l->ground()
@@ -206,14 +206,14 @@ bool InductionHelper::isInductionLiteral(Literal* l) {
 
 bool InductionHelper::isInductionTermFunctor(unsigned f) {
   CALL("InductionHelper::isInductionTermFunctor");
-  static Options::InductionChoice kind = env.options->inductionChoice();
-  static bool all = (kind == Options::InductionChoice::ALL);
-  static bool goal_plus = (kind == Options::InductionChoice::GOAL_PLUS);
-  static bool complexTermsAllowed = env.options->inductionOnComplexTerms();
-  return ((complexTermsAllowed || env.signature->functionArity(f)==0) &&
+  VTHREAD_LOCAL static Options::InductionChoice kind = env->options->inductionChoice();
+  VTHREAD_LOCAL static bool all = (kind == Options::InductionChoice::ALL);
+  VTHREAD_LOCAL static bool goal_plus = (kind == Options::InductionChoice::GOAL_PLUS);
+  VTHREAD_LOCAL static bool complexTermsAllowed = env->options->inductionOnComplexTerms();
+  return ((complexTermsAllowed || env->signature->functionArity(f)==0) &&
           (all ||
-           env.signature->getFunction(f)->inGoal() ||
-           (goal_plus && env.signature->getFunction(f)->inductionSkolem()) // set in NewCNF
+           env->signature->getFunction(f)->inGoal() ||
+           (goal_plus && env->signature->getFunction(f)->inductionSkolem()) // set in NewCNF
           )
          );
 }
@@ -225,7 +225,7 @@ bool InductionHelper::isIntInductionTermListInLiteral(TermList& tl, Literal* l) 
   // Term tl has to be an integer term, and not an interpreted constant.
   unsigned f = tl.term()->functor();
   // TODO: move this check to later (when we know the bounds)
-  if ((env.signature->getFunction(f)->fnType()->result() != Term::intSort()) ||
+  if ((env->signature->getFunction(f)->fnType()->result() != Term::intSort()) ||
       theory->isInterpretedConstant(f))
   {
     return false;
@@ -241,12 +241,12 @@ bool InductionHelper::isIntInductionTermListInLiteral(TermList& tl, Literal* l) 
 
 bool InductionHelper::isStructInductionFunctor(unsigned f) {
   CALL("InductionHelper::isStructInductionFunctor");
-  static bool complexTermsAllowed = env.options->inductionOnComplexTerms();
-  return (env.signature->isTermAlgebraSort(env.signature->getFunction(f)->fnType()->result()) &&
+  VTHREAD_LOCAL static bool complexTermsAllowed = env->options->inductionOnComplexTerms();
+  return (env->signature->isTermAlgebraSort(env->signature->getFunction(f)->fnType()->result()) &&
            // skip base constructors even if induction on complex terms is on:
-          ((complexTermsAllowed && env.signature->functionArity(f) != 0) ||
+          ((complexTermsAllowed && env->signature->functionArity(f) != 0) ||
            // otherwise skip all constructors:
-           !env.signature->getFunction(f)->termAlgebraCons())
+           !env->signature->getFunction(f)->termAlgebraCons())
          );
 }
 

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -283,7 +283,7 @@ Clause* DuplicateLiteralRemovalISE::simplify(Clause* c)
 
   //literals that will be skipped, skipping starts on the top of the stack
   //and goes from the end of the clause
-  static LiteralStack skipped;
+  VTHREAD_LOCAL static LiteralStack skipped;
   skipped.reset();
 
   //we handle low length specially, not to have to use the set
@@ -311,7 +311,7 @@ Clause* DuplicateLiteralRemovalISE::simplify(Clause* c)
     }
   }
   else {
-    static DHSet<Literal*> seen;
+    VTHREAD_LOCAL static DHSet<Literal*> seen;
     seen.reset();
     //here we rely on the fact that the iterator traverses the clause from
     //the first to the last literal
@@ -352,9 +352,9 @@ Clause* DuplicateLiteralRemovalISE::simplify(Clause* c)
 
 #if DEBUG_DUPLICATE_LITERALS
   {
-    static DHSet<Literal*> origLits;
+    VTHREAD_LOCAL static DHSet<Literal*> origLits;
     origLits.reset();
-    static DHSet<Literal*> newLits;
+    VTHREAD_LOCAL static DHSet<Literal*> newLits;
     newLits.reset();
     origLits.loadFromIterator(Clause::Iterator(*c));
     newLits.loadFromIterator(Clause::Iterator(*d));
@@ -426,7 +426,7 @@ Clause* TrivialInequalitiesRemovalISE::simplify(Clause* c)
 {
   CALL("TrivialInequalitiesRemovalISE::simplify");
 
-  static DArray<Literal*> lits(32);
+  VTHREAD_LOCAL static DArray<Literal*> lits(32);
 
   typedef ApplicativeHelper AH;
 

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -219,12 +219,12 @@ Clause* ChoiceDefinitionISE::simplify(Clause* c)
   if(!isPositive(lit1) && is_of_form_xy(lit1, x) &&
       isPositive(lit2) && is_of_form_xfx(lit2, x, f)){
     unsigned fun = f.term()->functor();
-    env.signature->addChoiceOperator(fun);
+    env->signature->addChoiceOperator(fun);
     return 0;
   } else if(!isPositive(lit2) && is_of_form_xy(lit2, x) && 
              isPositive(lit1) && is_of_form_xfx(lit1, x, f)) {
     unsigned fun = f.term()->functor();
-    env.signature->addChoiceOperator(fun);
+    env->signature->addChoiceOperator(fun);
     return 0;
   }
   return c;
@@ -348,7 +348,7 @@ Clause* DuplicateLiteralRemovalISE::simplify(Clause* c)
   }
   ASS(skipped.isEmpty());
   ASS_EQ(origIdx,-1);
-  env.statistics->duplicateLiterals += length - newLength;
+  env->statistics->duplicateLiterals += length - newLength;
 
 #if DEBUG_DUPLICATE_LITERALS
   {
@@ -469,7 +469,7 @@ Clause* TrivialInequalitiesRemovalISE::simplify(Clause* c)
   for (int i = newLength-1;i >= 0;i--) {
     (*d)[i] = lits[newLength-i-1];
   }
-  env.statistics->trivialInequalities += found;
+  env->statistics->trivialInequalities += found;
 
   return d;
 }

--- a/Inferences/Injectivity.cpp
+++ b/Inferences/Injectivity.cpp
@@ -119,9 +119,9 @@ TermList Injectivity::createNewLhs(TermList oldhead, TermStack& termArgs, unsign
     typeArg = typeArg->next();
   }
 
-  Signature::Symbol* func = env.signature->getFunction(oldhead.term()->functor());
+  Signature::Symbol* func = env->signature->getFunction(oldhead.term()->functor());
   vstring pref = "inv_" + func->name() + "_";
-  unsigned iFunc = env.signature->addFreshFunction(func->arity(), pref.c_str() ); 
+  unsigned iFunc = env->signature->addFreshFunction(func->arity(), pref.c_str() ); 
 
   OperatorType* funcType = func->fnType();
   TermList type = funcType->result(); 
@@ -142,7 +142,7 @@ TermList Injectivity::createNewLhs(TermList oldhead, TermStack& termArgs, unsign
   TermList inverseType = Term::arrowSort(sorts, newResult);
 
   OperatorType* invFuncType = OperatorType::getConstantsType(inverseType, funcType->typeArgsArity());
-  Signature::Symbol* invFunc = env.signature->getFunction(iFunc);
+  Signature::Symbol* invFunc = env->signature->getFunction(iFunc);
   invFunc->setType(invFuncType);
   TermList invFuncHead = TermList(Term::create(iFunc, func->arity(), typeArgs.begin()));
 

--- a/Inferences/InnerRewriting.cpp
+++ b/Inferences/InnerRewriting.cpp
@@ -42,7 +42,7 @@ bool InnerRewriting::perform(Clause* cl, Clause*& replacement, ClauseIterator& p
           Literal* nLit = EqHelper::replace(lit,lhs,rhs);
           if (nLit != lit) {
             if(EqHelper::isEqTautology(nLit)) {
-              env.statistics->innerRewritesToEqTaut++;
+              env->statistics->innerRewritesToEqTaut++;
               return true;
             }
 
@@ -59,7 +59,7 @@ bool InnerRewriting::perform(Clause* cl, Clause*& replacement, ClauseIterator& p
                 Literal* oLit = (*cl)[k];
                 Literal* rLit = EqHelper::replace(oLit,lhs,rhs);
                 if(EqHelper::isEqTautology(rLit)) {
-                  env.statistics->innerRewritesToEqTaut++;
+                  env->statistics->innerRewritesToEqTaut++;
                   res->destroy();
                   return true;
                 }
@@ -67,7 +67,7 @@ bool InnerRewriting::perform(Clause* cl, Clause*& replacement, ClauseIterator& p
               }
             }
 
-            env.statistics->innerRewrites++;
+            env->statistics->innerRewrites++;
 
             replacement = res;
             return true;

--- a/Inferences/InterpretedEvaluation.cpp
+++ b/Inferences/InterpretedEvaluation.cpp
@@ -114,7 +114,7 @@ Clause* InterpretedEvaluation::simplify(Clause* cl)
       if(constant) {
         if(constTrue) {
           //cout << "evaluate " << cl->toString() << " to true" << endl;
-          env.statistics->evaluations++;
+          env->statistics->evaluations++;
           return 0;
         } else {
           continue;
@@ -124,7 +124,7 @@ Clause* InterpretedEvaluation::simplify(Clause* cl)
       newLits[next++]=res;
 /*
 #if VDEBUG
-      if (env.options->literalComparisonMode() != Options::LiteralComparisonMode::REVERSE 
+      if (env->options->literalComparisonMode() != Options::LiteralComparisonMode::REVERSE 
           && _ordering.compare(res, lit) != Ordering::Result::LESS) {
         DBG("res: ", res->toString())
         DBG("lit: ", lit->toString())
@@ -153,7 +153,7 @@ Clause* InterpretedEvaluation::simplify(Clause* cl)
       (*res)[i] = newLits[i];
     }
 
-    env.statistics->evaluations++;
+    env->statistics->evaluations++;
     return res; 
 
   } catch (MachineArithmeticException) {

--- a/Inferences/InterpretedEvaluation.cpp
+++ b/Inferences/InterpretedEvaluation.cpp
@@ -95,7 +95,7 @@ Clause* InterpretedEvaluation::simplify(Clause* cl)
     if(cl->isTheoryAxiom()) return cl;
 
 
-    static DArray<Literal*> newLits(32);
+    VTHREAD_LOCAL static DArray<Literal*> newLits(32);
     unsigned clen=cl->length();
     bool modified=false;
     newLits.ensure(clen);

--- a/Inferences/Narrow.cpp
+++ b/Inferences/Narrow.cpp
@@ -174,11 +174,11 @@ Clause* Narrow::performNarrow(
 
   //0 means unlimited
   bool incr = false;
-  unsigned lim = env.options->maxXXNarrows();
+  unsigned lim = env->options->maxXXNarrows();
   if(lim != 0){
     if(comb < Signature::I_COMB && argNum == 1){
       if(nClause->inference().xxNarrows() == lim){
-        env.statistics->discardedNonRedundantClauses++;
+        env->statistics->discardedNonRedundantClauses++;
         return 0;
       } else {
         incr = true;
@@ -249,7 +249,7 @@ Clause* Narrow::performNarrow(
 
   // If proof extra is on let's compute the positions we have performed
   // Narrow on 
-  /*if(env.options->proofExtra()==Options::ProofExtra::FULL){
+  /*if(env->options->proofExtra()==Options::ProofExtra::FULL){
     
     inf->setExtra(extra);
   }*/ //TODO update proof extra
@@ -272,7 +272,7 @@ Clause* Narrow::performNarrow(
       if (afterCheck) {
         TimeCounter tc(TC_LITERAL_ORDER_AFTERCHECK);
         if (i < nClause->numSelected() && ordering.compare(currAfter,nLiteralS) == Ordering::GREATER) {
-          env.statistics->inferencesBlockedForOrderingAftercheck++;
+          env->statistics->inferencesBlockedForOrderingAftercheck++;
           goto construction_fail;
         }
       }
@@ -280,7 +280,7 @@ Clause* Narrow::performNarrow(
     }
   }
 
-  env.statistics->narrow++;
+  env->statistics->narrow++;
   return res;
 
 construction_fail:

--- a/Inferences/NegativeExt.cpp
+++ b/Inferences/NegativeExt.cpp
@@ -157,7 +157,7 @@ struct NegativeExt::ResultFn
       }
     }
 
-    env.statistics->negativeExtensionality++;
+    env->statistics->negativeExtensionality++;
  
     return res;
   }

--- a/Inferences/PrimitiveInstantiation.cpp
+++ b/Inferences/PrimitiveInstantiation.cpp
@@ -103,7 +103,7 @@ struct PrimitiveInstantiation::ResultFn
       (*res)[i] = currAfter;
     }
 
-    env.statistics->primitiveInstantiations++;  
+    env->statistics->primitiveInstantiations++;  
     return res;
   }
   

--- a/Inferences/RefutationSeekerFSE.cpp
+++ b/Inferences/RefutationSeekerFSE.cpp
@@ -78,7 +78,7 @@ void RefutationSeekerFSE::perform(Clause* cl, ForwardSimplificationPerformer* si
 
     Clause* refutation = new(0) Clause(0, inpType, inf);
     refutation->setAge(cl->age());
-    env.statistics->resolution++;
+    env->statistics->resolution++;
 
     simplPerformer->perform(res.clause, refutation);
     return;

--- a/Inferences/RenamingOnTheFly.cpp
+++ b/Inferences/RenamingOnTheFly.cpp
@@ -60,7 +60,7 @@ ClauseIterator RenamingOnTheFly::produceClauses(Clause* c)
   CALL("RenamingOnTheFly::produceClauses");  
 
   //0 means dont rename
-  static int namingBound = env.options->naming();
+  static int namingBound = env->options->naming();
 
   TermList troo = TermList(Term::foolTrue());
   TermList boolSort = Term::boolSort();
@@ -150,8 +150,8 @@ ClauseIterator RenamingOnTheFly::produceClauses(Clause* c)
       }
 
       if(namingBound > 0 && 
-         env.signature->formulaCount(formula.term()) >= namingBound) {
-        env.signature->formulaNamed(formula.term());
+         env->signature->formulaCount(formula.term()) >= namingBound) {
+        env->signature->formulaNamed(formula.term());
 
         //create name
         static DHMap<unsigned,TermList> varSorts;
@@ -191,9 +191,9 @@ ClauseIterator RenamingOnTheFly::produceClauses(Clause* c)
           VList::push(args[i].var(), vl);
         }
 
-        unsigned fun = env.signature->addNameFunction(args.size());
+        unsigned fun = env->signature->addNameFunction(args.size());
         TermList sort = Term::arrowSort(argSorts, Term::boolSort());
-        Signature::Symbol* sym = env.signature->getFunction(fun);
+        Signature::Symbol* sym = env->signature->getFunction(fun);
         sym->setType(OperatorType::getConstantsType(sort, vl)); 
         TermList funApplied = TermList(Term::create(fun, args.size(), args.begin()));
         TermList name = AH::createAppTerm(sort, funApplied, termArgs);

--- a/Inferences/SLQueryBackwardSubsumption.cpp
+++ b/Inferences/SLQueryBackwardSubsumption.cpp
@@ -146,17 +146,17 @@ void SLQueryBackwardSubsumption::perform(Clause* cl,
     }
   }
 
-  static DArray<LiteralList*> matchedLits(32);
+  VTHREAD_LOCAL static DArray<LiteralList*> matchedLits(32);
   matchedLits.init(clen, 0);
 
   ClauseList* subsumed=0;
 
-  static DHSet<unsigned> basePreds;
+  VTHREAD_LOCAL static DHSet<unsigned> basePreds;
   bool basePredsInit=false;
   bool mustPredInit=false;
   unsigned mustPred;
 
-  static DHSet<Clause*> checkedClauses;
+  VTHREAD_LOCAL static DHSet<Clause*> checkedClauses;
   checkedClauses.reset();
 
   SLQueryResultIterator rit=_index->getInstances( (*cl)[lmIndex], false, false);

--- a/Inferences/SLQueryBackwardSubsumption.cpp
+++ b/Inferences/SLQueryBackwardSubsumption.cpp
@@ -112,7 +112,7 @@ void SLQueryBackwardSubsumption::perform(Clause* cl,
     unsigned subsumedCnt=subsumedClauses.size();
     simplifications=pvi( getMappingIterator(
 	    subsumedClauses, ClauseToBwSimplRecordFn()) );
-    env.statistics->backwardSubsumed+=subsumedCnt;
+    env->statistics->backwardSubsumed+=subsumedCnt;
     return;
   }
 
@@ -126,7 +126,7 @@ void SLQueryBackwardSubsumption::perform(Clause* cl,
     unsigned subsumedCnt=subsumedClauses.size();
     simplifications=pvi( getMappingIterator(
 	    subsumedClauses, ClauseToBwSimplRecordFn()) );
-    env.statistics->backwardSubsumed+=subsumedCnt;
+    env->statistics->backwardSubsumed+=subsumedCnt;
     RSTAT_CTR_INC_MANY("bs0 unit performed",subsumedCnt);
     return;
   }
@@ -264,7 +264,7 @@ void SLQueryBackwardSubsumption::perform(Clause* cl,
     RSTAT_CTR_INC("bs1 3 final check");
     if(MLMatcher::canBeMatched(cl,icl,matchedLits.array(),0)) {
       ClauseList::push(icl, subsumed);
-      env.statistics->backwardSubsumed++;
+      env->statistics->backwardSubsumed++;
       RSTAT_CTR_INC("bs1 4 performed");
     }
 

--- a/Inferences/SLQueryForwardSubsumption.cpp
+++ b/Inferences/SLQueryForwardSubsumption.cpp
@@ -133,8 +133,8 @@ void SLQueryForwardSubsumption::perform(Clause* cl, ForwardSimplificationPerform
 
   if(gens)
   {
-    static DArray<LiteralList*> matches(32);
-    static MatchMap matchMap;
+    VTHREAD_LOCAL static DArray<LiteralList*> matches(32);
+    VTHREAD_LOCAL static MatchMap matchMap;
 
     CMMap::Iterator git(*gens);
     while(git.hasNext()) {

--- a/Inferences/SLQueryForwardSubsumption.cpp
+++ b/Inferences/SLQueryForwardSubsumption.cpp
@@ -111,7 +111,7 @@ void SLQueryForwardSubsumption::perform(Clause* cl, ForwardSimplificationPerform
       SLQueryResult res=rit.next();
       unsigned rlen=res.clause->length();
       if(rlen==1 && ColorHelper::compatible(cl->color(), res.clause->color())) {
-	env.statistics->forwardSubsumed++;
+	env->statistics->forwardSubsumed++;
 	simplPerformer->perform(res.clause, 0);
 	goto fin;
       } else if(rlen>clen) {
@@ -180,7 +180,7 @@ void SLQueryForwardSubsumption::perform(Clause* cl, ForwardSimplificationPerform
       }
 
       if(!mclMatchFailed && ColorHelper::compatible(cl->color(), mcl->color())) {
-	env.statistics->forwardSubsumed++;
+	env->statistics->forwardSubsumed++;
 	simplPerformer->perform(mcl, 0);
 	goto fin;
       }

--- a/Inferences/SubVarSup.cpp
+++ b/Inferences/SubVarSup.cpp
@@ -292,7 +292,7 @@ Clause* SubVarSup::performSubVarSup(
 
   // If proof extra is on let's compute the positions we have performed
   // SubVarSup on 
-  if(env.options->proofExtra()==Options::ProofExtra::FULL){
+  if(env->options->proofExtra()==Options::ProofExtra::FULL){
     //TODO update for proof extra
   }
 
@@ -317,7 +317,7 @@ Clause* SubVarSup::performSubVarSup(
       if (afterCheck) {
         TimeCounter tc(TC_LITERAL_ORDER_AFTERCHECK);
         if (i < rwClause->numSelected() && ordering.compare(currAfter,rwLitS) == Ordering::GREATER) {
-          env.statistics->inferencesBlockedForOrderingAftercheck++;
+          env->statistics->inferencesBlockedForOrderingAftercheck++;
           goto construction_fail;
         }
       }
@@ -345,11 +345,11 @@ Clause* SubVarSup::performSubVarSup(
   res->setAge(newAge);
   
   if(rwClause==eqClause) {
-    env.statistics->selfSubVarSup++;
+    env->statistics->selfSubVarSup++;
   } else if(eqIsResult) {
-    env.statistics->forwardSubVarSup++;
+    env->statistics->forwardSubVarSup++;
   } else {
-    env.statistics->backwardSubVarSup++;
+    env->statistics->backwardSubVarSup++;
   }
 
   //cout << "SUBVARSUP " + res->toString() << endl;

--- a/Inferences/SubsumptionDemodulationHelper.cpp
+++ b/Inferences/SubsumptionDemodulationHelper.cpp
@@ -170,7 +170,7 @@ Clause* SDHelper::generateSubsumptionResolutionClause(Clause* cl, Literal* resLi
 SDHelper::ClauseComparisonResult SDHelper::clauseCompare(Literal* const lits1[], unsigned n1, Literal* const lits2[], unsigned n2, Ordering const& ordering)
 {
   // "-lcm reverse" messes up the ordering
-  ASS(env.options->literalComparisonMode() != Options::LiteralComparisonMode::REVERSE);
+  ASS(env->options->literalComparisonMode() != Options::LiteralComparisonMode::REVERSE);
 
   // Copy given literals so we can sort them
   vvector<Literal*> c1(lits1, lits1+n1);

--- a/Inferences/SubsumptionDemodulationHelper.hpp
+++ b/Inferences/SubsumptionDemodulationHelper.hpp
@@ -350,11 +350,11 @@ bool termContainsAllVariablesOfOtherUnderSubst(TermList term, TermList other, Ap
 {
   CALL("termContainsAllVariablesOfOtherUnderSubst");
 
-  static vunordered_set<unsigned int> vars(16);
+  VTHREAD_LOCAL static vunordered_set<unsigned int> vars(16);
   vars.clear();
 
-  static VariableIterator vit;
-  static VariableIterator vit2;
+  VTHREAD_LOCAL static VariableIterator vit;
+  VTHREAD_LOCAL static VariableIterator vit2;
 
   // collect term's vars after substitution
   vit.reset(term);

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -197,8 +197,8 @@ ClauseIterator Superposition::generateClauses(Clause* premise)
   //cout << "SUPERPOSITION with " << premise->toString() << endl;
 
   //TODO probably shouldn't go here!
-  static bool withConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
-  static bool extByAbstraction = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION)
+  VTHREAD_LOCAL static bool withConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
+  VTHREAD_LOCAL static bool extByAbstraction = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION)
                                && env.statistics->higherOrder;
 
   auto itf1 = premise->getSelectedLiteralIterator();
@@ -499,7 +499,7 @@ Clause* Superposition::performSuperposition(
 
   Literal* tgtLitS = EqHelper::replace(rwLitS,rwTermS,tgtTermS);
 
-  static bool doSimS = getOptions().simulatenousSuperposition();
+  VTHREAD_LOCAL static bool doSimS = getOptions().simulatenousSuperposition();
 
   //check we don't create an equational tautology (this happens during self-superposition)
   if(EqHelper::isEqTautology(tgtLitS)) {
@@ -508,7 +508,7 @@ Clause* Superposition::performSuperposition(
 
   unsigned newLength = rwLength+eqLength-1+conLength + isTypeSub;
 
-  static bool afterCheck = getOptions().literalMaximalityAftercheck() && _salg->getLiteralSelector().isBGComplete();
+  VTHREAD_LOCAL static bool afterCheck = getOptions().literalMaximalityAftercheck() && _salg->getLiteralSelector().isBGComplete();
 
   inf_destroyer.disable(); // ownership passed to the the clause below
   Clause* res = new(newLength) Clause(newLength, inf);
@@ -638,7 +638,7 @@ Clause* Superposition::performSuperposition(
       TermList sort = SortHelper::getResultSort(rT.term());
       Literal* constraint = Literal::createEquality(false,qT,rT,sort);
 
-      static Options::UnificationWithAbstraction uwa = env.options->unificationWithAbstraction();
+      VTHREAD_LOCAL static Options::UnificationWithAbstraction uwa = env.options->unificationWithAbstraction();
       if(uwa==Options::UnificationWithAbstraction::GROUND && 
          !constraint->ground() &&
          (!theory->isInterpretedFunction(qT) && !theory->isInterpretedConstant(qT)) &&

--- a/Inferences/TautologyDeletionISE.cpp
+++ b/Inferences/TautologyDeletionISE.cpp
@@ -47,7 +47,7 @@ Clause* TautologyDeletionISE::simplify(Clause* c)
     // l is positive
     if (_deleteEqTautologies && EqHelper::isEqTautology(l)) {
       // literal t = t
-      env.statistics->equationalTautologies++;
+      env->statistics->equationalTautologies++;
       return 0;
     }
     plits[pos++] = l;
@@ -73,7 +73,7 @@ Clause* TautologyDeletionISE::simplify(Clause* c)
         }
         break;
       case 0:
-        env.statistics->simpleTautologies++;
+        env->statistics->simpleTautologies++;
         return 0;
       case 1:
         n++;

--- a/Inferences/TautologyDeletionISE.cpp
+++ b/Inferences/TautologyDeletionISE.cpp
@@ -30,8 +30,8 @@ Clause* TautologyDeletionISE::simplify(Clause* c)
 {
   CALL("TautologyDeletionISE::simplify");
 
-  static DArray<Literal*> plits(32); // array of positive literals
-  static DArray<Literal*> nlits(32); // array of negative literals
+  VTHREAD_LOCAL static DArray<Literal*> plits(32); // array of positive literals
+  VTHREAD_LOCAL static DArray<Literal*> nlits(32); // array of negative literals
 
   int pos = 0;
   int neg = 0;
@@ -152,7 +152,7 @@ void TautologyDeletionISE::sort(Literal** lits,int to)
   ASS(to > 1);
 
   // array behaves as a stack of calls to quicksort
-  static DArray<int> ft(32);
+  VTHREAD_LOCAL static DArray<int> ft(32);
 
   to--;
   ft.ensure(to);

--- a/Inferences/TermAlgebraReasoning.cpp
+++ b/Inferences/TermAlgebraReasoning.cpp
@@ -76,7 +76,7 @@ namespace Inferences {
     CALL("termAlgebraConstructor");
 
     if (t->isTerm()) {
-      Signature::Symbol *s = env.signature->getFunction(t->term()->functor());
+      Signature::Symbol *s = env->signature->getFunction(t->term()->functor());
 
       if (s->termAlgebraCons()) {
         return s;
@@ -130,11 +130,11 @@ namespace Inferences {
         if (lit->isPositive()) {
           // equality of the form f(x) = g(y), delete literal from clause
           Clause* res = removeLit(c, i, SimplifyingInference1(InferenceRule::TERM_ALGEBRA_DISTINCTNESS, c));
-          env.statistics->taDistinctnessSimplifications++;
+          env->statistics->taDistinctnessSimplifications++;
           return res;
         } else {
           // inequality of the form f(x) != g(y) are theory tautologies
-          env.statistics->taDistinctnessTautologyDeletions++;
+          env->statistics->taDistinctnessTautologyDeletions++;
           return 0;
         }
       }
@@ -157,7 +157,7 @@ namespace Inferences {
         _clause(clause)
     {
       if (lit->polarity() && sameConstructorsEquality(lit)) {
-        _type = env.signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
+        _type = env->signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
         _length = lit->nthArgument(0)->term()->arity();
       } else {
         _length = 0;
@@ -181,7 +181,7 @@ namespace Inferences {
       
       Clause * res = replaceLit(_clause, _lit, l, GeneratingInference1(InferenceRule::TERM_ALGEBRA_INJECTIVITY_GENERATING, _clause));
       _index++;
-      env.statistics->taInjectivitySimplifications++;
+      env->statistics->taInjectivitySimplifications++;
       return res;
     }
   private:
@@ -233,13 +233,13 @@ namespace Inferences {
       Literal *lit = (*c)[i];
       if (sameConstructorsEquality(lit) && lit->isPositive()) {
         if (lit->nthArgument(0)->term()->arity() == 1) {
-          OperatorType *type = env.signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
+          OperatorType *type = env->signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
           Literal *newlit = Literal::createEquality(true,
                                                     *lit->nthArgument(0)->term()->nthArgument(0),
                                                     *lit->nthArgument(1)->term()->nthArgument(0),
                                                     type->arg(0));
           Clause* res = replaceLit(c, lit, newlit, SimplifyingInference1(InferenceRule::TERM_ALGEBRA_INJECTIVITY_SIMPLIFYING, c));
-          env.statistics->taInjectivitySimplifications++;
+          env->statistics->taInjectivitySimplifications++;
           return res;
         }
       }
@@ -253,7 +253,7 @@ namespace Inferences {
     Literal *lit = (*c)[i];
     if (sameConstructorsEquality(lit) && !lit->polarity()) {
       unsigned arity = lit->nthArgument(0)->term()->arity();
-      OperatorType *type = env.signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
+      OperatorType *type = env->signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
       for (unsigned j = 0; j < arity; j++) {
         Literal *l = Literal::createEquality(true,
                                              *lit->nthArgument(0)->term()->nthArgument(j),
@@ -283,7 +283,7 @@ namespace Inferences {
     for (int i = length - 1; i >= 0; i--) {
       if (litCondition(c, i)) {
         Literal *lit = (*c)[i];
-        OperatorType *type = env.signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
+        OperatorType *type = env->signature->getFunction(lit->nthArgument(0)->term()->functor())->fnType();
         unsigned oldLength = c->length();
         unsigned arity = lit->nthArgument(0)->term()->arity();
         unsigned newLength = oldLength + arity - 1;
@@ -304,7 +304,7 @@ namespace Inferences {
                                            type->arg(i));
           (*res)[oldLength + i - 1] = newLit;
         }
-        env.statistics->taNegativeInjectivitySimplifications++;
+        env->statistics->taNegativeInjectivitySimplifications++;
 
         return res;
       }
@@ -437,9 +437,9 @@ namespace Inferences {
     Term *t = tl->term();
     
     TermList sort = SortHelper::getResultSort(t);
-    ASS(env.signature->isTermAlgebraSort(sort));
+    ASS(env->signature->isTermAlgebraSort(sort));
 
-    if (env.signature->getTermAlgebraOfSort(sort)->allowsCyclicTerms()) {
+    if (env->signature->getTermAlgebraOfSort(sort)->allowsCyclicTerms()) {
       return;
     }
 
@@ -457,7 +457,7 @@ namespace Inferences {
 
     while (toVisit.isNonEmpty()) {
       Term *u = toVisit.pop();
-      if (env.signature->getFunction(u->functor())->termAlgebraCons()) {
+      if (env->signature->getFunction(u->functor())->termAlgebraCons()) {
         for (unsigned i = 0; i < u->arity(); i++) {
           if (SortHelper::getArgSort(u, i) == sort) {
             TermList *s = u->nthArgument(i);
@@ -508,7 +508,7 @@ namespace Inferences {
                                                 *_subterms.pop(),
                                                 _sort);
       Clause* res = replaceLit(_clause, _lit, newlit, GeneratingInference1(InferenceRule::TERM_ALGEBRA_ACYCLICITY, _clause));
-      env.statistics->taAcyclicityGeneratedDisequalities++;
+      env->statistics->taAcyclicityGeneratedDisequalities++;
       return res;
     }
         

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -326,7 +326,7 @@ void TheoryInstAndSimp::selectTheoryLiterals(Clause* cl, Stack<Literal*>& theory
 #endif
 
   ASS_NEQ(
-    env.options->theoryInstAndSimp(),
+    env->options->theoryInstAndSimp(),
     Shell::Options::TheoryInstSimp::OFF
   );
 
@@ -428,7 +428,7 @@ void TheoryInstAndSimp::originalSelectTheoryLiterals(Clause* cl, Stack<Literal*>
   cout << "originalSelectTheoryLiterals["<<forZ3<<"] in " << cl->toString() << endl;
 #endif
 
-  VTHREAD_LOCAL static Shell::Options::TheoryInstSimp selection = env.options->theoryInstAndSimp();
+  VTHREAD_LOCAL static Shell::Options::TheoryInstSimp selection = env->options->theoryInstAndSimp();
   ASS(selection!=Shell::Options::TheoryInstSimp::OFF);
 
   Stack<Literal*> weak;
@@ -448,7 +448,7 @@ void TheoryInstAndSimp::originalSelectTheoryLiterals(Clause* cl, Stack<Literal*>
     //TODO I do this kind of check all over the place but differently every time!
     if(interpreted && lit->isEquality() && !lit->isTwoVarEquality()) {  
       for(TermList* ts = lit->args(); ts->isNonEmpty(); ts = ts->next()){
-        if(ts->isTerm() && !env.signature->getFunction(ts->term()->functor())->interpreted()){
+        if(ts->isTerm() && !env->signature->getFunction(ts->term()->functor())->interpreted()){
           interpreted=false;
           break;
         }
@@ -600,9 +600,9 @@ Term* getFreshConstant(unsigned index, TermList srt)
 
   Stack<Term*>* sortedConstants = constants.getOrInit(move(srt), [](Stack<Term*>** toInit) { *toInit = new Stack<Term*>(); });
   while(index+1 > sortedConstants->length()){
-    unsigned sym = env.signature->addFreshFunction(0,"$inst");
+    unsigned sym = env->signature->addFreshFunction(0,"$inst");
     OperatorType* type = OperatorType::getConstantsType(srt);
-    env.signature->getFunction(sym)->setType(type);
+    env->signature->getFunction(sym)->setType(type);
     Term* fresh = Term::createConstant(sym);
     sortedConstants->push(fresh);
   }
@@ -619,7 +619,7 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*>& theor
   // We use a new SMT solver
   // currently these are not needed outside of this function so we put them here
   VTHREAD_LOCAL static SAT2FO naming;
-  VTHREAD_LOCAL static Z3Interfacing solver(*env.options,naming);
+  VTHREAD_LOCAL static Z3Interfacing solver(*env->options,naming);
   solver.reset(); // the solver will reset naming
 
 
@@ -703,7 +703,7 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*>& theor
         sol.subst.bind(v,t);
       } else {
         // Failed to obtain a value; could be an algebraic number or some other currently unhandled beast...
-        env.statistics->theoryInstSimpLostSolution++;
+        env->statistics->theoryInstSimpLostSolution++;
         goto fail;
       }
     }
@@ -766,7 +766,7 @@ partial_check_end:
       }
 
       if(!containsPartial){
-        env.statistics->theoryInstSimpTautologies++;
+        env->statistics->theoryInstSimpTautologies++;
         // do this directly in salg
         //_salg->removeActiveOrPassiveClause(_premise);
         _red=true;
@@ -813,7 +813,7 @@ partial_check_end:
       _splitter->onNewClause(inst);
     }
 
-    env.statistics->theoryInstSimp++;
+    env->statistics->theoryInstSimp++;
 #if DPRINT
     cout << "to get " << res->toString() << endl;
 #endif
@@ -834,7 +834,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
 
   if(premise->isPureTheoryDescendant()){ return ClauseIterator::getEmpty(); }
 
-  VTHREAD_LOCAL static Options::TheoryInstSimp thi = env.options->theoryInstAndSimp();
+  VTHREAD_LOCAL static Options::TheoryInstSimp thi = env->options->theoryInstAndSimp();
 
   VTHREAD_LOCAL static Stack<Literal*> selectedLiterals;
   selectedLiterals.reset();
@@ -853,7 +853,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
   }
 
   // we have an eligable candidate
-  env.statistics->theoryInstSimpCandidates++;
+  env->statistics->theoryInstSimpCandidates++;
 
   // TODO use limits
 
@@ -910,7 +910,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
 
     auto out = getPersistentIterator(it4); // we need immediate evaluation, so that premiseRedundant is set just after the call!
 
-    if (!env.options->thiTautologyDeletion()) {
+    if (!env->options->thiTautologyDeletion()) {
       premiseRedundant = false;
     }
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -428,7 +428,7 @@ void TheoryInstAndSimp::originalSelectTheoryLiterals(Clause* cl, Stack<Literal*>
   cout << "originalSelectTheoryLiterals["<<forZ3<<"] in " << cl->toString() << endl;
 #endif
 
-  static Shell::Options::TheoryInstSimp selection = env.options->theoryInstAndSimp();
+  VTHREAD_LOCAL static Shell::Options::TheoryInstSimp selection = env.options->theoryInstAndSimp();
   ASS(selection!=Shell::Options::TheoryInstSimp::OFF);
 
   Stack<Literal*> weak;
@@ -588,7 +588,7 @@ void TheoryInstAndSimp::originalSelectTheoryLiterals(Clause* cl, Stack<Literal*>
 Term* getFreshConstant(unsigned index, TermList srt)
 {
   CALL("TheoryInstAndSimp::getFreshConstant");
-  static Map<TermList, Stack<Term*>*> constants;
+  VTHREAD_LOCAL static Map<TermList, Stack<Term*>*> constants;
 
   /*
   We skolemize at some point in instantiation. For that we need fresh constants.
@@ -618,8 +618,8 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*>& theor
 
   // We use a new SMT solver
   // currently these are not needed outside of this function so we put them here
-  static SAT2FO naming;
-  static Z3Interfacing solver(*env.options,naming);
+  VTHREAD_LOCAL static SAT2FO naming;
+  VTHREAD_LOCAL static Z3Interfacing solver(*env.options,naming);
   solver.reset(); // the solver will reset naming
 
 
@@ -665,7 +665,7 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*>& theor
     SATLiteral slit = naming.toSAT(lit);
 
     // now add the SAT representation
-    static SATLiteralStack satLits;
+    VTHREAD_LOCAL static SATLiteralStack satLits;
     satLits.reset();
     satLits.push(slit);
     SATClause* sc = SATClause::fromStack(satLits);
@@ -834,9 +834,9 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
 
   if(premise->isPureTheoryDescendant()){ return ClauseIterator::getEmpty(); }
 
-  static Options::TheoryInstSimp thi = env.options->theoryInstAndSimp();
+  VTHREAD_LOCAL static Options::TheoryInstSimp thi = env.options->theoryInstAndSimp();
 
-  static Stack<Literal*> selectedLiterals;
+  VTHREAD_LOCAL static Stack<Literal*> selectedLiterals;
   selectedLiterals.reset();
 
   if(thi == Options::TheoryInstSimp::NEW){
@@ -860,7 +860,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
   Clause* flattened = premise;
   if(thi != Options::TheoryInstSimp::NEW){
     // we will use flattening which is non-recursive and sharing
-    static TheoryFlattening flattener((thi==Options::TheoryInstSimp::FULL),true);
+    VTHREAD_LOCAL static TheoryFlattening flattener((thi==Options::TheoryInstSimp::FULL),true);
 
     flattened = flattener.apply(premise,selectedLiterals);
 
@@ -871,7 +871,7 @@ ClauseIterator TheoryInstAndSimp::generateClauses(Clause* premise,bool& premiseR
       _splitter->onNewClause(flattened);
     }
 
-    static Stack<Literal*> theoryLiterals;
+    VTHREAD_LOCAL static Stack<Literal*> theoryLiterals;
     theoryLiterals.reset();
 
     // Now go through the abstracted clause and select the things we send to SMT

--- a/Inferences/URResolution.cpp
+++ b/Inferences/URResolution.cpp
@@ -324,7 +324,7 @@ void URResolution::processAndGetClauses(Item* itm, unsigned startIdx, ClauseList
   while(itms) {
     Item* itm = ItemList::pop(itms);
     ClauseList::push(itm->generateClause(), acc);
-    env.statistics->urResolution++;
+    env->statistics->urResolution++;
     delete itm;
   }
 }

--- a/InstGen/IGAlgorithm.cpp
+++ b/InstGen/IGAlgorithm.cpp
@@ -864,7 +864,11 @@ MainLoopResult IGAlgorithm::runImpl()
 	_instGenResolutionRatio.doSecond();
 	doResolutionStep();
       }
+#if VTHREADED
+      env.checkTimeSometime<1>();
+#else
       env.checkTimeSometime<100>();
+#endif
     }
     if(restarting) {
       if(restartKindRatio>0) {

--- a/InstGen/IGAlgorithm.cpp
+++ b/InstGen/IGAlgorithm.cpp
@@ -216,14 +216,14 @@ redundancy_check:
     }
     if (redundant) {
       cl->destroyIfUnnecessary();
-      env.statistics->instGenRedundantClauses++;
+      env->statistics->instGenRedundantClauses++;
       return false;
     }
   }
-  if (env.options->showNew()) {
-    env.beginOutput();
-    env.out() << "[IG] new: " << cl->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showNew()) {
+    env->beginOutput();
+    env->out() << "[IG] new: " << cl->toString() << std::endl;
+    env->endOutput();
   }
 
   if(_globalSubsumption) {
@@ -248,7 +248,7 @@ redundancy_check:
   _variantIdx->insert(cl);
 
   _unprocessed.push(cl);
-  env.statistics->instGenKeptClauses++;
+  env->statistics->instGenKeptClauses++;
   return true;
 }
 
@@ -261,7 +261,7 @@ Clause* IGAlgorithm::getFORefutation(SATClause* satRefutation, SATClauseList* sa
 
   Inference foInf(FromSatRefutation(InferenceRule::SAT_INSTGEN_REFUTATION, prems,
           // satPremises may be nullptr already, if our solver does not support minimization
-          env.options->minimizeSatProofs() ? satPremises : nullptr));
+          env->options->minimizeSatProofs() ? satPremises : nullptr));
 
   Clause* foRef = Clause::fromIterator(LiteralIterator::getEmpty(), foInf);
   return foRef;
@@ -280,10 +280,10 @@ void IGAlgorithm::processUnprocessed()
     //so it cancels out with the increase we'd have to do for it
     _passive.add(cl);
     
-    if (env.options->showPassive()) {
-      env.beginOutput();
-      env.out() << "[IG] passive: " << cl->toString() << std::endl;
-      env.endOutput();
+    if (env->options->showPassive()) {
+      env->beginOutput();
+      env->out() << "[IG] passive: " << cl->toString() << std::endl;
+      env->endOutput();
     }
 
     SATClause* sc = _gnd->ground(cl);
@@ -387,7 +387,7 @@ void IGAlgorithm::finishGeneratingClause(Clause* orig, ResultSubstitution& subst
   // make age also depend on the age of otherCl
   res->setAge(max(orig->age(), otherCl->age())+1);
 
-  env.statistics->instGenGeneratedClauses++;
+  env->statistics->instGenGeneratedClauses++;
   bool added = addClause(res);
   (void)added;
 
@@ -626,7 +626,7 @@ void IGAlgorithm::doResolutionStep()
     return;
   }
   try {
-    ScopedLet<Options*> optLet(env.options,&_saturationOptions);
+    ScopedLet<Options*> optLet(env->options,&_saturationOptions);
     _saturationAlgorithm->doOneAlgorithmStep();
   }
   catch(MainLoopFinishedException e)
@@ -657,10 +657,10 @@ void IGAlgorithm::activate(Clause* cl, bool wasDeactivated)
 
   selectAndAddToIndex(cl);
   
-  if (env.options->showActive()) {
-    env.beginOutput();
-    env.out() << "[IG] active: " << cl->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showActive()) {
+    env->beginOutput();
+    env->out() << "[IG] active: " << cl->toString() << std::endl;
+    env->endOutput();
   }
   
   unsigned clen = cl->length();
@@ -832,7 +832,7 @@ MainLoopResult IGAlgorithm::runImpl()
     bool restarting = false;
     unsigned loopIterCnt = 0;
     while(_unprocessed.isNonEmpty() || !_passive.isEmpty()) {
-      env.statistics->instGenIterations++;
+      env->statistics->instGenIterations++;
       processUnprocessed();
       // ASS_EQ(_satSolver->getStatus(), SATSolver::SATISFIABLE);
 
@@ -865,9 +865,9 @@ MainLoopResult IGAlgorithm::runImpl()
 	doResolutionStep();
       }
 #if VTHREADED
-      env.checkTimeSometime<1>();
+      env->checkTimeSometime<1>();
 #else
-      env.checkTimeSometime<100>();
+      env->checkTimeSometime<100>();
 #endif
     }
     if(restarting) {
@@ -911,10 +911,10 @@ MainLoopResult IGAlgorithm::onModelFound()
       //we need to print this early because model generating can take some time
       reportSpiderStatus('-');
       if(szsOutputMode()) {
-        env.beginOutput();
-        env.out() << "% SZS status "<<( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
+        env->beginOutput();
+        env->out() << "% SZS status "<<( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
             << " for " << _opt.problemName() << endl << flush;
-        env.endOutput();
+        env->endOutput();
         UIHelper::satisfiableStatusWasAlreadyOutput = true;
       }
 
@@ -924,7 +924,7 @@ MainLoopResult IGAlgorithm::onModelFound()
       vostringstream modelStm;
       bool modelAvailable = ModelPrinter(*this).tryOutput(modelStm);
       if(modelAvailable) {
-	env.statistics->model = modelStm.str();
+	env->statistics->model = modelStm.str();
       }
       else {
 	res.saturatedSet = 0;

--- a/InstGen/IGAlgorithm.cpp
+++ b/InstGen/IGAlgorithm.cpp
@@ -227,7 +227,7 @@ redundancy_check:
   }
 
   if(_globalSubsumption) {
-    static Stack<Unit*> prems_dummy;
+    VTHREAD_LOCAL static Stack<Unit*> prems_dummy;
     
     Clause* newCl = _globalSubsumption->perform(cl,prems_dummy);
     if(newCl!=cl) {
@@ -438,8 +438,8 @@ void IGAlgorithm::tryGeneratingInstances(Clause* cl, unsigned litIdx)
       continue;//literal is no longer selected
     }
 
-    static LiteralStack genLits1;
-    static LiteralStack genLits2;
+    VTHREAD_LOCAL static LiteralStack genLits1;
+    VTHREAD_LOCAL static LiteralStack genLits2;
     bool properInstance1;
     bool properInstance2;
 
@@ -498,7 +498,7 @@ unsigned IGAlgorithm::lookaheadSelection(Clause* cl, unsigned selCnt)
 {
   CALL("IGAlgorithm::lookaheadSelection");
 
-  static DArray<VirtualIterator<SLQueryResult>> iters; //IG unification iterators
+  VTHREAD_LOCAL static DArray<VirtualIterator<SLQueryResult>> iters; //IG unification iterators
   iters.ensure(selCnt);
 
   for(unsigned i=0; i<selCnt; i++) {
@@ -507,7 +507,7 @@ unsigned IGAlgorithm::lookaheadSelection(Clause* cl, unsigned selCnt)
         [this](SLQueryResult& unif) { return isSelected(unif.literal); }));
   }
 
-  static Stack<unsigned> candidates; // just to make sure we break the ties in a fair way
+  VTHREAD_LOCAL static Stack<unsigned> candidates; // just to make sure we break the ties in a fair way
   candidates.reset();
   do {
     for(unsigned i=0;i<selCnt;i++) {
@@ -690,7 +690,7 @@ void IGAlgorithm::doImmediateReactivation()
 {
   CALL("IGAlgorithm::doImmediateReactivation");
 
-  static ClauseStack toActivate;
+  VTHREAD_LOCAL static ClauseStack toActivate;
   toActivate.reset();
 
   ClauseStack::Iterator dit(_deactivated);
@@ -713,7 +713,7 @@ void IGAlgorithm::doPassiveReactivation()
 {
   CALL("IGAlgorithm::doPassiveReactivation");
 
-  static ClauseStack toActivate;
+  VTHREAD_LOCAL static ClauseStack toActivate;
   toActivate.reset();
 
   RCClauseStack::DelIterator ait(_active);
@@ -754,7 +754,7 @@ void IGAlgorithm::restartWithCurrentClauses()
 {
   CALL("IGAlgorithm::restartWithCurrentClauses");
 
-  static RCClauseStack allClauses;
+  VTHREAD_LOCAL static RCClauseStack allClauses;
   allClauses.reset();
 
   while(_active.isNonEmpty()) {

--- a/InstGen/ModelPrinter.cpp
+++ b/InstGen/ModelPrinter.cpp
@@ -45,15 +45,15 @@ bool ModelPrinter::haveNonDefaultSorts()
 {
   CALL("ModelPrinter::haveNonDefaultSorts");
 
-  unsigned funs = env.signature->functions();
+  unsigned funs = env->signature->functions();
   for(unsigned i=0; i<funs; i++) {
-    if(env.signature->isTypeConOrSup(i)){ continue; }
-    OperatorType* type = env.signature->getFunction(i)->fnType();
+    if(env->signature->isTypeConOrSup(i)){ continue; }
+    OperatorType* type = env->signature->getFunction(i)->fnType();
     if(!type->isAllDefault()) { return false; }
   }
-  unsigned preds = env.signature->predicates();
+  unsigned preds = env->signature->predicates();
   for(unsigned i=1; i<preds; i++) {
-    OperatorType* type = env.signature->getPredicate(i)->predType();
+    OperatorType* type = env->signature->getPredicate(i)->predType();
     if(!type->isAllDefault()) { return false; }
   }
   return true;
@@ -63,10 +63,10 @@ bool ModelPrinter::isEprProblem()
 {
   CALL("ModelPrinter::isEprProblem");
 
-  unsigned funCnt = env.signature->functions();
+  unsigned funCnt = env->signature->functions();
   for(unsigned i=0; i<funCnt; i++) {
-    if(env.signature->isTypeConOrSup(i)){ continue; }
-    if(env.signature->functionArity(i)>0) {
+    if(env->signature->isTypeConOrSup(i)){ continue; }
+    if(env->signature->functionArity(i)>0) {
       return false;
     }
   }
@@ -88,7 +88,7 @@ bool ModelPrinter::tryOutput(ostream& stm)
     bool assignment;
     removedPreds.next(pred, assignment);
     ASS_NEQ(pred,0);
-    unsigned arity = env.signature->predicateArity(pred);
+    unsigned arity = env->signature->predicateArity(pred);
     args.reset();
     for(unsigned i=0; i<arity; i++) {
       args.push(TermList(i, false));
@@ -99,9 +99,9 @@ bool ModelPrinter::tryOutput(ostream& stm)
 
   collectTrueLits();
   //TODO fix the below AYB
-  if(env.signature->functions()!=0) {
+  if(env->signature->functions()!=0) {
     if(_usedConstants.isEmpty()) {
-      unsigned newFunc = env.signature->addFreshFunction(0,"c");
+      unsigned newFunc = env->signature->addFreshFunction(0,"c");
       TermList newConstTrm(Term::create(newFunc, 0, 0));
       _usedConstants.push(newConstTrm);
       _usedConstantSet.insert(newFunc);
@@ -121,7 +121,7 @@ bool ModelPrinter::isEquality(Literal* lit)
 {
   CALL("ModelPrinter::isEquality");
 
-  return lit->isEquality() || env.signature->getPredicate(lit->functor())->equalityProxy();
+  return lit->isEquality() || env->signature->getPredicate(lit->functor())->equalityProxy();
 }
 
 /**
@@ -199,7 +199,7 @@ void ModelPrinter::generateNewInstances(Literal* base, TermStack& domain, DHSet<
   VTHREAD_LOCAL static DArray<TermList> args;
   VTHREAD_LOCAL static DArray<bool> variables;
   VTHREAD_LOCAL static DArray<unsigned> nextIndexes;
-  OperatorType* predType = env.signature->getPredicate(base->functor())->predType();
+  OperatorType* predType = env->signature->getPredicate(base->functor())->predType();
 
   args.ensure(arity);
   variables.ensure(arity);
@@ -303,7 +303,7 @@ void ModelPrinter::analyzeEqualityAndPopulateDomain()
   LiteralStack eqInsts;
   getInstances(_trueEqs, eqInstDomain, eqInsts);
 
-  unsigned funCnt = env.signature->functions();
+  unsigned funCnt = env->signature->functions();
   IntUnionFind uif(funCnt);
 
   LiteralStack::Iterator eqit(eqInsts);
@@ -329,7 +329,7 @@ void ModelPrinter::analyzeEqualityAndPopulateDomain()
     ALWAYS(ecElIt.hasNext());
     unsigned firstFunc = ecElIt.next();
     //TODO is the below correct? AYB
-    if(env.signature->isTypeConOrSup(firstFunc)){ continue; }
+    if(env->signature->isTypeConOrSup(firstFunc)){ continue; }
 
     if(!_usedConstantSet.contains(firstFunc)) {
       ASS(!ecElIt.hasNext()); //constant that is not used is alone in its equivalence class
@@ -338,9 +338,9 @@ void ModelPrinter::analyzeEqualityAndPopulateDomain()
     TermList firstTerm = TermList(Term::create(firstFunc, 0, 0));
     vstring firstTermStr = firstTerm.toString();
     TermList eqClassSort = SortHelper::getResultSort(firstTerm.term());
-    unsigned reprFunc = env.signature->addStringConstant(firstTermStr);
+    unsigned reprFunc = env->signature->addStringConstant(firstTermStr);
     OperatorType* reprType = OperatorType::getConstantsType(eqClassSort);
-    env.signature->getFunction(reprFunc)->setType(reprType);
+    env->signature->getFunction(reprFunc)->setType(reprType);
     TermList reprTerm = TermList(Term::create(reprFunc, 0, 0));
     _rewrites.insert(firstTerm, reprTerm);
 

--- a/InstGen/ModelPrinter.cpp
+++ b/InstGen/ModelPrinter.cpp
@@ -196,9 +196,9 @@ void ModelPrinter::generateNewInstances(Literal* base, TermStack& domain, DHSet<
   unsigned arity = base->arity();
   unsigned domSz= domain.size();
 
-  static DArray<TermList> args;
-  static DArray<bool> variables;
-  static DArray<unsigned> nextIndexes;
+  VTHREAD_LOCAL static DArray<TermList> args;
+  VTHREAD_LOCAL static DArray<bool> variables;
+  VTHREAD_LOCAL static DArray<unsigned> nextIndexes;
   OperatorType* predType = env.signature->getPredicate(base->functor())->predType();
 
   args.ensure(arity);
@@ -284,7 +284,7 @@ void ModelPrinter::getInstances(LiteralStack& trueLits, TermStack& domain, Liter
 {
   CALL("ModelPrinter::getInstances");
 
-  static DHSet<Literal*> instSet;
+  VTHREAD_LOCAL static DHSet<Literal*> instSet;
   instSet.reset();
 
   std::sort(trueLits.begin(), trueLits.end(), InstLitComparator());
@@ -359,7 +359,7 @@ void ModelPrinter::rewriteLits(LiteralStack& lits)
 {
   CALL("ModelPrinter::rewriteLits");
 
-  static TermStack args;
+  VTHREAD_LOCAL static TermStack args;
 
   LiteralStack::Iterator iter(lits);
   while(iter.hasNext()) {

--- a/Kernel/ApplicativeHelper.cpp
+++ b/Kernel/ApplicativeHelper.cpp
@@ -58,7 +58,7 @@ TermList ApplicativeHelper::createAppTerm(TermList s1, TermList s2, TermList arg
   args.push(s2);
   args.push(arg1);
   args.push(arg2);
-  unsigned app = env.signature->getApp();
+  unsigned app = env->signature->getApp();
   if(shared){
     return TermList(Term::create(app, 4, args.begin()));
   }
@@ -107,7 +107,7 @@ TermList ApplicativeHelper::getResultApplieadToNArgs(TermList arrowSort, unsigne
   CALL("ApplicativeHelper::getResultApplieadToNArgs");
   
   while(argNum > 0){
-    ASS(arrowSort.isTerm() && env.signature->getFunction(arrowSort.term()->functor())->arrow());
+    ASS(arrowSort.isTerm() && env->signature->getFunction(arrowSort.term()->functor())->arrow());
     arrowSort = *arrowSort.term()->nthArgument(1);
     argNum--;
   }
@@ -123,7 +123,7 @@ TermList ApplicativeHelper::getNthArg(TermList arrowSort, unsigned argNum)
 
   TermList res;
   while(argNum >=1){
-    ASS(arrowSort.isTerm() && env.signature->getFunction(arrowSort.term()->functor())->arrow());
+    ASS(arrowSort.isTerm() && env->signature->getFunction(arrowSort.term()->functor())->arrow());
     res = *arrowSort.term()->nthArgument(0);
     arrowSort = *arrowSort.term()->nthArgument(1);
     argNum--;
@@ -135,7 +135,7 @@ TermList ApplicativeHelper::getResultSort(TermList sort)
 {
   CALL("ApplicativeHelper::getResultSort");
 
-  while(sort.isTerm() && env.signature->getFunction(sort.term()->functor())->arrow()){
+  while(sort.isTerm() && env->signature->getFunction(sort.term()->functor())->arrow()){
     sort = *sort.term()->nthArgument(1);
   }
   return sort;
@@ -146,7 +146,7 @@ unsigned ApplicativeHelper::getArity(TermList sort)
   CALL("ApplicativeHelper::getArity");
 
   unsigned arity = 0;
-  while(sort.isTerm() && env.signature->getFunction(sort.term()->functor())->arrow()){
+  while(sort.isTerm() && env->signature->getFunction(sort.term()->functor())->arrow()){
     sort = *sort.term()->nthArgument(1);
     arity++; 
   }
@@ -268,7 +268,7 @@ TermList ApplicativeHelper::getHead(TermList t)
     return t; 
   }
 
-  while(env.signature->getFunction(t.term()->functor())->app()){
+  while(env->signature->getFunction(t.term()->functor())->app()){
     t = *t.term()->nthArgument(2);
     if(!t.isTerm() || t.term()->isSpecial()){ break; } 
   }
@@ -280,7 +280,7 @@ TermList ApplicativeHelper::getHead(Term* t)
   CALL("ApplicativeHelper::getHead(Term*)");
   
   TermList trm = TermList(t);
-  while(env.signature->getFunction(t->functor())->app()){
+  while(env->signature->getFunction(t->functor())->app()){
     trm = *t->nthArgument(2);
     if(!trm.isTerm() || trm.term()->isSpecial()){ break; }
     t = trm.term(); 
@@ -292,13 +292,13 @@ bool ApplicativeHelper::isComb(const TermList head)
 {
   CALL("ApplicativeHelper::isComb");
   if(head.isVar()){ return false; }
-  return env.signature->getFunction(head.term()->functor())->combinator() != Signature::NOT_COMB;
+  return env->signature->getFunction(head.term()->functor())->combinator() != Signature::NOT_COMB;
 }
 
 Signature::Combinator ApplicativeHelper::getComb (const TermList head) 
 {
   CALL("ApplicativeHelper::getComb");
-  return env.signature->getFunction(head.term()->functor())->combinator();
+  return env->signature->getFunction(head.term()->functor())->combinator();
 }
 
 Signature::Proxy ApplicativeHelper::getProxy(const TermList t)
@@ -307,14 +307,14 @@ Signature::Proxy ApplicativeHelper::getProxy(const TermList t)
   if(t.isVar()){
     return Signature::NOT_PROXY;
   }
-  return env.signature->getFunction(t.term()->functor())->proxy();
+  return env->signature->getFunction(t.term()->functor())->proxy();
 }
 
 
 bool ApplicativeHelper::isApp(const Term* t)
 {
   CALL("ApplicativeHelper::isApp(Term*)");
-  return env.signature->getFunction(t->functor())->app(); 
+  return env->signature->getFunction(t->functor())->app(); 
 }
 
 bool ApplicativeHelper::isApp(const TermList* tl)
@@ -330,7 +330,7 @@ bool ApplicativeHelper::isArrowSort(const TermList t)
   if(t.isVar()){
     return false;
   }
-  return env.signature->getFunction(t.term()->functor())->arrow(); 
+  return env->signature->getFunction(t.term()->functor())->arrow(); 
 }
 
 bool ApplicativeHelper::isType(const Term* t)
@@ -386,12 +386,12 @@ bool ApplicativeHelper::isBool(TermList t){
 
 bool ApplicativeHelper::isTrue(TermList term){
   CALL("ApplicativeHelper::isTrue");
-  return term.isTerm() && env.signature->isFoolConstantSymbol(true, term.term()->functor());
+  return term.isTerm() && env->signature->isFoolConstantSymbol(true, term.term()->functor());
 }
 
 bool ApplicativeHelper::isFalse(TermList term){
   CALL("ApplicativeHelper::isFalse");
-  return term.isTerm() && env.signature->isFoolConstantSymbol(false, term.term()->functor());
+  return term.isTerm() && env->signature->isFoolConstantSymbol(false, term.term()->functor());
 }
 
 bool ApplicativeHelper::isSafe(TermStack& args)

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -137,7 +137,7 @@ protected:
     CALL("CompleteBestLiteralSelector::doSelection");
     ASS_G(eligible, 1); //trivial cases should be taken care of by the base LiteralSelector
 
-    VTHREAD_LOCAL static bool combSup = env.options->combinatorySup();
+    VTHREAD_LOCAL static bool combSup = env->options->combinatorySup();
 
     VTHREAD_LOCAL static DArray<Literal*> litArr(64);
     VTHREAD_LOCAL static Set<unsigned> maxTermHeads;

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -137,10 +137,10 @@ protected:
     CALL("CompleteBestLiteralSelector::doSelection");
     ASS_G(eligible, 1); //trivial cases should be taken care of by the base LiteralSelector
 
-    static bool combSup = env.options->combinatorySup();
+    VTHREAD_LOCAL static bool combSup = env.options->combinatorySup();
 
-    static DArray<Literal*> litArr(64);
-    static Set<unsigned> maxTermHeads;
+    VTHREAD_LOCAL static DArray<Literal*> litArr(64);
+    VTHREAD_LOCAL static Set<unsigned> maxTermHeads;
     maxTermHeads.reset();
     litArr.initFromArray(eligible,*c);
     litArr.sortInversed(_comp);
@@ -205,7 +205,7 @@ protected:
       c->setSelected(eligible);
     } else if(!singleSelected) {
       //select multiple maximal literals
-      static Stack<Literal*> replaced(16);
+      VTHREAD_LOCAL static Stack<Literal*> replaced(16);
       Set<Literal*> maxSet;
       unsigned selCnt=0;
 

--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -52,9 +52,9 @@ using namespace Lib;
 using namespace Saturation;
 using namespace Shell;
 
-size_t Clause::_auxCurrTimestamp = 0;
+VTHREAD_LOCAL size_t Clause::_auxCurrTimestamp = 0;
 #if VDEBUG
-bool Clause::_auxInUse = false;
+VTHREAD_LOCAL bool Clause::_auxInUse = false;
 #endif
 
 
@@ -198,7 +198,7 @@ void Clause::destroy()
 {
   CALL("Clause::destroy");
 
-  static Stack<Clause*> toDestroy(32);
+  VTHREAD_LOCAL static Stack<Clause*> toDestroy(32);
   Clause* cl = this;
   for(;;) {
     Inference::Iterator it = cl->_inference.iterator();
@@ -232,7 +232,7 @@ void Clause::setStore(Store s)
 
 #if VDEBUG
   //assure there is one selected clause
-  static Clause* selected=0;
+  VTHREAD_LOCAL static Clause* selected=0;
   if (_store==SELECTED) {
     ASS_EQ(selected, this);
     selected=0;
@@ -629,8 +629,8 @@ unsigned Clause::computeWeightForClauseSelection(unsigned w, unsigned splitWeigh
 {
   CALL("Clause::computeWeightForClauseSelection(unsigned w, ...)");
 
-  static unsigned nongoalWeightCoeffNum = opt.nongoalWeightCoefficientNumerator();
-  static unsigned nongoalWeightCoefDenom = opt.nongoalWeightCoefficientDenominator();
+  VTHREAD_LOCAL static unsigned nongoalWeightCoeffNum = opt.nongoalWeightCoefficientNumerator();
+  VTHREAD_LOCAL static unsigned nongoalWeightCoefDenom = opt.nongoalWeightCoefficientDenominator();
 
   w += splitWeight;
 
@@ -674,7 +674,7 @@ unsigned Clause::varCnt()
 {
   CALL("Clause::varCnt");
 
-  static DHSet<unsigned> vars;
+  VTHREAD_LOCAL static DHSet<unsigned> vars;
   vars.reset();
   collectVars(vars);
   return vars.size();

--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -153,17 +153,17 @@ Clause* Clause::fromStack(const Stack<Literal*>& lits, const Inference& inf)
 
 /**
  * Create a clause with the same content as @c c. The inference of the
- * created clause refers to @c c using the REORDER_LITERALS inference.
+ * created clause refers to @c c using the @c rule inference.
  *
  * The age of @c c is used, however the selected literals are not kept.
  *
  * BDDs and splitting history from @c c is also copied into the new clause.
  */
-Clause* Clause::fromClause(Clause* c)
+Clause* Clause::fromClause(Clause* c, InferenceRule rule)
 {
   CALL("Clause::fromClause");
 
-  Clause* res = fromIterator(Clause::Iterator(*c), SimplifyingInference1(InferenceRule::REORDER_LITERALS, c));
+  Clause* res = fromIterator(Clause::Iterator(*c), NonspecificInference1(rule, c));
 
   if (c->splits()) {
     res->setSplits(c->splits());

--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -395,7 +395,7 @@ vstring Clause::toString() const
   // print inference and ids of parent clauses
   result += " " + inferenceAsString();
 
-  if(env.options->proofExtra()!=Options::ProofExtra::OFF){
+  if(env->options->proofExtra()!=Options::ProofExtra::OFF){
     // print statistics: each entry should have the form key:value
     result += vstring(" {");
       
@@ -403,7 +403,7 @@ vstring Clause::toString() const
     unsigned weight = (_weight ? _weight : computeWeight());
     result += vstring(",w:") + Int::toString(weight);
     
-    unsigned weightForClauseSelection = (_weightForClauseSelection ? _weightForClauseSelection : computeWeightForClauseSelection(*env.options));
+    unsigned weightForClauseSelection = (_weightForClauseSelection ? _weightForClauseSelection : computeWeightForClauseSelection(*env->options));
     if(weightForClauseSelection!=weight){
       result += vstring(",wCS:") + Int::toString(weightForClauseSelection);
     }
@@ -412,14 +412,14 @@ vstring Clause::toString() const
       result += vstring(",nSel:") + Int::toString(numSelected());
     }
 
-    if (env.colorUsed) {
+    if (env->colorUsed) {
       result += vstring(",col:") + Int::toString(color());
     }
 
     if(derivedFromGoal()){
       result += vstring(",goal:1");
     }
-    if(env.maxSineLevel > 1) { // this is a cryptic way of saying "did we run Sine to compute sine levels?"
+    if(env->maxSineLevel > 1) { // this is a cryptic way of saying "did we run Sine to compute sine levels?"
       result += vstring(",sine:")+Int::toString((unsigned)_inference.getSineLevel());
     }
 
@@ -427,13 +427,13 @@ vstring Clause::toString() const
       result += vstring(",ptD:1");
     }
 
-    if(env.options->induction() != Shell::Options::Induction::NONE){
+    if(env->options->induction() != Shell::Options::Induction::NONE){
       result += vstring(",inD:") + Int::toString(_inference.inductionDepth());
     }
     result += ",thAx:" + Int::toString((int)(_inference.th_ancestors));
     result += ",allAx:" + Int::toString((int)(_inference.all_ancestors));
 
-    result += ",thDist:" + Int::toString( _inference.th_ancestors * env.options->theorySplitQueueExpectedRatioDenom() - _inference.all_ancestors);
+    result += ",thDist:" + Int::toString( _inference.th_ancestors * env->options->theorySplitQueueExpectedRatioDenom() - _inference.all_ancestors);
     result += vstring("}");
   }
 
@@ -478,7 +478,7 @@ void Clause::computeColor() const
 
   Color color = COLOR_TRANSPARENT;
 
-  if (env.colorUsed) {
+  if (env->colorUsed) {
     unsigned clen=length();
     for(unsigned i=0;i<clen;i++) {
       color = static_cast<Color>(color | (*this)[i]->color());
@@ -612,7 +612,7 @@ unsigned Clause::computeWeightForClauseSelection(const Options& opt) const
       TermFunIterator it(_literals[i]);
       it.next(); // skip literal symbol
       while(it.hasNext()){
-        found |= env.signature->getFunction(it.next())->inGoal();
+        found |= env->signature->getFunction(it.next())->inGoal();
       }
     }
     if(!found){ derivedFromGoal=false; }

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -42,7 +42,7 @@ using namespace Lib;
  * When creating a clause object, several things usually need to be done
  * besides calling a constructor:
  * - Fill the Clause with Literals
- * - Increase a relevant counter in the env.statistics object
+ * - Increase a relevant counter in the env->statistics object
  */
 class Clause
   : public Unit

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -88,7 +88,7 @@ public:
   {
     CALL("Clause::fromIterator");
 
-    static Stack<Literal*> st;
+    VTHREAD_LOCAL static Stack<Literal*> st;
     st.reset();
     st.loadFromIterator(litit);
     return fromStack(st, inf);
@@ -376,7 +376,7 @@ protected:
   unsigned _weightForClauseSelection;
 
   /** number of references to this clause */
-  unsigned _refCnt;
+  VATOMIC(unsigned) _refCnt;
   /** for splitting: timestamp marking when has the clause been reduced or restored by splitting */
   unsigned _reductionTimestamp;
   /** a map that translates Literal* to its index in the clause */
@@ -387,9 +387,9 @@ protected:
   size_t _auxTimestamp;
   void* _auxData;
 
-  static size_t _auxCurrTimestamp;
+  VTHREAD_LOCAL static size_t _auxCurrTimestamp;
 #if VDEBUG
-  static bool _auxInUse;
+  VTHREAD_LOCAL static bool _auxInUse;
 #endif
 
 //#endif

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -94,7 +94,7 @@ public:
     return fromStack(st, inf);
   }
 
-  static Clause* fromClause(Clause* c);
+  static Clause* fromClause(Clause* c, InferenceRule rule = InferenceRule::REORDER_LITERALS);
 
   /**
    * Return the (reference to) the nth literal

--- a/Kernel/ColorHelper.cpp
+++ b/Kernel/ColorHelper.cpp
@@ -104,7 +104,7 @@ Clause* ColorHelper::skolemizeColoredConstants(Clause* c)
   }
 
   unsigned clen = c->length();
-  static LiteralStack resStack;
+  VTHREAD_LOCAL static LiteralStack resStack;
   resStack.reset();
   resStack.loadFromIterator(Clause::Iterator(*c));
 
@@ -139,7 +139,7 @@ void ColorHelper::ensureSkolemReplacement(Term* t, TermMap& map)
   unsigned varCnt = norm->getDistinctVars();
   unsigned newFn = env.signature->addSkolemFunction(varCnt, "CU");
 
-  static Stack<TermList> argStack;
+  VTHREAD_LOCAL static Stack<TermList> argStack;
   argStack.reset();
   //variables in normalized term are X0,..X<varCnt-1>, so we put the
   //same into the Skolem term
@@ -193,7 +193,7 @@ Clause* ColorHelper::skolemizeColoredTerms(Clause* c)
 {
   CALL("ColorHelper::skolemizeColoredTerms");
 
-  static TermMap replMap;
+  VTHREAD_LOCAL static TermMap replMap;
   replMap.reset();
 
   collectSkolemReplacements(c, replMap);
@@ -201,7 +201,7 @@ Clause* ColorHelper::skolemizeColoredTerms(Clause* c)
     return 0;
   }
 
-  static LiteralStack resStack;
+  VTHREAD_LOCAL static LiteralStack resStack;
   resStack.reset();
 
   unsigned clen = c->length();

--- a/Kernel/ColorHelper.cpp
+++ b/Kernel/ColorHelper.cpp
@@ -43,10 +43,10 @@ bool ColorHelper::isTransparent(bool predicate, unsigned functor)
 
   Signature::Symbol* sym;
   if (predicate) {
-    sym = env.signature->getPredicate(functor);
+    sym = env->signature->getPredicate(functor);
   }
   else {
-    sym = env.signature->getFunction(functor);
+    sym = env->signature->getFunction(functor);
   }
   return sym->color()==COLOR_TRANSPARENT;
 }
@@ -113,7 +113,7 @@ Clause* ColorHelper::skolemizeColoredConstants(Clause* c)
   while (coloredConstants.isNonEmpty()) {
     TermList replaced = TermList(coloredConstants.pop());
 
-    unsigned newFn = env.signature->addSkolemFunction(0);
+    unsigned newFn = env->signature->addSkolemFunction(0);
     TermList newTrm = TermList(Term::create(newFn, 0, 0));
 
     for (unsigned i=0; i<clen; i++) {
@@ -137,7 +137,7 @@ void ColorHelper::ensureSkolemReplacement(Term* t, TermMap& map)
     return;
   }
   unsigned varCnt = norm->getDistinctVars();
-  unsigned newFn = env.signature->addSkolemFunction(varCnt, "CU");
+  unsigned newFn = env->signature->addSkolemFunction(varCnt, "CU");
 
   VTHREAD_LOCAL static Stack<TermList> argStack;
   argStack.reset();
@@ -235,10 +235,10 @@ void ColorHelper::tryUnblock(Clause* c, SaturationAlgorithm* salg)
 //    Clause* unblocked = skolemizeColoredConstants(c);
     Clause* unblocked = skolemizeColoredTerms(c);
     if (unblocked) {
-      if (env.options->showBlocked()) {
-	env.beginOutput();
-	env.out()<<"Unblocking clause "<<unblocked->toString()<<endl;
-	env.endOutput();
+      if (env->options->showBlocked()) {
+	env->beginOutput();
+	env->out()<<"Unblocking clause "<<unblocked->toString()<<endl;
+	env->endOutput();
       }
       salg->addNewClause(unblocked);
     }

--- a/Kernel/ColorHelper.hpp
+++ b/Kernel/ColorHelper.hpp
@@ -36,7 +36,7 @@ public:
   static Color combine(Color c1, Color c2)
   {
     CALL("ColorHelper::combine");
-    ASS(env.colorUsed || (c1|c2)!=COLOR_INVALID);
+    ASS(env->colorUsed || (c1|c2)!=COLOR_INVALID);
     return static_cast<Color>(c1|c2);
   }
 

--- a/Kernel/Constraint.cpp
+++ b/Kernel/Constraint.cpp
@@ -140,7 +140,7 @@ void Constraint::reduce(bool allowDecimals)
 {
   CALL("Constraint::reduce");
 
-  static Stack<CoeffNumber*> nums;
+  VTHREAD_LOCAL static Stack<CoeffNumber*> nums;
   nums.reset();
 
   nums.push(&_freeCoeff);
@@ -198,8 +198,8 @@ Constraint* Constraint::resolve(Var resolvedVar, Constraint& c1, Constraint& c2,
   rc1 = CoeffNumber::zero();
   rc2 = CoeffNumber::zero();
 #endif
-  static CoeffStack otherC1;
-  static CoeffStack otherC2;
+  VTHREAD_LOCAL static CoeffStack otherC1;
+  VTHREAD_LOCAL static CoeffStack otherC2;
   otherC1.reset();
   otherC2.reset();
 
@@ -237,7 +237,7 @@ Constraint* Constraint::resolve(Var resolvedVar, Constraint& c1, Constraint& c2,
   CoeffNumber c1Mul = rc2.abs();
   CoeffNumber c2Mul = rc1.abs();
 
-  static CoeffStack acc;
+  VTHREAD_LOCAL static CoeffStack acc;
   acc.reset();
 
   CoeffNumber val;

--- a/Kernel/Constraint.hpp
+++ b/Kernel/Constraint.hpp
@@ -168,7 +168,7 @@ public:
   {
     CALL("Constraint::fromBagIterator");
 
-    static CoeffArray bag;
+    VTHREAD_LOCAL static CoeffArray bag;
     bag.initFromIterator(coeffIterator);
     bag.sort(CoeffComparator());
 

--- a/Kernel/Curryfier.hpp
+++ b/Kernel/Curryfier.hpp
@@ -83,14 +83,14 @@ private:
     t->makeSymbol(_applyFn,2);
     *(t->nthArgument(0))=fn;
     *(t->nthArgument(1))=arg;
-    return TermList(env.sharing->insert(t));
+    return TermList(env->sharing->insert(t));
   }
   TermList getCurryFn(unsigned function)
   {
     if(!_constantTerms.find(function)) {
       Term* t = new(0) Term;
       t->makeSymbol(_curryConstants[function],0);
-      _constantTerms.insert(function,TermList(env.sharing->insert(t)));
+      _constantTerms.insert(function,TermList(env->sharing->insert(t)));
     }
     return _constantTerms.get(function);
   }
@@ -98,7 +98,7 @@ private:
   Curryfier()
   : _curryConstants(32)
   {
-    Signature* sig=env.signature;
+    Signature* sig=env->signature;
     int funCnt=sig->functions();
     _curryConstants.ensure(funCnt);
     _constantTerms.ensure(funCnt);

--- a/Kernel/Curryfier.hpp
+++ b/Kernel/Curryfier.hpp
@@ -70,7 +70,7 @@ public:
 
   static Curryfier* instance()
   {
-    static Curryfier* res=0;
+    VTHREAD_LOCAL static Curryfier* res=0;
     if(!res) {
       res=new Curryfier();
     }

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -83,10 +83,10 @@ Term* EqHelper::replace(Term* trm0, TermList tSrc, TermList tDest)
   CALL("EqHelper::replace(Term*,...)");
   ASS(trm0->shared());
 
-  static Stack<TermList*> toDo(8);
-  static Stack<Term*> terms(8);
-  static Stack<bool> modified(8);
-  static Stack<TermList> args(8);
+  VTHREAD_LOCAL static Stack<TermList*> toDo(8);
+  VTHREAD_LOCAL static Stack<Term*> terms(8);
+  VTHREAD_LOCAL static Stack<bool> modified(8);
+  VTHREAD_LOCAL static Stack<TermList> args(8);
   ASS(toDo.isEmpty());
   ASS(terms.isEmpty());
   modified.reset();

--- a/Kernel/FlatTerm.cpp
+++ b/Kernel/FlatTerm.cpp
@@ -158,7 +158,7 @@ void FlatTerm::swapCommutativePredicateArguments()
   }
   ASS_EQ(secStart+secLen,_length);
 
-  static DArray<Entry> buf;
+  VTHREAD_LOCAL static DArray<Entry> buf;
   if(firstLen>secLen) {
     buf.ensure(firstLen);
     memcpy(buf.array(), &_data[firstStart], firstLen*sizeof(Entry));

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -309,7 +309,7 @@ vstring Formula::toString(const Formula* formula)
 
     case BOOL_TERM: {
       vstring term = f->getBooleanTerm().toString();
-      res += env.options->showFOOL() ? "$formula{" + term + "}" : term;
+      res += env->options->showFOOL() ? "$formula{" + term + "}" : term;
 
       continue;
     }

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -719,7 +719,7 @@ Formula* Formula::trueFormula()
 {
   CALL("Formula::trueFormula");
 
-  static Formula* res = new Formula(true);
+  VTHREAD_LOCAL static Formula* res = new Formula(true);
   return res;
 }
 
@@ -727,7 +727,7 @@ Formula* Formula::falseFormula()
 {
   CALL("Formula::falseFormula");
 
-  static Formula* res = new Formula(false);
+  VTHREAD_LOCAL static Formula* res = new Formula(false);
   return res;
 }
 

--- a/Kernel/Formula.hpp
+++ b/Kernel/Formula.hpp
@@ -348,10 +348,10 @@ class BoolTermFormula
       }
     } else {
       unsigned functor = term->functor();
-      if (env.signature->isFoolConstantSymbol(true, functor)) {
+      if (env->signature->isFoolConstantSymbol(true, functor)) {
         return new Formula(true);
       } else {
-        ASS(env.signature->isFoolConstantSymbol(false, functor));
+        ASS(env->signature->isFoolConstantSymbol(false, functor));
         return new Formula(false);
       }
     }

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -460,7 +460,7 @@ bool ScanAndApplyLiteralTransformer::apply(FormulaUnit* unit, Unit*& res)
 
   Formula* f = unit->formula();
 
-  static UnitStack prems;
+  VTHREAD_LOCAL static UnitStack prems;
   prems.reset();
 
   LitFormulaTransformer ft(*this, prems);
@@ -485,10 +485,10 @@ bool ScanAndApplyLiteralTransformer::apply(Clause* cl, Unit*& res)
 {
   CALL("ScanAndApplyLiteralTransformer::apply(Clause*,Unit*&)");
 
-  static LiteralStack lits;
+  VTHREAD_LOCAL static LiteralStack lits;
   lits.reset();
 
-  static UnitStack prems;
+  VTHREAD_LOCAL static UnitStack prems;
   prems.reset();
 
   bool modified = false;

--- a/Kernel/Grounder.cpp
+++ b/Kernel/Grounder.cpp
@@ -236,9 +236,9 @@ IGGrounder::IGGrounder(SATSolver* satSolver) : Grounder(satSolver)
 {
   _tgtTerm = TermList(0, false);
   //TODO: make instantiation happen with the most prolific symbol of each sort
-/*  unsigned funs = env.signature->functions();
+/*  unsigned funs = env->signature->functions();
   for(unsigned i=0; i<funs; i++) {
-    if(env.signature->functionArity(i)==0) {
+    if(env->signature->functionArity(i)==0) {
       _tgtTerm = TermList(Term::createConstant(i));
       break;
     }

--- a/Kernel/Grounder.cpp
+++ b/Kernel/Grounder.cpp
@@ -73,7 +73,7 @@ void Grounder::groundNonProp(Clause* cl, SATLiteralStack& acc, Literal** normLit
 {
   CALL("Grounder::groundNonProp/2");
 
-  static DArray<Literal*> lits;
+  VTHREAD_LOCAL static DArray<Literal*> lits;
 
   unsigned clen = cl->length();
 
@@ -109,7 +109,7 @@ SATClause* Grounder::groundNonProp(Clause* cl, Literal** normLits)
 {
   CALL("Grounder::groundNonProp(Clause*,Literal**)");
 
-  static SATLiteralStack gndLits;
+  VTHREAD_LOCAL static SATLiteralStack gndLits;
   gndLits.reset();
 
   groundNonProp(cl, gndLits, normLits);
@@ -181,7 +181,7 @@ struct GlobalSubsumptionGrounder::OrderNormalizingComparator
       return la->header()<lb->header();
     }
     //now get just some total deterministic order
-    static DisagreementSetIterator dsit;
+    VTHREAD_LOCAL static DisagreementSetIterator dsit;
     dsit.reset(la, lb, false);
     ALWAYS(dsit.hasNext());
     pair<TermList,TermList> da = dsit.next();
@@ -211,13 +211,13 @@ void GlobalSubsumptionGrounder::normalize(unsigned cnt, Literal** lits)
     lits[0] = Renaming::normalize(lits[0]);
   }
 
-  static Stack<unsigned> litOrder;
+  VTHREAD_LOCAL static Stack<unsigned> litOrder;
   litOrder.reset();
   litOrder.loadFromIterator(getRangeIterator(0u,cnt));
 
   std::sort(litOrder.begin(), litOrder.end(), OrderNormalizingComparator(lits));
 
-  static Renaming normalizer;
+  VTHREAD_LOCAL static Renaming normalizer;
   normalizer.reset();
 
   for(unsigned i=0; i<cnt; i++) {

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -640,6 +640,8 @@ vstring Kernel::ruleName(InferenceRule rule)
   switch (rule) {
   case InferenceRule::INPUT:
     return "input";
+  case InferenceRule::COPY_FOR_THREAD:
+    return "copy into thread";
   case InferenceRule::NEGATED_CONJECTURE:
     return "negated conjecture";
   case InferenceRule::ANSWER_LITERAL:

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -276,20 +276,20 @@ vstring Inference::toString() const
 
   result += ", incl: " + Int::toString(_included);
   result += ", ptd: " + Int::toString(_isPureTheoryDescendant);
-  if(env.options->addCombAxioms()){
+  if(env->options->addCombAxioms()){
     result += ", cad: " + Int::toString(_combAxiomsDescendant);
   }
-  if(env.options->addProxyAxioms()){
+  if(env->options->addProxyAxioms()){
    result += ", pad: " + Int::toString(_proxyAxiomsDescendant);
   }
-  if(env.options->addCombAxioms() && env.options->addProxyAxioms()){
+  if(env->options->addCombAxioms() && env->options->addProxyAxioms()){
     result += ", had: " + Int::toString(_holAxiomsDescendant);
   }
   result += ", id: " + Int::toString(_inductionDepth);
-  if(env.options->maxXXNarrows() > 0){
+  if(env->options->maxXXNarrows() > 0){
     result += ", xxNarrs " + Int::toString(_XXNarrows);
   }
-  if(env.options->prioritiseClausesProducedByLongReduction()){
+  if(env->options->prioritiseClausesProducedByLongReduction()){
     result += ", redLen " + Int::toString(_reductions);
   }
   result += ", sl: " + Int::toString(_sineLevel);

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -111,6 +111,8 @@ enum class InferenceRule : unsigned char {
    * (preprocessing/normalisation) FORMULA TRANSFORMATION SHOULD BELONG
    * (see also INTERNAL_FORMULA_TRANSFORMATION_LAST and isFormulaTransformation below). */
   GENERIC_FORMULA_TRANSFORMATION,
+  /** copying for threaded mode */
+  COPY_FOR_THREAD,
   /** negated conjecture from the input */
   NEGATED_CONJECTURE,
   /** introduction of answer literal into the conjecture,

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -1084,7 +1084,7 @@ void InferenceStore::outputProof(ostream& out, UnitList* units)
 
 InferenceStore* InferenceStore::instance()
 {
-  static ScopedPtr<InferenceStore> inst(new InferenceStore());
+  VTHREAD_LOCAL static ScopedPtr<InferenceStore> inst(new InferenceStore());
   
   return inst.ptr();
 }

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -206,7 +206,7 @@ template<typename VarContainer>
 vstring getQuantifiedStr(const VarContainer& vars, vstring inner, bool innerParentheses=true)
 {
   CALL("getQuantifiedStr(VarContainer, vstring)");
-  static DHMap<unsigned,TermList> d;
+  VTHREAD_LOCAL static DHMap<unsigned,TermList> d;
   return getQuantifiedStr(vars,inner,d,innerParentheses);
 }
 
@@ -508,8 +508,8 @@ protected:
 
   void printStep(Unit* us)
   {
-    static unsigned lastP = Unit::getLastParsingNumber();
-    static float chunk = lastP / 10.0;
+    VTHREAD_LOCAL static unsigned lastP = Unit::getLastParsingNumber();
+    float chunk = lastP / 10.0;
     if(us->number() <= lastP){
       if(us->number() == lastP){ 
         last_one = true;

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -269,9 +269,9 @@ struct InferenceStore::ProofPrinter
   {
     CALL("InferenceStore::ProofPrinter::ProofPrinter");
 
-    outputAxiomNames=env.options->outputAxiomNames();
+    outputAxiomNames=env->options->outputAxiomNames();
     delayPrinting=true;
-    proofExtra=env.options->proofExtra()!=Options::ProofExtra::OFF;
+    proofExtra=env->options->proofExtra()!=Options::ProofExtra::OFF;
   }
 
   void scheduleForPrinting(Unit* us)
@@ -327,7 +327,7 @@ protected:
       case InferenceRule::INT_INF_DOWN_GEN_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_DOWN_GEN_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->generalizedInductionInProof++;
+        env->statistics->generalizedInductionInProof++;
       case InferenceRule::INDUCTION_AXIOM:
       case InferenceRule::INT_INF_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_UP_INDUCTION_AXIOM:
@@ -335,7 +335,7 @@ protected:
       case InferenceRule::INT_INF_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_DOWN_INDUCTION_AXIOM:
-        env.statistics->inductionInProof++;
+        env->statistics->inductionInProof++;
         break;
       default:
         ;
@@ -343,25 +343,25 @@ protected:
     switch (rule) {
       case InferenceRule::INDUCTION_AXIOM:
       case InferenceRule::GEN_INDUCTION_AXIOM:
-        env.statistics->structInductionInProof++;
+        env->statistics->structInductionInProof++;
         break;
       case InferenceRule::INT_INF_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_INF_UP_GEN_INDUCTION_AXIOM:
       case InferenceRule::INT_INF_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_INF_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->intInfInductionInProof++;
+        env->statistics->intInfInductionInProof++;
         break;
       case InferenceRule::INT_FIN_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_UP_GEN_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->intFinInductionInProof++;
+        env->statistics->intFinInductionInProof++;
         break;
       case InferenceRule::INT_DB_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_UP_GEN_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->intDBInductionInProof++;
+        env->statistics->intDBInductionInProof++;
         break;
       default:
         ;
@@ -369,27 +369,27 @@ protected:
     switch (rule) {
       case InferenceRule::INT_INF_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_INF_UP_GEN_INDUCTION_AXIOM:
-        env.statistics->intInfUpInductionInProof++;
+        env->statistics->intInfUpInductionInProof++;
         break;
       case InferenceRule::INT_INF_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_INF_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->intInfDownInductionInProof++;
+        env->statistics->intInfDownInductionInProof++;
         break;
       case InferenceRule::INT_FIN_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_UP_GEN_INDUCTION_AXIOM:
-        env.statistics->intFinUpInductionInProof++;
+        env->statistics->intFinUpInductionInProof++;
         break;
       case InferenceRule::INT_FIN_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_FIN_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->intFinDownInductionInProof++;
+        env->statistics->intFinDownInductionInProof++;
         break;
       case InferenceRule::INT_DB_UP_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_UP_GEN_INDUCTION_AXIOM:
-        env.statistics->intDBUpInductionInProof++;
+        env->statistics->intDBUpInductionInProof++;
         break;
       case InferenceRule::INT_DB_DOWN_INDUCTION_AXIOM:
       case InferenceRule::INT_DB_DOWN_GEN_INDUCTION_AXIOM:
-        env.statistics->intDBDownInductionInProof++;
+        env->statistics->intDBDownInductionInProof++;
         break;
       default:
         ;
@@ -402,7 +402,7 @@ protected:
     else {
       out << _is->getUnitIdStr(cs) << ". ";
       FormulaUnit* fu=static_cast<FormulaUnit*>(cs);
-      if (env.colorUsed && fu->inheritedColor() != COLOR_INVALID) {
+      if (env->colorUsed && fu->inheritedColor() != COLOR_INVALID) {
         out << " IC" << fu->inheritedColor() << " ";
       }
       out << fu->formula()->toString() << ' ';
@@ -427,7 +427,7 @@ protected:
 
       // print Extra
       vstring extra;
-      if (env.proofExtra && env.proofExtra->find(cs,extra) && extra != "") {
+      if (env->proofExtra && env->proofExtra->find(cs,extra) && extra != "") {
         out << ", " << extra;
       }
       out << "]" << endl;
@@ -668,8 +668,8 @@ protected:
     CALL("InferenceStore::TPTPProofPrinter::getFofString");
 
     vstring kind = "fof";
-    if(env.statistics->hasTypes){ kind="tff"; }
-    if(env.statistics->higherOrder){ kind="thf"; }
+    if(env->statistics->hasTypes){ kind="tff"; }
+    if(env->statistics->higherOrder){ kind="thf"; }
 
     return kind+"("+id+","+getRole(rule,origin)+",("+"\n"
 	+"  "+formula+"),\n"
@@ -717,10 +717,10 @@ protected:
     while(symIt.hasNext()) {
       SymbolId sym = symIt.next();
       if (sym.first) {
-	symsStr << env.signature->functionName(sym.second);
+	symsStr << env->signature->functionName(sym.second);
       }
       else {
-	symsStr << env.signature->predicateName(sym.second);
+	symsStr << env->signature->predicateName(sym.second);
       }
       if (symIt.hasNext()) {
 	symsStr << ',';
@@ -770,11 +770,11 @@ protected:
     vstring inferenceStr;
     if (rule==InferenceRule::INPUT) {
       vstring fileName;
-      if (env.options->inputFile()=="") {
+      if (env->options->inputFile()=="") {
 	fileName="unknown";
       }
       else {
-	fileName="'"+env.options->inputFile()+"'";
+	fileName="'"+env->options->inputFile()+"'";
       }
       vstring axiomName;
       if (!outputAxiomNames || !Parse::TPTP::findAxiomName(us, axiomName)) {
@@ -962,8 +962,8 @@ protected:
     UIHelper::outputSymbolDeclarations(out);
 
     vstring kind = "fof";
-    if(env.statistics->hasTypes){ kind="tff"; } 
-    if(env.statistics->higherOrder){ kind="thf"; }
+    if(env->statistics->hasTypes){ kind="tff"; } 
+    if(env->statistics->higherOrder){ kind="thf"; }
 
     out << kind
         << "(r"<<_is->getUnitIdStr(cs)
@@ -1027,7 +1027,7 @@ InferenceStore::ProofPrinter* InferenceStore::createProofPrinter(ostream& out)
 {
   CALL("InferenceStore::createProofPrinter");
 
-  switch(env.options->proof()) {
+  switch(env->options->proof()) {
   case Options::Proof::ON:
     return new ProofPrinter(out, this);
   case Options::Proof::PROOFCHECK:

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -213,7 +213,7 @@ class FracLess {
   inline static unsigned functor() { return number::lessF(); }
 
   static Literal* normalizedLit(bool polarity, TermList lhs, TermList rhs) {
-    static auto zero = TermList(number::zeroT());
+    VTHREAD_LOCAL static auto zero = TermList(number::zeroT());
     return number::less(
               polarity,
               zero,
@@ -234,8 +234,8 @@ class IntLess {
   inline static unsigned functor() { return number::lessF(); }
 
   static Literal* normalizedLit(bool polarity, TermList lhs, TermList rhs) {
-    static auto one  = TermList(number::oneT());
-    static auto zero = TermList(number::zeroT());
+    VTHREAD_LOCAL static auto one  = TermList(number::oneT());
+    VTHREAD_LOCAL static auto zero = TermList(number::zeroT());
     if (polarity) {
       return number::less(
               /* polarity */ true, 

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -136,7 +136,7 @@ CLASS_NAME(InterpretedLiteralEvaluator::ACFunEvaluator<AbelianGroup>);
 
   using ConstantType = typename AbelianGroup::ConstantType;
 
-  ACFunEvaluator() : _fun(env.signature->getInterpretingSymbol(AbelianGroup::interpreation)) { }
+  ACFunEvaluator() : _fun(env->signature->getInterpretingSymbol(AbelianGroup::interpreation)) { }
   const unsigned _fun; 
 
   virtual bool canEvaluateFunc(unsigned func) { return func == _fun; }
@@ -621,7 +621,7 @@ protected:
   bool trySimplifyUnaryMinus(const unsigned& uminus_functor, const TermList& inner, TermList& result)
   { 
     DEBUG("trySimplifyUnaryMinus(uminus(", inner, "))")
-    ASS_EQ(uminus_functor, env.signature->getInterpretingSymbol(number::minusI));
+    ASS_EQ(uminus_functor, env->signature->getInterpretingSymbol(number::minusI));
     if (inner.isTerm()) {
       /* complex term */
       auto& t = *inner.term();
@@ -1033,7 +1033,7 @@ InterpretedLiteralEvaluator::InterpretedLiteralEvaluator(bool doNormalize) : _no
   _evals.push(new ConversionEvaluator());
   _evals.push(new EqualityEvaluator());
 
-  if(env.options->useACeval()){
+  if(env->options->useACeval()){
 
   // Special AC evaluators are added to be tried first for Plus and Multiply
 
@@ -1143,7 +1143,7 @@ bool InterpretedLiteralEvaluator::balance(Literal* lit,Literal*& resLit,Stack<Li
   }
   // so we have t1 a constant and t2 something that has an interpreted function at the top
 
-  Signature::Symbol* conSym = env.signature->getFunction(t1.term()->functor());
+  Signature::Symbol* conSym = env->signature->getFunction(t1.term()->functor());
   TermList srt;
   if(conSym->integerConstant()) srt = Term::intSort();
   else if(conSym->rationalConstant()) srt = Term::rationalSort();
@@ -1264,8 +1264,8 @@ bool InterpretedLiteralEvaluator::balancePlus(Interpretation plus, Interpretatio
 {
   CALL("InterpretedLiteralEvaluator::balancePlus");
 
-    unsigned um = env.signature->getInterpretingSymbol(unaryMinus);
-    unsigned ip = env.signature->getInterpretingSymbol(plus);
+    unsigned um = env->signature->getInterpretingSymbol(unaryMinus);
+    unsigned ip = env->signature->getInterpretingSymbol(plus);
     TermList* B = 0;
     if(AplusB->nthArgument(0)==A){
       B = AplusB->nthArgument(1);
@@ -1291,7 +1291,7 @@ bool InterpretedLiteralEvaluator::balanceMultiply(Interpretation divide,Constant
     ASS(srt == Term::realSort() || srt == Term::rationalSort()); 
 #endif
 
-    unsigned div = env.signature->getInterpretingSymbol(divide);
+    unsigned div = env->signature->getInterpretingSymbol(divide);
     TermList* B = 0;
     if(AmultiplyB->nthArgument(0)==A){
       B = AmultiplyB->nthArgument(1);
@@ -1330,7 +1330,7 @@ bool InterpretedLiteralEvaluator::balanceIntegerMultiply(
     if(!theory->tryInterpretConstant(C,ccon)){ return false; }
 
     // we are going to use rounding division but ensure that it is non-rounding
-    unsigned div = env.signature->getInterpretingSymbol(Theory::INT_QUOTIENT_E);
+    unsigned div = env->signature->getInterpretingSymbol(Theory::INT_QUOTIENT_E);
     TermList* B = 0;
     if(AmultiplyB->nthArgument(0)==A){
       B = AmultiplyB->nthArgument(1);
@@ -1360,7 +1360,7 @@ bool InterpretedLiteralEvaluator::balanceDivide(Interpretation multiply,
     ASS(srt == Term::realSort() || srt == Term::rationalSort());
 #endif
 
-    unsigned mul = env.signature->getInterpretingSymbol(multiply);
+    unsigned mul = env->signature->getInterpretingSymbol(multiply);
     if(AoverB->nthArgument(0)!=A)return false;
 
     TermList* B = AoverB->nthArgument(1);
@@ -1418,7 +1418,7 @@ class LiteralNormalizer
   // static bool canNormalizePred(Theory::Interpretation pred);
   // static bool canNormalize(const Literal& l)
   // {
-  //   return canNormalize(env.signature->getPredicate(l.getPredicate))
+  //   return canNormalize(env->signature->getPredicate(l.getPredicate))
   // }
 
 public:
@@ -1505,7 +1505,7 @@ bool InterpretedLiteralEvaluator::evaluate(Literal* lit, bool& isConstant, Liter
   // ASS(tit.hasNext()); tit.next(); // pop off literal symbol
   // while(tit.hasNext()){
   //   unsigned f = tit.next();
-  //   if(!env.signature->getFunction(f)->interpreted()){
+  //   if(!env->signature->getFunction(f)->interpreted()){
   //     isConstant=false;
   //     return (lit!=resLit);
   //   } 

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -202,7 +202,7 @@ void KBO::State::traverse(TermList tl,int coef)
   }
 
   TermList* ts=t->args();
-  static Stack<TermList*> stack(4);
+  VTHREAD_LOCAL static Stack<TermList*> stack(4);
   for(;;) {
     if(!ts->next()->isEmpty()) {
       stack.push(ts->next());
@@ -236,7 +236,7 @@ void KBO::State::traverse(Term* t1, Term* t2)
   unsigned depth=1;
   unsigned lexValidDepth=0;
 
-  static Stack<TermList*> stack(32);
+  VTHREAD_LOCAL static Stack<TermList*> stack(32);
   stack.push(t1->args());
   stack.push(t2->args());
   TermList* ss; //t1 subterms

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -292,13 +292,13 @@ struct PredSigTraits {
   { return "predicate"; }
 
   static unsigned nSymbols() 
-  { return env.signature->predicates(); }
+  { return env->signature->predicates(); }
 
   static bool isColored(unsigned functor) 
-  { return env.signature->predicateColored(functor);}
+  { return env->signature->predicateColored(functor);}
 
   static bool tryGetFunctor(const vstring& sym, unsigned arity, unsigned& out) 
-  { return env.signature->tryGetPredicateNumber(sym,arity, out); }
+  { return env->signature->tryGetPredicateNumber(sym,arity, out); }
 
   static const vstring& weightFileName(const Options& opts) 
   { return opts.predicateWeights(); } 
@@ -310,7 +310,7 @@ struct PredSigTraits {
   { return false; } 
 
   static Signature::Symbol* getSymbol(unsigned functor) 
-  { return env.signature->getPredicate(functor); } 
+  { return env->signature->getPredicate(functor); } 
 };
 #endif
 
@@ -320,25 +320,25 @@ struct FuncSigTraits {
   { return "function"; }
 
   static unsigned nSymbols() 
-  { return env.signature->functions(); } 
+  { return env->signature->functions(); } 
 
   static bool isColored(unsigned functor) 
-  { return env.signature->functionColored(functor);}
+  { return env->signature->functionColored(functor);}
 
   static bool tryGetFunctor(const vstring& sym, unsigned arity, unsigned& out) 
-  { return env.signature->tryGetFunctionNumber(sym,arity, out); }
+  { return env->signature->tryGetFunctionNumber(sym,arity, out); }
 
   static const vstring& weightFileName(const Options& opts) 
   { return opts.functionWeights(); } 
 
   static bool isUnaryFunction (unsigned functor) 
-  { return env.signature->getFunction(functor)->arity() == 1; } 
+  { return env->signature->getFunction(functor)->arity() == 1; } 
 
   static bool isConstantSymbol(unsigned functor) 
-  { return env.signature->getFunction(functor)->arity() == 0; } 
+  { return env->signature->getFunction(functor)->arity() == 0; } 
 
   static Signature::Symbol* getSymbol(unsigned functor) 
-  { return env.signature->getFunction(functor); } 
+  { return env->signature->getFunction(functor); } 
 };
 
 
@@ -467,9 +467,9 @@ KboWeightMap<SigTraits> KBO::weightsFromFile(const Options& opts) const
 
 void throwError(UserErrorException e) { throw e; }
 void warnError(UserErrorException e) { 
-  env.beginOutput();
-  env.out() << "WARNING: Your KBO is probably not well-founded. Reason: " << e.msg() << std::endl;
-  env.endOutput();
+  env->beginOutput();
+  env->out() << "WARNING: Your KBO is probably not well-founded. Reason: " << e.msg() << std::endl;
+  env->endOutput();
 }
 
 
@@ -506,8 +506,8 @@ void KBO::checkAdmissibility(HandleError handle) const
   auto maximalFunctions = Map<SortType, FunctionSymbol>();
 
   for (FunctionSymbol i = 0; i < nFunctions; i++) {
-    if(env.signature->isTypeConOrSup(i)){ continue; }
-    auto sort = env.signature->getFunction(i)->fnType()->result();
+    if(env->signature->isTypeConOrSup(i)){ continue; }
+    auto sort = env->signature->getFunction(i)->fnType()->result();
     /* register min function */
     auto maxFn = maximalFunctions.getOrInit(std::move(sort), [&](FunctionSymbol* toInit){ *toInit = i; } );
     if (compareFunctionPrecedences(maxFn, i)) {
@@ -519,15 +519,15 @@ void KBO::checkAdmissibility(HandleError handle) const
   unsigned varWght = _funcWeights._specialWeights._variableWeight;
 
   for (unsigned i = 0; i < nFunctions; i++) {
-    if(env.signature->isTypeConOrSup(i)){ continue; }
-    auto sort = env.signature->getFunction(i)->fnType()->result();
-    auto arity = env.signature->getFunction(i)->arity();
+    if(env->signature->isTypeConOrSup(i)){ continue; }
+    auto sort = env->signature->getFunction(i)->fnType()->result();
+    auto arity = env->signature->getFunction(i)->arity();
 
     if (_funcWeights._weights[i] < varWght && arity == 0) {
-      handle(UserErrorException("weight of constants (i.e. ", env.signature->getFunction(i)->name(), ") must be greater or equal to the variable weight (", varWght, ")"));
+      handle(UserErrorException("weight of constants (i.e. ", env->signature->getFunction(i)->name(), ") must be greater or equal to the variable weight (", varWght, ")"));
 
     } else if (_funcWeights.symbolWeight(i) == 0 && arity == 1 && maximalFunctions.get(sort) != i) {
-      handle(UserErrorException( "a unary function of weight zero (i.e.: ", env.signature->getFunction(i)->name(), ") must be maximal wrt. the precedence ordering"));
+      handle(UserErrorException( "a unary function of weight zero (i.e.: ", env->signature->getFunction(i)->name(), ") must be maximal wrt. the precedence ordering"));
 
     }
   }
@@ -823,7 +823,7 @@ bool KboSpecialWeights<PredSigTraits>::tryGetWeight(unsigned functor, unsigned& 
 
 bool KboSpecialWeights<FuncSigTraits>::tryGetWeight(unsigned functor, unsigned& weight) const
 {
-  auto sym = env.signature->getFunction(functor);
+  auto sym = env->signature->getFunction(functor);
   if (sym->integerConstant())  { weight = _numInt;  return true; }
   if (sym->rationalConstant()) { weight = _numRat;  return true; }
   if (sym->realConstant())     { weight = _numReal; return true; }

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -281,8 +281,8 @@ struct NormalizedLinearComparatorByWeight : public LiteralComparator
       }
     }
 
-    static DHMap<unsigned, unsigned> firstNums;
-    static DHMap<unsigned, unsigned> secondNums;
+    VTHREAD_LOCAL static DHMap<unsigned, unsigned> firstNums;
+    VTHREAD_LOCAL static DHMap<unsigned, unsigned> secondNums;
     firstNums.reset();
     secondNums.reset();
 

--- a/Kernel/LiteralSelector.cpp
+++ b/Kernel/LiteralSelector.cpp
@@ -42,7 +42,7 @@ namespace Kernel
  * the polarity of the predicate should be reversed for the purposes of
  * literal selection
  */
-ZIArray<bool> LiteralSelector::_reversePredicate;
+VTHREAD_LOCAL ZIArray<bool> LiteralSelector::_reversePredicate;
 
 
 /**

--- a/Kernel/LiteralSelector.cpp
+++ b/Kernel/LiteralSelector.cpp
@@ -79,7 +79,7 @@ int LiteralSelector::getSelectionPriority(Literal* l) const
 {
   CALL("LiteralSelector::getSelectionPriority");
 
-  Signature::Symbol* psym=env.signature->getPredicate(l->functor());
+  Signature::Symbol* psym=env->signature->getPredicate(l->functor());
   if(psym->label() || psym->answerPredicate()) {
     return -2;
   }

--- a/Kernel/LiteralSelector.hpp
+++ b/Kernel/LiteralSelector.hpp
@@ -107,7 +107,7 @@ private:
    */
   bool _reversePolarity;
 
-  static ZIArray<bool> _reversePredicate;
+  VTHREAD_LOCAL static ZIArray<bool> _reversePredicate;
 };
 
 /**

--- a/Kernel/LookaheadLiteralSelector.cpp
+++ b/Kernel/LookaheadLiteralSelector.cpp
@@ -59,7 +59,7 @@ struct LookaheadLiteralSelector::GenIteratorIterator
 
     SaturationAlgorithm* salg=SaturationAlgorithm::tryGetInstance();
     if(!salg) {
-      static bool errAnnounced = false;
+      VTHREAD_LOCAL static bool errAnnounced = false;
       if(!errAnnounced) {
 	errAnnounced = true;
 	env.beginOutput();
@@ -187,14 +187,14 @@ Literal* LookaheadLiteralSelector::pickTheBest(Literal** lits, unsigned cnt)
   CALL("LookaheadLiteralSelector::pickTheBest");
   ASS_G(cnt,1); //special cases are handled elsewhere
 
-  static DArray<VirtualIterator<void> > runifs; //resolution unification iterators
+  VTHREAD_LOCAL static DArray<VirtualIterator<void> > runifs; //resolution unification iterators
   runifs.ensure(cnt);
 
   for(unsigned i=0;i<cnt;i++) {
     runifs[i]=getGeneraingInferenceIterator(lits[i]);
   }
 
-  static Stack<Literal*> candidates;
+  VTHREAD_LOCAL static Stack<Literal*> candidates;
   candidates.reset();
   do {
     for(unsigned i=0;i<cnt;i++) {
@@ -273,7 +273,7 @@ void LookaheadLiteralSelector::doSelection(Clause* c, unsigned eligible)
   LiteralList* maximals=0;
   Literal* singleSel=0;
 
-  static LiteralStack selectable;
+  VTHREAD_LOCAL static LiteralStack selectable;
   selectable.reset();
 
   if(_completeSelection) {

--- a/Kernel/LookaheadLiteralSelector.cpp
+++ b/Kernel/LookaheadLiteralSelector.cpp
@@ -62,9 +62,9 @@ struct LookaheadLiteralSelector::GenIteratorIterator
       VTHREAD_LOCAL static bool errAnnounced = false;
       if(!errAnnounced) {
 	errAnnounced = true;
-	env.beginOutput();
-	env.out()<<"Using LookaheadLiteralSelector without having an SaturationAlgorithm object\n";
-	env.endOutput();
+	env->beginOutput();
+	env->out()<<"Using LookaheadLiteralSelector without having an SaturationAlgorithm object\n";
+	env->endOutput();
       }
       //we are too early, there's no saturation algorithm and therefore no generating inferences
       prepared=false;

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -69,8 +69,8 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 {
   CALL("createLiteralBindings");
 
-  static UUMap variablePositions;
-  static BinaryHeap<unsigned,Int> varNums;
+  VTHREAD_LOCAL static UUMap variablePositions;
+  VTHREAD_LOCAL static BinaryHeap<unsigned,Int> varNums;
   variablePositions.reset();
   varNums.reset();
 
@@ -736,7 +736,7 @@ void MLMatcher::getBindings(vunordered_map<unsigned, TermList>& outBindings) con
 
 bool MLMatcher::canBeMatched(Literal** baseLits, unsigned baseLen, Clause* instance, LiteralList const* const* alts, Literal* resolvedLit, bool multiset)
 {
-  static MLMatcher::Impl matcher;
+  VTHREAD_LOCAL static MLMatcher::Impl matcher;
   matcher.init(baseLits, baseLen, instance, alts, resolvedLit, multiset);
   return matcher.nextMatch();
 }

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -640,7 +640,7 @@ bool MLMatcher::Impl::nextMatch()
     s_counter++;
     if(s_counter==50000) {
       s_counter=0;
-      if(env.timeLimitReached()) {
+      if(env->timeLimitReached()) {
         throw TimeLimitExceededException();
       }
     }

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -83,8 +83,8 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
 {
   CALL("createLiteralBindings");
 
-  static UUMap variablePositions;
-  static BinaryHeap<unsigned,Int> varNums;
+  VTHREAD_LOCAL static UUMap variablePositions;
+  VTHREAD_LOCAL static BinaryHeap<unsigned,Int> varNums;
   variablePositions.reset();
   varNums.reset();
 

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -1079,7 +1079,7 @@ bool MLMatcherSD::Impl::nextMatch()
     if(s_counter==50000) {
       // std::cerr << "counter reached 50k" << std::endl;
       s_counter=0;
-      if(env.timeLimitReached()) {
+      if(env->timeLimitReached()) {
         throw TimeLimitExceededException();
       }
     }

--- a/Kernel/MLVariant.cpp
+++ b/Kernel/MLVariant.cpp
@@ -463,7 +463,7 @@ bool MLVariant::isVariant(Literal* const * cl1Lits, Clause* cl2, LiteralList** a
     counter++;
     if(counter==50000) {
       counter=0;
-      if(env.timeLimitReached()) {
+      if(env->timeLimitReached()) {
         throw TimeLimitExceededException();
       }
     }

--- a/Kernel/MLVariant.cpp
+++ b/Kernel/MLVariant.cpp
@@ -80,8 +80,8 @@ bool createLiteralBindings(Literal* baseLit, LiteralList* alts, Clause* instCl,
 {
   CALL("createLiteralBindings");
 
-  static UUMap variablePositions;
-  static BinaryHeap<unsigned,Int> varNums;
+  VTHREAD_LOCAL static UUMap variablePositions;
+  VTHREAD_LOCAL static BinaryHeap<unsigned,Int> varNums;
   variablePositions.reset();
   varNums.reset();
 
@@ -203,7 +203,7 @@ struct MatchingData {
 
     //we'll create inverse binding to check that two variables
     //don't have the same binding
-    static UUMap inverse;
+    VTHREAD_LOCAL static UUMap inverse;
     inverse.reset();
 
     //check that no variable is bound to two different ones
@@ -313,22 +313,22 @@ MatchingData* getMatchingData(Literal* const * baseLits0, unsigned baseLen, Clau
 {
   CALL("getMatchingData");
 
-  static DArray<Literal*> baseLits(32);
-  static DArray<LiteralList*> altsArr(32);
+  VTHREAD_LOCAL static DArray<Literal*> baseLits(32);
+  VTHREAD_LOCAL static DArray<LiteralList*> altsArr(32);
   baseLits.initFromArray(baseLen,baseLits0);
   altsArr.initFromArray(baseLen,alts);
 
-  static DArray<unsigned> varCnts(32);
-  static DArray<unsigned*> boundVarNums(32);
-  static DArray<unsigned**> altPtrs(32);
-  static TriangularArray<unsigned> remaining(32);
-  static DArray<unsigned> nextAlts(32);
+  VTHREAD_LOCAL static DArray<unsigned> varCnts(32);
+  VTHREAD_LOCAL static DArray<unsigned*> boundVarNums(32);
+  VTHREAD_LOCAL static DArray<unsigned**> altPtrs(32);
+  VTHREAD_LOCAL static TriangularArray<unsigned> remaining(32);
+  VTHREAD_LOCAL static DArray<unsigned> nextAlts(32);
 
-  static DArray<unsigned> boundVarNumData(64);
+  VTHREAD_LOCAL static DArray<unsigned> boundVarNumData(64);
   //Referenced list of an alternative contains binding for each variable of
   //the base literal, and then a record identifying the alternative literal itself.
-  static DArray<unsigned*> altBindingPtrs(128);
-  static DArray<unsigned> altBindingsData(256);
+  VTHREAD_LOCAL static DArray<unsigned*> altBindingPtrs(128);
+  VTHREAD_LOCAL static DArray<unsigned> altBindingsData(256);
   varCnts.ensure(baseLen);
   boundVarNums.init(baseLen,0);
   altPtrs.ensure(baseLen);
@@ -374,7 +374,7 @@ MatchingData* getMatchingData(Literal* const * baseLits0, unsigned baseLen, Clau
   altBindingPtrs.ensure(altCnt);
   altBindingsData.ensure(altBindingsCnt);
 
-  static MatchingData res;
+  VTHREAD_LOCAL static MatchingData res;
   res.len=baseLen;
   res.varCnts=varCnts.array();
   res.boundVarNums=boundVarNums.array();
@@ -411,7 +411,7 @@ bool MLVariant::isVariant(Literal* const * cl1Lits, Clause* cl2, LiteralList** a
     return false;
   }
 
-  static DArray<unsigned> matchRecord(32);
+  VTHREAD_LOCAL static DArray<unsigned> matchRecord(32);
   unsigned matchRecordLen=clen;
   matchRecord.init(matchRecordLen,0xFFFFFFFF);
 
@@ -478,7 +478,7 @@ bool MLVariant::isVariant(Literal* const * cl1Lits, Clause* cl2, bool complement
 
   bool fail=false;
   unsigned clen=cl2->length();
-  static DArray<LiteralList*> alts(32);
+  VTHREAD_LOCAL static DArray<LiteralList*> alts(32);
   alts.init(clen, 0);
 
   for(unsigned i2=0;i2<clen;i2++) {

--- a/Kernel/MainLoop.cpp
+++ b/Kernel/MainLoop.cpp
@@ -43,11 +43,11 @@ void MainLoopResult::updateStatistics()
 {
   CALL("MainLoopResult::updateStatistics");
 
-  env.statistics->terminationReason = terminationReason;
-  env.statistics->refutation = refutation;
-  env.statistics->saturatedSet = saturatedSet;
+  env->statistics->terminationReason = terminationReason;
+  env->statistics->refutation = refutation;
+  env->statistics->saturatedSet = saturatedSet;
   if(refutation) {
-    env.statistics->maxInductionDepth = refutation->inference().inductionDepth();
+    env->statistics->maxInductionDepth = refutation->inference().inductionDepth();
   }
 }
 
@@ -110,13 +110,13 @@ MainLoop* MainLoop::createFromOptions(Problem& prb, const Options& opt)
 
   switch (opt.saturationAlgorithm()) {
   case Options::SaturationAlgorithm::INST_GEN:
-    if(env.statistics->polymorphic || env.statistics->higherOrder){
+    if(env->statistics->polymorphic || env->statistics->higherOrder){
       USER_ERROR("The inst gen calculus is currently not compatible with polymorphism or higher-order constructs");       
     }
     res = new IGAlgorithm(prb, opt);
     break;
   case Options::SaturationAlgorithm::FINITE_MODEL_BUILDING:
-    if(env.statistics->polymorphic || env.statistics->higherOrder){
+    if(env->statistics->polymorphic || env->statistics->higherOrder){
       USER_ERROR("Finite model buillding is currently not compatible with polymorphism or higher-order constructs");       
     }
     //TODO should return inappropriate result instead of error

--- a/Kernel/MatchTag.cpp
+++ b/Kernel/MatchTag.cpp
@@ -29,8 +29,8 @@ const unsigned MatchTag::CONTENT_BITS;
 void MatchTag::init(Term* t) {
   ASS(t->shared());
 
-  static Stack<TermList*> stack(32);
-  static Stack<Term*> terms(32);
+  VTHREAD_LOCAL static Stack<TermList*> stack(32);
+  VTHREAD_LOCAL static Stack<Term*> terms(32);
 
   terms.push(t);
   stack.push(t->args());

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -63,7 +63,7 @@ TermList MatchingUtils::getInstanceFromMatch(TermList matchedBase,
 
   using namespace __MU_Aux;
 
-  static MapBinderAndApplicator bap;
+  VTHREAD_LOCAL static MapBinderAndApplicator bap;
   bap.reset();
 
   ALWAYS( matchTerms(matchedBase, matchedInstance, bap) );
@@ -77,7 +77,7 @@ Formula* MatchingUtils::getInstanceFromMatch(Literal* matchedBase,
 
   using namespace __MU_Aux;
 
-  static MapBinderAndApplicator bap;
+  VTHREAD_LOCAL static MapBinderAndApplicator bap;
   bap.reset();
 
   ALWAYS( match(matchedBase, matchedInstance, false, bap) );
@@ -121,8 +121,8 @@ bool MatchingUtils::haveReversedVariantArgs(Term* l1, Term* l2)
   ASS_EQ(l1->arity(), 2);
   ASS_EQ(l2->arity(), 2);
 
-  static DHMap<unsigned,unsigned,IdentityHash> leftToRight;
-  static DHMap<unsigned,unsigned,IdentityHash> rightToLeft;
+  VTHREAD_LOCAL static DHMap<unsigned,unsigned,IdentityHash> leftToRight;
+  VTHREAD_LOCAL static DHMap<unsigned,unsigned,IdentityHash> rightToLeft;
   leftToRight.reset();
   rightToLeft.reset();
 
@@ -177,8 +177,8 @@ bool MatchingUtils::haveVariantArgs(Term* l1, Term* l2)
     return true;
   }
 
-  static DHMap<unsigned,unsigned,IdentityHash> leftToRight;
-  static DHMap<unsigned,unsigned,IdentityHash> rightToLeft;
+  VTHREAD_LOCAL static DHMap<unsigned,unsigned,IdentityHash> leftToRight;
+  VTHREAD_LOCAL static DHMap<unsigned,unsigned,IdentityHash> rightToLeft;
   leftToRight.reset();
   rightToLeft.reset();
 
@@ -210,7 +210,7 @@ bool MatchingUtils::matchReversedArgs(Literal* base, Literal* instance)
   ASS_EQ(base->arity(), 2);
   ASS_EQ(instance->arity(), 2);
 
-  static MapBinder binder;
+  VTHREAD_LOCAL static MapBinder binder;
   binder.reset();
 
   bool bTwoVarEq = base->isTwoVarEquality();
@@ -225,7 +225,7 @@ bool MatchingUtils::matchArgs(Term* base, Term* instance)
 {
   CALL("MatchingUtils::matchArgs");
 
-  static MapBinder binder;
+  VTHREAD_LOCAL static MapBinder binder;
   binder.reset();
 
   return matchArgs(base, instance, binder);
@@ -341,8 +341,8 @@ bool OCMatchIterator::occursCheck()
 {
   CALL("OCMatchIterator::occursCheck");
 
-  static DHMap<unsigned, OCStatus> statuses;
-  static Stack<int> toDo;
+  VTHREAD_LOCAL static DHMap<unsigned, OCStatus> statuses;
+  VTHREAD_LOCAL static Stack<int> toDo;
   statuses.reset();
   toDo.reset();
   BoundStack::Iterator bit(_bound);

--- a/Kernel/Matcher.hpp
+++ b/Kernel/Matcher.hpp
@@ -49,7 +49,7 @@ public:
   {
     CALL("MatchingUtils::match");
 
-    static MapBinder binder;
+    VTHREAD_LOCAL static MapBinder binder;
     return match(base, instance, complementary, binder);
   }
 
@@ -334,7 +334,7 @@ bool MatchingUtils::matchArgs(Term* base, Term* instance, Binder& binder)
   TermList* bt=base->args();
   TermList* it=instance->args();
 
-  static Stack<TermList*> subterms(32);
+  VTHREAD_LOCAL static Stack<TermList*> subterms(32);
   subterms.reset();
 
   for (;;) {

--- a/Kernel/MismatchHandler.cpp
+++ b/Kernel/MismatchHandler.cpp
@@ -52,7 +52,7 @@ bool UWAMismatchHandler::checkUWA(TermList t1, TermList t2)
 
     bool okay = true;
    
-    static Shell::Options::UnificationWithAbstraction opt = env.options->unificationWithAbstraction();
+    VTHREAD_LOCAL static Shell::Options::UnificationWithAbstraction opt = env.options->unificationWithAbstraction();
     if(opt == Shell::Options::UnificationWithAbstraction::OFF){ return false; }
 
       switch(opt){

--- a/Kernel/MismatchHandler.cpp
+++ b/Kernel/MismatchHandler.cpp
@@ -52,7 +52,7 @@ bool UWAMismatchHandler::checkUWA(TermList t1, TermList t2)
 
     bool okay = true;
    
-    VTHREAD_LOCAL static Shell::Options::UnificationWithAbstraction opt = env.options->unificationWithAbstraction();
+    VTHREAD_LOCAL static Shell::Options::UnificationWithAbstraction opt = env->options->unificationWithAbstraction();
     if(opt == Shell::Options::UnificationWithAbstraction::OFF){ return false; }
 
       switch(opt){
@@ -64,8 +64,8 @@ bool UWAMismatchHandler::checkUWA(TermList t1, TermList t2)
           break;
         case Shell::Options::UnificationWithAbstraction::CONSTANT:
           okay &= !bothNumbers && (t1Interp || t2Interp);
-          okay &= (t1Interp || env.signature->functionArity(t1.term()->functor()));
-          okay &= (t2Interp || env.signature->functionArity(t2.term()->functor()));
+          okay &= (t1Interp || env->signature->functionArity(t1.term()->functor()));
+          okay &= (t2Interp || env->signature->functionArity(t2.term()->functor()));
           break; 
         case Shell::Options::UnificationWithAbstraction::ALL:
         case Shell::Options::UnificationWithAbstraction::GROUND:

--- a/Kernel/NumTraits.hpp
+++ b/Kernel/NumTraits.hpp
@@ -81,7 +81,7 @@ struct NumTraits;
     static const Theory::Interpretation name ## I = Theory::SORT_SHORT ## _INTERPRETATION;                    \
                                                                                                               \
     static unsigned name ## F() {                                                                             \
-      static const unsigned functor = env.signature->getInterpretingSymbol(name ## I);                        \
+      VTHREAD_LOCAL static const unsigned functor = env.signature->getInterpretingSymbol(name ## I);          \
       return functor;                                                                                         \
     }                                                                                                         \
 
@@ -111,7 +111,7 @@ struct NumTraits;
 #define IMPL_NUM_TRAITS__SPECIAL_CONSTANT(name, value, isName)                                                \
     constexpr static ConstantType name ## C = ConstantType(value);                                            \
     static Term* name ## T() {  /* TODO refactor to const& Term */                                            \
-      static Term* trm = theory->representConstant(name ## C);                                                \
+      VTHREAD_LOCAL static Term* trm = theory->representConstant(name ## C);                                  \
       return trm;                                                                                             \
     }                                                                                                         \
     static TermList name() {                                                                                  \

--- a/Kernel/NumTraits.hpp
+++ b/Kernel/NumTraits.hpp
@@ -81,7 +81,7 @@ struct NumTraits;
     static const Theory::Interpretation name ## I = Theory::SORT_SHORT ## _INTERPRETATION;                    \
                                                                                                               \
     static unsigned name ## F() {                                                                             \
-      VTHREAD_LOCAL static const unsigned functor = env.signature->getInterpretingSymbol(name ## I);          \
+      VTHREAD_LOCAL static const unsigned functor = env->signature->getInterpretingSymbol(name ## I);          \
       return functor;                                                                                         \
     }                                                                                                         \
 

--- a/Kernel/Number.cpp
+++ b/Kernel/Number.cpp
@@ -161,7 +161,7 @@ void reduceIntNumbers(size_t cnt, NativeNumber** vals)
 int getDecimalPlaces(double dbVal)
 {
   dbVal = fmod(dbVal, 1); /* NO NEED TO CONSIDER NUMBERS TO THE LEFT OF THE DECIMAL */
-  static const int MAX_DP = 24;
+  const int MAX_DP = 24;
   double THRES = pow(0.1, MAX_DP);
   if (dbVal == 0.0)
     return 0;
@@ -362,7 +362,7 @@ void CoeffNumber::reduceNumbers(size_t cnt, CoeffNumber** vals, bool allowDecima
 ;
   }
   else {
-    static Stack<NativeNumber*> numPtrs;
+    VTHREAD_LOCAL static Stack<NativeNumber*> numPtrs;
     numPtrs.reset();
     for(size_t i=0; i<cnt; i++) {
       numPtrs.push(&(vals[i]->native()));
@@ -382,7 +382,7 @@ BoundNumber BoundNumber::getRandomValue(const BoundNumber& min, const BoundNumbe
 
   ASS_L(min,max);
   if(usePrecise()) {
-    static const unsigned randomDivisor = 64;
+    const unsigned randomDivisor = 64;
     Precise diff = max.precise()-min.precise();
     Precise part = (diff*(Random::getInteger(randomDivisor-2)+1))/randomDivisor;
     return BoundNumber(min.precise()+part);

--- a/Kernel/Number.hpp
+++ b/Kernel/Number.hpp
@@ -48,8 +48,8 @@ protected:
 
   static NativeNumber parseString(vstring str);
 
-  static bool _usePrecise;
-  static bool _useRational;
+  VTHREAD_LOCAL static bool _usePrecise;
+  VTHREAD_LOCAL static bool _useRational;
 };
 
 /**

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -243,6 +243,9 @@ Ordering::Result Ordering::getEqualityArgumentOrder(Literal* eq) const
     return compare(*eq->nthArgument(0), *eq->nthArgument(1));
   }
 
+#if VTHREADED
+  return compare(*eq->nthArgument(0), *eq->nthArgument(1));
+#else
   Result res;
   ArgumentOrderVals precomputed = static_cast<ArgumentOrderVals>(eq->getArgumentOrderValue());
   if(precomputed!=0) {
@@ -251,12 +254,10 @@ Ordering::Result Ordering::getEqualityArgumentOrder(Literal* eq) const
   }
   else {
     res = compare(*eq->nthArgument(0), *eq->nthArgument(1));
-#if VTHREADED
-    if(env.options->mode() != Options::Mode::THREADED)
-#endif
-      eq->setArgumentOrderValue(res);
+    eq->setArgumentOrderValue(res);
   }
   return res;
+#endif
 }
 
 //////////////////////////////////////////////////

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -47,7 +47,7 @@
 using namespace Lib;
 using namespace Kernel;
 
-OrderingSP Ordering::s_globalOrdering;
+VTHREAD_LOCAL OrderingSP Ordering::s_globalOrdering;
 
 Ordering::Ordering()
 {
@@ -251,7 +251,10 @@ Ordering::Result Ordering::getEqualityArgumentOrder(Literal* eq) const
   }
   else {
     res = compare(*eq->nthArgument(0), *eq->nthArgument(1));
-    eq->setArgumentOrderValue(res);
+#if VTHREADED
+    if(env.options->mode() != Options::Mode::THREADED)
+#endif
+      eq->setArgumentOrderValue(res);
   }
   return res;
 }

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -406,7 +406,7 @@ Ordering::Result PrecedenceOrdering::compareFunctionPrecedences(unsigned fun1, u
     if(s2->interpreted()) {
       return GREATER;
     }
-    static bool reverse = env.options->introducedSymbolPrecedence() == Shell::Options::IntroducedSymbolPrecedence::BOTTOM;
+    bool reverse = env.options->introducedSymbolPrecedence() == Shell::Options::IntroducedSymbolPrecedence::BOTTOM;
     //two non-interpreted functions
     return fromComparison(Int::compare(
         fun1 >= _functions ? (int)(reverse ? -fun1 : fun1) : _functionPrecedences[fun1],
@@ -472,7 +472,7 @@ struct FnBoostWrapper
 
   Comparison compare(unsigned f1, unsigned f2)
   {
-    static Options::SymbolPrecedenceBoost boost = env.options->symbolPrecedenceBoost();
+    Options::SymbolPrecedenceBoost boost = env.options->symbolPrecedenceBoost();
     Comparison res = EQUAL;
     bool u1 = env.signature->getFunction(f1)->inUnit(); 
     bool u2 = env.signature->getFunction(f2)->inUnit(); 
@@ -511,7 +511,7 @@ struct PredBoostWrapper
 
   Comparison compare(unsigned p1, unsigned p2)
   {
-    static Options::SymbolPrecedenceBoost boost = env.options->symbolPrecedenceBoost();
+    Options::SymbolPrecedenceBoost boost = env.options->symbolPrecedenceBoost();
     Comparison res = EQUAL;
     bool u1 = env.signature->getPredicate(p1)->inUnit();
     bool u2 = env.signature->getPredicate(p2)->inUnit();

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -22,6 +22,7 @@
 #include "Debug/Assertion.hpp"
 
 #include "Lib/Comparison.hpp"
+#include "Lib/Threading.hpp"
 #include "Lib/SmartPtr.hpp"
 #include "Lib/DArray.hpp"
 
@@ -148,7 +149,7 @@ private:
    * better performance, as the equality orientation will be cached
    * inside the sharing structure.
    */
-  static OrderingSP s_globalOrdering;
+  VTHREAD_LOCAL static OrderingSP s_globalOrdering;
 }; // class Ordering
 
 // orderings that rely on symbol precedence

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -19,10 +19,12 @@
 #include "Lib/TimeCounter.hpp"
 #include "Lib/VirtualIterator.hpp"
 
+#include "Shell/Options.hpp"
 #include "Shell/Property.hpp"
 #include "Shell/Statistics.hpp"
 
 #include "Clause.hpp"
+#include "FormulaUnit.hpp"
 #include "Term.hpp"
 
 #include "Problem.hpp"
@@ -118,8 +120,17 @@ void Problem::addUnits(UnitList* newUnits)
     if(u->isClause()) {
       static_cast<Clause*>(u)->incRefCnt();
     }
+#if VTHREADED 
+    if(env->options->mode() == Options::Mode::THREADED) {
+      if(u->isClause())
+        u = Clause::fromClause(static_cast<Clause *>(u), InferenceRule::COPY_FOR_THREAD);
+      else
+        u = new FormulaUnit(static_cast<FormulaUnit *>(u)->formula(), FormulaTransformation(InferenceRule::COPY_FOR_THREAD, u));
+    }
+#endif
+    UnitList::push(u, _units);
   }
-  _units = UnitList::concat(newUnits, _units);
+
   if(_propertyValid) {
     TimeCounter tc(TC_PROPERTY_EVALUATION);
     _property->add(newUnits);

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -276,7 +276,7 @@ void Problem::refreshProperty() const
   CALL("Problem::refreshProperty");
 
   TimeCounter tc(TC_PROPERTY_EVALUATION);
-  ScopedLet<Statistics::ExecutionPhase> phaseLet(env.statistics->phase, Statistics::PROPERTY_SCANNING);
+  ScopedLet<Statistics::ExecutionPhase> phaseLet(env->statistics->phase, Statistics::PROPERTY_SCANNING);
 
   if(_property) {
     delete _property;

--- a/Kernel/Renaming.cpp
+++ b/Kernel/Renaming.cpp
@@ -87,7 +87,7 @@ bool Renaming::identity() const
  */
 void Renaming::normalizeVariables(const Term* t)
 {
-  static VariableIterator vit;
+  VTHREAD_LOCAL static VariableIterator vit;
   vit.reset(t);
   while(vit.hasNext()) {
     TermList var=vit.next();
@@ -125,7 +125,7 @@ Literal* Renaming::normalize(Literal* l)
 {
   CALL("Renaming::normalize(Literal*)");
 
-  static Renaming n;
+  VTHREAD_LOCAL static Renaming n;
   n.reset();
   n.normalizeVariables(l);
   return n.apply(l);
@@ -135,7 +135,7 @@ Term* Renaming::normalize(Term* trm)
 {
   CALL("Renaming::normalize(Term*)");
 
-  static Renaming n;
+  VTHREAD_LOCAL static Renaming n;
   n.reset();
   n.normalizeVariables(trm);
   return n.apply(trm);

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -153,7 +153,7 @@ TermList RobSubstitution::getSpecialVarTop(unsigned specialVar) const
     TermSpec binding;
     bool found=_bank.find(v,binding);
     if(!found || binding.index==UNBOUND_INDEX) {
-      static TermList auxVarTerm(1,false);
+      VTHREAD_LOCAL static TermList auxVarTerm(1,false);
       return auxVarTerm;
     } else if(binding.term.isTerm()) {
       return binding.term;
@@ -336,7 +336,7 @@ bool RobSubstitution::occurs(VarSpec vs, TermSpec ts)
     }
   }
   typedef DHSet<VarSpec, VarSpec::Hash1> EncounterStore;
-  static EncounterStore encountered;
+  VTHREAD_LOCAL static EncounterStore encountered;
   encountered.reset();
 
   for(;;){
@@ -388,8 +388,8 @@ bool RobSubstitution::unify(TermSpec t1, TermSpec t2,MismatchHandler* hndlr)
   BacktrackData localBD;
   bdRecord(localBD);
 
-  static Stack<TTPair> toDo(64);
-  static Stack<TermList*> subterms(64);
+  VTHREAD_LOCAL static Stack<TTPair> toDo(64);
+  VTHREAD_LOCAL static Stack<TermList*> subterms(64);
   ASS(toDo.isEmpty() && subterms.isEmpty());
 
   // Save encountered unification pairs to avoid
@@ -553,7 +553,7 @@ bool RobSubstitution::match(TermSpec base, TermSpec instance)
   BacktrackData localBD;
   bdRecord(localBD);
 
-  static Stack<TermList*> subterms(64);
+  VTHREAD_LOCAL static Stack<TermList*> subterms(64);
   ASS(subterms.isEmpty());
 
   TermList* bt=&base.term;
@@ -644,7 +644,7 @@ bool RobSubstitution::match(TermSpec base, TermSpec instance)
 Literal* RobSubstitution::apply(Literal* lit, int index) const
 {
   CALL("RobSubstitution::apply(Literal*...)");
-  static DArray<TermList> ts(32);
+  VTHREAD_LOCAL static DArray<TermList> ts(32);
 
   if (lit->ground()) {
     return lit;
@@ -667,12 +667,12 @@ TermList RobSubstitution::apply(TermList trm, int index) const
 {
   CALL("RobSubstitution::apply(TermList...)");
 
-  static Stack<TermList*> toDo(8);
-  static Stack<int> toDoIndex(8);
-  static Stack<Term*> terms(8);
-  static Stack<VarSpec> termRefVars(8);
-  static Stack<TermList> args(8);
-  static DHMap<VarSpec, TermList, VarSpec::Hash1, VarSpec::Hash2> known;
+  VTHREAD_LOCAL static Stack<TermList*> toDo(8);
+  VTHREAD_LOCAL static Stack<int> toDoIndex(8);
+  VTHREAD_LOCAL static Stack<Term*> terms(8);
+  VTHREAD_LOCAL static Stack<VarSpec> termRefVars(8);
+  VTHREAD_LOCAL static Stack<TermList> args(8);
+  VTHREAD_LOCAL static DHMap<VarSpec, TermList, VarSpec::Hash1, VarSpec::Hash2> known;
 
   //is inserted into termRefVars, if respective
   //term in terms isn't referenced by any variable
@@ -757,13 +757,13 @@ size_t RobSubstitution::getApplicationResultWeight(TermList trm, int index) cons
 {
   CALL("RobSubstitution::getApplicationResultWeight");
 
-  static Stack<TermList*> toDo(8);
-  static Stack<int> toDoIndex(8);
-  static Stack<Term*> terms(8);
-  static Stack<VarSpec> termRefVars(8);
-  static Stack<size_t> argSizes(8);
+  VTHREAD_LOCAL static Stack<TermList*> toDo(8);
+  VTHREAD_LOCAL static Stack<int> toDoIndex(8);
+  VTHREAD_LOCAL static Stack<Term*> terms(8);
+  VTHREAD_LOCAL static Stack<VarSpec> termRefVars(8);
+  VTHREAD_LOCAL static Stack<size_t> argSizes(8);
 
-  static DHMap<VarSpec, size_t, VarSpec::Hash1, VarSpec::Hash2> known;
+  VTHREAD_LOCAL static DHMap<VarSpec, size_t, VarSpec::Hash1, VarSpec::Hash2> known;
   known.reset();
 
   //is inserted into termRefVars, if respective
@@ -848,7 +848,7 @@ size_t RobSubstitution::getApplicationResultWeight(TermList trm, int index) cons
 size_t RobSubstitution::getApplicationResultWeight(Literal* lit, int index) const
 {
   CALL("RobSubstitution::getApplicationResultWeight");
-  static DArray<TermList> ts(32);
+  VTHREAD_LOCAL static DArray<TermList> ts(32);
 
   if (lit->ground()) {
     return lit->weight();

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -486,7 +486,7 @@ bool RobSubstitution::unify(TermSpec t1, TermSpec t2,MismatchHandler* hndlr)
               // mechanism used by higher-order logic to pruduce constraints.
               // until then the first condition ensures that the handler is never called
               // incorrectly. HOL also uses a handler, but it shouldn't be called here.
-              if(env.statistics->higherOrder || !hndlr || !hndlr->handle(this,tsss.term,tsss.index,tstt.term,tstt.index)){
+              if(env->statistics->higherOrder || !hndlr || !hndlr->handle(this,tsss.term,tsss.index,tstt.term,tstt.index)){
                 mismatch=true;
                 break;
               }

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -27,6 +27,10 @@ using namespace Shell;
 const unsigned Signature::STRING_DISTINCT_GROUP = 0;
 VATOMIC(int) Signature::_nextFreshSymbolNumber(0);
 
+#if VTHREADED
+static std::atomic<unsigned> fresh_id(0);
+#endif
+
 /**
  * Standard constructor.
  * @since 03/05/2013 train London-Manchester, argument numericConstant added
@@ -35,6 +39,9 @@ VATOMIC(int) Signature::_nextFreshSymbolNumber(0);
 Signature::Symbol::Symbol(const vstring& nm, unsigned arity, bool interpreted, bool stringConstant,bool numericConstant,
                           bool overflownConstant, bool super)
   :
+#if VTHREADED
+    _id(fresh_id++),
+#endif
     _name(nm),
     _arity(arity),
     _typeArgsArity(0),

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -104,11 +104,11 @@ void Signature::Symbol::addToDistinctGroup(unsigned group,unsigned this_number)
 
   List<unsigned>::push(group, _distinctGroups);
 
-  env.signature->_distinctGroupsAddedTo=true;
+  env->signature->_distinctGroupsAddedTo=true;
 
-  Signature::DistinctGroupMembers members = env.signature->_distinctGroupMembers[group];
+  Signature::DistinctGroupMembers members = env->signature->_distinctGroupMembers[group];
   if(members->size() <= DistinctGroupExpansion::EXPAND_UP_TO_SIZE
-                       || env.options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING){
+                       || env->options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING){
     // we add one more than EXPAND_UP_TO_SIZE to signal to DistinctGroupExpansion::apply not to expand
     // ... instead DistinctEqualitySimplifier will take over
     members->push(this_number);
@@ -583,11 +583,11 @@ const vstring& Signature::functionName(int number)
   // because the user cannot define constants with these names herself
   // and the formula, obtained by toString() with "$true" or "$false"
   // in term position would be syntactically valid in FOOL
-  if (!env.options->showFOOL() && isFoolConstantSymbol(false,number)) {
+  if (!env->options->showFOOL() && isFoolConstantSymbol(false,number)) {
     static vstring fols("$false");
     return fols;
   }
-  if (!env.options->showFOOL() && isFoolConstantSymbol(true,number)) { 
+  if (!env->options->showFOOL() && isFoolConstantSymbol(true,number)) { 
     static vstring troo("$true");
     return troo;
   }
@@ -679,7 +679,7 @@ unsigned Signature::addFunction (const vstring& name,
     getFunction(result)->unmarkIntroduced();
     return result;
   }
-  if (env.options->arityCheck()) {
+  if (env->options->arityCheck()) {
     unsigned prev;
     if (_arityCheck.find(name,prev)) {
       unsigned prevArity = prev/2;
@@ -849,7 +849,7 @@ unsigned Signature::addPredicate (const vstring& name,
     getPredicate(result)->unmarkIntroduced();
     return result;
   }
-  if (env.options->arityCheck()) {
+  if (env->options->arityCheck()) {
     unsigned prev;
     if (_arityCheck.find(name,prev)) {
       unsigned prevArity = prev/2;
@@ -1004,7 +1004,7 @@ void Signature::Symbol::addColor(Color color)
 {
   ASS_L(color,3);
   ASS_G(color,0);
-  ASS(env.colorUsed);
+  ASS(env->colorUsed);
 
   if (_color && color != static_cast<Color>(_color)) {
     USER_ERROR("A symbol cannot have two colors");
@@ -1059,7 +1059,7 @@ bool Signature::isProtectedName(vstring name)
     return true;
   }
 
-  vstring protectedPrefix = env.options->protectedPrefix();
+  vstring protectedPrefix = env->options->protectedPrefix();
   if (protectedPrefix.size()==0) {
     return false;
   }

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -248,27 +248,27 @@ Signature::~Signature ()
 
 #if VTHREADED
 /** 
- * Clone a Signature data from another. Used after spawning threads.
+ * Copy-construct Signature. Used after spawning threads.
  */
-void Signature::clone_from(Signature *other) {
-  _dividesNvalues = other->_dividesNvalues;
-  _foolConstantsDefined = other->_foolConstantsDefined;
-  _foolTrue = other->_foolTrue;
-  _foolFalse = other->_foolFalse;
-  _nextFreshSymbolNumber = other->_nextFreshSymbolNumber;
-  _skolemFunctionCount = other->_skolemFunctionCount;
-  _distinctGroupPremises = other->_distinctGroupPremises;
-  _distinctGroupMembers = other->_distinctGroupMembers;
-  _distinctGroupsAddedTo = other->_distinctGroupsAddedTo;
-  _iSymbols.loadFromMap(other->_iSymbols);
-  _strings = other->_strings;
-  _integers = other->_integers;
-  _rationals = other->_rationals;
-  _reals = other->_reals;
-  _termAlgebras.loadFromMap(other->_termAlgebras);
+Signature::Signature(const Signature &other) {
+  _dividesNvalues = other._dividesNvalues;
+  _foolConstantsDefined = other._foolConstantsDefined;
+  _foolTrue = other._foolTrue;
+  _foolFalse = other._foolFalse;
+  _nextFreshSymbolNumber = other._nextFreshSymbolNumber;
+  _skolemFunctionCount = other._skolemFunctionCount;
+  _distinctGroupPremises = other._distinctGroupPremises;
+  _distinctGroupMembers = other._distinctGroupMembers;
+  _distinctGroupsAddedTo = other._distinctGroupsAddedTo;
+  _iSymbols.loadFromMap(other._iSymbols);
+  _strings = other._strings;
+  _integers = other._integers;
+  _rationals = other._rationals;
+  _reals = other._reals;
+  _termAlgebras.loadFromMap(other._termAlgebras);
 
 #define CLONE_SYMBOL_TABLE(NAME) {\
-  Stack<Symbol*>::BottomFirstIterator NAME_it(other->NAME);\
+  Stack<Symbol*>::BottomFirstIterator NAME_it(other.NAME);\
   while(NAME_it.hasNext()) {\
     NAME.push(NAME_it.next()->clone());\
   }\
@@ -278,7 +278,7 @@ void Signature::clone_from(Signature *other) {
 #undef CLONE_SYMBOL_TABLE
 
 #define CLONE_NAME_LOOKUP(NAME) {\
-  SymbolMap::Iterator NAME_it(other->NAME);\
+  SymbolMap::Iterator NAME_it(other.NAME);\
   while(NAME_it.hasNext()) {\
     vstring key;\
     unsigned value;\
@@ -291,7 +291,7 @@ void Signature::clone_from(Signature *other) {
   CLONE_NAME_LOOKUP(_varNames);
   CLONE_NAME_LOOKUP(_arityCheck);
 #undef CLONE_NAME_LOOKUP
-} // Signature::copy_from
+} // Signature(const Signature &)
 #endif
 
 /**

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -26,9 +26,6 @@ using namespace Shell;
 
 const unsigned Signature::STRING_DISTINCT_GROUP = 0;
 VATOMIC(int) Signature::_nextFreshSymbolNumber(0);
-#if VTHREADED
-std::atomic<unsigned> fresh_id(0);
-#endif
 
 /**
  * Standard constructor.
@@ -38,9 +35,6 @@ std::atomic<unsigned> fresh_id(0);
 Signature::Symbol::Symbol(const vstring& nm, unsigned arity, bool interpreted, bool stringConstant,bool numericConstant,
                           bool overflownConstant, bool super)
   :
-#if VTHREADED
-    _id(fresh_id++),
-#endif
     _name(nm),
     _arity(arity),
     _typeArgsArity(0),

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -234,6 +234,7 @@ Signature::Signature ():
 {
   CALL("Signature::Signature");
 
+  // if this is the first time the constructor runs, do equality shenanigans
 #if VTHREADED
   static bool is_main = true;
   if(is_main) {
@@ -253,6 +254,7 @@ Signature::Signature ():
     is_main = false;
   }
 #endif
+  // otherwise, don't bother: we're about to be cloned from the parent thread
 } // Signature::Signature
 
 /* adding equality predicate used to be carried out in the constructor

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -25,6 +25,10 @@ using namespace Kernel;
 using namespace Shell;
 
 const unsigned Signature::STRING_DISTINCT_GROUP = 0;
+VATOMIC(int) Signature::_nextFreshSymbolNumber(0);
+#if VTHREADED
+std::atomic<unsigned> fresh_id(0);
+#endif
 
 /**
  * Standard constructor.
@@ -33,7 +37,11 @@ const unsigned Signature::STRING_DISTINCT_GROUP = 0;
  */
 Signature::Symbol::Symbol(const vstring& nm, unsigned arity, bool interpreted, bool stringConstant,bool numericConstant,
                           bool overflownConstant, bool super)
-  : _name(nm),
+  :
+#if VTHREADED
+    _id(fresh_id++),
+#endif
+    _name(nm),
     _arity(arity),
     _typeArgsArity(0),
     _type(0),
@@ -184,7 +192,6 @@ Signature::Signature ():
     _foolConstantsDefined(false), _foolTrue(0), _foolFalse(0),
     _funs(32),
     _preds(32),
-    _nextFreshSymbolNumber(0),
     _skolemFunctionCount(0),
     _distinctGroupsAddedTo(false),
     _strings(0),
@@ -255,7 +262,6 @@ Signature::Signature(const Signature &other) {
   _foolConstantsDefined = other._foolConstantsDefined;
   _foolTrue = other._foolTrue;
   _foolFalse = other._foolFalse;
-  _nextFreshSymbolNumber = other._nextFreshSymbolNumber;
   _skolemFunctionCount = other._skolemFunctionCount;
   _distinctGroupPremises = other._distinctGroupPremises;
   _distinctGroupMembers = other._distinctGroupMembers;

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -404,7 +404,7 @@ class Signature
     RealSymbol *clone() const override { return new RealSymbol(*this); }
 #endif
     RealSymbol(const RealConstantType& val)
-    : Symbol((env.options->proof() == Shell::Options::Proof::PROOFCHECK) ? "$to_real("+val.toString()+")" : val.toNiceString(), 0, true), _realValue(val)
+    : Symbol((env->options->proof() == Shell::Options::Proof::PROOFCHECK) ? "$to_real("+val.toString()+")" : val.toNiceString(), 0, true), _realValue(val)
     {
       CALL("RealSymbol");
 

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -554,6 +554,7 @@ class Signature
 
   Signature();
   ~Signature();
+  void clone_from(Signature *);
 
   CLASS_NAME(Signature);
   USE_ALLOCATOR(Signature);

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -81,6 +81,10 @@ class Signature
   class Symbol {
   
   protected:
+#if VTHREADED
+    /** unique identifier between threads */
+    unsigned _id;
+#endif
     /** print name */
     vstring _name;
 
@@ -202,6 +206,10 @@ class Signature
     inline unsigned arity() const { return _arity; }
     /** Return the type argument arity of the symbol. Only accurate once type has been set. */
     inline unsigned typeArgsArity() const { ASS_REP(_type, name()); return _typeArgsArity; }
+#if VTHREADED
+    /** Return the unique id of the symbol */
+    inline const unsigned id() const { return _id; }
+#endif
     /** Return the name of the symbol */
     inline const vstring& name() const { return _name; }
     /** Return true iff the object is of type InterpretedSymbol */
@@ -498,6 +506,17 @@ class Signature
     ASS(!Theory::isPolymorphic(interp));
     return haveInterpretingSymbol(interp,Theory::getNonpolymorphicOperatorType(interp));
   }
+
+#if VTHREADED
+  /** return the id of a function with a given number */
+  const unsigned functionId(int number) {
+    return _funs[number]->id();
+  }
+  /** return the id of a predicate with a given number */
+  const unsigned predicateId(int number) {
+    return _preds[number]->id();
+  }
+#endif
 
   /** return the name of a function with a given number */
   const vstring& functionName(int number);
@@ -898,7 +917,7 @@ private:
   /** Map for the arity_check options: maps symbols to their arities */
   SymbolMap _arityCheck;
   /** Last number used for fresh functions and predicates */
-  int _nextFreshSymbolNumber;
+  static VATOMIC(int) _nextFreshSymbolNumber;
 
   /** Number of Skolem functions (this is just for LaTeX output) */
   unsigned _skolemFunctionCount;

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -576,7 +576,7 @@ class Signature
   Signature();
   ~Signature();
 #if VTHREADED
-  void clone_from(Signature *);
+  Signature(const Signature &);
 #endif
 
   CLASS_NAME(Signature);

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -22,7 +22,6 @@
 
 #include "Debug/Assertion.hpp"
 
-#include "Indexing/TermSharing.hpp"
 #include "Lib/Allocator.hpp"
 #include "Lib/Stack.hpp"
 #include "Lib/DHSet.hpp"
@@ -84,7 +83,7 @@ class Signature
   protected:
 #if VTHREADED
     /** unique identifier between threads */
-    unsigned _id;
+    unsigned  _id;
 #endif
     /** print name */
     vstring _name;
@@ -507,19 +506,6 @@ class Signature
     ASS(!Theory::isPolymorphic(interp));
     return haveInterpretingSymbol(interp,Theory::getNonpolymorphicOperatorType(interp));
   }
-
-#if VTHREADED
-  /** return the id of a function with a given number */
-  const unsigned functionId(int number) {
-    ACQ_TERM_SHARING_LOCK;
-    return _funs[number]->id();
-  }
-  /** return the id of a predicate with a given number */
-  const unsigned predicateId(int number) {
-    ACQ_TERM_SHARING_LOCK;
-    return _preds[number]->id();
-  }
-#endif
 
   /** return the name of a function with a given number */
   const vstring& functionName(int number);

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -22,6 +22,7 @@
 
 #include "Debug/Assertion.hpp"
 
+#include "Indexing/TermSharing.hpp"
 #include "Lib/Allocator.hpp"
 #include "Lib/Stack.hpp"
 #include "Lib/DHSet.hpp"
@@ -510,10 +511,12 @@ class Signature
 #if VTHREADED
   /** return the id of a function with a given number */
   const unsigned functionId(int number) {
+    ACQ_TERM_SHARING_LOCK;
     return _funs[number]->id();
   }
   /** return the id of a predicate with a given number */
   const unsigned predicateId(int number) {
+    ACQ_TERM_SHARING_LOCK;
     return _preds[number]->id();
   }
 #endif

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -507,6 +507,17 @@ class Signature
     return haveInterpretingSymbol(interp,Theory::getNonpolymorphicOperatorType(interp));
   }
 
+#if VTHREADED
+  /** return the id of a function with a given number */
+  const unsigned functionId(int number) {
+    return _funs[number]->id();
+  }
+  /** return the id of a predicate with a given number */
+  const unsigned predicateId(int number) {
+    return _preds[number]->id();
+  }
+#endif
+
   /** return the name of a function with a given number */
   const vstring& functionName(int number);
   /** return the name of a predicate with a given number */

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -155,6 +155,16 @@ class Signature
     Combinator _comb;
 
   public:
+#if VTHREADED
+    /**
+     * virtual constructor ("clone") for Symbol and its subclasses
+     * see https://isocpp.org/wiki/faq/virtual-functions#virtual-ctors
+    */
+    virtual Symbol *clone() const { return new Symbol(*this); }
+#endif
+    //dummy: ensure we call the right operator-delete for derived classes
+    virtual ~Symbol() = default;
+
     /** standard constructor */
     Symbol(const vstring& nm,unsigned arity, bool interpreted=false, bool stringConstant=false,bool numericConstant=false,bool overflownConstant=false, bool super = false);
     void destroyFnSymbol();
@@ -301,7 +311,7 @@ class Signature
     USE_ALLOCATOR(Symbol);
   }; // class Symbol
 
-  class InterpretedSymbol
+  class InterpretedSymbol final
   : public Symbol
   {
     friend class Signature;
@@ -310,7 +320,9 @@ class Signature
     Interpretation _interp;
 
   public:
-
+#if VTHREADED
+    InterpretedSymbol *clone() const override { return new InterpretedSymbol(*this); }
+#endif
     InterpretedSymbol(const vstring& nm, Interpretation interp)
     : Symbol(nm, Theory::getArity(interp), true), _interp(interp)
     {
@@ -324,7 +336,7 @@ class Signature
     inline Interpretation getInterpretation() const { ASS_REP(interpreted(), _name); return _interp; }
   };
 
-  class IntegerSymbol
+  class IntegerSymbol final
   : public Symbol
   {
     friend class Signature;
@@ -333,6 +345,9 @@ class Signature
     IntegerConstantType _intValue;
 
   public:
+#if VTHREADED
+    IntegerSymbol *clone() const override { return new IntegerSymbol(*this); }
+#endif
     IntegerSymbol(const IntegerConstantType& val)
     : Symbol(val.toString(), 0, true), _intValue(val)
     {
@@ -344,7 +359,7 @@ class Signature
     USE_ALLOCATOR(IntegerSymbol);
   };
 
-  class RationalSymbol
+  class RationalSymbol final
   : public Symbol
   {
     friend class Signature;
@@ -353,6 +368,9 @@ class Signature
     RationalConstantType _ratValue;
 
   public:
+#if VTHREADED
+    RationalSymbol *clone() const override { return new RationalSymbol(*this); }
+#endif
     RationalSymbol(const RationalConstantType& val)
     : Symbol(val.toString(), 0, true), _ratValue(val)
     {
@@ -364,7 +382,7 @@ class Signature
     USE_ALLOCATOR(RationalSymbol);
   };
 
-  class RealSymbol
+  class RealSymbol final
   : public Symbol
   {
     friend class Signature;
@@ -373,6 +391,9 @@ class Signature
     RealConstantType _realValue;
 
   public:
+#if VTHREADED
+    RealSymbol *clone() const override { return new RealSymbol(*this); }
+#endif
     RealSymbol(const RealConstantType& val)
     : Symbol((env.options->proof() == Shell::Options::Proof::PROOFCHECK) ? "$to_real("+val.toString()+")" : val.toNiceString(), 0, true), _realValue(val)
     {
@@ -554,7 +575,9 @@ class Signature
 
   Signature();
   ~Signature();
+#if VTHREADED
   void clone_from(Signature *);
+#endif
 
   CLASS_NAME(Signature);
   USE_ALLOCATOR(Signature);

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -38,9 +38,9 @@ OperatorType* SortHelper::getType(Term* t)
   CALL("SortHelper::getType(Term*)");
 
   if (t->isLiteral()) {
-    return env.signature->getPredicate(t->functor())->predType();
+    return env->signature->getPredicate(t->functor())->predType();
   }
-  return env.signature->getFunction(t->functor())->fnType();
+  return env->signature->getFunction(t->functor())->fnType();
 } // getType
 
 /**
@@ -87,7 +87,7 @@ TermList SortHelper::getResultSort(const Term* t)
 
   Substitution subst;
   getTypeSub(t, subst);
-  Signature::Symbol* sym = env.signature->getFunction(t->functor());
+  Signature::Symbol* sym = env->signature->getFunction(t->functor());
   TermList result = sym->fnType()->result();
   //cout << "the type is " + sym->fnType()->toString() << endl;
   ASS(!subst.isEmpty()  || (result.isTerm() && (result.term()->isSuper() || result.term()->ground())));  
@@ -100,7 +100,7 @@ TermList SortHelper::getResultSortMono(const Term* t)
   ASS(!t->isSpecial());
   ASS(!t->isLiteral());
 
-  Signature::Symbol* sym = env.signature->getFunction(t->functor());
+  Signature::Symbol* sym = env->signature->getFunction(t->functor());
   return sym->fnType()->result();
 }
 
@@ -405,8 +405,8 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
           case Term::SF_LET: {
             TermList binding = sd->getBinding();
             bool isPredicate = binding.isTerm() && binding.term()->isBoolean();
-            Signature::Symbol* symbol = isPredicate ? env.signature->getPredicate(sd->getFunctor())
-                                                    : env.signature->getFunction(sd->getFunctor());
+            Signature::Symbol* symbol = isPredicate ? env->signature->getPredicate(sd->getFunctor())
+                                                    : env->signature->getFunction(sd->getFunctor());
             unsigned position = 0;
             VList::Iterator vit(sd->getVariables());
             while (vit.hasNext()) {
@@ -437,7 +437,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
 
           case Term::SF_LET_TUPLE: {
             TermList binding = sd->getBinding();
-            Signature::Symbol* symbol = env.signature->getFunction(sd->getFunctor());
+            Signature::Symbol* symbol = env->signature->getFunction(sd->getFunctor());
 
             CollectTask newTask;
             newTask.fncTag = COLLECT_TERMLIST;
@@ -626,8 +626,8 @@ void SortHelper::collectVariableSorts(TermList ts, TermList contextSort, DHMap<u
     case Term::SF_LET: {
       TermList binding = sd->getBinding();
       bool isPredicate = binding.isTerm() && binding.term()->isBoolean();
-      Signature::Symbol* symbol = isPredicate ? env.signature->getPredicate(sd->getFunctor())
-                                              : env.signature->getFunction(sd->getFunctor());
+      Signature::Symbol* symbol = isPredicate ? env->signature->getPredicate(sd->getFunctor())
+                                              : env->signature->getFunction(sd->getFunctor());
       unsigned position = 0;
       Formula::VarList::Iterator vit(sd->getVariables());
       while (vit.hasNext()) {
@@ -651,7 +651,7 @@ void SortHelper::collectVariableSorts(TermList ts, TermList contextSort, DHMap<u
 
     case Term::SF_LET_TUPLE: {
       TermList binding = sd->getBinding();
-      Signature::Symbol* symbol = env.signature->getFunction(sd->getFunctor());
+      Signature::Symbol* symbol = env->signature->getFunction(sd->getFunctor());
       collectVariableSorts(binding, symbol->fnType()->result(), map);
       ts.push(term->nthArgument(0));
       break;
@@ -806,7 +806,7 @@ bool SortHelper::tryGetVariableSort(TermList var, Term* t0, TermList& result)
         if ( binding == var) {
           // get result sort of the functor
           unsigned f = t->getSpecialData()->getFunctor();
-          Signature::Symbol* sym = env.signature->getFunction(f);
+          Signature::Symbol* sym = env->signature->getFunction(f);
           result = sym->fnType()->result();
           return true;
         }
@@ -914,8 +914,8 @@ bool SortHelper::areImmediateSortsValidPoly(Term* t)
 /*
 #if VDEBUG
       cout << "the term is " + t->toString() << endl;
-      cout << "the type of function " + env.signature->getFunction(t->functor())->name() + " is: " + type->toString() << endl;
-      //cout << "function name : "+ env.signature->getFunction(t->functor())->name() << endl;
+      cout << "the type of function " + env->signature->getFunction(t->functor())->name() + " is: " + type->toString() << endl;
+      //cout << "function name : "+ env->signature->getFunction(t->functor())->name() << endl;
       //cout << "function name 2 :" + t->functionName() << endl;
       cout << "error with expected " << instantiatedTypeSort.toString() << " and actual " << argSort.toString() << " when functor is " << t->functor() << " and arg is " << arg << endl;
       ASSERTION_VIOLATION;
@@ -974,7 +974,7 @@ bool SortHelper::isTupleSort(TermList sort)
 {
   CALL("SortHelper::isTupleSort");  
   if(!sort.isTerm()){ return false; }
-  return env.signature->getFunction(sort.term()->functor())->tupleSort(); 
+  return env->signature->getFunction(sort.term()->functor())->tupleSort(); 
 }
 
 /*
@@ -990,7 +990,7 @@ bool SortHelper::isArraySort(TermList sort)
 {
   CALL("SortHelper::isArraySort");  
   if(!sort.isTerm()){ return false; }
-  return env.signature->getFunction(sort.term()->functor())->arraySort(); 
+  return env->signature->getFunction(sort.term()->functor())->arraySort(); 
 }
 
 bool SortHelper::isBoolSort(TermList sort)

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -1043,7 +1043,7 @@ bool SortHelper::areSortsValid(Clause* cl)
 {
   CALL("SortHelper::areSortsValid");
 
-  static DHMap<unsigned,TermList> varSorts;
+  VTHREAD_LOCAL static DHMap<unsigned,TermList> varSorts;
   varSorts.reset();
 
   unsigned clen = cl->length();

--- a/Kernel/SortHelper.hpp
+++ b/Kernel/SortHelper.hpp
@@ -82,10 +82,10 @@ public:
   static bool isInterpretedNonBool(unsigned s);
   //convenience functions
   static unsigned sortNum(TermList sort){
-    return env.sorts->getSortNum(sort);
+    return env->sorts->getSortNum(sort);
   }
   static TermList sortTerm(unsigned sortNum){
-    return env.sorts->getSortTerm(sortNum);
+    return env->sorts->getSortTerm(sortNum);
   }
 
   static void normaliseArgSorts(VList* qVars, TermStack& argSorts);

--- a/Kernel/Sorts.cpp
+++ b/Kernel/Sorts.cpp
@@ -147,7 +147,7 @@ OperatorType::OperatorTypes& OperatorType::operatorTypes() {
     }
   };
 
-  VTHREAD_LOCAL static DeletingOperatorTypes _operatorTypes;
+  static DeletingOperatorTypes _operatorTypes;
   return _operatorTypes;
 }
 

--- a/Kernel/Sorts.cpp
+++ b/Kernel/Sorts.cpp
@@ -147,7 +147,7 @@ OperatorType::OperatorTypes& OperatorType::operatorTypes() {
     }
   };
 
-  static DeletingOperatorTypes _operatorTypes;
+  VTHREAD_LOCAL static DeletingOperatorTypes _operatorTypes;
   return _operatorTypes;
 }
 

--- a/Kernel/Sorts.cpp
+++ b/Kernel/Sorts.cpp
@@ -165,7 +165,7 @@ OperatorType* OperatorType::getTypeFromKey(OperatorType::OperatorKey* key, unsig
   /*
   cout << "getTypeFromKey(" << key->length() << "): ";
   for (unsigned i = 0; i < key->length(); i++) {
-    cout << (((*key)[i] == PREDICATE_FLAG) ? "FFFF" : env.sorts->sortName((*key)[i])) << ",";
+    cout << (((*key)[i] == PREDICATE_FLAG) ? "FFFF" : env->sorts->sortName((*key)[i])) << ",";
   }
   */
 

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -145,7 +145,7 @@ public:
   static Literal* applyToLiteral(Literal* lit, Subst subst)
   {
     CALL("SubstHelper::applyToLiteral");
-    static DArray<TermList> ts(32);
+    VTHREAD_LOCAL static DArray<TermList> ts(32);
 
     int arity = lit->arity();
     ts.ensure(arity);

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -808,7 +808,12 @@ unsigned Term::hash() const
 {
   CALL("Term::hash");
 
-  unsigned hash = Hash::hash(_functor);
+#if VTHREADED
+  unsigned functor = env.signature->functionId(_functor);
+#else
+  unsigned functor = _functor;
+#endif
+  unsigned hash = Hash::hash(functor);
   if (_arity == 0) {
     return hash;
   }
@@ -824,7 +829,13 @@ unsigned Literal::hash() const
 {
   CALL("Literal::hash");
 
-  unsigned hash = Hash::hash(isPositive() ? (2*_functor) : (2*_functor+1));
+#if VTHREADED
+  unsigned functor = env.signature->predicateId(_functor);
+#else
+  unsigned functor = _functor;
+#endif
+
+  unsigned hash = Hash::hash(isPositive() ? (2*functor) : (2*functor+1));
   if (_arity == 0) {
     return hash;
   }
@@ -842,7 +853,13 @@ unsigned Literal::oppositeHash() const
 {
   CALL("Literal::hash");
 
-  unsigned hash = Hash::hash( (!isPositive()) ? (2*_functor) : (2*_functor+1));
+#if VTHREADED
+  unsigned functor = env.signature->predicateId(_functor);
+#else
+  unsigned functor = _functor;
+#endif
+
+  unsigned hash = Hash::hash( (!isPositive()) ? (2*functor) : (2*functor+1));
   if (_arity == 0) {
     return hash;
   }

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -476,16 +476,16 @@ vstring Term::headToString() const
       case Term::SF_FORMULA: {
         ASS_EQ(arity(), 0);
         vstring formula = sd->getFormula()->toString();
-        return env.options->showFOOL() ? "$term{" + formula + "}" : formula;
+        return env->options->showFOOL() ? "$term{" + formula + "}" : formula;
       }
       case Term::SF_LET: {
         ASS_EQ(arity(), 1);
         TermList binding = sd->getBinding();
         bool isPredicate = binding.isTerm() && binding.term()->isBoolean();
-        vstring functor = isPredicate ? env.signature->predicateName(sd->getFunctor())
-                                      : env.signature->functionName(sd->getFunctor());
-        OperatorType* type = isPredicate ? env.signature->getPredicate(sd->getFunctor())->predType()
-                                         : env.signature->getFunction(sd->getFunctor())->fnType();
+        vstring functor = isPredicate ? env->signature->predicateName(sd->getFunctor())
+                                      : env->signature->functionName(sd->getFunctor());
+        OperatorType* type = isPredicate ? env->signature->getPredicate(sd->getFunctor())->predType()
+                                         : env->signature->getFunction(sd->getFunctor())->fnType();
 
         const VList* variables = sd->getVariables();
         vstring variablesList = "";
@@ -525,14 +525,14 @@ vstring Term::headToString() const
         unsigned tupleFunctor = sd->getFunctor();
         TermList binding = sd->getBinding();
 
-        OperatorType* fnType = env.signature->getFunction(tupleFunctor)->fnType();
+        OperatorType* fnType = env->signature->getFunction(tupleFunctor)->fnType();
 
         vstring symbolsList = "";
         vstring typesList = "";
         for (unsigned i = 0; i < VList::length(symbols); i++) {
           Signature::Symbol* symbol = (fnType->arg(i) == Term::boolSort())
-            ? env.signature->getPredicate(VList::nth(symbols, i))
-            : env.signature->getFunction(VList::nth(symbols, i));
+            ? env->signature->getPredicate(VList::nth(symbols, i))
+            : env->signature->getFunction(VList::nth(symbols, i));
           symbolsList += symbol->name();
           typesList += symbol->name() + ": " + fnType->arg(i).toString();
           if (i != VList::length(symbols) - 1) {
@@ -575,7 +575,7 @@ vstring Term::headToString() const
     if (Theory::tuples()->findProjection(functor(), isLiteral(), proj)) {
       return "$proj(" + Int::toString(proj) + ", ";
     }
-    bool print = (env.signature->getFunction(_functor)->combinator() == Signature::NOT_COMB) && arity() ;
+    bool print = (env->signature->getFunction(_functor)->combinator() == Signature::NOT_COMB) && arity() ;
     return (isLiteral() ? static_cast<const Literal *>(this)->predicateName() : functionName() + (print ? "(" : ""));
   }
 }
@@ -618,7 +618,7 @@ vstring TermList::asArgsToString() const
     }
     const Term* t = ts->term();
   
-    if(!t->isSpecial() && env.signature->getFunction(t->functor())->arrow()){
+    if(!t->isSpecial() && env->signature->getFunction(t->functor())->arrow()){
       res += t->toString();
       continue;
     }
@@ -662,7 +662,7 @@ vstring Term::toString(bool topLevel) const
   bool printArgs = true;
 
   if(!isSpecial() && !isLiteral()){
-    if(env.signature->getFunction(_functor)->arrow()){
+    if(env->signature->getFunction(_functor)->arrow()){
       ASS(arity() == 2);
       vstring res;
       TermList arg1 = *(nthArgument(0));
@@ -671,7 +671,7 @@ vstring Term::toString(bool topLevel) const
       res += arg1.toString(false) + " " + functionName() + " " + arg2.toString();
       res += topLevel ? "" : ")";
       return res;
-    }else if(env.signature->getFunction(_functor)->app()){
+    }else if(env->signature->getFunction(_functor)->app()){
       ASS(arity() == 4);
       vstring res;
       TermList arg1 = *(nthArgument(2));
@@ -681,7 +681,7 @@ vstring Term::toString(bool topLevel) const
     //  res += topLevel ? "" : ")";
       return res;
     }
-    printArgs = env.signature->getFunction(_functor)->combinator() == Signature::NOT_COMB;
+    printArgs = env->signature->getFunction(_functor)->combinator() == Signature::NOT_COMB;
   }
 
   vstring s = headToString();
@@ -711,7 +711,7 @@ vstring Literal::toString() const
     }
 
     vstring res = s + lhs->next()->toString();
-    if (env.statistics->higherOrder || 
+    if (env->statistics->higherOrder || 
        (SortHelper::getEqualityArgumentSort(this) == Term::boolSort())){
       res = "("+res+")";
     }
@@ -748,12 +748,12 @@ const vstring& Term::functionName() const
 
 #if VDEBUG
   static vstring nonexisting("<function does not exists>");
-  if (_functor>=static_cast<unsigned>(env.signature->functions())) {
+  if (_functor>=static_cast<unsigned>(env->signature->functions())) {
     return nonexisting;
   }
 #endif
 
-  return env.signature->functionName(_functor);
+  return env->signature->functionName(_functor);
 } // Term::functionName
 
 /**
@@ -766,12 +766,12 @@ const vstring& Literal::predicateName() const
 
 #if VDEBUG
   static vstring nonexisting("<predicate does not exists>");
-  if (_functor>=static_cast<unsigned>(env.signature->predicates())) {
+  if (_functor>=static_cast<unsigned>(env->signature->predicates())) {
     return nonexisting;
   }
 #endif
 
-  return env.signature->predicateName(_functor);
+  return env->signature->predicateName(_functor);
 } // Literal::predicateName
 
 
@@ -871,7 +871,7 @@ unsigned Literal::oppositeHashUnderSignature(Signature *signature) const
  */
 Literal* Literal::complementaryLiteral(Literal* l)
 {
-  Literal* res=env.sharing->tryGetOpposite(l);
+  Literal* res=env->sharing->tryGetOpposite(l);
   if (!res) {
     res=create(l,!l->polarity());
   }
@@ -901,7 +901,7 @@ Term* Term::create(Term* t,TermList* args)
     }
   }
   if (share) {
-    s = env.sharing->insert(s);
+    s = env->sharing->insert(s);
   }
   return s;
 }
@@ -912,7 +912,7 @@ Term* Term::create(Term* t,TermList* args)
 Term* Term::create(unsigned function, unsigned arity, const TermList* args)
 {
   CALL("Term::create/3");
-  ASS_EQ(env.signature->functionArity(function), arity);
+  ASS_EQ(env->signature->functionArity(function), arity);
 
   Term* s = new(arity) Term;
   s->makeSymbol(function,arity);
@@ -931,7 +931,7 @@ Term* Term::create(unsigned function, unsigned arity, const TermList* args)
     ++curArg;
   }
   if (share) {
-    s = env.sharing->insert(s);
+    s = env->sharing->insert(s);
   }
   return s;
 }
@@ -944,7 +944,7 @@ Term* Term::createConstant(const vstring& name)
 {
   CALL("Term::createConstant");
 
-  unsigned symbolNumber = env.signature->addFunction(name,0);
+  unsigned symbolNumber = env->signature->addFunction(name,0);
   return createConstant(symbolNumber);
 }
 
@@ -974,7 +974,7 @@ Term* Term::createNonShared(Term* t,TermList* args)
 Term* Term::createNonShared(unsigned function, unsigned arity, TermList* args)
 {
   CALL("Term::createNonShared/3");
-  ASS_EQ(env.signature->functionArity(function), arity);
+  ASS_EQ(env->signature->functionArity(function), arity);
 
   Term* s = new(arity) Term;
   s->makeSymbol(function,arity);
@@ -1027,8 +1027,8 @@ Term* Term::createLet(unsigned functor, VList* variables, TermList binding, Term
   ASS_EQ(distinctVars.size(), VList::length(variables));
 
   bool isPredicate = binding.isTerm() && binding.term()->isBoolean();
-  const unsigned int arity = isPredicate ? env.signature->predicateArity(functor)
-                                         : env.signature->functionArity(functor);
+  const unsigned int arity = isPredicate ? env->signature->predicateArity(functor)
+                                         : env->signature->functionArity(functor);
   ASS_EQ(arity, VList::length(variables));
 #endif
 
@@ -1053,7 +1053,7 @@ Term* Term::createTupleLet(unsigned tupleFunctor, VList* symbols, TermList bindi
   CALL("Term::createTupleLet");
 
 #if VDEBUG
-  Signature::Symbol* tupleSymbol = env.signature->getFunction(tupleFunctor);
+  Signature::Symbol* tupleSymbol = env->signature->getFunction(tupleFunctor);
   ASS_EQ(tupleSymbol->arity(), VList::length(symbols));
   ASS_REP(SortHelper::isTupleSort(tupleSymbol->fnType()->result()), tupleFunctor);
 
@@ -1201,56 +1201,56 @@ Term* Term::create(unsigned fn, std::initializer_list<TermList> args)
  */ 
 Term* Term::foolTrue(){
   CALL("Term::foolTrue");
-  static Term* _foolTrue = createConstant(env.signature->getFoolConstantSymbol(true));
+  static Term* _foolTrue = createConstant(env->signature->getFoolConstantSymbol(true));
   return _foolTrue;
 }
 
 Term* Term::foolFalse(){
   CALL("Term::foolFalse");
-  static Term* _foolFalse = createConstant(env.signature->getFoolConstantSymbol(false));
+  static Term* _foolFalse = createConstant(env->signature->getFoolConstantSymbol(false));
   return _foolFalse;
 }
 
 TermList Term::superSort(){
   CALL("Term::superSort");
-  static unsigned super = env.signature->addFunction("$tType",0);
+  static unsigned super = env->signature->addFunction("$tType",0);
   static Term* _super  = createNonShared(super, 0, 0);
   return TermList(_super);
 }
 
 TermList Term::defaultSort(){
   CALL("Term::defaultSort");
-  static Term* _default = createConstant(env.signature->getDefaultSort());
+  static Term* _default = createConstant(env->signature->getDefaultSort());
   return TermList(_default); 
 }
   
 TermList Term::boolSort(){
   CALL("Term::boolSort");
-  static Term* _bool = createConstant(env.signature->getBoolSort()); 
+  static Term* _bool = createConstant(env->signature->getBoolSort()); 
   return TermList(_bool); 
 }
 
 TermList Term::intSort(){
   CALL("Term::intSort");
-  static Term* _int = createConstant(env.signature->getIntSort()); 
+  static Term* _int = createConstant(env->signature->getIntSort()); 
   return TermList(_int); 
 }
  
 TermList Term::realSort(){
   CALL("Term::realSort");
-  static Term* _real = createConstant(env.signature->getRealSort()); 
+  static Term* _real = createConstant(env->signature->getRealSort()); 
   return TermList(_real); 
 }
 
 TermList Term::rationalSort(){
   CALL("Term::rationalSort");
-  static Term* _rat = createConstant(env.signature->getRatSort());
+  static Term* _rat = createConstant(env->signature->getRatSort());
   return TermList(_rat); 
 }
 
 TermList Term::arrowSort(TermList s1, TermList s2){
   CALL("Term::arrowSort/1");
-  unsigned arrow = env.signature->getArrowConstructor();
+  unsigned arrow = env->signature->getArrowConstructor();
   return TermList(create2(arrow, s1, s2));
   //Do not need to add to sorts as that is only for FMB
   //FMB and higher-order never combine.
@@ -1276,19 +1276,19 @@ TermList Term::arrowSort(TermStack& domSorts, TermList range)
 TermList Term::arraySort(TermList indexSort, TermList innerSort)
 {
   CALL("Term::arraySort");
-  unsigned array = env.signature->getArrayConstructor();
+  unsigned array = env->signature->getArrayConstructor();
   TermList sort = TermList(create2(array, indexSort, innerSort));
-  env.sorts->addSort(sort);
-  env.sorts->addArraySort(sort);
+  env->sorts->addSort(sort);
+  env->sorts->addArraySort(sort);
   return sort;
 }
 
 TermList Term::tupleSort(unsigned arity, TermList* sorts)
 {
   CALL("Term::tupleSort");
-  unsigned tuple = env.signature->getTupleConstructor(arity);
+  unsigned tuple = env->signature->getTupleConstructor(arity);
   TermList sort = TermList(create(tuple, arity, sorts));
-  env.sorts->addSort(sort);
+  env->sorts->addSort(sort);
   return sort;
 }
 
@@ -1351,19 +1351,19 @@ unsigned Term::computeDistinctVars() const
 bool Term::skip() const
 {
   if (isLiteral()) {
-    if (!env.signature->getPredicate(functor())->skip()) {
+    if (!env->signature->getPredicate(functor())->skip()) {
       return false;
     }
   }
   else {
-    if (!env.signature->getFunction(functor())->skip()) {
+    if (!env->signature->getFunction(functor())->skip()) {
       return false;
     }
   }
   NonVariableIterator nvi(const_cast<Term*>(this));
   while (nvi.hasNext()) {
     unsigned func=nvi.next().term()->functor();
-    if (!env.signature->getFunction(func)->skip()) {
+    if (!env->signature->getFunction(func)->skip()) {
       return false;
     }
   }
@@ -1373,11 +1373,11 @@ bool Term::skip() const
 bool Term::isBoolean() const {
   const Term* term = this;
   while (true) {
-    if (env.signature->isFoolConstantSymbol(true, term->functor()) ||
-        env.signature->isFoolConstantSymbol(false, term->functor())) return true;
+    if (env->signature->isFoolConstantSymbol(true, term->functor()) ||
+        env->signature->isFoolConstantSymbol(false, term->functor())) return true;
     if (!term->isSpecial()){
       bool val = !term->isLiteral() && 
-      env.signature->getFunction(term->functor())->fnType()->result() == Term::boolSort();
+      env->signature->getFunction(term->functor())->fnType()->result() == Term::boolSort();
       return val;
     }
     switch (term->getSpecialData()->getType()) {
@@ -1429,7 +1429,7 @@ Literal* Literal::create(unsigned predicate, unsigned arity, bool polarity, bool
 {
   CALL("Literal::create/4");
   ASS_G(predicate, 0); //equality is to be created by createEquality
-  ASS_EQ(env.signature->predicateArity(predicate), arity);
+  ASS_EQ(env->signature->predicateArity(predicate), arity);
 
 
   Literal* l = new(arity) Literal(predicate, arity, polarity, commutative);
@@ -1443,7 +1443,7 @@ Literal* Literal::create(unsigned predicate, unsigned arity, bool polarity, bool
     }
   }
   if (share) {
-    l = env.sharing->insert(l);
+    l = env->sharing->insert(l);
   }
   return l;
 }
@@ -1473,10 +1473,10 @@ Literal* Literal::create(Literal* l,bool polarity)
   }
   if (l->shared()) {
     if (l->isTwoVarEquality()) {
-      m = env.sharing->insertVariableEquality(m, l->twoVarEqSort());
+      m = env->sharing->insertVariableEquality(m, l->twoVarEqSort());
     }
     else {
-      m = env.sharing->insert(m);
+      m = env->sharing->insert(m);
     }
   }
   return m;
@@ -1508,7 +1508,7 @@ Literal* Literal::create(Literal* l,TermList* args)
     }
   }
   if (share) {
-    m = env.sharing->insert(m);
+    m = env->sharing->insert(m);
   }
   return m;
 } // Literal::create
@@ -1539,14 +1539,14 @@ Literal* Literal::createEquality (bool polarity, TermList arg1, TermList arg2, T
        ASS_REP(arg2.isVar(), arg2.toString());
        return createVariableEquality(polarity, arg1, arg2, sort);
      }
-     ASS(env.sharing->isWellSortednessCheckingDisabled() || checkSortSubst.match(sort, 0, srt2, 1));
+     ASS(env->sharing->isWellSortednessCheckingDisabled() || checkSortSubst.match(sort, 0, srt2, 1));
    }
    else {    
-    ASS_REP2(env.sharing->isWellSortednessCheckingDisabled() || checkSortSubst.match(sort, 0, srt1, 1), sort.toString(), srt1.toString());
+    ASS_REP2(env->sharing->isWellSortednessCheckingDisabled() || checkSortSubst.match(sort, 0, srt1, 1), sort.toString(), srt1.toString());
 #if VDEBUG
      if (SortHelper::tryGetResultSort(arg2, srt2)) {
        checkSortSubst.reset();
-       ASS_REP2(env.sharing->isWellSortednessCheckingDisabled() || checkSortSubst.match(sort, 0, srt2, 1), sort.toString(), arg2.toString() + " :  " + srt2.toString());
+       ASS_REP2(env->sharing->isWellSortednessCheckingDisabled() || checkSortSubst.match(sort, 0, srt2, 1), sort.toString(), arg2.toString() + " :  " + srt2.toString());
      }
 #endif
    }
@@ -1554,7 +1554,7 @@ Literal* Literal::createEquality (bool polarity, TermList arg1, TermList arg2, T
    *lit->nthArgument(0)=arg1;
    *lit->nthArgument(1)=arg2;
    if (arg1.isSafe() && arg2.isSafe()) {
-     lit = env.sharing->insert(lit);
+     lit = env->sharing->insert(lit);
    }
    return lit;
 }
@@ -1571,7 +1571,7 @@ Literal* Literal::createVariableEquality (bool polarity, TermList arg1, TermList
   Literal* lit=new(2) Literal(0,2,polarity,true);
   *lit->nthArgument(0)=arg1;
   *lit->nthArgument(1)=arg2;
-  lit = env.sharing->insertVariableEquality(lit, variableSort);
+  lit = env->sharing->insertVariableEquality(lit, variableSort);
   return lit;
 }
 
@@ -1729,7 +1729,7 @@ Literal* Literal::flattenOnArgument(const Literal* lit,int n)
   unsigned newArity = lit->arity() + t->arity() - 1;
   vstring newName = lit->predicateName() + '%' + Int::toString(n) +
                    '%' + t->functionName();
-  unsigned newPredicate = env.signature->addPredicate(newName,newArity);
+  unsigned newPredicate = env->signature->addPredicate(newName,newArity);
 
   Literal* newLiteral = new(newArity) Literal(newPredicate,newArity,
 					      lit->polarity(),false);
@@ -1754,7 +1754,7 @@ Literal* Literal::flattenOnArgument(const Literal* lit,int n)
   }
   ASS(newArgs->isEmpty());
 
-  return env.sharing->insert(newLiteral);
+  return env->sharing->insert(newLiteral);
 } // Literal::flattenOnArgument
 
 bool Kernel::positionIn(TermList& subterm,TermList* term,vstring& position)

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -803,16 +803,11 @@ Literal* Literal::apply(Substitution& subst)
  * @pre The term must be non-variable
  * @since 28/12/2007 Manchester
  */
-unsigned Term::hashUnderSignature(Signature *signature) const
+unsigned Term::hash() const
 {
-  CALL("Term::hashUnderSignature");
+  CALL("Term::hash");
 
-#if VTHREADED
-  unsigned functor = signature->functionId(_functor);
-#else
-  unsigned functor = _functor;
-#endif
-  unsigned hash = Hash::hash(functor);
+  unsigned hash = Hash::hash(_functor);
   if (_arity == 0) {
     return hash;
   }
@@ -824,17 +819,11 @@ unsigned Term::hashUnderSignature(Signature *signature) const
  * Return the hash function of the top-level of a literal.
  * @since 30/03/2008 Flight Murcia-Manchester
  */
-unsigned Literal::hashUnderSignature(Signature *signature) const
+unsigned Literal::hash() const
 {
-  CALL("Literal::hashUnderSignature");
+  CALL("Literal::hash");
 
-#if VTHREADED
-  unsigned functor = signature->predicateId(_functor);
-#else
-  unsigned functor = _functor;
-#endif
-
-  unsigned hash = Hash::hash(isPositive() ? (2*functor) : (2*functor+1));
+  unsigned hash = Hash::hash(isPositive() ? (2*_functor) : (2*_functor+1));
   if (_arity == 0) {
     return hash;
   }
@@ -848,17 +837,11 @@ unsigned Literal::hashUnderSignature(Signature *signature) const
 /**
  * Return the hash function of the top-level of a literal with opposite polarity.
  */
-unsigned Literal::oppositeHashUnderSignature(Signature *signature) const
+unsigned Literal::oppositeHash() const
 {
-  CALL("Literal::oppositeHashUnderSignature");
+  CALL("Literal::oppositeHash");
 
-#if VTHREADED
-  unsigned functor = signature->predicateId(_functor);
-#else
-  unsigned functor = _functor;
-#endif
-
-  unsigned hash = Hash::hash( (!isPositive()) ? (2*functor) : (2*functor+1));
+  unsigned hash = Hash::hash( (!isPositive()) ? (2*_functor) : (2*_functor+1));
   if (_arity == 0) {
     return hash;
   }

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1512,7 +1512,7 @@ Literal* Literal::createEquality (bool polarity, TermList arg1, TermList arg2, T
 
    TermList srt1, srt2;
 #if VDEBUG
-   static RobSubstitution checkSortSubst;
+   VTHREAD_LOCAL static RobSubstitution checkSortSubst;
    checkSortSubst.reset();
 #endif
 

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -798,18 +798,17 @@ Literal* Literal::apply(Substitution& subst)
   return SubstHelper::apply(this, subst);
 } // Literal::apply
 
-
 /**
  * Return the hash function of the top-level of a complex term.
  * @pre The term must be non-variable
  * @since 28/12/2007 Manchester
  */
-unsigned Term::hash() const
+unsigned Term::hashUnderSignature(Signature *signature) const
 {
-  CALL("Term::hash");
+  CALL("Term::hashUnderSignature");
 
 #if VTHREADED
-  unsigned functor = env.signature->functionId(_functor);
+  unsigned functor = signature->functionId(_functor);
 #else
   unsigned functor = _functor;
 #endif
@@ -825,12 +824,12 @@ unsigned Term::hash() const
  * Return the hash function of the top-level of a literal.
  * @since 30/03/2008 Flight Murcia-Manchester
  */
-unsigned Literal::hash() const
+unsigned Literal::hashUnderSignature(Signature *signature) const
 {
-  CALL("Literal::hash");
+  CALL("Literal::hashUnderSignature");
 
 #if VTHREADED
-  unsigned functor = env.signature->predicateId(_functor);
+  unsigned functor = signature->predicateId(_functor);
 #else
   unsigned functor = _functor;
 #endif
@@ -849,12 +848,12 @@ unsigned Literal::hash() const
 /**
  * Return the hash function of the top-level of a literal with opposite polarity.
  */
-unsigned Literal::oppositeHash() const
+unsigned Literal::oppositeHashUnderSignature(Signature *signature) const
 {
-  CALL("Literal::hash");
+  CALL("Literal::oppositeHashUnderSignature");
 
 #if VTHREADED
-  unsigned functor = env.signature->predicateId(_functor);
+  unsigned functor = signature->predicateId(_functor);
 #else
   unsigned functor = _functor;
 #endif

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -104,8 +104,8 @@ void Term::destroyNonShared()
   TermList selfRef;
   selfRef.setTerm(this);
   TermList* ts=&selfRef;
-  static Stack<TermList*> stack(4);
-  static Stack<Term*> deletingStack(8);
+  VTHREAD_LOCAL static Stack<TermList*> stack(4);
+  VTHREAD_LOCAL static Stack<Term*> deletingStack(8);
 
   for(;;) {
     if (ts->tag()==REF && !ts->term()->shared()) {
@@ -213,7 +213,7 @@ bool TermList::sameTopFunctor(TermList ss, TermList tt)
  */
 bool TermList::equals(TermList t1, TermList t2)
 {
-  static Stack<TermList*> stack(8);
+  VTHREAD_LOCAL static Stack<TermList*> stack(8);
   ASS(stack.isEmpty());
 
   TermList* ss=&t1;
@@ -291,7 +291,7 @@ bool Term::containsSubterm(TermList trm)
   }
 
   TermList* ts=args();
-  static Stack<TermList*> stack(4);
+  VTHREAD_LOCAL static Stack<TermList*> stack(4);
   stack.reset();
   for(;;) {
     if (*ts==trm) {
@@ -355,10 +355,10 @@ bool TermList::containsAllVariablesOf(TermList t)
 bool Term::containsAllVariablesOf(Term* t)
 {
   CALL("Term::containsAllVariablesOf");
-  static DHSet<TermList> vars;
+  VTHREAD_LOCAL static DHSet<TermList> vars;
   vars.reset();
 
-  static VariableIterator vit;
+  VTHREAD_LOCAL static VariableIterator vit;
 
   //collect own vars
   vit.reset(this);
@@ -380,10 +380,10 @@ bool TermList::containsAllVariableOccurrencesOf(TermList t)
 {
   CALL("TermList:containsAllVariableOccurrencesOf");
   // varBalance[x] = (#occurrences of x in this) - (#occurrences of x in t)
-  static vunordered_map<unsigned int, int> varBalance(16);
+  VTHREAD_LOCAL static vunordered_map<unsigned int, int> varBalance(16);
   varBalance.clear();
 
-  static VariableIterator vit;
+  VTHREAD_LOCAL static VariableIterator vit;
 
   // collect own vars
   vit.reset(*this);

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -27,7 +27,6 @@
 #include "Debug/Tracer.hpp"
 
 #include "Lib/Allocator.hpp"
-#include "Lib/Environment.hpp"
 #include "Lib/Portability.hpp"
 #include "Lib/Comparison.hpp"
 #include "Lib/Stack.hpp"
@@ -394,9 +393,7 @@ public:
   /** return the arguments */
   TermList* args()
   { return _args + _arity; }
-  unsigned hash() const
-  { return hashUnderSignature(env->signature); };
-  unsigned hashUnderSignature(Signature *) const;
+  unsigned hash() const;
 
   /** return the arity */
   unsigned arity() const
@@ -832,12 +829,8 @@ public:
 
   static Literal* flattenOnArgument(const Literal*,int argumentNumber);
 
-  unsigned hash() const
-  { return hashUnderSignature(env->signature); }
-  unsigned hashUnderSignature(Signature *) const;
-  unsigned oppositeHash() const
-  { return oppositeHashUnderSignature(env->signature); }
-  unsigned oppositeHashUnderSignature(Signature *) const;
+  unsigned hash() const;
+  unsigned oppositeHash() const;
   static Literal* complementaryLiteral(Literal* l);
   /** If l is positive, return l; otherwise return its complementary literal. */
   static Literal* positiveLiteral(Literal* l) {

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -27,6 +27,7 @@
 #include "Debug/Tracer.hpp"
 
 #include "Lib/Allocator.hpp"
+#include "Lib/Environment.hpp"
 #include "Lib/Portability.hpp"
 #include "Lib/Comparison.hpp"
 #include "Lib/Stack.hpp"
@@ -393,7 +394,10 @@ public:
   /** return the arguments */
   TermList* args()
   { return _args + _arity; }
-  unsigned hash() const;
+  unsigned hash() const
+  { return hashUnderSignature(env.signature); };
+  unsigned hashUnderSignature(Signature *) const;
+
   /** return the arity */
   unsigned arity() const
   { return _arity; }
@@ -828,8 +832,12 @@ public:
 
   static Literal* flattenOnArgument(const Literal*,int argumentNumber);
 
-  unsigned hash() const;
-  unsigned oppositeHash() const;
+  unsigned hash() const
+  { return hashUnderSignature(env.signature); }
+  unsigned hashUnderSignature(Signature *) const;
+  unsigned oppositeHash() const
+  { return oppositeHashUnderSignature(env.signature); }
+  unsigned oppositeHashUnderSignature(Signature *) const;
   static Literal* complementaryLiteral(Literal* l);
   /** If l is positive, return l; otherwise return its complementary literal. */
   static Literal* positiveLiteral(Literal* l) {

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -395,7 +395,7 @@ public:
   TermList* args()
   { return _args + _arity; }
   unsigned hash() const
-  { return hashUnderSignature(env.signature); };
+  { return hashUnderSignature(env->signature); };
   unsigned hashUnderSignature(Signature *) const;
 
   /** return the arity */
@@ -833,10 +833,10 @@ public:
   static Literal* flattenOnArgument(const Literal*,int argumentNumber);
 
   unsigned hash() const
-  { return hashUnderSignature(env.signature); }
+  { return hashUnderSignature(env->signature); }
   unsigned hashUnderSignature(Signature *) const;
   unsigned oppositeHash() const
-  { return oppositeHashUnderSignature(env.signature); }
+  { return oppositeHashUnderSignature(env->signature); }
   unsigned oppositeHashUnderSignature(Signature *) const;
   static Literal* complementaryLiteral(Literal* l);
   /** If l is positive, return l; otherwise return its complementary literal. */

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -544,6 +544,9 @@ public:
   }
   unsigned getDistinctVars() const
   {
+#if VTHREADED
+    return computeDistinctVars();
+#else
     if(_args[0]._info.distinctVars==TERM_DIST_VAR_UNKNOWN) {
       unsigned res=computeDistinctVars();
       if(res<TERM_DIST_VAR_UNKNOWN) {
@@ -554,6 +557,7 @@ public:
       ASS_L(_args[0]._info.distinctVars,0x100000);
       return _args[0]._info.distinctVars;
     }
+#endif
   }
 
   bool couldBeInstanceOf(Term* t)

--- a/Kernel/TermIterators.cpp
+++ b/Kernel/TermIterators.cpp
@@ -448,9 +448,9 @@ TermList NonVariableNonTypeIterator::next()
   _added = 0;  
   Signature::Symbol* sym;
   if (t->isLiteral()) {
-    sym = env.signature->getPredicate(t->functor());
+    sym = env->signature->getPredicate(t->functor());
   } else{
-    sym = env.signature->getFunction(t->functor());
+    sym = env->signature->getFunction(t->functor());
   }
   unsigned taArity; 
   unsigned arity;

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -230,9 +230,9 @@ Term* TermTransformerTransformTransformed::transform(Term* term)
   CALL("TermTransformerTransformTransformed::transform(Term* term)");
   ASS(term->shared());
 
-  static Stack<TermList*> toDo(8);
-  static Stack<Term*> terms(8);
-  static Stack<TermList> args(8);
+  VTHREAD_LOCAL static Stack<TermList*> toDo(8);
+  VTHREAD_LOCAL static Stack<Term*> terms(8);
+  VTHREAD_LOCAL static Stack<TermList> args(8);
   /* all stacks must be reset since the function might have been aborted by an exception */
   args.reset();
   terms.reset();
@@ -314,7 +314,7 @@ Literal* TermTransformerTransformTransformed::transform(Literal* lit)
 Formula* TermTransformerTransformTransformed::transform(Formula* f)
 {
   CALL("TermTransformerTransformTransformed::transform(Formula* f)");
-  static TermTransformerTransformTransformedFormulaTransformer ttft(*this);
+  VTHREAD_LOCAL static TermTransformerTransformTransformedFormulaTransformer ttft(*this);
   return ttft.transform(f);
 }
 

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -1461,7 +1461,7 @@ OperatorType* Theory::getNonpolymorphicOperatorType(Interpretation i)
 
   unsigned arity = getArity(i);
 
-  static DArray<TermList> domainSorts;
+  VTHREAD_LOCAL static DArray<TermList> domainSorts;
   domainSorts.init(arity, sort);
 
   if (isFunction(i)) {

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -623,11 +623,11 @@ vstring RealConstantType::toNiceString() const
 // Theory
 //
 
-Theory Theory::theory_obj;  // to facilitate destructor call at deinitization
-Theory::Tuples Theory::tuples_obj;
+VTHREAD_LOCAL Theory Theory::theory_obj;  // to facilitate destructor call at deinitization
+VTHREAD_LOCAL Theory::Tuples Theory::tuples_obj;
 
-Theory* theory = &Theory::theory_obj;
-Theory::Tuples* theory_tuples = &Theory::tuples_obj;
+VTHREAD_LOCAL Theory* theory = &Theory::theory_obj;
+VTHREAD_LOCAL Theory::Tuples* theory_tuples = &Theory::tuples_obj;
 
 /**
  * Accessor for the singleton instance of the Theory class.

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -1201,15 +1201,15 @@ unsigned Theory::Tuples::getFunctor(TermList tupleSort) {
   TermList* sorts = tupleSort.term()->args();
 
   theory->defineTupleTermAlgebra(arity, sorts);
-  ASS(env.signature->isTermAlgebraSort(tupleSort));
-  Shell::TermAlgebra* ta = env.signature->getTermAlgebraOfSort(tupleSort);
+  ASS(env->signature->isTermAlgebraSort(tupleSort));
+  Shell::TermAlgebra* ta = env->signature->getTermAlgebraOfSort(tupleSort);
 
   return ta->constructor(0)->functor();
 }
 
 bool Theory::Tuples::isFunctor(unsigned functor) {
   CALL("Theory::Tuples::isFunctor(unsigned)");
-  TermList tupleSort = env.signature->getFunction(functor)->fnType()->result();
+  TermList tupleSort = env->signature->getFunction(functor)->fnType()->result();
   return SortHelper::isTupleSort(tupleSort);
 }
 
@@ -1222,8 +1222,8 @@ unsigned Theory::Tuples::getProjectionFunctor(unsigned proj, TermList tupleSort)
   TermList* sorts = tupleSort.term()->args();
 
   theory->defineTupleTermAlgebra(arity, sorts);
-  ASS(env.signature->isTermAlgebraSort(tupleSort));
-  Shell::TermAlgebra* ta = env.signature->getTermAlgebraOfSort(tupleSort);
+  ASS(env->signature->isTermAlgebraSort(tupleSort));
+  Shell::TermAlgebra* ta = env->signature->getTermAlgebraOfSort(tupleSort);
 
   Shell::TermAlgebraConstructor* c = ta->constructor(0);
 
@@ -1236,8 +1236,8 @@ unsigned Theory::Tuples::getProjectionFunctor(unsigned proj, TermList tupleSort)
 bool Theory::Tuples::findProjection(unsigned projFunctor, bool isPredicate, unsigned &proj) {
   CALL("Theory::Tuples::findProjection");
 
-  OperatorType* projType = isPredicate ? env.signature->getPredicate(projFunctor)->predType()
-                                       : env.signature->getFunction(projFunctor)->fnType();
+  OperatorType* projType = isPredicate ? env->signature->getPredicate(projFunctor)->predType()
+                                       : env->signature->getFunction(projFunctor)->fnType();
 
   if (projType->arity() != 1) {
     return false;
@@ -1249,11 +1249,11 @@ bool Theory::Tuples::findProjection(unsigned projFunctor, bool isPredicate, unsi
     return false;
   }
 
-  if (!env.signature->isTermAlgebraSort(tupleSort)) {
+  if (!env->signature->isTermAlgebraSort(tupleSort)) {
     return false;
   }
 
-  Shell::TermAlgebraConstructor* c = env.signature->getTermAlgebraOfSort(tupleSort)->constructor(0);
+  Shell::TermAlgebraConstructor* c = env->signature->getTermAlgebraOfSort(tupleSort)->constructor(0);
   for (unsigned i = 0; i < c->arity(); i++) {
     if (projFunctor == c->destructorFunctor(i)) {
       proj = i;
@@ -1476,25 +1476,25 @@ void Theory::defineTupleTermAlgebra(unsigned arity, TermList* sorts) {
 
   TermList tupleSort = Term::tupleSort(arity, sorts);
 
-  if (env.signature->isTermAlgebraSort(tupleSort)) {
+  if (env->signature->isTermAlgebraSort(tupleSort)) {
     return;
   }
 
-  unsigned functor = env.signature->addFreshFunction(arity, "tuple");
+  unsigned functor = env->signature->addFreshFunction(arity, "tuple");
   OperatorType* tupleType = OperatorType::getFunctionType(arity, sorts, tupleSort);
-  env.signature->getFunction(functor)->setType(tupleType);
-  env.signature->getFunction(functor)->markTermAlgebraCons();
+  env->signature->getFunction(functor)->setType(tupleType);
+  env->signature->getFunction(functor)->markTermAlgebraCons();
 
   Array<unsigned> destructors(arity);
   for (unsigned i = 0; i < arity; i++) {
     TermList projSort = sorts[i];
     unsigned destructor;
     if (projSort == Term::boolSort()) {
-      destructor = env.signature->addFreshPredicate(1, "proj");
-      env.signature->getPredicate(destructor)->setType(OperatorType::getPredicateType({ tupleSort }));
+      destructor = env->signature->addFreshPredicate(1, "proj");
+      env->signature->getPredicate(destructor)->setType(OperatorType::getPredicateType({ tupleSort }));
     } else {
-      destructor = env.signature->addFreshFunction(1, "proj");
-      env.signature->getFunction(destructor)->setType(OperatorType::getFunctionType({ tupleSort }, projSort));
+      destructor = env->signature->addFreshFunction(1, "proj");
+      env->signature->getFunction(destructor)->setType(OperatorType::getFunctionType({ tupleSort }, projSort));
     }
     destructors[i] = destructor;
   }
@@ -1502,7 +1502,7 @@ void Theory::defineTupleTermAlgebra(unsigned arity, TermList* sorts) {
   Shell::TermAlgebraConstructor* constructor = new Shell::TermAlgebraConstructor(functor, destructors);
 
   Shell::TermAlgebraConstructor* constructors[] = { constructor };
-  env.signature->addTermAlgebra(new Shell::TermAlgebra(tupleSort, 1, constructors, false));
+  env->signature->addTermAlgebra(new Shell::TermAlgebra(tupleSort, 1, constructors, false));
 }
 
 bool Theory::isInterpretedConstant(unsigned func)
@@ -1513,7 +1513,7 @@ bool Theory::isInterpretedConstant(unsigned func)
     return false;
   }
 
-  return env.signature->getFunction(func)->interpreted() && env.signature->functionArity(func)==0;
+  return env->signature->getFunction(func)->interpreted() && env->signature->functionArity(func)==0;
 }
 
 /**
@@ -1525,7 +1525,7 @@ bool Theory::isInterpretedConstant(Term* t)
 
   if (t->isSpecial()) { return false; }
 
-  return t->arity()==0 && env.signature->getFunction(t->functor())->interpreted();
+  return t->arity()==0 && env->signature->getFunction(t->functor())->interpreted();
 }
 
 /**
@@ -1545,7 +1545,7 @@ bool Theory::isInterpretedNumber(Term* t)
 {
   CALL("Theory::isInterpretedNumber(TermList)");
 
-  return isInterpretedConstant(t) && env.signature->getFunction(t->functor())->interpretedNumber();
+  return isInterpretedConstant(t) && env->signature->getFunction(t->functor())->interpretedNumber();
 }
 
 /**
@@ -1555,7 +1555,7 @@ bool Theory::isInterpretedNumber(TermList t)
 {
   CALL("Theory::isInterpretedNumber(TermList)");
 
-  return isInterpretedConstant(t) && env.signature->getFunction(t.term()->functor())->interpretedNumber();
+  return isInterpretedConstant(t) && env->signature->getFunction(t.term()->functor())->interpretedNumber();
 }
 
 /**
@@ -1565,7 +1565,7 @@ bool Theory::isInterpretedPredicate(unsigned pred)
 {
   CALL("Theory::isInterpretedPredicate(unsigned)");
 
-  return env.signature->getPredicate(pred)->interpreted();
+  return env->signature->getPredicate(pred)->interpreted();
 }
 
 /**
@@ -1591,7 +1591,7 @@ bool Theory::isInterpretedPredicate(Literal* lit, Interpretation itp)
 {
   CALL("Theory::isInterpretedPredicate/2");
 
-  return env.signature->getPredicate(lit->functor())->interpreted() &&
+  return env->signature->getPredicate(lit->functor())->interpreted() &&
       interpretPredicate(lit)==itp;
 }
 
@@ -1603,7 +1603,7 @@ bool Theory::isInterpretedFunction(unsigned func)
     return false;
   }
 
-  return env.signature->getFunction(func)->interpreted() && env.signature->functionArity(func)!=0;
+  return env->signature->getFunction(func)->interpreted() && env->signature->functionArity(func)!=0;
 }
 bool Theory::isInterpretedPartialFunction(unsigned func)
 {
@@ -1612,7 +1612,7 @@ bool Theory::isInterpretedPartialFunction(unsigned func)
   if(!isInterpretedFunction(func)){ return false; }
 
   bool result =  isPartialFunction(interpretFunction(func));
-  ASS(!result || env.signature->functionArity(func)==2);
+  ASS(!result || env->signature->functionArity(func)==2);
   return result;
 }
 
@@ -1684,7 +1684,7 @@ Interpretation Theory::interpretFunction(unsigned func)
   ASS(isInterpretedFunction(func));
 
   Signature::InterpretedSymbol* sym =
-      static_cast<Signature::InterpretedSymbol*>(env.signature->getFunction(func));
+      static_cast<Signature::InterpretedSymbol*>(env->signature->getFunction(func));
 
   return sym->getInterpretation();
 }
@@ -1717,7 +1717,7 @@ Interpretation Theory::interpretPredicate(unsigned pred)
   ASS(isInterpretedPredicate(pred));
 
   Signature::InterpretedSymbol* sym =
-      static_cast<Signature::InterpretedSymbol*>(env.signature->getPredicate(pred));
+      static_cast<Signature::InterpretedSymbol*>(env->signature->getPredicate(pred));
 
   return sym->getInterpretation();
 }
@@ -1749,7 +1749,7 @@ bool Theory::tryInterpretConstant(const Term* t, IntegerConstantType& res)
     return false;
   }
   unsigned func = t->functor();
-  Signature::Symbol* sym = env.signature->getFunction(func);
+  Signature::Symbol* sym = env->signature->getFunction(func);
   if (!sym->integerConstant()) {
     return false;
   }
@@ -1772,7 +1772,7 @@ bool Theory::tryInterpretConstant(const Term* t, RationalConstantType& res)
     return false;
   }
   unsigned func = t->functor();
-  Signature::Symbol* sym = env.signature->getFunction(func);
+  Signature::Symbol* sym = env->signature->getFunction(func);
   if (!sym->rationalConstant()) {
     return false;
   }
@@ -1795,7 +1795,7 @@ bool Theory::tryInterpretConstant(const Term* t, RealConstantType& res)
     return false;
   }
   unsigned func = t->functor();
-  Signature::Symbol* sym = env.signature->getFunction(func);
+  Signature::Symbol* sym = env->signature->getFunction(func);
   if (!sym->realConstant()) {
     return false;
   }
@@ -1807,7 +1807,7 @@ Term* Theory::representConstant(const IntegerConstantType& num)
 {
   CALL("Theory::representConstant(const IntegerConstantType&)");
 
-  unsigned func = env.signature->addIntegerConstant(num);
+  unsigned func = env->signature->addIntegerConstant(num);
   return Term::create(func, 0, 0);
 }
 
@@ -1815,7 +1815,7 @@ Term* Theory::representConstant(const RationalConstantType& num)
 {
   CALL("Theory::representConstant(const RationalConstantType&)");
 
-  unsigned func = env.signature->addRationalConstant(num);
+  unsigned func = env->signature->addRationalConstant(num);
   return Term::create(func, 0, 0);
 }
 
@@ -1823,7 +1823,7 @@ Term* Theory::representConstant(const RealConstantType& num)
 {
   CALL("Theory::representConstant(const RealConstantType&)");
 
-  unsigned func = env.signature->addRealConstant(num);
+  unsigned func = env->signature->addRealConstant(num);
   return Term::create(func, 0, 0);
 }
 
@@ -1837,13 +1837,13 @@ Term* Theory::representIntegerConstant(vstring str)
   catch(ArithmeticException&) {
     NOT_IMPLEMENTED;
 //    bool added;
-//    unsigned fnNum = env.signature->addFunction(str, 0, added);
+//    unsigned fnNum = env->signature->addFunction(str, 0, added);
 //    if (added) {
-//      env.signature->getFunction(fnNum)->setType(new FunctionType(Sorts::SRT_INTEGER));
-//      env.signature->addToDistinctGroup(fnNum, Signature::INTEGER_DISTINCT_GROUP);
+//      env->signature->getFunction(fnNum)->setType(new FunctionType(Sorts::SRT_INTEGER));
+//      env->signature->addToDistinctGroup(fnNum, Signature::INTEGER_DISTINCT_GROUP);
 //    }
 //    else {
-//      ASS(env.signature->getFunction(fnNum))
+//      ASS(env->signature->getFunction(fnNum))
 //    }
   }
 }

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -400,7 +400,7 @@ public:
 
   unsigned getArrayExtSkolemFunction(TermList sort);
 
-  static Theory theory_obj;
+  VTHREAD_LOCAL static Theory theory_obj;
   static Theory* instance();
 
   void defineTupleTermAlgebra(unsigned arity, TermList* sorts);
@@ -517,7 +517,7 @@ public:
     bool findProjection(unsigned projFunctor, bool isPredicate, unsigned &proj);
   };
 
-  static Theory::Tuples tuples_obj;
+  VTHREAD_LOCAL static Theory::Tuples tuples_obj;
   static Theory::Tuples* tuples();
 };
 
@@ -526,7 +526,7 @@ typedef Theory::Interpretation Interpretation;
 /**
  * Pointer to the singleton Theory instance
  */
-extern Theory* theory;
+VTHREAD_LOCAL extern Theory* theory;
 
 }
 

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -34,9 +34,9 @@
 
 using namespace Kernel;
 
-unsigned Unit::_lastNumber = 0;
-unsigned Unit::_firstNonPreprocessingNumber = 0;
-unsigned Unit::_lastParsingNumber = 0;
+VTHREAD_LOCAL unsigned Unit::_lastNumber = 0;
+VTHREAD_LOCAL unsigned Unit::_firstNonPreprocessingNumber = 0;
+VTHREAD_LOCAL unsigned Unit::_lastParsingNumber = 0;
 
 /**
  * Should be called after the preprocessing and before the start

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -45,9 +45,9 @@ VTHREAD_LOCAL unsigned Unit::_lastParsingNumber = 0;
 void Unit::onPreprocessingEnd()
 {
   CALL("Unit::onPreprocessingEnd");
-  if(!_firstNonPreprocessingNumber) {
-    _firstNonPreprocessingNumber=_lastNumber+1;
-  }
+  ASS(!_firstNonPreprocessingNumber);
+
+  _firstNonPreprocessingNumber=_lastNumber+1;
 }
 
 /** New unit of a given kind */

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -45,9 +45,9 @@ unsigned Unit::_lastParsingNumber = 0;
 void Unit::onPreprocessingEnd()
 {
   CALL("Unit::onPreprocessingEnd");
-  ASS(!_firstNonPreprocessingNumber);
-
-  _firstNonPreprocessingNumber=_lastNumber+1;
+  if(!_firstNonPreprocessingNumber) {
+    _firstNonPreprocessingNumber=_lastNumber+1;
+  }
 }
 
 /** New unit of a given kind */

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -34,9 +34,9 @@
 
 using namespace Kernel;
 
-VTHREAD_LOCAL unsigned Unit::_lastNumber = 0;
 VTHREAD_LOCAL unsigned Unit::_firstNonPreprocessingNumber = 0;
-VTHREAD_LOCAL unsigned Unit::_lastParsingNumber = 0;
+VATOMIC(unsigned) Unit::_lastNumber(0);
+unsigned Unit::_lastParsingNumber = 0;
 
 /**
  * Should be called after the preprocessing and before the start

--- a/Kernel/Unit.hpp
+++ b/Kernel/Unit.hpp
@@ -20,6 +20,7 @@
 #include "Forwards.hpp"
 
 #include "Lib/List.hpp"
+#include "Lib/Threading.hpp"
 #include "Lib/VString.hpp"
 #include "Kernel/Inference.hpp"
 

--- a/Kernel/Unit.hpp
+++ b/Kernel/Unit.hpp
@@ -162,12 +162,12 @@ protected:
   Unit(Kind kind, const Inference& inf);
 
   /** Used to enumerate units */
-  static unsigned _lastNumber;
+  static VATOMIC(unsigned) _lastNumber;
 
   /** Used to determine which clauses come from preprocessing
    *
    * 0 means preprocessing is not over yet.*/
-  static unsigned _firstNonPreprocessingNumber;
+  VTHREAD_LOCAL static unsigned _firstNonPreprocessingNumber;
 
   static unsigned _lastParsingNumber;
 }; // class Unit

--- a/Kernel/V2CIndex.cpp
+++ b/Kernel/V2CIndex.cpp
@@ -23,7 +23,7 @@ namespace Kernel
 {
 
 V2CIndex::V2CIndex()
- : _varCnt(env.signature->vars()), _pos(_varCnt), _neg(_varCnt)
+ : _varCnt(env->signature->vars()), _pos(_varCnt), _neg(_varCnt)
 {
   CALL("V2CIndex::V2CIndex");
 }

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -365,11 +365,7 @@ void Allocator::deallocateKnown(void* obj,size_t size)
   cout << *desc << ": DK\n" << flush;
 #endif
   ASS_EQ(desc->address, obj);
-// TODO shared signatures break this for threaded builds
-// this is because symbol classes don't match once copied - should be fixed with shared signatures
-#if !VTHREADED
-ASS_STR_EQ(desc->cls,className);
-#endif
+  ASS_STR_EQ(desc->cls,className);
   ASS_EQ(desc->size, size);
   ASS(desc->allocated);
   ASS(desc->known);

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -32,7 +32,7 @@
  *  C++ new and delete for (de)allocating all data structures.
  */
 #ifndef USE_SYSTEM_ALLOCATION
-#if TSAN
+#if VTHREADED
 #define USE_SYSTEM_ALLOCATION 1
 #else
 #define USE_SYSTEM_ALLOCATION 0
@@ -1089,7 +1089,7 @@ void* operator new(size_t sz) {
    * here be dragons!
    * 
    * space for thread_local variables are allocated lazily by calling this function
-   * this messes with some assumptions that Allocator has, * and doesn't always show up immediately
+   * this messes with some assumptions that Allocator has, and doesn't always show up immediately
    * 
    * TODO: fix this properly somehow?
    */

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -589,16 +589,16 @@ Allocator::Page* Allocator::allocatePages(size_t size)
   // check if the allocation isn't too big
   if(index>=MAX_PAGES) {
 #if SAFE_OUT_OF_MEM_SOLUTION
-    env.beginOutput();
+    env->beginOutput();
     reportSpiderStatus('m');
-    env.out() << "Unsupported amount of allocated memory: "<<realSize<<"!\n";
-    if(env.statistics) {
-      env.statistics->print(env.out());
+    env->out() << "Unsupported amount of allocated memory: "<<realSize<<"!\n";
+    if(env->statistics) {
+      env->statistics->print(env->out());
     }
 #if VDEBUG
-    Debug::Tracer::printStack(env.out());
+    Debug::Tracer::printStack(env->out());
 #endif
-    env.endOutput();
+    env->endOutput();
     System::terminateImmediately(1);
 #else
     throw Lib::MemoryLimitExceededException();
@@ -612,21 +612,21 @@ Allocator::Page* Allocator::allocatePages(size_t size)
   else {
     size_t newSize = _usedMemory+realSize;
     if (_tolerated && newSize > _tolerated) {
-      env.statistics->terminationReason = Shell::Statistics::MEMORY_LIMIT;
+      env->statistics->terminationReason = Shell::Statistics::MEMORY_LIMIT;
       //increase the limit, so that the exception can be handled properly.
       _tolerated=newSize+1000000;
 
 #if SAFE_OUT_OF_MEM_SOLUTION
-      env.beginOutput();
+      env->beginOutput();
       reportSpiderStatus('m');
-      env.out() << "Memory limit exceeded!\n";
+      env->out() << "Memory limit exceeded!\n";
 # if VDEBUG
 	Allocator::reportUsageByClasses();
 # endif
-      if(env.statistics) {
-	env.statistics->print(env.out());
+      if(env->statistics) {
+	env->statistics->print(env->out());
       }
-      env.endOutput();
+      env->endOutput();
       System::terminateImmediately(1);
 #else
       throw Lib::MemoryLimitExceededException();
@@ -636,15 +636,15 @@ Allocator::Page* Allocator::allocatePages(size_t size)
 
     char* mem = static_cast<char*>(malloc(realSize));
     if (!mem) {
-      env.beginOutput();
+      env->beginOutput();
       reportSpiderStatus('m');
-      env.out() << "Memory limit exceeded!\n";
-      if(env.statistics) {
+      env->out() << "Memory limit exceeded!\n";
+      if(env->statistics) {
         // statistics should be fine when out of memory, but not RuntimeStatistics, which allocate a Stack
         // (i.e. potential crazy exception recursion may happen in DEBUG mode)
-        env.statistics->print(env.out());
+        env->statistics->print(env->out());
       }
-      env.endOutput();
+      env->endOutput();
       System::terminateImmediately(1);
 
       // CANNOT throw vampire exception when out of memory - it contains allocations because of the message string
@@ -982,10 +982,10 @@ Allocator::Descriptor* Allocator::Descriptor::find (const void* addr)
     try {
       map = new Descriptor [capacity];
     } catch(bad_alloc&) {
-      env.beginOutput();
+      env->beginOutput();
       reportSpiderStatus('m');
-      env.out() << "Memory limit exceeded!\n";
-      env.endOutput();
+      env->out() << "Memory limit exceeded!\n";
+      env->endOutput();
       System::terminateImmediately(1);
 
       // CANNOT throw vampire exception when out of memory - it contains allocations because of the message string

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -365,7 +365,11 @@ void Allocator::deallocateKnown(void* obj,size_t size)
   cout << *desc << ": DK\n" << flush;
 #endif
   ASS_EQ(desc->address, obj);
-  ASS_STR_EQ(desc->cls,className);
+// TODO shared signatures break this for threaded builds
+// this is because symbol classes don't match once copied - should be fixed with shared signatures
+#if !VTHREADED
+ASS_STR_EQ(desc->cls,className);
+#endif
   ASS_EQ(desc->size, size);
   ASS(desc->allocated);
   ASS(desc->known);

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -1059,6 +1059,9 @@ unsigned Allocator::Descriptor::hash (const void* addr)
 
 #endif
 
+// TSan provides its own global new/delete
+#if (defined(__has_feature) && __has_feature(thread_sanitizer))
+#else
 /**
  * In debug mode we replace the global new and delete (also the array versions)
  * and terminate in cases when they are used "unwillingly".
@@ -1129,6 +1132,7 @@ void operator delete[](void* obj) throw() {
     DEALLOC_UNKNOWN(obj,"global new[]");
   }
 }
+#endif // !TSan
 
 #if VTEST
 

--- a/Lib/Allocator.hpp
+++ b/Lib/Allocator.hpp
@@ -27,13 +27,6 @@
 #include "Portability.hpp"
 #include "Threading.hpp"
 
-#if VTHREADED
-#include <mutex>
-#define ACQ_ALLOCATOR_LOCK const std::lock_guard<std::recursive_mutex> __vampire_allocator_lock(_mutex)
-#else
-#define ACQ_ALLOCATOR_LOCK
-#endif
-
 #if VDEBUG
 #include <string>
 #endif
@@ -77,34 +70,22 @@ public:
   Allocator();
   ~Allocator();
 
-// mutex for global allocator data
-#if VTHREADED
-  static std::recursive_mutex _mutex;
-
-  static void lockPermanently() {
-    _mutex.lock();
-  };
-#endif
-  
   /** Return the amount of used memory */
   static size_t getUsedMemory()
   {
     CALLC("Allocator::getUsedMemory",MAKE_CALLS);
-    ACQ_ALLOCATOR_LOCK;
     return _usedMemory;
   }
   /** Return the global memory limit (in bytes) */
   static size_t getMemoryLimit()
   {
     CALLC("Allocator::getMemoryLimit",MAKE_CALLS);
-    ACQ_ALLOCATOR_LOCK;
     return _memoryLimit;
   }
   /** Set the global memory limit (in bytes) */
   static void setMemoryLimit(size_t size)
   {
     CALLC("Allocator::setMemoryLimit",MAKE_CALLS);
-    ACQ_ALLOCATOR_LOCK;
     _memoryLimit = size;
     _tolerated = size + (size/10);
   }

--- a/Lib/Cache.hpp
+++ b/Lib/Cache.hpp
@@ -53,7 +53,7 @@ using namespace Shell;
  */
 bool canExpandToBytes(size_t sz)
 {
-  return sz<(MAXIMAL_ALLOCATION/2) && sz<(env.options->memoryLimit()-Allocator::getUsedMemory());
+  return sz<(MAXIMAL_ALLOCATION/2) && sz<(env->options->memoryLimit()-Allocator::getUsedMemory());
 }
 
 }

--- a/Lib/DArray.hpp
+++ b/Lib/DArray.hpp
@@ -344,7 +344,7 @@ public:
     }
 
     // array behaves as a stack of calls to quicksort
-    static DArray<size_t> ft(32);
+    VTHREAD_LOCAL static DArray<size_t> ft(32);
 
     size_t from = 0;
     size_t to=size()-1;

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -104,15 +104,17 @@ Environment::~Environment()
   }
 
 // #if CHECK_LEAKS
-  delete sharing;
   delete signature;
-  delete sorts;
   delete statistics;
-  if (predicateSineLevels) delete predicateSineLevels;
   {
     BYPASSING_ALLOCATOR; // use of std::function in options
     delete options;
   }
+#if !VTHREADED
+  delete sorts;
+  delete sharing;
+#endif
+  if (predicateSineLevels) delete predicateSineLevels;
 // #endif
 }
 

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -126,7 +126,7 @@ bool Environment::timeLimitReached() const
   CALL("Environment::timeLimitReached");
 
   if (options->timeLimitInDeciseconds() &&
-      timer->elapsedDeciseconds() > options->timeLimitInDeciseconds()) {
+      timer->elapsedDeciseconds() >= options->timeLimitInDeciseconds()) {
     statistics->terminationReason = Shell::Statistics::TIME_LIMIT;
     Timer::setTimeLimitEnforcement(false);
     return true;

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -58,7 +58,14 @@ Environment::Environment()
   statistics = new Statistics;  
   sorts = new Sorts;
   signature = new Signature;
+
+  // only one sharing object per process: guarded with internal lock
+#if VTHREADED
+  static TermSharing *shared_sharing = new TermSharing;
+  sharing = shared_sharing;
+#else
   sharing = new TermSharing;
+#endif
 
   //view comment in Signature.cpp
   signature->addEquality();
@@ -92,7 +99,9 @@ Environment::~Environment()
   }
 
 // #if CHECK_LEAKS
+#if !VTHREADED
   delete sharing;
+#endif
   delete signature;
   delete sorts;
   delete statistics;

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -42,9 +42,13 @@ using namespace Shell;
  * @since 06/05/2007 Manchester
  */
 Environment::Environment()
-  : signature(0),
-    sharing(0),
-    property(0),
+  : options(nullptr),
+    sorts(nullptr),
+    signature(nullptr),
+    sharing(nullptr),
+    statistics(nullptr),
+    property(nullptr),
+    timer(nullptr),
     maxSineLevel(1),
     predicateSineLevels(nullptr),
     colorUsed(false),
@@ -54,18 +58,19 @@ Environment::Environment()
 {
   START_CHECKING_FOR_ALLOCATOR_BYPASSES;
 
+#if VTHREADED
+  static bool is_thread = false;
+  if(is_thread) {
+    return;
+  }
+  is_thread = true;
+#endif
+
   options = new Options;
   statistics = new Statistics;  
   sorts = new Sorts;
   signature = new Signature;
-
-  // only one sharing object per process: guarded with internal lock
-#if VTHREADED
-  static TermSharing *shared_sharing = new TermSharing;
-  sharing = shared_sharing;
-#else
   sharing = new TermSharing;
-#endif
 
   //view comment in Signature.cpp
   signature->addEquality();
@@ -99,9 +104,7 @@ Environment::~Environment()
   }
 
 // #if CHECK_LEAKS
-#if !VTHREADED
   delete sharing;
-#endif
   delete signature;
   delete sorts;
   delete statistics;

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -38,6 +38,9 @@ using namespace Kernel;
 using namespace Indexing;
 using namespace Shell;
 
+VTHREAD_LOCAL Environment *env(nullptr);
+Environment _ROOT_ENV;
+
 /**
  * @since 06/05/2007 Manchester
  */
@@ -65,6 +68,7 @@ Environment::Environment()
   }
   is_thread = true;
 #endif
+  env = this;
 
   options = new Options;
   statistics = new Statistics;  
@@ -218,7 +222,7 @@ ostream& Environment::out()
 }
 
 /**
- * Direct @b env.out() into @b pipe or to @b cout if @b pipe is zero
+ * Direct @b env->out() into @b pipe or to @b cout if @b pipe is zero
  *
  * This function cannot be called when an output is in progress.
  */
@@ -238,7 +242,4 @@ void Environment::setPriorityOutput(ostream* stm)
   _priorityOutput=stm;
 
 }
-
-// global environment object, constructed before main() and used everywhere
-Environment env;
 }

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -109,7 +109,8 @@ private:
   SyncPipe* _pipe;
 }; // class Environment
 
-extern VTHREAD_LOCAL Environment env;
+extern VTHREAD_LOCAL Environment *env;
+extern Environment _ROOT_ENV;
 
 }
 #endif

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -78,7 +78,7 @@ public:
   template<int Period>
   void checkTimeSometime() const
   {
-    static int counter=0;
+    VTHREAD_LOCAL static int counter=0;
     counter++;
     if(counter==Period) {
       counter=0;

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -24,6 +24,10 @@
 #include "DHMap.hpp"
 #include "Threading.hpp"
 
+namespace CASC {
+  class ThreadScheduleExecutor;
+};
+
 namespace Lib {
 
 using namespace std;
@@ -40,6 +44,10 @@ class Environment
 public:
   Environment();
   ~Environment();
+  // we need to poke about with members when setting up a thread
+#if VTHREADED
+  friend class CASC::ThreadScheduleExecutor;
+#endif
 
   /** options for the current proof attempt */
   Shell::Options* options;

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -22,6 +22,7 @@
 #include "Forwards.hpp"
 #include "Exception.hpp"
 #include "DHMap.hpp"
+#include "Threading.hpp"
 
 namespace Lib {
 
@@ -100,7 +101,7 @@ private:
   SyncPipe* _pipe;
 }; // class Environment
 
-extern Environment env;
+extern VTHREAD_LOCAL Environment env;
 
 }
 #endif

--- a/Lib/Exception.cpp
+++ b/Lib/Exception.cpp
@@ -23,7 +23,7 @@
 namespace Lib
 {
 
-int Exception::s_exceptionCounter=0;
+VTHREAD_LOCAL int Exception::s_exceptionCounter=0;
 
 Exception::Exception (const char* msg, int line)
   : _message((vstring(msg)+": "+Int::toString(line)).c_str())

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -19,6 +19,7 @@
 #include <iostream>
 
 #include "LastCopyWatcher.hpp"
+#include "Threading.hpp"
 #include "VString.hpp"
 
 namespace Lib {
@@ -98,7 +99,7 @@ protected:
 
   /** Number of currently existing Exception objects
    * (not counting copies of the same object) */
-  static int s_exceptionCounter;
+  VTHREAD_LOCAL static int s_exceptionCounter;
 
 }; // Exception
 

--- a/Lib/ImplicationSetClosure.hpp
+++ b/Lib/ImplicationSetClosure.hpp
@@ -43,7 +43,7 @@ public:
     CALL("ImplicationSetClosure::add");
 
     if(_selected.contains(val)) { return; }
-    static Stack<T> todo;
+    VTHREAD_LOCAL static Stack<T> todo;
     todo.reset();
     todo.push(val);
     while(todo.isNonEmpty()) {

--- a/Lib/IntUnionFind.cpp
+++ b/Lib/IntUnionFind.cpp
@@ -85,7 +85,7 @@ int IntUnionFind::root(int c) const
 {
   CALL("IntUnionFind::root");
 
-  static Stack<int> path(8);
+  VTHREAD_LOCAL static Stack<int> path(8);
   ASS(path.isEmpty());
   int prev=-1;
 

--- a/Lib/Random.cpp
+++ b/Lib/Random.cpp
@@ -22,10 +22,10 @@
 
 using namespace Lib;
 
-int Random::_seed = 1;
-int Random::_remainingBits = 0;
+VTHREAD_LOCAL int Random::_seed = 1;
+VTHREAD_LOCAL int Random::_remainingBits = 0;
 const int Random::_bitsPerInt = Random::bitsPerInt ();
-unsigned Random::_bits;
+VTHREAD_LOCAL unsigned Random::_bits;
 
 /**
  * Return value between @c min and @c max (excluding the bounds)

--- a/Lib/Random.hpp
+++ b/Lib/Random.hpp
@@ -24,6 +24,8 @@
 #include <cstdlib>
 #include <ctime>
 
+#include "Lib/Threading.hpp"
+
 namespace Lib
 {
 
@@ -34,13 +36,13 @@ namespace Lib
 class Random 
 {
   /** seed */
-  static int _seed;
+  VTHREAD_LOCAL static int _seed;
   /** number of remaining bits */
-  static int _remainingBits;
+  VTHREAD_LOCAL static int _remainingBits;
   /** number of random bits that can be extracted from one random integer */
   static const int _bitsPerInt; 
   /** integer used for extracting random bits */
-  static unsigned _bits; 
+  VTHREAD_LOCAL static unsigned _bits; 
 
   static int bitsPerInt ();     // finds _bitsPerInt;
 

--- a/Lib/Recycler.hpp
+++ b/Lib/Recycler.hpp
@@ -83,7 +83,7 @@ private:
   template<typename T>
   static Stack<T*>& getStore() throw()
   {
-    static OwnedPtrStack<T> store(4);
+    VTHREAD_LOCAL static OwnedPtrStack<T> store(4);
     return store;
   }
 };

--- a/Lib/SharedSet.hpp
+++ b/Lib/SharedSet.hpp
@@ -116,7 +116,7 @@ public:
     bool p1Superset = true;
     bool p2Superset = true;
 
-    static ItemStack acc;
+    VTHREAD_LOCAL static ItemStack acc;
     acc.reset();
 
     const T* p1=_items;
@@ -175,7 +175,7 @@ public:
       return this;
     }
 
-    static ItemStack acc;
+    VTHREAD_LOCAL static ItemStack acc;
     ASS(acc.isEmpty());
 
     const T* p1=_items;
@@ -216,7 +216,7 @@ public:
       return getEmpty();
     }
 
-    static ItemStack acc;
+    VTHREAD_LOCAL static ItemStack acc;
     ASS(acc.isEmpty());
 
     const T* p1=_items;
@@ -326,7 +326,7 @@ public:
   {
     CALL("SharedSet::getEmpty");
 
-    static SharedSet empty(0);    
+    VTHREAD_LOCAL static SharedSet empty(0);    
     
     return &empty;
   }
@@ -335,7 +335,7 @@ public:
   {
     CALL("SharedSet::getRange");
 
-    static ItemStack is;
+    VTHREAD_LOCAL static ItemStack is;
     ASS(is.isEmpty());
 
     for(T itm=first;itm!=afterLast;itm++) {
@@ -351,7 +351,7 @@ public:
   template<class It>
   static const SharedSet* getFromIterator(It it)
   {
-    static ItemStack is;
+    VTHREAD_LOCAL static ItemStack is;
     is.reset();
     is.loadFromIterator(it);
     return getFromArray(is.begin(), is.length());
@@ -365,7 +365,7 @@ public:
       return getEmpty();
     }
 
-    static ItemStack is;
+    VTHREAD_LOCAL static ItemStack is;
     ASS(is.isEmpty());
 
     bool sorted=true;
@@ -522,7 +522,7 @@ private:
 
   static SharingStruct& getSStruct()
   {
-    static SharingStruct sstruct;
+    VTHREAD_LOCAL static SharingStruct sstruct;
     return sstruct;
   }
 

--- a/Lib/SmartPtr.hpp
+++ b/Lib/SmartPtr.hpp
@@ -36,7 +36,7 @@ private:
   
     inline explicit RefCounter(int v) : _val(v) {}
   
-    int _val;
+    VATOMIC(int) _val;
   };
 
 public:
@@ -54,8 +54,7 @@ public:
   SmartPtr(const SmartPtr& ptr) : _obj(ptr._obj), _refCnt(ptr._refCnt)
   {
     if(_obj && _refCnt) {
-      ASS(_refCnt->_val > 0);
-      (_refCnt->_val)++;
+      ALWAYS(_refCnt->_val++ > 0);
     }
   }
   inline
@@ -64,9 +63,9 @@ public:
     if(!_obj || !_refCnt) {
       return;
     }
-    (_refCnt->_val)--;
-    ASS(_refCnt->_val >= 0);
-    if(! _refCnt->_val) {
+    auto after = --_refCnt->_val;
+    ASS(after >= 0);
+    if(!after) {
       checked_delete(_obj);
       delete _refCnt;
     }
@@ -85,9 +84,9 @@ public:
     }
 
     if(oldObj && oldCnt) {
-      (oldCnt->_val)--;
-      ASS(oldCnt->_val >= 0);
-      if(! oldCnt->_val) {
+      auto after = --oldCnt->_val;
+      ASS(after >= 0);
+      if(!after) {
         checked_delete(oldObj);
         delete oldCnt;
       }

--- a/Lib/Sort.hpp
+++ b/Lib/Sort.hpp
@@ -61,7 +61,7 @@ void sort(C* first, C* afterLast)
   }
 
   // array behaves as a stack of calls to quicksort
-  static DArray<size_t> ft(32);
+  VTHREAD_LOCAL static DArray<size_t> ft(32);
 
   size_t from = 0;
   size_t to=size-1;

--- a/Lib/StringUtils.cpp
+++ b/Lib/StringUtils.cpp
@@ -28,7 +28,7 @@ vstring StringUtils::replaceChar(vstring str, char src, char target)
   CALL("StringUtils::replaceChar");
 
   size_t len=str.size();
-  static DArray<char> buf;
+  VTHREAD_LOCAL static DArray<char> buf;
   buf.ensure(len);
 
   const char* sptr=str.c_str();
@@ -57,7 +57,7 @@ vstring StringUtils::sanitizeSuffix(vstring str)
   CALL("StringUtils::sanitizeSuffix");
 
   size_t len=str.size();
-  static DArray<char> buf;
+  VTHREAD_LOCAL static DArray<char> buf;
   buf.ensure(len);
 
   const char* sptr=str.c_str();
@@ -133,7 +133,7 @@ void StringUtils::splitStr(const char* str, char delimiter, Stack<vstring>& stri
 {
   CALL("StringUtils::splitStr");
 
-  static Stack<char> currPart;
+  VTHREAD_LOCAL static Stack<char> currPart;
   currPart.reset();
 
   const char* curr = str;
@@ -156,7 +156,7 @@ bool StringUtils::readEquality(const char* str, char eqChar, vstring& lhs, vstri
 {
   CALL("StringUtils::readEquality");
 
-  static Stack<vstring> parts;
+  VTHREAD_LOCAL static Stack<vstring> parts;
   parts.reset();
   splitStr(str, eqChar, parts);
   if(parts.size()!=2) {
@@ -174,7 +174,7 @@ bool StringUtils::readEqualities(const char* str, char delimiter, char eqChar, D
 {
   CALL("StringUtils::readEqualities");
 
-  static Stack<vstring> parts;
+  VTHREAD_LOCAL static Stack<vstring> parts;
   parts.reset();
   splitStr(str, delimiter, parts);
 

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -80,7 +80,7 @@ void Multiprocessing::executeFuncList(VoidFuncList* lst)
 pid_t Multiprocessing::fork()
 {
   CALL("Multiprocessing::fork");
-  ASS(!env.haveOutput());
+  ASS(!env->haveOutput());
 
   executeFuncList(_preFork);
   errno=0;
@@ -138,7 +138,7 @@ pid_t Multiprocessing::waitForChildTerminationOrTime(unsigned timeMs,int& resVal
   int status;
   pid_t childPid;
 
-  int dueTime = env.timer->elapsedMilliseconds()+timeMs;
+  int dueTime = env->timer->elapsedMilliseconds()+timeMs;
 
   for(;;) {
     errno=0;
@@ -147,7 +147,7 @@ pid_t Multiprocessing::waitForChildTerminationOrTime(unsigned timeMs,int& resVal
       SYSTEM_FAIL("Call to waitpid() function failed.", errno);
     }
     if(childPid==0) {
-      if(dueTime<=env.timer->elapsedMilliseconds()) {
+      if(dueTime<=env->timer->elapsedMilliseconds()) {
 	return 0;
       }
       sleep(50);

--- a/Lib/Sys/SyncPipe.cpp
+++ b/Lib/Sys/SyncPipe.cpp
@@ -187,7 +187,7 @@ void SyncPipe::neverWrite()
   CALL("SyncPipe::neverWrite");
   ASS(canWrite());  //@b neverWrite() can only be called once
   ASS(!isWriting());
-  ASS(env.getOutputPipe()!=this); //we cannot forbid writing to pipe that we use as output
+  ASS(env->getOutputPipe()!=this); //we cannot forbid writing to pipe that we use as output
 
   int res=close(_writeDescriptor);
   if(res==-1) {

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -195,7 +195,12 @@ void handleSignal (int sigNum)
 	if(outputAllowed()) {
 	  if(env.options && env.statistics) {
 	    env.beginOutput();
-	    env.out() << getpid() << " Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
+      env.out() << getpid();
+      #if VTHREADED
+      if(env.options->mode() == Options::Mode::THREADED)
+        env.out() << "/" << std::this_thread::get_id();
+      #endif
+	    env.out() << " Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
 	    env.statistics->print(env.out());
 #if VDEBUG
 	    Debug::Tracer::printStack(env.out());

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -142,10 +142,10 @@ void handleSignal (int sigNum)
       }
       handled = true;
       if(outputAllowed(true)) {
-	if(env.options) {
-	  env.beginOutput();
-	  env.out() << "Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
-	  env.endOutput();
+	if(env->options) {
+	  env->beginOutput();
+	  env->out() << "Aborted by signal " << signalDescription << " on " << env->options->inputFile() << "\n";
+	  env->endOutput();
 	} else {
 	  cout << "Aborted by signal " << signalDescription << "\n";
 	}
@@ -153,10 +153,10 @@ void handleSignal (int sigNum)
       return;
     case SIGXCPU:
       if(outputAllowed(true)) {
-	if(env.options) {
-	  env.beginOutput();
-	  env.out() << "External time out (SIGXCPU) on " << env.options->inputFile() << "\n";
-	  env.endOutput();
+	if(env->options) {
+	  env->beginOutput();
+	  env->out() << "External time out (SIGXCPU) on " << env->options->inputFile() << "\n";
+	  env->endOutput();
 	} else {
 	  cout << "External time out (SIGXCPU)\n";
 	}
@@ -193,19 +193,19 @@ void handleSignal (int sigNum)
 	reportSpiderFail();
 	handled = true;
 	if(outputAllowed()) {
-	  if(env.options && env.statistics) {
-	    env.beginOutput();
-      env.out() << getpid();
+	  if(env->options && env->statistics) {
+	    env->beginOutput();
+      env->out() << getpid();
       #if VTHREADED
-      if(env.options->mode() == Options::Mode::THREADED)
-        env.out() << "/" << std::this_thread::get_id();
+      if(env->options->mode() == Options::Mode::THREADED)
+        env->out() << "/" << std::this_thread::get_id();
       #endif
-	    env.out() << " Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
-	    env.statistics->print(env.out());
+	    env->out() << " Aborted by signal " << signalDescription << " on " << env->options->inputFile() << "\n";
+	    env->statistics->print(env->out());
 #if VDEBUG
-	    Debug::Tracer::printStack(env.out());
+	    Debug::Tracer::printStack(env->out());
 #endif
-	    env.endOutput();
+	    env->endOutput();
 	  } else {
 	    cout << getpid() << "Aborted by signal " << signalDescription << "\n";
 #if VDEBUG

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -283,7 +283,7 @@ void System::onTermination()
 {
   CALL("System::onTermination");
 
-  static bool called=false;
+  static VATOMIC(bool) called(false);
   if(called) {
     return;
   }

--- a/Lib/Threading.hpp
+++ b/Lib/Threading.hpp
@@ -1,0 +1,19 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#ifndef __Threading__
+#define __Threading__
+
+#if VTHREADED
+#define VTHREAD_LOCAL thread_local
+#else
+#define VTHREAD_LOCAL
+#endif
+
+#endif

--- a/Lib/Threading.hpp
+++ b/Lib/Threading.hpp
@@ -10,6 +10,7 @@
 #ifndef __Threading__
 #define __Threading__
 
+// thread_local, std::atomic<T> only if Vampire is compiled thread-safe
 #if VTHREADED
 #include <atomic>
 #define VTHREAD_LOCAL thread_local
@@ -19,6 +20,11 @@
 #define VATOMIC(T) T
 #endif
 
+/* detect ThreadSanitizer
+ * this causes some trouble for Vampire,
+ * notably because it provides its own global new/delete operators
+ * it's very useful, however...
+ */
 #if (defined(__has_feature) && __has_feature(thread_sanitizer))
 #define TSAN 1
 #else

--- a/Lib/Threading.hpp
+++ b/Lib/Threading.hpp
@@ -11,9 +11,18 @@
 #define __Threading__
 
 #if VTHREADED
+#include <atomic>
 #define VTHREAD_LOCAL thread_local
+#define VATOMIC(T) std::atomic<T>
 #else
 #define VTHREAD_LOCAL
+#define VATOMIC(T) T
+#endif
+
+#if (defined(__has_feature) && __has_feature(thread_sanitizer))
+#define TSAN 1
+#else
+#define TSAN 0
 #endif
 
 #endif

--- a/Lib/TimeCounter.cpp
+++ b/Lib/TimeCounter.cpp
@@ -50,7 +50,7 @@ void TimeCounter::reinitialize()
 
   initialize();
 
-  int currTime=env.timer->elapsedMilliseconds();
+  int currTime=env->timer->elapsedMilliseconds();
 
   TimeCounter* counter = s_currTop;
   while(counter) {
@@ -68,7 +68,7 @@ void TimeCounter::initialize()
 
   s_initialized=true;
 
-  if(!env.options->timeStatistics()) {
+  if(!env->options->timeStatistics()) {
     s_measuring=false;
     return;
   }
@@ -101,7 +101,7 @@ void TimeCounter::startMeasuring(TimeCounterUnit tcu)
   previousTop = s_currTop;
   s_currTop = this;
 
-  int currTime=env.timer->elapsedMilliseconds();
+  int currTime=env->timer->elapsedMilliseconds();
 
   _tcu=tcu;
   s_measureInitTimes[_tcu]=currTime;
@@ -117,7 +117,7 @@ void TimeCounter::stopMeasuring()
   }
   ASS_GE(s_measureInitTimes[_tcu], 0);
 
-  int currTime=env.timer->elapsedMilliseconds();
+  int currTime=env->timer->elapsedMilliseconds();
   int measuredTime = currTime-s_measureInitTimes[_tcu];
   s_measuredTimes[_tcu] += measuredTime;
   s_measureInitTimes[_tcu]=-1;
@@ -136,7 +136,7 @@ void TimeCounter::snapShot()
 {
   CALL("TimeCounter::snapShot");
 
-  int currTime=env.timer->elapsedMilliseconds();
+  int currTime=env->timer->elapsedMilliseconds();
 
   TimeCounter* counter = s_currTop;
   while(counter) {

--- a/Lib/TimeCounter.cpp
+++ b/Lib/TimeCounter.cpp
@@ -28,12 +28,12 @@ using namespace std;
 using namespace Shell;
 using namespace Lib;
 
-bool TimeCounter::s_measuring = true;
-bool TimeCounter::s_initialized = false;
-int TimeCounter::s_measuredTimes[__TC_ELEMENT_COUNT];
-int TimeCounter::s_measuredTimesChildren[__TC_ELEMENT_COUNT];
-int TimeCounter::s_measureInitTimes[__TC_ELEMENT_COUNT];
-TimeCounter* TimeCounter::s_currTop = 0;
+VTHREAD_LOCAL bool TimeCounter::s_measuring = true;
+VTHREAD_LOCAL bool TimeCounter::s_initialized = false;
+VTHREAD_LOCAL int TimeCounter::s_measuredTimes[__TC_ELEMENT_COUNT];
+VTHREAD_LOCAL int TimeCounter::s_measuredTimesChildren[__TC_ELEMENT_COUNT];
+VTHREAD_LOCAL int TimeCounter::s_measureInitTimes[__TC_ELEMENT_COUNT];
+VTHREAD_LOCAL TimeCounter* TimeCounter::s_currTop = 0;
 
 /**
  * Reinitializes the time counting

--- a/Lib/TimeCounter.hpp
+++ b/Lib/TimeCounter.hpp
@@ -166,7 +166,7 @@ private:
    * Determines whether the time measurement will be performed.
    *
    * Initially is set to @b true, and the first time the measurement is requested,
-   * the env.options structure is checked, whether measurement should indeed be done,
+   * the env->options structure is checked, whether measurement should indeed be done,
    * and if not, it is set to @b false.
    */
   VTHREAD_LOCAL static bool s_measuring;

--- a/Lib/TimeCounter.hpp
+++ b/Lib/TimeCounter.hpp
@@ -155,7 +155,7 @@ private:
    *
    * The currently passing time contribute's to this counter's "own" time.
    */
-  static TimeCounter* s_currTop;
+  VTHREAD_LOCAL static TimeCounter* s_currTop;
 
   /**
    * To store s_currTop when (*this) becomes the new top.
@@ -169,28 +169,28 @@ private:
    * the env.options structure is checked, whether measurement should indeed be done,
    * and if not, it is set to @b false.
    */
-  static bool s_measuring;
+  VTHREAD_LOCAL static bool s_measuring;
   /**
    * Contains true if the @b s_measuredTimes and @b s_measureInitTimes arrays
    * have been initialized.
    */
-  static bool s_initialized;
+  VTHREAD_LOCAL static bool s_initialized;
   /**
    * Contains number of milliseconds passed in each TimeCounterUnit.
    */
-  static int s_measuredTimes[];
+  VTHREAD_LOCAL static int s_measuredTimes[];
   /**
    * Contains number of milliseconds passed in each TimeCounterUnit's children.
    *
    * "ownTime" = "measuredTime" - "measuredTimesChildren"
    */
-  static int s_measuredTimesChildren[];
+  VTHREAD_LOCAL static int s_measuredTimesChildren[];
   /**
    * For each TimeCounterUnit contains either -1 if the unit is not being
    * measured, or a non-negative number representing initial time of the current
    * block in the unit.
    */
-  static int s_measureInitTimes[];
+  VTHREAD_LOCAL static int s_measureInitTimes[];
 };
 
 };

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -34,17 +34,15 @@ void Lib::Timer::ensureTimerInitialized() {}
 void Lib::Timer::deinitializeTimer() {}
 void Lib::Timer::makeChildrenIncluded() {}
 
-std::chrono::steady_clock::time_point start_time =
-  std::chrono::steady_clock::now();
-
 int Lib::Timer::miliseconds() {
   CALL("Timer::miliseconds");
 
   auto now = std::chrono::steady_clock::now();
-  auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-    now - start_time
+  auto ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+  auto epoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+    ms.time_since_epoch()
   );
-  return ms.count();
+  return epoch.count();
 }
 #else
 

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -39,6 +39,7 @@ using namespace Lib;
 VTHREAD_LOCAL bool Timer::s_timeLimitEnforcement = true;
 
 // threads + SIGALRM is not a happy combination
+// there again, rusage() is also broken, but less broken than SIGALRM
 // TODO: figure this out
 #if UNIX_USE_SIGALRM && !VTHREADED
 

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -12,6 +12,9 @@
  * Implements class Timer.
  */
 
+#if VTHREADED
+#include <atomic>
+#endif
 #include <ctime>
 #include <unistd.h>
 #include <sys/types.h>
@@ -36,7 +39,7 @@
 using namespace std;
 using namespace Lib;
 
-bool Timer::s_timeLimitEnforcement = true;
+VTHREAD_LOCAL bool Timer::s_timeLimitEnforcement = true;
 
 #if UNIX_USE_SIGALRM
 
@@ -51,7 +54,11 @@ bool Timer::s_timeLimitEnforcement = true;
 
 #include "Shell/UIHelper.hpp"
 
+#if VTHREADED
+std::atomic<int> timer_sigalrm_counter(-1);
+#else
 int timer_sigalrm_counter=-1;
+#endif
 
 long Timer::s_ticksPerSec;
 int Timer::s_initGuarantedMiliseconds;
@@ -100,7 +107,6 @@ timer_sigalrm_handler (int sig)
     System::terminateImmediately(1);
   }
 #endif
-
 
   timer_sigalrm_counter++;
 
@@ -348,7 +354,7 @@ void Timer::printMSString(ostream& str, int ms)
 
 Timer* Timer::instance()
 {
-  static ScopedPtr<Timer> inst(new Timer());
+  VTHREAD_LOCAL static ScopedPtr<Timer> inst(new Timer());
   
   return inst.ptr();
 }

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -95,28 +95,28 @@ void timeLimitReached()
   // so any code below that allocates might corrupt the allocator state.
   // Therefore, the printing below should avoid allocations!
 
-  env.beginOutput();
+  env->beginOutput();
   reportSpiderStatus('t');
   if (outputAllowed()) {
-    addCommentSignForSZS(env.out());
-    env.out() << "Time limit reached!\n";
+    addCommentSignForSZS(env->out());
+    env->out() << "Time limit reached!\n";
 
     if (UIHelper::portfolioParent) { // the boss
-      addCommentSignForSZS(env.out());
-      env.out() << "Proof not found in time ";
-      Timer::printMSString(env.out(),env.timer->elapsedMilliseconds());
-      env.out() << endl;
+      addCommentSignForSZS(env->out());
+      env->out() << "Proof not found in time ";
+      Timer::printMSString(env->out(),env->timer->elapsedMilliseconds());
+      env->out() << endl;
 
       if (szsOutputMode()) {
-        env.out() << "% SZS status Timeout for "
-                        << (env.options ? env.options->problemName().c_str() : "unknown") << endl;
+        env->out() << "% SZS status Timeout for "
+                        << (env->options ? env->options->problemName().c_str() : "unknown") << endl;
       }
     } else // the actual child
-      if (env.statistics) {
-        env.statistics->print(env.out());
+      if (env->statistics) {
+        env->statistics->print(env->out());
     }
   }
-  env.endOutput();
+  env->endOutput();
 
   System::terminateImmediately(1);
 }
@@ -133,7 +133,7 @@ timer_sigalrm_handler (int sig)
 
   timer_sigalrm_counter++;
 
-  if(Timer::s_timeLimitEnforcement && env.timeLimitReached()) {
+  if(Timer::s_timeLimitEnforcement && env->timeLimitReached()) {
     timeLimitReached();
   }
 

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -12,9 +12,6 @@
  * Implements class Timer.
  */
 
-#if VTHREADED
-#include <atomic>
-#endif
 #include <ctime>
 #include <unistd.h>
 #include <sys/types.h>
@@ -41,7 +38,9 @@ using namespace Lib;
 
 VTHREAD_LOCAL bool Timer::s_timeLimitEnforcement = true;
 
-#if UNIX_USE_SIGALRM
+// threads + SIGALRM is not a happy combination
+// TODO: figure this out
+#if UNIX_USE_SIGALRM && !VTHREADED
 
 #include <cerrno>
 #include <unistd.h>
@@ -54,11 +53,7 @@ VTHREAD_LOCAL bool Timer::s_timeLimitEnforcement = true;
 
 #include "Shell/UIHelper.hpp"
 
-#if VTHREADED
-std::atomic<int> timer_sigalrm_counter(-1);
-#else
 int timer_sigalrm_counter=-1;
-#endif
 
 long Timer::s_ticksPerSec;
 int Timer::s_initGuarantedMiliseconds;

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -120,7 +120,7 @@ public:
 
   static void syncClock();
 
-  static bool s_timeLimitEnforcement;
+  VTHREAD_LOCAL static bool s_timeLimitEnforcement;
 private:
   /** true if the timer must account for the time spent in
    * children (otherwise it may or may not) */

--- a/Lib/VirtualIterator.hpp
+++ b/Lib/VirtualIterator.hpp
@@ -137,7 +137,7 @@ public:
   /** Return an empty iterator */
   static VirtualIterator getEmpty()
   {
-    static VirtualIterator inst(new EmptyIterator<T>());
+    VTHREAD_LOCAL static VirtualIterator inst(new EmptyIterator<T>());
     return inst;
   }
 

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -137,7 +137,7 @@ void TPTP::parse()
       break;
     case THF:
       _isThf = true;
-      env.statistics->higherOrder = true;
+      env->statistics->higherOrder = true;
     case TFF:
       _isFof = false;
       tff();
@@ -255,7 +255,7 @@ void TPTP::parse()
       symbolDefinition();
       break;
     case TUPLE_DEFINITION:
-      if(!env.options->newCNF()){ USER_ERROR("Set --newcnf on if using tuples"); }
+      if(!env->options->newCNF()){ USER_ERROR("Set --newcnf on if using tuples"); }
       tupleDefinition();
       break;
     case END_LET:
@@ -265,7 +265,7 @@ void TPTP::parse()
       endTheoryFunction();
       break;
     case END_TUPLE:
-      if(!env.options->newCNF()){ USER_ERROR("Set --newcnf on if using tuples"); }
+      if(!env->options->newCNF()){ USER_ERROR("Set --newcnf on if using tuples"); }
       endTuple();
       break;
     default:
@@ -1213,7 +1213,7 @@ int TPTP::positiveDecimal(int pos)
 void TPTP::unitList()
 {
   CALL("TPTP::unitList");
-  if (env.timeLimitReached()) {
+  if (env->timeLimitReached()) {
     // empty states to avoid infinite loop
     while (!_states.isEmpty()) {
       _states.pop();
@@ -1416,8 +1416,8 @@ void TPTP::tff()
         bool added = false;
         unsigned fun = arity == 0
             ? addUninterpretedConstant(nm, _overflow, added)
-            : env.signature->addFunction(nm, arity, added);
-        Signature::Symbol* symbol = env.signature->getFunction(fun);
+            : env->signature->addFunction(nm, arity, added);
+        Signature::Symbol* symbol = env->signature->getFunction(fun);
         OperatorType* ot = OperatorType::getFunctionTypeUniformRange(arity, Term::superSort(), Term::superSort());
         if (!added) {
           if(symbol->fnType()!=ot){
@@ -1945,7 +1945,7 @@ void TPTP::endApp()
   args.push(s2);
   args.push(lhs);
   args.push(rhs);
-  unsigned app = env.signature->getApp();
+  unsigned app = env->signature->getApp();
   
   _termLists.push(TermList(Term::create(app, 4, args.begin())));
   _lastPushed = TM;
@@ -2053,7 +2053,7 @@ void TPTP::endTheoryFunction() {
   }
 
   OperatorType* type = Theory::getArrayOperatorType(arraySort,itp);
-  unsigned symbol = env.signature->getInterpretingSymbol(itp, type);
+  unsigned symbol = env->signature->getInterpretingSymbol(itp, type);
   unsigned arity = Theory::getArity(itp);
 
   if (Theory::isFunction(itp)) {
@@ -2123,7 +2123,7 @@ void TPTP::include()
   // here should be a computation of the new include directory according to
   // the TPTP standard, so far we just set it to ""
   _includeDirectory = "";
-  vstring fileName(env.options->includeFileName(relativeName));
+  vstring fileName(env->options->includeFileName(relativeName));
   {
     BYPASSING_ALLOCATOR; // we cannot make ifstream allocated via Allocator
     _in = new ifstream(fileName.c_str());
@@ -2289,7 +2289,7 @@ void TPTP::funApp()
       return;
 
     case T_ITE:
-      if(env.statistics->higherOrder){
+      if(env->statistics->higherOrder){
         //Does higher-order even use this code? I dont think so.
         USER_ERROR("Higher-order Vampire is currently not compatible with FOOL reasoning");
       }
@@ -2303,7 +2303,7 @@ void TPTP::funApp()
       return;
 
     case T_LET: {
-      if(env.statistics->higherOrder){
+      if(env->statistics->higherOrder){
         //Does higher-order even use this code? I dont think so.        
         USER_ERROR("Higher-order  Vampire is currently not compatible with FOOL reasoning");
       }
@@ -2378,13 +2378,13 @@ void TPTP::endLetTypes()
   bool isPredicate = type->isPredicateType();
 
   unsigned symbol = isPredicate
-                  ? env.signature->addFreshPredicate(arity, name.c_str())
-                  : env.signature->addFreshFunction(arity,  name.c_str());
+                  ? env->signature->addFreshPredicate(arity, name.c_str())
+                  : env->signature->addFreshFunction(arity,  name.c_str());
 
   if (isPredicate) {
-    env.signature->getPredicate(symbol)->setType(type);
+    env->signature->getPredicate(symbol)->setType(type);
   } else {
-    env.signature->getFunction(symbol)->setType(type);
+    env->signature->getFunction(symbol)->setType(type);
   }
 
   LetSymbolName symbolName(name, arity);
@@ -2548,8 +2548,8 @@ void TPTP::symbolDefinition()
 
   if (arity > 0) {
     OperatorType* type = isPredicate
-                       ? env.signature->getPredicate(symbol)->predType()
-                       : env.signature->getFunction(symbol)->fnType();
+                       ? env->signature->getPredicate(symbol)->predType()
+                       : env->signature->getFunction(symbol)->fnType();
 
     unsigned index = 0;
     while (vars.isNonEmpty()) {
@@ -2608,7 +2608,7 @@ void TPTP::tupleDefinition()
 
     TermList sort = isPredicate
                   ? Term::boolSort()
-                  : env.signature->getFunction(symbol)->fnType()->result();
+                  : env->signature->getFunction(symbol)->fnType()->result();
     sorts.push(sort);
 
     if (getTok(0).tag == T_NAME) {
@@ -2650,16 +2650,16 @@ void TPTP::endDefinition() {
 
   TermList refSort = isPredicate
                      ? Term::boolSort()
-                     : env.signature->getFunction(symbol)->fnType()->result();
+                     : env->signature->getFunction(symbol)->fnType()->result();
 
   if (refSort != definitionSort) {
     vstring definitionSortName = definitionSort.toString();
     vstring refSymbolName = isPredicate
-                            ? env.signature->predicateName(symbol)
-                            : env.signature->functionName(symbol);
+                            ? env->signature->predicateName(symbol)
+                            : env->signature->functionName(symbol);
     OperatorType* type = isPredicate
-                         ? env.signature->getPredicate(symbol)->predType()
-                         : env.signature->getFunction(symbol)->fnType();
+                         ? env->signature->getPredicate(symbol)->predType()
+                         : env->signature->getFunction(symbol)->fnType();
     USER_ERROR("The term " + definition.toString() + " of the sort " + definitionSortName +
                " is used as definition of the symbol " + refSymbolName +
                " of the type " + type->toString());
@@ -2726,7 +2726,7 @@ void TPTP::endLet()
 
     bool isTuple = false;
     if (!isPredicate) {
-      TermList resultSort = env.signature->getFunction(symbol)->fnType()->result();
+      TermList resultSort = env->signature->getFunction(symbol)->fnType()->result();
       isTuple = SortHelper::isTupleSort(resultSort);
     }
 
@@ -2926,14 +2926,14 @@ void TPTP::term()
     case T_INT:
     case T_REAL:
     case T_RAT: {
-      if(/*env.statistics->polymorphic ||*/ env.statistics->higherOrder){
+      if(/*env->statistics->polymorphic ||*/ env->statistics->higherOrder){
         USER_ERROR("Polymorphic Vampire is currently not compatible with theory reasoning");
       }
       resetToks();
       unsigned number;
       switch (tok.tag) {
         case T_STRING:
-          number = env.signature->addStringConstant(tok.content);
+          number = env->signature->addStringConstant(tok.content);
           break;
         case T_INT:
           number = addIntegerConstant(tok.content,_overflow,_isFof);
@@ -2949,7 +2949,7 @@ void TPTP::term()
       }
       Term *t = new(0) Term;
       t->makeSymbol(number, 0);
-      t = env.sharing->insert(t);
+      t = env->sharing->insert(t);
       TermList constant(t);
       _termLists.push(constant);
       return;
@@ -3003,7 +3003,7 @@ void TPTP::endTerm()
   }
 
   LetSymbolReference ref;
-  if (env.signature->predicateExists(name, arity) ||
+  if (env->signature->predicateExists(name, arity) ||
       (findLetSymbol(LetSymbolName(name, arity), ref) && IS_PREDICATE(ref)) ||
       findInterpretedPredicate(name, arity)) {
     // if the function symbol is actually a predicate,
@@ -3181,7 +3181,7 @@ Formula* TPTP::createPredicateApplication(vstring name, unsigned arity)
       bool dummy;
       pred = addPredicate(name, arity, dummy, _termLists.top());
     } else {
-      pred = env.signature->addPredicate(name, 0);
+      pred = env->signature->addPredicate(name, 0);
     }
   }
   if (pred == -1) { // equality
@@ -3204,20 +3204,20 @@ Formula* TPTP::createPredicateApplication(vstring name, unsigned arity)
       return distinct_formula;
     }else{
       // Otherwise record them as being in a distinct group
-      unsigned grpIdx = env.signature->createDistinctGroup(0);
+      unsigned grpIdx = env->signature->createDistinctGroup(0);
       for(int i = arity-1;i >=0; i--){
         TermList ts = _termLists.pop();
         if(!ts.isTerm() || ts.term()->arity()!=0){
           USER_ERROR("$distinct should only be used positively with constants");
         }
-        env.signature->addToDistinctGroup(ts.term()->functor(),grpIdx);
+        env->signature->addToDistinctGroup(ts.term()->functor(),grpIdx);
       }
       return new Formula(true); // we ignore it, it evaluates to true as we have recorded it elsewhere
     }
   }
   // not equality or distinct
   Literal* lit = new(arity) Literal(pred,arity,true,false);
-  OperatorType* type = env.signature->getPredicate(pred)->predType();
+  OperatorType* type = env->signature->getPredicate(pred)->predType();
   bool safe = true;
   for (int i = arity-1;i >= 0;i--) {
     TermList sort = type->arg(i);
@@ -3240,7 +3240,7 @@ Formula* TPTP::createPredicateApplication(vstring name, unsigned arity)
     *(lit->nthArgument(i)) = ts;
   }
   if (safe) {
-    lit = env.sharing->insert(lit);
+    lit = env->sharing->insert(lit);
   }
   return new AtomicFormula(lit);
 } // createPredicateApplication
@@ -3270,7 +3270,7 @@ TermList TPTP::createFunctionApplication(vstring name, unsigned arity)
   }
   Term* t = new(arity) Term;
   t->makeSymbol(fun,arity);
-  OperatorType* type = env.signature->getFunction(fun)->fnType();
+  OperatorType* type = env->signature->getFunction(fun)->fnType();
   bool safe = true;
   for (int i = arity-1;i >= 0;i--) {
     TermList sort = type->arg(i);
@@ -3294,12 +3294,12 @@ TermList TPTP::createFunctionApplication(vstring name, unsigned arity)
     safe = safe && ss.isSafe();
   }
   if (safe) {
-    t = env.sharing->insert(t);
+    t = env->sharing->insert(t);
   }
   TermList ts(t);
   TermList resultSort = type->result();
   if(resultSort == Term::superSort()){
-    env.sorts->addSort(ts);
+    env->sorts->addSort(ts);
   }
   return ts;
 }
@@ -3608,12 +3608,12 @@ void TPTP::endFof()
 
   Unit* unit;
   if (isFof) { // fof() or tff()
-    env.statistics->inputFormulas++;
+    env->statistics->inputFormulas++;
     unit = new FormulaUnit(f,FromInput(_lastInputType));
     unit->setInheritedColor(_currentColor);
   }
   else { // cnf()
-    env.statistics->inputClauses++;
+    env->statistics->inputClauses++;
     // convert the input formula f to a clause
     Stack<Formula*> forms;
     Stack<Literal*> lits;
@@ -3664,7 +3664,7 @@ void TPTP::endFof()
     _unitSources->insert(unit,source);
   }
 
-  if (env.options->outputAxiomNames()) {
+  if (env->options->outputAxiomNames()) {
     assignAxiomName(unit,nm);
   }
 #if DEBUG_SHOW_UNITS
@@ -3679,19 +3679,19 @@ void TPTP::endFof()
     if(!isFof) USER_ERROR("conjecture is not allowed in cnf");
     if(_seenConjecture) USER_ERROR("Vampire only supports a single conjecture in a problem");
     _seenConjecture=true;
-    if (_isQuestion && ((env.options->mode() == Options::Mode::CLAUSIFY) || (env.options->mode() == Options::Mode::TCLAUSIFY)) && f->connective() == EXISTS) {
+    if (_isQuestion && ((env->options->mode() == Options::Mode::CLAUSIFY) || (env->options->mode() == Options::Mode::TCLAUSIFY)) && f->connective() == EXISTS) {
       // create an answer predicate
       QuantifiedFormula* g = static_cast<QuantifiedFormula*>(f);
       unsigned arity = VList::length(g->vars());
-      unsigned pred = env.signature->addPredicate("$$answer",arity);
-      env.signature->getPredicate(pred)->markAnswerPredicate();
+      unsigned pred = env->signature->addPredicate("$$answer",arity);
+      env->signature->getPredicate(pred)->markAnswerPredicate();
       Literal* a = new(arity) Literal(pred,arity,true,false);
       VList::Iterator vs(g->vars());
       int i = 0;
       while (vs.hasNext()) {
         a->nthArgument(i++)->makeVar(vs.next());
       }
-      a = env.sharing->insert(a);
+      a = env->sharing->insert(a);
       f = new QuantifiedFormula(FORALL,
         g->vars(),
         g->sorts(),
@@ -3715,13 +3715,13 @@ void TPTP::endFof()
   case UnitInputType::CLAIM:
     {
       bool added;
-      unsigned pred = env.signature->addPredicate(nm,0,added);
+      unsigned pred = env->signature->addPredicate(nm,0,added);
       if (!added) {
   USER_ERROR("Names of claims must be unique: "+nm);
       }
-      env.signature->getPredicate(pred)->markLabel();
+      env->signature->getPredicate(pred)->markLabel();
       Literal* a = new(0) Literal(pred,0,true,false);
-      a = env.sharing->insert(a);
+      a = env->sharing->insert(a);
       Formula* claim = new AtomicFormula(a);
       VList* vs = f->freeVariables();
       if (VList::isNonEmpty(vs)) {
@@ -3780,8 +3780,8 @@ void TPTP::endTff()
   bool added;
   Signature::Symbol* symbol;
   if (isPredicate) {
-    unsigned pred = env.signature->addPredicate(name, arity, added);
-    symbol = env.signature->getPredicate(pred);
+    unsigned pred = env->signature->addPredicate(name, arity, added);
+    symbol = env->signature->getPredicate(pred);
     if (!added) {
       // GR: Multiple identical type declarations for a symbol are allowed
       if(symbol->predType() != ot){
@@ -3796,8 +3796,8 @@ void TPTP::endTff()
   } else {
     unsigned fun = arity == 0
                    ? addUninterpretedConstant(name, _overflow, added)
-                   : env.signature->addFunction(name, arity, added);
-    symbol = env.signature->getFunction(fun);
+                   : env->signature->addFunction(name, arity, added);
+    symbol = env->signature->getFunction(fun);
     if (!added) {
       if(symbol->fnType() != ot){
         USER_ERROR("Function symbol type is declared after its use: " + name);
@@ -3888,7 +3888,7 @@ OperatorType* TPTP::constructOperatorType(Type* t, VList* vars)
   bool isPredicate = resultSort == Term::boolSort();
   unsigned arity = (unsigned)argumentSorts.size();
 
-  if(env.statistics->polymorphic){
+  if(env->statistics->polymorphic){
     SortHelper::normaliseArgSorts(vars, argumentSorts);
     SortHelper::normaliseSort(vars, resultSort);
   }
@@ -4164,7 +4164,7 @@ void TPTP::simpleType()
   Token& tok = getTok(0);
 
   if(tok.tag == T_TYPE_QUANT) {
-    env.statistics->polymorphic = true;
+    env->statistics->polymorphic = true;
     resetToks();
     _typeTags.push(TT_QUANTIFIED);
     consumeToken(T_LBRA);
@@ -4613,10 +4613,10 @@ unsigned TPTP::addFunction(vstring name,int arity,bool& added,TermList& arg)
 				 Theory::REAL_TO_REAL);
   } 
   if (name == "vPI"  || name == "vSIGMA"){
-    return env.signature->getPiSigmaProxy(name); 
+    return env->signature->getPiSigmaProxy(name); 
   }
   if (arity > 0) {
-    return env.signature->addFunction(name,arity,added);
+    return env->signature->addFunction(name,arity,added);
   }
   return addUninterpretedConstant(name,_overflow,added);
 } // addFunction
@@ -4686,7 +4686,7 @@ int TPTP::addPredicate(vstring name,int arity,bool& added,TermList& arg)
     // special case for distinct, dealt with in formulaInfix
     return -2;
   }
-  return env.signature->addPredicate(name,arity,added);
+  return env->signature->addPredicate(name,arity,added);
 } // addPredicate
 
 
@@ -4706,13 +4706,13 @@ unsigned TPTP::addOverloadedFunction(vstring name,int arity,int symbolArity,bool
     n = n->next();
   }
   if (srt == Term::intSort()) {
-    return env.signature->addInterpretedFunction(integer,name);
+    return env->signature->addInterpretedFunction(integer,name);
   }
   if (srt == Term::rationalSort()) {
-    return env.signature->addInterpretedFunction(rational,name);
+    return env->signature->addInterpretedFunction(rational,name);
   }
   if (srt == Term::realSort()) {
-    return env.signature->addInterpretedFunction(real,name);
+    return env->signature->addInterpretedFunction(real,name);
   }
   USER_ERROR((vstring)"The symbol " + name + " is used with a non-numeric type");
 } // addOverloadedFunction
@@ -4734,13 +4734,13 @@ unsigned TPTP::addOverloadedPredicate(vstring name,int arity,int symbolArity,boo
   }
   
   if (srt == Term::intSort()) {
-    return env.signature->addInterpretedPredicate(integer,name);
+    return env->signature->addInterpretedPredicate(integer,name);
   }
   if (srt == Term::rationalSort()) {
-    return env.signature->addInterpretedPredicate(rational,name);
+    return env->signature->addInterpretedPredicate(rational,name);
   }
   if (srt == Term::realSort()) {
-    return env.signature->addInterpretedPredicate(real,name);
+    return env->signature->addInterpretedPredicate(real,name);
   }
   USER_ERROR((vstring)"The symbol " + name + " is used with a non-numeric type");
 } // addOverloadedPredicate
@@ -4792,14 +4792,14 @@ unsigned TPTP::addIntegerConstant(const vstring& name, Set<vstring>& overflow, b
   CALL("TPTP::addIntegerConstant");
 
   try {
-    return env.signature->addIntegerConstant(name,defaultSort);
+    return env->signature->addIntegerConstant(name,defaultSort);
   }
   catch (Kernel::ArithmeticException&) {
     bool added;
-    unsigned fun = env.signature->addFunction(name,0,added,true /* overflown constant*/);
+    unsigned fun = env->signature->addFunction(name,0,added,true /* overflown constant*/);
     if (added) {
       overflow.insert(name);
-      Signature::Symbol* symbol = env.signature->getFunction(fun);
+      Signature::Symbol* symbol = env->signature->getFunction(fun);
       symbol->setType(OperatorType::getConstantsType(defaultSort ? Term::defaultSort() : Term::intSort()));
     }
     else if (!overflow.contains(name)) {
@@ -4826,16 +4826,16 @@ unsigned TPTP::addRationalConstant(const vstring& name, Set<vstring>& overflow, 
   size_t i = name.find_first_of("/");
   ASS(i != vstring::npos);
   try {
-    return env.signature->addRationalConstant(name.substr(0,i),
+    return env->signature->addRationalConstant(name.substr(0,i),
 					      name.substr(i+1),
 					      defaultSort);
   }
   catch(Kernel::ArithmeticException&) {
     bool added;
-    unsigned fun = env.signature->addFunction(name,0,added,true /* overflown constant*/);
+    unsigned fun = env->signature->addFunction(name,0,added,true /* overflown constant*/);
     if (added) {
       overflow.insert(name);
-      Signature::Symbol* symbol = env.signature->getFunction(fun);
+      Signature::Symbol* symbol = env->signature->getFunction(fun);
       symbol->setType(OperatorType::getConstantsType(defaultSort ? Term::defaultSort() : Term::rationalSort()));
     }
     else if (!overflow.contains(name)) {
@@ -4860,14 +4860,14 @@ unsigned TPTP::addRealConstant(const vstring& name, Set<vstring>& overflow, bool
   CALL("TPTP::addRealConstant");
 
   try {
-    return env.signature->addRealConstant(name,defaultSort);
+    return env->signature->addRealConstant(name,defaultSort);
   }
   catch(Kernel::ArithmeticException&) {
     bool added;
-    unsigned fun = env.signature->addFunction(name,0,added,true /* overflown constant*/);
+    unsigned fun = env->signature->addFunction(name,0,added,true /* overflown constant*/);
     if (added) {
       overflow.insert(name);
-      Signature::Symbol* symbol = env.signature->getFunction(fun);
+      Signature::Symbol* symbol = env->signature->getFunction(fun);
       symbol->setType(OperatorType::getConstantsType(defaultSort ? Term::defaultSort() : Term::realSort()));
     }
     else if (!overflow.contains(name)) {
@@ -4895,11 +4895,11 @@ unsigned TPTP::addUninterpretedConstant(const vstring& name, Set<vstring>& overf
   //and cannot occur in the input AYB
   if(name == "vAND" || name == "vOR" || name == "vIMP" ||
      name == "vIFF" || name == "vXOR"){
-    return env.signature->getBinaryProxy(name);
+    return env->signature->getBinaryProxy(name);
   } else if (name == "vNOT"){
-    return env.signature->getNotProxy();
+    return env->signature->getNotProxy();
   }
-  return env.signature->addFunction(name,0,added);
+  return env->signature->addFunction(name,0,added);
 } // TPTP::addUninterpretedConstant
 
 /**
@@ -4942,7 +4942,7 @@ void TPTP::vampire()
     case T_INT:
     case T_REAL:
     case T_NAME:
-      env.options->set(opt,tok.content);
+      env->options->set(opt,tok.content);
       resetToks();
       break;
     default:
@@ -4988,11 +4988,11 @@ void TPTP::vampire()
       bool polarity;
       if(pol=="true"){polarity=true;}else if(pol=="false"){polarity=false;}
       else{ PARSE_ERROR("polarity expected (true/false)",getTok(0)); }
-      unsigned f = env.signature->addPredicate(symb,arity);
+      unsigned f = env->signature->addPredicate(symb,arity);
       theory->registerLaTeXPredName(f,polarity,temp);
     }
     else{
-      unsigned f = env.signature->addFunction(symb,arity);
+      unsigned f = env->signature->addFunction(symb,arity);
       theory->registerLaTeXFuncName(f,temp);
     }
   }
@@ -5037,10 +5037,10 @@ void TPTP::vampire()
     else {
       PARSE_ERROR("'left', 'right' or 'skip' expected",getTok(0));
     }
-    env.colorUsed = true;
+    env->colorUsed = true;
     Signature::Symbol* sym = pred
-                             ? env.signature->getPredicate(env.signature->addPredicate(symb,arity))
-                             : env.signature->getFunction(env.signature->addFunction(symb,arity));
+                             ? env->signature->getPredicate(env->signature->addPredicate(symb,arity))
+                             : env->signature->getFunction(env->signature->addFunction(symb,arity));
     if (skip) {
       sym->markSkip();
     }
@@ -5304,8 +5304,8 @@ void TPTP::printStacks() {
         unsigned symbol  = f.second.first;
         bool isPredicate = f.second.second;
 
-        vstring symbolName = isPredicate ? env.signature->predicateName(symbol)
-                                         : env.signature->functionName (symbol);
+        vstring symbolName = isPredicate ? env->signature->predicateName(symbol)
+                                         : env->signature->functionName (symbol);
 
         cout << name << "/" << arity << " -> " << symbolName;
         if (--i > 0) {
@@ -5333,8 +5333,8 @@ void TPTP::printStacks() {
         unsigned symbol  = f.second.first;
         bool isPredicate = f.second.second;
 
-        vstring symbolName = isPredicate ? env.signature->predicateName(symbol)
-                                         : env.signature->functionName (symbol);
+        vstring symbolName = isPredicate ? env->signature->predicateName(symbol)
+                                         : env->signature->functionName (symbol);
 
         cout << name << "/" << arity << " -> " << symbolName;
         if (--i > 0) {
@@ -5360,8 +5360,8 @@ void TPTP::printStacks() {
         LetSymbolReference ref = lbit.next();
         unsigned symbol = SYMBOL(ref);
         bool isPredicate = IS_PREDICATE(ref);
-        vstring symbolName = isPredicate ? env.signature->predicateName(symbol)
-                                         : env.signature->functionName (symbol);
+        vstring symbolName = isPredicate ? env->signature->predicateName(symbol)
+                                         : env->signature->functionName (symbol);
         cout << symbolName;
         if (--i > 0) {
           cout << ", ";

--- a/SAT/BufferedSolver.cpp
+++ b/SAT/BufferedSolver.cpp
@@ -41,7 +41,7 @@ bool BufferedSolver::checkAndRecordImplied(SATClause* cl)
 {
   CALL("BufferedSolver::checkAndRecordImplied");
 
-  static SATLiteralStack newLiterals;
+  VTHREAD_LOCAL static SATLiteralStack newLiterals;
   newLiterals.reset();
 
   for(unsigned lIndex=0;lIndex<cl->length();lIndex++)

--- a/SAT/FallbackSolverWrapper.cpp
+++ b/SAT/FallbackSolverWrapper.cpp
@@ -59,7 +59,7 @@ SATSolver::Status FallbackSolverWrapper::solve(unsigned conflictCountLimit)
     status = _fallback->solve(conflictCountLimit);
     _usingFallback = true;
     ASS(status != Status::UNKNOWN);
-    env.statistics->smtFallbacks++;
+    env->statistics->smtFallbacks++;
   } 
   else{
     _usingFallback = false;

--- a/SAT/MinisatInterfacing.cpp
+++ b/SAT/MinisatInterfacing.cpp
@@ -120,7 +120,7 @@ void MinisatInterfacing::addClause(SATClause* cl)
   
   ASS_EQ(_assumptions.size(),0);
                 
-  static vec<Lit> mcl;
+  VTHREAD_LOCAL static vec<Lit> mcl;
   mcl.clear();
     
   unsigned clen=cl->length();
@@ -218,10 +218,10 @@ SATClauseList* MinisatInterfacing::minimizePremiseList(SATClauseList* premises, 
 
   Minisat::Solver solver;
 
-  static DHMap<int,SATClause*> var2prem;
+  VTHREAD_LOCAL static DHMap<int,SATClause*> var2prem;
   var2prem.reset();
 
-  static vec<Lit> ass; // assumptions for the final call
+  VTHREAD_LOCAL static vec<Lit> ass; // assumptions for the final call
   ass.clear();
 
   int cl_no = 0;
@@ -253,7 +253,7 @@ SATClauseList* MinisatInterfacing::minimizePremiseList(SATClauseList* premises, 
   while(it) {
     SATClause* cl = it->head();
 
-    static vec<Lit> mcl;
+    VTHREAD_LOCAL static vec<Lit> mcl;
     mcl.clear();
 
     // translate the clause to minisat's language (shift vars by offset)

--- a/SAT/MinisatInterfacingNewSimp.cpp
+++ b/SAT/MinisatInterfacingNewSimp.cpp
@@ -47,16 +47,16 @@ MinisatInterfacingNewSimp::MinisatInterfacingNewSimp(const Shell::Options& opts,
 }
 
 void MinisatInterfacingNewSimp::reportMinisatOutOfMemory() {
-  env.beginOutput();
+  env->beginOutput();
   reportSpiderStatus('m');
-  env.out() << "Minisat ran out of memory" << endl;
-  if(env.statistics) {
-    env.statistics->print(env.out());
+  env->out() << "Minisat ran out of memory" << endl;
+  if(env->statistics) {
+    env->statistics->print(env->out());
   }
 #if VDEBUG
-  Debug::Tracer::printStack(env.out());
+  Debug::Tracer::printStack(env->out());
 #endif
-  env.endOutput();
+  env->endOutput();
   System::terminateImmediately(1);
 }
 

--- a/SAT/MinisatInterfacingNewSimp.cpp
+++ b/SAT/MinisatInterfacingNewSimp.cpp
@@ -156,7 +156,7 @@ void MinisatInterfacingNewSimp::addClause(SATClause* cl)
   ASS_EQ(_assumptions.size(),0);
 
   try {
-    static vec<Lit> mcl;
+    VTHREAD_LOCAL static vec<Lit> mcl;
     mcl.clear();
     
     unsigned clen=cl->length();

--- a/SAT/Preprocess.cpp
+++ b/SAT/Preprocess.cpp
@@ -70,10 +70,10 @@ bool Preprocess::filterPureLiterals(unsigned varCnt, SATClauseList*& res)
 {
   CALL("Preprocess::filterPureLiterals(unsigned,SATClauseList*&)");
 
-  static Stack<unsigned> pureVars(64);
-  static DArray<int> positiveOccurences(128);
-  static DArray<int> negativeOccurences(128);
-  static DArray<SATClauseList*> occurences(128);
+  VTHREAD_LOCAL static Stack<unsigned> pureVars(64);
+  VTHREAD_LOCAL static DArray<int> positiveOccurences(128);
+  VTHREAD_LOCAL static DArray<int> negativeOccurences(128);
+  VTHREAD_LOCAL static DArray<SATClauseList*> occurences(128);
 
   // variables start from 1, but we want to use them as indexes to zero based arrays
   // current solution: add one extra (unused) slot
@@ -173,8 +173,8 @@ void Preprocess::propagateUnits(SATClauseIterator clauses,
 {
   CALL("Preprocess::propagateUnits");
 
-  static DHMap<unsigned, bool, IdentityHash> unitBindings;
-  static Stack<unsigned> removedLitIndexes(64);
+  VTHREAD_LOCAL static DHMap<unsigned, bool, IdentityHash> unitBindings;
+  VTHREAD_LOCAL static Stack<unsigned> removedLitIndexes(64);
 
   unitBindings.reset();
   SATClauseList* res=0;

--- a/SAT/Preprocess.cpp
+++ b/SAT/Preprocess.cpp
@@ -103,7 +103,7 @@ bool Preprocess::filterPureLiterals(unsigned varCnt, SATClauseList*& res)
   for(unsigned i=1;i<=varCnt;i++) {
     if( ((positiveOccurences[i]!=0)^(negativeOccurences[i]!=0)) && occurences[i] ) {
       pureVars.push(i);
-      env.statistics->satPureVarsEliminated++;
+      env->statistics->satPureVarsEliminated++;
     }
   }
 
@@ -130,13 +130,13 @@ bool Preprocess::filterPureLiterals(unsigned varCnt, SATClauseList*& res)
 	  positiveOccurences[lvar]--;
 	  if( positiveOccurences[lvar]==0 && negativeOccurences[lvar]!=0 && occurences[lvar] ) {
 	    pureVars.push(lvar);
-	    env.statistics->satPureVarsEliminated++;
+	    env->statistics->satPureVarsEliminated++;
 	  }
 	} else {
 	  negativeOccurences[lvar]--;
 	  if( positiveOccurences[lvar]!=0 && negativeOccurences[lvar]==0 && occurences[lvar] ) {
 	    pureVars.push(lvar);
-	    env.statistics->satPureVarsEliminated++;
+	    env->statistics->satPureVarsEliminated++;
 	  }
 	}
       }

--- a/SAT/SAT2FO.cpp
+++ b/SAT/SAT2FO.cpp
@@ -71,7 +71,7 @@ SATClause* SAT2FO::toSAT(Clause* cl)
 
   Clause::Iterator cit(*cl);
 
-  static SATLiteralStack satLits;
+  VTHREAD_LOCAL static SATLiteralStack satLits;
   satLits.reset();
 
   while (cit.hasNext()) {
@@ -117,7 +117,7 @@ SATClause* SAT2FO::createConflictClause(LiteralStack& unsatCore, InferenceRule r
 {
   CALL("SAT2FO::createConflictClause");
 
-  static LiteralStack negStack;
+  VTHREAD_LOCAL static LiteralStack negStack;
   negStack.reset();
   LiteralStack::ConstIterator ucit(unsatCore);
   while(ucit.hasNext()) {

--- a/SAT/SATClause.cpp
+++ b/SAT/SATClause.cpp
@@ -147,7 +147,7 @@ bool SATClause::hasUniqueVariables() const
 {
   CALL("SATClause::hasUniqueVariables");
 
-  static DHSet<int> seen;
+  VTHREAD_LOCAL static DHSet<int> seen;
   seen.reset();
   unsigned clen=length();
   for(unsigned i=0; i<clen; i++) {

--- a/SAT/SATClause.cpp
+++ b/SAT/SATClause.cpp
@@ -65,12 +65,12 @@ SATClause::SATClause(unsigned length,bool kept)
   : _activity(0), _length(length), _kept(kept?1:0), _nonDestroyable(0), _inference(0)
 //      , _genCounter(0xFFFFFFFF)
 {
-  env.statistics->satClauses++;
+  env->statistics->satClauses++;
   if(length==1) {
-    env.statistics->unitSatClauses++;
+    env->statistics->unitSatClauses++;
   }
   else if(length==2) {
-    env.statistics->binarySatClauses++;
+    env->statistics->binarySatClauses++;
   }
 
   // call a constructor on the literals

--- a/SAT/SATInference.cpp
+++ b/SAT/SATInference.cpp
@@ -44,7 +44,7 @@ UnitList* SATInference::getFOPremises(SATClause* cl)
   ASS(cl);
   ASS(cl->inference());
 
-  static Stack<Unit*> prems;
+  VTHREAD_LOCAL static Stack<Unit*> prems;
   prems.reset();
 
   collectFOPremises(cl, prems);
@@ -78,8 +78,8 @@ void SATInference::collectPropAxioms(SATClause* cl, SATClauseStack& res)
 {
   CALL("SATInference::collectPropAxioms");
 
-  static Stack<SATClause*> toDo;
-  static DHSet<SATClause*> seen;
+  VTHREAD_LOCAL static Stack<SATClause*> toDo;
+  VTHREAD_LOCAL static DHSet<SATClause*> seen;
   toDo.reset();
   seen.reset();
 

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -144,8 +144,8 @@ void SATInference::collectFilteredFOPremises(SATClause* cl, Stack<Unit*>& acc, F
   CALL("SATInference::collectFilteredFOPremises");
   ASS_ALLOC_TYPE(cl, "SATClause");
 
-  static Stack<SATClause*> toDo;
-  static DHSet<SATClause*> seen;
+  VTHREAD_LOCAL static Stack<SATClause*> toDo;
+  VTHREAD_LOCAL static DHSet<SATClause*> seen;
   toDo.reset();
   seen.reset();
 

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -170,7 +170,7 @@ SATSolver::Status Z3Interfacing::solveUnderAssumptions(const SATLiteralStack& as
   // load assumptions:
   SATLiteralStack::ConstIterator it(assumps);
 
-  static DHMap<vstring,SATLiteral> lookup;
+  VTHREAD_LOCAL static DHMap<vstring,SATLiteral> lookup;
   lookup.reset();
   unsigned n=0;
   vstring ps="$_$_$";

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -102,9 +102,9 @@ void Z3Interfacing::addClause(SATClause* cl,bool withGuard)
   PRINT_CPP("{ expr cl = exprs.back(); exprs.pop_back(); cout << \"clause: \" << cl << endl; solver.add(cl); }")
   
   if(_showZ3){
-    env.beginOutput();
-    env.out() << "[Z3] add (clause): " << z3clause << std::endl;
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "[Z3] add (clause): " << z3clause << std::endl;
+    env->endOutput();
   }
 
   _solver.add(z3clause);
@@ -125,9 +125,9 @@ SATSolver::Status Z3Interfacing::solve(unsigned conflictCountLimit)
   z3::check_result result = _assumptions.empty() ? _solver.check() : _solver.check(_assumptions);
 
   if(_showZ3){
-    env.beginOutput();
-    env.out() << "[Z3] solve result: " << result << std::endl;
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "[Z3] solve result: " << result << std::endl;
+    env->endOutput();
   }
 
   switch(result){
@@ -387,7 +387,7 @@ z3::expr Z3Interfacing::getz3expr(Term* trm,bool isLit,bool&nameExpression,bool 
     OperatorType* type;
     bool is_equality = false;
     if(isLit){
-      symb = env.signature->getPredicate(trm->functor());
+      symb = env->signature->getPredicate(trm->functor());
       OperatorType* ptype = symb->predType();
       type = ptype;
       range_sort = Term::boolSort();
@@ -397,7 +397,7 @@ z3::expr Z3Interfacing::getz3expr(Term* trm,bool isLit,bool&nameExpression,bool 
          ASS(trm->arity()==2);
       }
     }else{
-      symb = env.signature->getFunction(trm->functor());
+      symb = env->signature->getFunction(trm->functor());
       OperatorType* ftype = symb->fnType();
       type = ftype;
       range_sort = SortHelper::getResultSort(trm);
@@ -420,13 +420,13 @@ z3::expr Z3Interfacing::getz3expr(Term* trm,bool isLit,bool&nameExpression,bool 
         RationalConstantType value = symb->rationalValue();
         return _context.real_val(value.numerator().toInner(),value.denominator().toInner());
       }
-      if(!isLit && env.signature->isFoolConstantSymbol(true,trm->functor())){
+      if(!isLit && env->signature->isFoolConstantSymbol(true,trm->functor())){
 
         PRINT_CPP("exprs.push_back(c.bool_val(true));")
 
         return _context.bool_val(true);
       }
-      if(!isLit && env.signature->isFoolConstantSymbol(false,trm->functor())){
+      if(!isLit && env->signature->isFoolConstantSymbol(false,trm->functor())){
 
         PRINT_CPP("exprs.push_back(c.bool_val(false));")
 
@@ -450,7 +450,7 @@ z3::expr Z3Interfacing::getz3expr(Term* trm,bool isLit,bool&nameExpression,bool 
       }
 
       // If not value then create constant symbol
-      //cout << "HERE " << env.sorts->sortName(range_sort) << " for " << symb->name() << endl; 
+      //cout << "HERE " << env->sorts->sortName(range_sort) << " for " << symb->name() << endl; 
       return getNameConst(symb->name(),getz3sort(range_sort));
     }
     ASS(trm->arity()>0);
@@ -792,9 +792,9 @@ z3::expr Z3Interfacing::getRepresentation(SATLiteral slit,bool withGuard)
         z3::expr naming = (bname == e);
         _solver.add(naming);
   if(_showZ3){
-    env.beginOutput();
-    env.out() << "[Z3] add (naming): " << naming << std::endl;
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "[Z3] add (naming): " << naming << std::endl;
+    env->endOutput();
   }
       }
 
@@ -890,9 +890,9 @@ void Z3Interfacing::addRealNonZero(z3::expr t)
    z3::expr zero = _context.real_val(0);
    z3::expr side = t!=zero;
   if(_showZ3){
-    env.beginOutput();
-    env.out() << "[Z3] add (RealNonZero): " << side << std::endl;
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "[Z3] add (RealNonZero): " << side << std::endl;
+    env->endOutput();
   }
   _solver.add(side);
 }
@@ -906,13 +906,13 @@ void Z3Interfacing::addTruncatedOperations(z3::expr_vector args, Interpretation 
 {
   CALL("Z3Interfacing::addTruncatedOperations");
   
-  unsigned qfun = env.signature->getInterpretingSymbol(qi);
-  Signature::Symbol* qsymb = env.signature->getFunction(qfun); 
+  unsigned qfun = env->signature->getInterpretingSymbol(qi);
+  Signature::Symbol* qsymb = env->signature->getFunction(qfun); 
   ASS(qsymb);
   z3::symbol qs = _context.str_symbol(qsymb->name().c_str());
   
-  unsigned rfun = env.signature->getInterpretingSymbol(ti);
-  Signature::Symbol* rsymb = env.signature->getFunction(rfun);
+  unsigned rfun = env->signature->getInterpretingSymbol(ti);
+  Signature::Symbol* rsymb = env->signature->getFunction(rfun);
   z3::symbol rs = _context.str_symbol(rsymb->name().c_str());
 
   z3::expr e1 = args[0];
@@ -970,12 +970,12 @@ void Z3Interfacing::addFloorOperations(z3::expr_vector args, Interpretation qi, 
 {
   CALL("Z3Interfacing::addFloorOperations");
 
-  unsigned qfun = env.signature->getInterpretingSymbol(qi);
-  Signature::Symbol* qsymb = env.signature->getFunction(qfun);
+  unsigned qfun = env->signature->getInterpretingSymbol(qi);
+  Signature::Symbol* qsymb = env->signature->getFunction(qfun);
   z3::symbol qs = _context.str_symbol(qsymb->name().c_str());
 
-  unsigned rfun = env.signature->getInterpretingSymbol(ti);
-  Signature::Symbol* rsymb = env.signature->getFunction(rfun);
+  unsigned rfun = env->signature->getInterpretingSymbol(ti);
+  Signature::Symbol* rsymb = env->signature->getFunction(rfun);
   z3::symbol rs = _context.str_symbol(rsymb->name().c_str());
 
   z3::expr e1 = args[0];

--- a/Saturation/AWPassiveClauseContainer.cpp
+++ b/Saturation/AWPassiveClauseContainer.cpp
@@ -267,7 +267,7 @@ Clause* AWPassiveClauseContainer::popSelected()
 
   auto shape = _opt.ageWeightRatioShape();
   unsigned frequency = _opt.ageWeightRatioShapeFrequency();
-  static unsigned count = 0;
+  VTHREAD_LOCAL static unsigned count = 0;
   count++;
 
   bool is_converging = shape == Options::AgeWeightRatioShape::CONVERGE;
@@ -325,7 +325,7 @@ void AWPassiveClauseContainer::onLimitsUpdated()
   //of clauses, differing only in their order.
   //(unless one of _ageRation or _weightRatio is equal to 0)
 
-  static Stack<Clause*> toRemove(256);
+  VTHREAD_LOCAL static Stack<Clause*> toRemove(256);
   ClauseQueue::Iterator wit(_weightQueue);
   while (wit.hasNext()) {
     Clause* cl=wit.next();

--- a/Saturation/AWPassiveClauseContainer.cpp
+++ b/Saturation/AWPassiveClauseContainer.cpp
@@ -111,7 +111,7 @@ bool WeightQueue::lessThan(Clause* c1,Clause* c2)
 {
   CALL("WeightQueue::lessThan");
 
-  if(env.options->prioritiseClausesProducedByLongReduction()){
+  if(env->options->prioritiseClausesProducedByLongReduction()){
     if(c1->inference().reductions() < c2->inference().reductions()){
       return false;
     }
@@ -345,7 +345,7 @@ void AWPassiveClauseContainer::onLimitsUpdated()
   while (toRemove.isNonEmpty()) {
     Clause* removed=toRemove.pop();
     RSTAT_CTR_INC("clauses discarded from passive on weight limit update");
-    env.statistics->discardedNonRedundantClauses++;
+    env->statistics->discardedNonRedundantClauses++;
     remove(removed);
   }
 }

--- a/Saturation/ClauseContainer.cpp
+++ b/Saturation/ClauseContainer.cpp
@@ -200,8 +200,8 @@ void ActiveClauseContainer::onLimitsUpdated()
     return;
   }
 
-  static DHSet<Clause*> checked;
-  static Stack<Clause*> toRemove(64);
+  VTHREAD_LOCAL static DHSet<Clause*> checked;
+  VTHREAD_LOCAL static Stack<Clause*> toRemove(64);
   checked.reset();
   toRemove.reset();
 

--- a/Saturation/ClauseContainer.cpp
+++ b/Saturation/ClauseContainer.cpp
@@ -232,7 +232,7 @@ void ActiveClauseContainer::onLimitsUpdated()
     ASS(removed->store()==Clause::ACTIVE);
 
     RSTAT_CTR_INC("clauses discarded from active on weight limit update");
-    env.statistics->discardedNonRedundantClauses++;
+    env->statistics->discardedNonRedundantClauses++;
 
     remove(removed);
     // ASS_NEQ(removed->store(), Clause::ACTIVE); -- the remove could have deleted the clause - do not touch!

--- a/Saturation/ConsequenceFinder.cpp
+++ b/Saturation/ConsequenceFinder.cpp
@@ -78,7 +78,7 @@ void ConsequenceFinder::onNewPropositionalClause(Clause* cl)
   Clause::Iterator it(*cl);
   while(it.hasNext()) {
     Literal* l=it.next();
-    if(!env.signature->getPredicate(l->functor())->label()) {
+    if(!env->signature->getPredicate(l->functor())->label()) {
       return;
     }
     if(l->isPositive()) {
@@ -91,9 +91,9 @@ void ConsequenceFinder::onNewPropositionalClause(Clause* cl)
     }
   }
 
-  env.beginOutput();
-  env.out() << "Pure cf clause: " << cl->toNiceString() <<endl;
-  env.endOutput();
+  env->beginOutput();
+  env->out() << "Pure cf clause: " << cl->toNiceString() <<endl;
+  env->endOutput();
 
   if(!horn || !pos) {
     return;
@@ -109,9 +109,9 @@ void ConsequenceFinder::onNewPropositionalClause(Clause* cl)
   //of the saturation algorithm loop
   _redundantsToHandle.push(red);
 
-  env.beginOutput();
-  env.out() << "Consequence found: " << env.signature->predicateName(red) << endl;
-  env.endOutput();
+  env->beginOutput();
+  env->out() << "Consequence found: " << env->signature->predicateName(red) << endl;
+  env->endOutput();
 }
 
 void ConsequenceFinder::onAllProcessed()
@@ -154,7 +154,7 @@ bool ConsequenceFinder::isRedundant(Clause* cl)
   Clause::Iterator it(*cl);
   while(it.hasNext()) {
     unsigned fn=it.next()->functor();
-    if(!env.signature->getPredicate(fn)->label()) {
+    if(!env->signature->getPredicate(fn)->label()) {
       continue;
     }
     if(_redundant[fn]) {
@@ -175,7 +175,7 @@ void ConsequenceFinder::onClauseInserted(Clause* cl)
   Clause::Iterator it(*cl);
   while(it.hasNext()) {
     unsigned fn=it.next()->functor();
-    if(!env.signature->getPredicate(fn)->label()) {
+    if(!env->signature->getPredicate(fn)->label()) {
       continue;
     }
     if(_redundant[fn]) {
@@ -205,7 +205,7 @@ void ConsequenceFinder::onClauseRemoved(Clause* cl)
   Clause::Iterator it(*cl);
   while(it.hasNext()) {
     unsigned fn=it.next()->functor();
-    if(!env.signature->getPredicate(fn)->label()) {
+    if(!env->signature->getPredicate(fn)->label()) {
       continue;
     }
     if(!_redundant[fn]) {

--- a/Saturation/ExtensionalityClauseContainer.cpp
+++ b/Saturation/ExtensionalityClauseContainer.cpp
@@ -61,7 +61,7 @@ Literal* ExtensionalityClauseContainer::addIfExtensionality(Clause* c) {
     //   * Exactly one X=Y
     //   * No inequality of same sort as X=Y
     //   * No equality except X=Y (optional).
-    static DHSet<TermList> negEqSorts;
+    VTHREAD_LOCAL static DHSet<TermList> negEqSorts;
     negEqSorts.reset();
   
     for (Clause::Iterator ci(*c); ci.hasNext(); ) {

--- a/Saturation/ExtensionalityClauseContainer.cpp
+++ b/Saturation/ExtensionalityClauseContainer.cpp
@@ -94,7 +94,7 @@ Literal* ExtensionalityClauseContainer::addIfExtensionality(Clause* c) {
     c->setExtensionality(true);
     add(ExtensionalityClause(c, varEq, sort));
     _size++;
-    env.statistics->extensionalityClauses++;
+    env->statistics->extensionalityClauses++;
     return varEq;
   }
 

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -103,8 +103,8 @@ long long LRS::estimatedReachableCount()
   }
 #endif
 
-  long long processed=env.statistics->activeClauses;
-  int currTime=env.timer->elapsedMilliseconds();
+  long long processed=env->statistics->activeClauses;
+  int currTime=env->timer->elapsedMilliseconds();
   long long timeSpent=currTime-_startTime;
   //the result is in miliseconds, as _opt.lrsFirstTimeCheck() is in percents.
   int firstCheck=_opt.lrsFirstTimeCheck()*_opt.timeLimitInDeciseconds();

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -75,7 +75,7 @@ bool LRS::shouldUpdateLimits()
 {
   CALL("LRS::shouldUpdateLimits");
 
-  static unsigned cnt=0;
+  VTHREAD_LOCAL static unsigned cnt=0;
   cnt++;
 
   //when there are limits, we check more frequently so we don't skip too much inferences
@@ -95,7 +95,7 @@ long long LRS::estimatedReachableCount()
   CALL("LRS::estimatedReachableCount");
 
 #if DETERMINISE_LRS_LOAD
-  static std::ifstream infile("lrs_data.txt");
+  VTHREAD_LOCAL static std::ifstream infile("lrs_data.txt");
   long long thing;
   if (infile >> thing) {
     cout << "reading " << thing << endl;
@@ -134,7 +134,7 @@ long long LRS::estimatedReachableCount()
   finish:
 
 #if DETERMINISE_LRS_SAVE
-  static std::ofstream outfile("lrs_data.txt");
+  VTHREAD_LOCAL static std::ofstream outfile("lrs_data.txt");
   outfile << result << endl;
 #endif
 

--- a/Saturation/LabelFinder.cpp
+++ b/Saturation/LabelFinder.cpp
@@ -55,8 +55,8 @@ void LabelFinder::onNewPropositionalClause(Clause* cl)
   unsigned predicate = (*cl)[0]->functor();
 
   // Looking for predicates
-  ASS(env.signature->getPredicate(predicate));
-  if(!env.signature->getPredicate(predicate)->label()){
+  ASS(env->signature->getPredicate(predicate));
+  if(!env->signature->getPredicate(predicate)->label()){
     return;
   }
 

--- a/Saturation/PersistentGrounding.cpp
+++ b/Saturation/PersistentGrounding.cpp
@@ -30,7 +30,7 @@ namespace Saturation {
 VTHREAD_LOCAL DHMap<unsigned, unsigned> PersistentGrounding::_splitMap;
 
 PersistentGrounding::PersistentGrounding()
-  : _fresh(0), _solver(new MinisatInterfacing(*env.options)) {
+  : _fresh(0), _solver(new MinisatInterfacing(*env->options)) {
   _solveTask = std::thread([&] { this->work(); });
 }
 

--- a/Saturation/PersistentGrounding.cpp
+++ b/Saturation/PersistentGrounding.cpp
@@ -39,7 +39,7 @@ PersistentGrounding::PersistentGrounding()
       continue;
     }
     OperatorType *type = fun->fnType();
-    unsigned sort = type->result();
+    unsigned sort = type->result().term()->getId();
     unsigned usage = fun->usageCnt();
     unsigned best = constants[sort];
     if(!best || env->signature->getFunction(best)->usageCnt() < usage)
@@ -104,7 +104,7 @@ void PersistentGrounding::enqueueClause(Clause *cl)
     struct MapToSortConstant {
       TermList apply(unsigned var)
       {
-        unsigned sort = SortHelper::getVariableSort(TermList(var, false), parent);
+        unsigned sort = SortHelper::getVariableSort(TermList(var, false), parent).term()->getId();
         return constants[sort];
       }
       Term *parent;

--- a/Saturation/PersistentGrounding.cpp
+++ b/Saturation/PersistentGrounding.cpp
@@ -1,0 +1,122 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file PersistentGrounding.cpp
+ * Implements class PersistentGrounding
+ */
+
+#if VTHREADED
+#include "PersistentGrounding.hpp"
+
+#include "Lib/SharedSet.hpp"
+#include "Kernel/Clause.hpp"
+#include "Kernel/SubstHelper.hpp"
+#include "SAT/MinisatInterfacing.hpp"
+#include "SAT/SATClause.hpp"
+#include "Saturation/Splitter.hpp"
+
+using namespace Kernel;
+using namespace SAT;
+
+namespace Saturation {
+
+PersistentGrounding::PersistentGrounding()
+  : _solver(new MinisatInterfacing(*env.options)) {
+  _solveTask = std::thread([&] { this->work(); });
+}
+
+PersistentGrounding *PersistentGrounding::instance() {
+  static PersistentGrounding *instance = new PersistentGrounding;
+  return instance;
+}
+
+void PersistentGrounding::work() {
+  while(true) {
+    // asserting phase
+    {
+      std::lock_guard<std::mutex> lock{_queueLock};
+      _solver->ensureVarCount(_fresh);
+      if(_queue.isEmpty()) {
+        // wait for more clauses to come through
+        std::this_thread::yield();
+        continue;
+      }
+      while(_queue.isNonEmpty()) {
+        SATClause *cl = _queue.pop_front();
+        _solver->addClause(cl);
+        // std::cout << cl->toString() << std::endl;
+      }
+    }
+    // solving phase
+    // std::cout << "solving..." << std::endl;
+    if(_solver->solve() == SAT::SATSolver::Status::UNSATISFIABLE) {
+      std::cout << "% SZS status PersistentlyUnsat" << std::endl;
+      break;
+    }
+  }
+}
+
+void PersistentGrounding::enqueue(Clause *cl) {
+  VTHREAD_LOCAL static SATLiteralStack clause;
+  clause.reset();
+
+  {
+    std::lock_guard<std::mutex> lock{_groundLock};
+
+    // like InstGen: maps all variables to the same distinct term
+    class MapToSame
+    {
+    public:
+      TermList apply(unsigned var)
+      {
+        return TermList(0, false);
+      }
+    };
+    // for regular literals, map them InstGen-style to ground literals
+    for(int i = 0; i < cl->length(); i++) {
+      MapToSame map;
+      Literal *ground = SubstHelper::apply(cl->literals()[i], map);
+      Literal *positive = Literal::positiveLiteral(ground);
+      unsigned *var;
+      if(_literalMap.getValuePtr(positive, var)) {    
+        *var = ++_fresh;
+      }
+      clause.push(SATLiteral(*var, ground->isPositive()));
+    }
+  }
+
+  // splits are already ground
+  // but: need treating differently as they might be per-thread
+  VTHREAD_LOCAL static DHMap<unsigned, unsigned> splitMap;
+  auto splits = cl->splits();
+  if(splits) {
+    SplitSet::Iterator it(*splits);
+    while(it.hasNext()) {
+      SplitLevel split = it.next();
+      SATLiteral literal = Splitter::getLiteralFromName(split);
+      unsigned *var;
+      if(splitMap.getValuePtr(literal.var(), var)) {
+        *var = ++_fresh;
+      }
+      // (sp1, ... spN) -> L1 \/ ... \/ LN
+      // could be read as
+      // ¬sp1 \/ ... \/ spN \/ L1 \/ ... \/ LN
+      // and therefore should be opposite polarity (i.e. isNegative()) below
+      // but it doesn't matter and this way is easier to read
+      clause.push(SATLiteral(*var, literal.isPositive()));
+    }
+  }
+
+  std::lock_guard<std::mutex> lock{_queueLock};
+  _queue.push_back(SATClause::fromStack(clause));
+}
+
+} // namespace Saturation
+#endif

--- a/Saturation/PersistentGrounding.hpp
+++ b/Saturation/PersistentGrounding.hpp
@@ -1,0 +1,50 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file PersistentGrounding.hpp
+ * Defines class PersistentGrounding for global grounding across proof attempts
+ */
+
+#if VTHREADED
+#ifndef __PersistentGrounding__
+#define __PersistentGrounding__
+
+#include <thread>
+
+#include "Forwards.hpp"
+#include "Lib/Deque.hpp"
+#include "Lib/DHMap.hpp"
+
+namespace Saturation {
+
+using namespace Kernel;
+using namespace Lib;
+using namespace SAT;
+
+class PersistentGrounding {
+  CLASS_NAME(PersistentGrounding)
+  USE_ALLOCATOR(PersistentGrounding)
+public:
+  PersistentGrounding();
+  static PersistentGrounding *instance();
+  void enqueue(Clause *);
+  void work();
+private:
+  std::thread _solveTask;
+  std::mutex _groundLock;
+  VATOMIC(unsigned) _fresh;
+  DHMap<Literal*, unsigned> _literalMap;
+  std::mutex _queueLock;
+  Deque<SATClause *> _queue;
+  SATSolver *_solver;
+}; // class PersistentGrounding;
+} // namespace Saturation
+#endif
+#endif

--- a/Saturation/PersistentGrounding.hpp
+++ b/Saturation/PersistentGrounding.hpp
@@ -16,6 +16,7 @@
 #ifndef __PersistentGrounding__
 #define __PersistentGrounding__
 
+#include <mutex>
 #include <thread>
 
 #include "Forwards.hpp"

--- a/Saturation/PersistentGrounding.hpp
+++ b/Saturation/PersistentGrounding.hpp
@@ -21,6 +21,7 @@
 #include "Forwards.hpp"
 #include "Lib/Deque.hpp"
 #include "Lib/DHMap.hpp"
+#include "Lib/Array.hpp"
 
 namespace Saturation {
 
@@ -41,6 +42,7 @@ private:
   std::thread _solveTask;
   std::mutex _lock;
   unsigned _fresh;
+  Array<TermList> _sortConstants;
   DHMap<Literal*, unsigned> _literalMap;
   VTHREAD_LOCAL static DHMap<unsigned, unsigned> _splitMap;
   Deque<SATClause *> _queue;

--- a/Saturation/PersistentGrounding.hpp
+++ b/Saturation/PersistentGrounding.hpp
@@ -43,7 +43,6 @@ private:
   std::thread _solveTask;
   std::mutex _lock;
   unsigned _fresh;
-  Array<TermList> _sortConstants;
   DHMap<Literal*, unsigned> _literalMap;
   VTHREAD_LOCAL static DHMap<unsigned, unsigned> _splitMap;
   Deque<SATClause *> _queue;

--- a/Saturation/PersistentGrounding.hpp
+++ b/Saturation/PersistentGrounding.hpp
@@ -34,14 +34,15 @@ class PersistentGrounding {
 public:
   PersistentGrounding();
   static PersistentGrounding *instance();
-  void enqueue(Clause *);
+  void enqueueClause(Clause *);
+  void enqueueSATClause(SATClause *);
   void work();
 private:
   std::thread _solveTask;
-  std::mutex _groundLock;
-  VATOMIC(unsigned) _fresh;
+  std::mutex _lock;
+  unsigned _fresh;
   DHMap<Literal*, unsigned> _literalMap;
-  std::mutex _queueLock;
+  VTHREAD_LOCAL static DHMap<unsigned, unsigned> _splitMap;
   Deque<SATClause *> _queue;
   SATSolver *_solver;
 }; // class PersistentGrounding;

--- a/Saturation/PredicateSplitPassiveClauseContainer.cpp
+++ b/Saturation/PredicateSplitPassiveClauseContainer.cpp
@@ -474,7 +474,7 @@ float TheoryMultiSplitPassiveClauseContainer::evaluateFeatureEstimate(unsigned, 
 {
   CALL("TheoryMultiSplitPassiveClauseContainer::evaluateFeatureEstimate");
   // heuristically compute likeliness that clause occurs in proof
-  static int expectedRatioDenominator = _opt.theorySplitQueueExpectedRatioDenom();
+  int expectedRatioDenominator = _opt.theorySplitQueueExpectedRatioDenom();
   return inf.th_ancestors * expectedRatioDenominator - inf.all_ancestors;
 }
 

--- a/Saturation/ProvingHelper.cpp
+++ b/Saturation/ProvingHelper.cpp
@@ -37,10 +37,10 @@ using namespace Kernel;
 using namespace Shell;
 
 /**
- * Run the Vampire saturation loop (based on the content of @b env.options )
+ * Run the Vampire saturation loop (based on the content of @b env->options )
  * on @b clauses
  *
- * The result of the loop is in @b env.statistics
+ * The result of the loop is in @b env->statistics
  *
  * The content of the @b units list after return from the function is
  * undefined
@@ -56,28 +56,28 @@ using namespace Shell;
     runVampireSaturationImpl(prb, opt);
   }
   catch(MemoryLimitExceededException&) {
-    env.statistics->terminationReason=Statistics::MEMORY_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::MEMORY_LIMIT;
+    env->statistics->refutation=0;
     size_t limit=Allocator::getMemoryLimit();
     //add extra 1 MB to allow proper termination
     Allocator::setMemoryLimit(limit+1000000);
   }
   catch(TimeLimitExceededException&) {
-    env.statistics->terminationReason=Statistics::TIME_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::TIME_LIMIT;
+    env->statistics->refutation=0;
   }
   catch(ActivationLimitExceededException&) {
-    env.statistics->terminationReason=Statistics::ACTIVATION_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::ACTIVATION_LIMIT;
+    env->statistics->refutation=0;
   }
 }
 
 /**
  * Run the Vampire preprocessing and saturation loop (based on the content
- * of @b env.options ) on @b units. If @b prop is nonzero, do not scan
+ * of @b env->options ) on @b units. If @b prop is nonzero, do not scan
  * properties of the units, but use @b prop as a property object instead.
  *
- * The result of the loop is in @b env.statistics
+ * The result of the loop is in @b env->statistics
  *
  * The content of the @b units list after return from the function is
  * undefined
@@ -101,19 +101,19 @@ void ProvingHelper::runVampire(Problem& prb, const Options& opt)
     runVampireSaturationImpl(prb, opt);
   }
   catch(MemoryLimitExceededException&) {
-    env.statistics->terminationReason=Statistics::MEMORY_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::MEMORY_LIMIT;
+    env->statistics->refutation=0;
     size_t limit=Allocator::getMemoryLimit();
     //add extra 1 MB to allow proper termination
     Allocator::setMemoryLimit(limit+1000000);
   }
   catch(TimeLimitExceededException&) {
-    env.statistics->terminationReason=Statistics::TIME_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::TIME_LIMIT;
+    env->statistics->refutation=0;
   }
   catch(ActivationLimitExceededException&) {
-    env.statistics->terminationReason=Statistics::ACTIVATION_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::ACTIVATION_LIMIT;
+    env->statistics->refutation=0;
   }
 }
 
@@ -126,11 +126,11 @@ void ProvingHelper::runVampire(Problem& prb, const Options& opt)
   CALL("ProvingHelper::runVampireSaturationImpl");
 
   Unit::onPreprocessingEnd();
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] onPreprocessingEnd(), Proving Helper" << std::endl;
-    UIHelper::outputAllPremises(env.out(), prb.units(), "New: ");
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] onPreprocessingEnd(), Proving Helper" << std::endl;
+    UIHelper::outputAllPremises(env->out(), prb.units(), "New: ");
+    env->endOutput();
   }
 
   //this point is reached both by the vampire mode (single strategy) and the portfolio mode (strategy schedule) when inside a strategy
@@ -140,13 +140,13 @@ void ProvingHelper::runVampire(Problem& prb, const Options& opt)
   Lib::Random::setSeed(opt.randomSeed());
   //decide whether to use poly or mono well-typedness test
   //after options have been read. Equality Proxy can introduce poly in mono.
-  env.sharing->setPoly();
+  env->sharing->setPoly();
 
-  env.statistics->phase=Statistics::SATURATION;
+  env->statistics->phase=Statistics::SATURATION;
   ScopedPtr<MainLoop> salg(MainLoop::createFromOptions(prb, opt));
 
   MainLoopResult sres(salg->run());
-  env.statistics->phase=Statistics::FINALIZATION;
+  env->statistics->phase=Statistics::FINALIZATION;
   Timer::setTimeLimitEnforcement(false);
   sres.updateStatistics();
 }

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -934,15 +934,15 @@ void SaturationAlgorithm::addUnprocessedClause(Clause* cl)
     return;
   }
 
+#if VTHREADED
+  if(_grounding)
+    _grounding->enqueueClause(cl);
+#endif
+
   if (cl->isEmpty()) {
     handleEmptyClause(cl);
     return;
   }
-
-#if VTHREADED
-  if(_grounding)
-    _grounding->enqueue(cl);
-#endif
 
   cl->setStore(Clause::UNPROCESSED);
   _unprocessed->add(cl);

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -913,7 +913,11 @@ void SaturationAlgorithm::addUnprocessedClause(Clause* cl)
   _generatedClauseCount++;
   env.statistics->generatedClauses++;
 
+#if VTHREADED
+  env.checkTimeSometime<1>();
+#else
   env.checkTimeSometime<64>();
+#endif
 
 
   cl=doImmediateSimplification(cl);

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -544,7 +544,7 @@ void SaturationAlgorithm::onClauseReduction(Clause* cl, Clause** replacements, u
   CALL("SaturationAlgorithm::onClauseReduction/4");
   ASS(cl);
 
-  static ClauseStack premStack;
+  VTHREAD_LOCAL static ClauseStack premStack;
   premStack.reset();
   premStack.loadFromIterator(premises);
 
@@ -793,9 +793,9 @@ Clause* SaturationAlgorithm::doImmediateSimplification(Clause* cl0)
 {
   CALL("SaturationAlgorithm::doImmediateSimplification");
 
-  static bool sosTheoryLimit = _opt.sos()==Options::Sos::THEORY;
-  static unsigned sosTheoryLimitAge = _opt.sosTheoryLimit();
-  static ClauseStack repStack;
+  VTHREAD_LOCAL static bool sosTheoryLimit = _opt.sos()==Options::Sos::THEORY;
+  VTHREAD_LOCAL static unsigned sosTheoryLimitAge = _opt.sosTheoryLimit();
+  VTHREAD_LOCAL static ClauseStack repStack;
   repStack.reset();
 
   SplitSet* splitSet = 0;

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -124,7 +124,7 @@ using namespace Saturation;
 #define REPORT_BW_SIMPL 0
 
 
-SaturationAlgorithm* SaturationAlgorithm::s_instance = 0;
+VTHREAD_LOCAL SaturationAlgorithm* SaturationAlgorithm::s_instance = 0;
 
 std::unique_ptr<PassiveClauseContainer> makeLevel0(bool isOutermost, const Options& opt, vstring name)
 {

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1039,7 +1039,7 @@ bool SaturationAlgorithm::forwardSimplify(Clause* cl)
     }
   }
 
-  static ClauseStack repStack;
+  VTHREAD_LOCAL static ClauseStack repStack;
 
   repStack.reset();
   SimplList::Iterator sit(_simplifiers);

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -340,10 +340,10 @@ void SaturationAlgorithm::tryUpdateFinalClauseCount()
   if (!inst) {
     return;
   }
-  env.statistics->finalActiveClauses = inst->_active->sizeEstimate();
-  env.statistics->finalPassiveClauses = inst->_passive->sizeEstimate();
+  env->statistics->finalActiveClauses = inst->_active->sizeEstimate();
+  env->statistics->finalPassiveClauses = inst->_passive->sizeEstimate();
   if (inst->_extensionality != 0) {
-    env.statistics->finalExtensionalityClauses = inst->_extensionality->size();
+    env->statistics->finalExtensionalityClauses = inst->_extensionality->size();
   }
 }
 
@@ -352,7 +352,7 @@ void SaturationAlgorithm::tryUpdateFinalClauseCount()
  */
 bool SaturationAlgorithm::isComplete()
 {
-  return _completeOptionSettings && !env.statistics->inferencesSkippedDueToColors;
+  return _completeOptionSettings && !env->statistics->inferencesSkippedDueToColors;
 }
 
 ClauseIterator SaturationAlgorithm::activeClauses()
@@ -370,10 +370,10 @@ void SaturationAlgorithm::onActiveAdded(Clause* c)
 {
   CALL("SaturationAlgorithm::onActiveAdded");
 
-  if (env.options->showActive()) {
-    env.beginOutput();    
-    env.out() << "[SA] active: " << c->toString() << std::endl;
-    env.endOutput();             
+  if (env->options->showActive()) {
+    env->beginOutput();    
+    env->out() << "[SA] active: " << c->toString() << std::endl;
+    env->endOutput();             
   }          
 }
 
@@ -412,10 +412,10 @@ void SaturationAlgorithm::onAllProcessed()
  */
 void SaturationAlgorithm::onPassiveAdded(Clause* c)
 {
-  if (env.options->showPassive()) {
-    env.beginOutput();
-    env.out() << "[SA] passive: " << c->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showPassive()) {
+    env->beginOutput();
+    env->out() << "[SA] passive: " << c->toString() << std::endl;
+    env->endOutput();
   }
   
   //when a clause is added to the passive container,
@@ -480,10 +480,10 @@ void SaturationAlgorithm::onNewClause(Clause* cl)
     _splitter->onNewClause(cl);
   }
 
-  if (env.options->showNew()) {
-    env.beginOutput();
-    env.out() << "[SA] new: " << cl->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showNew()) {
+    env->beginOutput();
+    env->out() << "[SA] new: " << cl->toString() << std::endl;
+    env->endOutput();
   }
 
   if (cl->isPropositional()) {
@@ -500,10 +500,10 @@ void SaturationAlgorithm::onNewUsefulPropositionalClause(Clause* c)
   CALL("SaturationAlgorithm::onNewUsefulPropositionalClause");
   ASS(c->isPropositional());
   
-  if (env.options->showNewPropositional()) {
-    env.beginOutput();
-    env.out() << "[SA] new propositional: " << c->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showNewPropositional()) {
+    env->beginOutput();
+    env->out() << "[SA] new propositional: " << c->toString() << std::endl;
+    env->endOutput();
   }
 
   if (_consFinder) {
@@ -559,20 +559,20 @@ void SaturationAlgorithm::onClauseReduction(Clause* cl, Clause** replacements, u
 
   Clause* replacement = numOfReplacements ? *replacements : 0;
 
-  if (env.options->showReductions()) {
-    env.beginOutput();
-    env.out() << "[SA] " << (forward ? "forward" : "backward") << " reduce: " << cl->toString() << endl;
+  if (env->options->showReductions()) {
+    env->beginOutput();
+    env->out() << "[SA] " << (forward ? "forward" : "backward") << " reduce: " << cl->toString() << endl;
     for(unsigned i = 0; i < numOfReplacements; i++){
       Clause* replacement = *replacements;
-      if(replacement){ env.out() << "      replaced by " << replacement->toString() << endl; }
+      if(replacement){ env->out() << "      replaced by " << replacement->toString() << endl; }
       replacements++;
     }
     ClauseStack::Iterator pit(premStack);
     while(pit.hasNext()){
       Clause* premise = pit.next();
-      if(premise){ env.out() << "     using " << premise->toString() << endl; }
+      if(premise){ env->out() << "     using " << premise->toString() << endl; }
     }
-    env.endOutput();
+    env->endOutput();
   }
 
   if (_splitter) {
@@ -650,7 +650,7 @@ void SaturationAlgorithm::passiveRemovedHandler(Clause* cl)
  */
 int SaturationAlgorithm::elapsedTime()
 {
-  return env.timer->elapsedMilliseconds()-_startTime;
+  return env->timer->elapsedMilliseconds()-_startTime;
 }
 
 /**
@@ -678,7 +678,7 @@ void SaturationAlgorithm::addInputClause(Clause* cl)
     unsigned level = cl->getSineLevel();
     // cout << "Adding " << cl->toString() << " level " << level;
     if (level == UINT_MAX) {
-      level = env.maxSineLevel-1; // as the next available (unused) value
+      level = env->maxSineLevel-1; // as the next available (unused) value
       // cout << " -> " << level;
     }
     // cout << endl;
@@ -695,7 +695,7 @@ void SaturationAlgorithm::addInputClause(Clause* cl)
     _instantiation->registerClause(cl);
   }
 
-  env.statistics->initialClauses++;
+  env->statistics->initialClauses++;
 }
 
 /**
@@ -760,7 +760,7 @@ simpl_start:
   }
 
   cl->setStore(Clause::ACTIVE);
-  env.statistics->activeClauses++;
+  env->statistics->activeClauses++;
   _active->add(cl);
 
   onSOSClauseAdded(cl);
@@ -795,7 +795,7 @@ void SaturationAlgorithm::init()
     _symEl->init(this);
   }
 
-  _startTime=env.timer->elapsedMilliseconds();
+  _startTime=env->timer->elapsedMilliseconds();
 }
 
 Clause* SaturationAlgorithm::doImmediateSimplification(Clause* cl0)
@@ -920,12 +920,12 @@ void SaturationAlgorithm::addUnprocessedClause(Clause* cl)
   CALL("SaturationAlgorithm::addUnprocessedClause");
 
   _generatedClauseCount++;
-  env.statistics->generatedClauses++;
+  env->statistics->generatedClauses++;
 
 #if VTHREADED
-  env.checkTimeSometime<1>();
+  env->checkTimeSometime<1>();
 #else
-  env.checkTimeSometime<64>();
+  env->checkTimeSometime<64>();
 #endif
 
 
@@ -1015,7 +1015,7 @@ bool SaturationAlgorithm::forwardSimplify(Clause* cl)
 
   if (!_passive->fulfilsAgeLimit(cl) && !_passive->fulfilsWeightLimit(cl)) {
     RSTAT_CTR_INC("clauses discarded by weight limit in forward simplification");
-    env.statistics->discardedNonRedundantClauses++;
+    env->statistics->discardedNonRedundantClauses++;
     return false;
   }
 
@@ -1160,7 +1160,7 @@ void SaturationAlgorithm::addToPassive(Clause* cl)
   ASS_EQ(cl->store(), Clause::UNPROCESSED);
 
   cl->setStore(Clause::PASSIVE);
-  env.statistics->passiveClauses++;
+  env->statistics->passiveClauses++;
 
   {
     TimeCounter tc(TC_PASSIVE_CONTAINER_MAINTENANCE);
@@ -1216,7 +1216,7 @@ bool SaturationAlgorithm::activate(Clause* cl)
 
   ASS_EQ(cl->store(), Clause::SELECTED);
   cl->setStore(Clause::ACTIVE);
-  env.statistics->activeClauses++;
+  env->statistics->activeClauses++;
   _active->add(cl);
 
 
@@ -1282,7 +1282,7 @@ start:
 
     newClausesToUnprocessed();
 
-    if (env.timeLimitReached()) {
+    if (env->timeLimitReached()) {
       throw TimeLimitExceededException();
     }
   }
@@ -1411,7 +1411,7 @@ MainLoopResult SaturationAlgorithm::runImpl()
       doOneAlgorithmStep();
 
       Timer::syncClock();
-      if (env.timeLimitReached()) {
+      if (env->timeLimitReached()) {
         throw TimeLimitExceededException();
       }
     }
@@ -1555,7 +1555,7 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   if (prb.hasEquality()) {
     gie->addFront(new EqualityFactoring());
     gie->addFront(new EqualityResolution());
-    if(env.options->superposition()){
+    if(env->options->superposition()){
       gie->addFront(new Superposition());
     }
   } else if(opt.unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF){
@@ -1574,18 +1574,18 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if(prb.hasFOOL() &&
-    env.statistics->higherOrder && env.options->booleanEqTrick()){
+    env->statistics->higherOrder && env->options->booleanEqTrick()){
   //  gie->addFront(new ProxyElimination::NOTRemovalGIE());
     gie->addFront(new BoolEqToDiseq());
   }
 
   if(opt.complexBooleanReasoning() && prb.hasBoolVar() &&
-     env.statistics->higherOrder && !opt.lambdaFreeHol()){
+     env->statistics->higherOrder && !opt.lambdaFreeHol()){
     gie->addFront(new PrimitiveInstantiation()); //TODO only add in some cases
     gie->addFront(new ElimLeibniz());
   }
 
-  if(env.options->choiceReasoning()){
+  if(env->options->choiceReasoning()){
     gie->addFront(new Choice());
   }
 
@@ -1607,9 +1607,9 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) &&
-      env.statistics->higherOrder && !prb.quantifiesOverPolymorphicVar()){
-    if(env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
-       env.options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
+      env->statistics->higherOrder && !prb.quantifiesOverPolymorphicVar()){
+    if(env->options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
+       env->options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
       gie->addFront(new LazyClausificationGIE());
     }
   }
@@ -1617,7 +1617,7 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   if (opt.injectivityReasoning()) {
     gie->addFront(new Injectivity());
   }
-  if(prb.hasEquality() && env.signature->hasTermAlgebras()) {
+  if(prb.hasEquality() && env->signature->hasTermAlgebras()) {
     if (opt.termAlgebraCyclicityCheck() == Options::TACyclicityCheck::RULE) {
       gie->addFront(new AcyclicityGIE());
     } else if (opt.termAlgebraCyclicityCheck() == Options::TACyclicityCheck::RULELIGHT) {
@@ -1641,9 +1641,9 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   //create simplification engine
 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) &&
-      env.statistics->higherOrder && !prb.quantifiesOverPolymorphicVar()){
-    if(env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
-       env.options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
+      env->statistics->higherOrder && !prb.quantifiesOverPolymorphicVar()){
+    if(env->options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
+       env->options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
       res->addSimplifierToFront(new LazyClausification());
     }
     //res->addSimplifierToFront(new RenamingOnTheFly());
@@ -1765,18 +1765,18 @@ ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, cons
     break;
   }
 
-  if(env.options->combinatorySup()){
+  if(env->options->combinatorySup()){
     res->addFront(new CombinatorDemodISE());
     res->addFront(new CombinatorNormalisationISE());
   }
 
-  if(env.options->choiceReasoning()){
+  if(env->options->choiceReasoning()){
     res->addFront(new ChoiceDefinitionISE());
   }
 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) &&
-      env.statistics->higherOrder && !env.options->addProxyAxioms()){
-    if(env.options->cnfOnTheFly() == Options::CNFOnTheFly::EAGER){
+      env->statistics->higherOrder && !env->options->addProxyAxioms()){
+    if(env->options->cnfOnTheFly() == Options::CNFOnTheFly::EAGER){
       /*res->addFrontMany(new ProxyISE());
       res->addFront(new OrImpAndProxyISE());
       res->addFront(new NotProxyISE());   
@@ -1794,10 +1794,10 @@ ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, cons
   }
 
   // Only add if there are distinct groups 
-  if(prb.hasEquality() && env.signature->hasDistinctGroups()) {
+  if(prb.hasEquality() && env->signature->hasDistinctGroups()) {
     res->addFront(new DistinctEqualitySimplifier());
   }
-  if(prb.hasEquality() && env.signature->hasTermAlgebras()) {
+  if(prb.hasEquality() && env->signature->hasTermAlgebras()) {
     if (opt.termAlgebraInferences()) {
       res->addFront(new DistinctnessISE());
       res->addFront(new InjectivityISE());
@@ -1805,16 +1805,16 @@ ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, cons
     }
   }
   if(prb.hasInterpretedOperations() || prb.hasInterpretedEquality()) {
-    if (env.options->gaussianVariableElimination()) {
+    if (env->options->gaussianVariableElimination()) {
       res->addFront(new GaussianVariableElimination());
     }
-    res->addFront(new InterpretedEvaluation(env.options->inequalityNormalization(), ordering));
+    res->addFront(new InterpretedEvaluation(env->options->inequalityNormalization(), ordering));
   }
   if(prb.hasEquality()) {
     res->addFront(new TrivialInequalitiesRemovalISE());
   }
   res->addFront(new TautologyDeletionISE());
-  if(env.options->newTautologyDel()){
+  if(env->options->newTautologyDel()){
     res->addFront(new TautologyDeletionISE2());
   }
   res->addFront(new DuplicateLiteralRemovalISE());

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -168,7 +168,7 @@ private:
   class TotalSimplificationPerformer;
   class PartialSimplificationPerformer;
 
-  static SaturationAlgorithm* s_instance;
+  VTHREAD_LOCAL static SaturationAlgorithm* s_instance;
 protected:
 
   bool _completeOptionSettings;

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -204,6 +204,9 @@ protected:
   ScopedPtr<LiteralSelector> _selector;
 
   Splitter* _splitter;
+#if VTHREADED
+  PersistentGrounding *_grounding;
+#endif
 
   ConsequenceFinder* _consFinder;
   LabelFinder* _labelFinder;

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -638,7 +638,7 @@ void SplittingBranchSelector::recomputeModel(SplitLevelStack& addedComps, SplitL
 // Splitter
 //////////////
 
-vstring Splitter::splPrefix = "";
+VTHREAD_LOCAL vstring Splitter::splPrefix = "";
 
 Splitter::Splitter()
 : _deleteDeactivated(Options::SplittingDeleteDeactivated::ON), _branchSelector(*this),

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -47,6 +47,7 @@
 
 #include "DP/ShortConflictMetaDP.hpp"
 
+#include "PersistentGrounding.hpp"
 #include "SaturationAlgorithm.hpp"
 
 namespace Saturation
@@ -977,6 +978,11 @@ bool Splitter::handleNonSplittable(Clause* cl)
     Formula* f = JunctionFormula::generalJunction(OR,resLst);
     FormulaUnit* scl = new FormulaUnit(f,NonspecificInferenceMany(InferenceRule::AVATAR_SPLIT_CLAUSE,ps));
 
+#if VTHREADED
+    if(env.options->persistentGrounding())
+      PersistentGrounding::instance()->enqueueSATClause(nsClause);
+#endif
+
     nsClause->setInference(new FOConversionInference(scl));
 
     if (_showSplitting) {
@@ -1142,6 +1148,10 @@ bool Splitter::doSplitting(Clause* cl)
   }
 
   SATClause* splitClause = SATClause::fromStack(satClauseLits);
+#if VTHREADED
+    if(env.options->persistentGrounding())
+      PersistentGrounding::instance()->enqueueSATClause(splitClause);
+#endif
 
   if (_showSplitting) {
     env.beginOutput();

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -391,8 +391,8 @@ SATSolver::Status SplittingBranchSelector::processDPConflicts()
   }
   
   SAT2FO& s2f = _parent.satNaming();
-  static LiteralStack gndAssignment;
-  static LiteralStack unsatCore;
+  VTHREAD_LOCAL static LiteralStack gndAssignment;
+  VTHREAD_LOCAL static LiteralStack unsatCore;
 
   while (true) { // breaks inside
     {
@@ -448,7 +448,7 @@ SATSolver::Status SplittingBranchSelector::processDPConflicts()
 
     RSTAT_CTR_INC("ssat_dp_model");
 
-    static LiteralStack model;
+    VTHREAD_LOCAL static LiteralStack model;
     model.reset();
 
     _dpModel->reset();
@@ -810,8 +810,8 @@ void Splitter::onAllProcessed()
   }
   _clausesAdded = false;
 
-  static SplitLevelStack toAdd;
-  static SplitLevelStack toRemove;
+  VTHREAD_LOCAL static SplitLevelStack toAdd;
+  VTHREAD_LOCAL static SplitLevelStack toRemove;
   
   toAdd.reset();
   toRemove.reset();  
@@ -950,7 +950,7 @@ bool Splitter::handleNonSplittable(Clause* cl)
 
     RSTAT_CTR_INC("ssat_self_dependent_component");
   } else {
-    static SATLiteralStack satLits;
+    VTHREAD_LOCAL static SATLiteralStack satLits;
     satLits.reset();
     collectDependenceLits(cl->splits(), satLits);
     satLits.push(getLiteralFromName(compName));
@@ -1038,7 +1038,7 @@ bool Splitter::getComponents(Clause* cl, Stack<LiteralStack>& acc)
 
   //Master literal of an variable is the literal
   //with lowest index, in which it appears.
-  static DHMap<unsigned, unsigned, IdentityHash> varMasters;
+  VTHREAD_LOCAL static DHMap<unsigned, unsigned, IdentityHash> varMasters;
   varMasters.reset();
   IntUnionFind components(clen);
 
@@ -1113,14 +1113,14 @@ bool Splitter::doSplitting(Clause* cl)
     return true; // the clause is ours now
   }
 
-  static Stack<LiteralStack> comps;
+  VTHREAD_LOCAL static Stack<LiteralStack> comps;
   comps.reset();
   // fills comps with components, returning if not splittable
   if(!getComponents(cl, comps)) {
     return handleNonSplittable(cl);
   }
 
-  static SATLiteralStack satClauseLits;
+  VTHREAD_LOCAL static SATLiteralStack satClauseLits;
   satClauseLits.reset();
 
   // Add literals for existing constraints 
@@ -1651,7 +1651,7 @@ bool Splitter::handleEmptyClause(Clause* cl)
     return false;
   }
 
-  static SATLiteralStack conflictLits;
+  VTHREAD_LOCAL static SATLiteralStack conflictLits;
   conflictLits.reset();
 
   collectDependenceLits(cl->splits(), conflictLits);

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -301,7 +301,7 @@ private:
   SaturationAlgorithm* _sa;
 
 public:
-  static vstring splPrefix;
+  VTHREAD_LOCAL static vstring splPrefix;
 
   // for observing the current model
   SplitLevel splitLevelBound() { return _db.size(); }

--- a/Saturation/SymElOutput.cpp
+++ b/Saturation/SymElOutput.cpp
@@ -138,20 +138,20 @@ void SymElOutput::outputSymbolElimination(Color eliminated, Clause* c)
   ASS_EQ(c->color(),COLOR_TRANSPARENT);
   ASS(!c->skip());
 
-  env.beginOutput();
+  env->beginOutput();
 
   //BDD::instance()->allowDefinitionOutput(false);
-  env.out()<<"%";
+  env->out()<<"%";
   if(eliminated==COLOR_LEFT) {
-    env.out()<<"Left";
+    env->out()<<"Left";
   } else {
     ASS_EQ(eliminated, COLOR_RIGHT);
-    env.out()<<"Right";
+    env->out()<<"Right";
   }
-  env.out()<<" symbol elimination"<<endl;
+  env->out()<<" symbol elimination"<<endl;
 
   vstring cname = "inv"+Int::toString(_symElNextClauseNumber);
-  while(env.signature->isPredicateName(cname, 0)) {
+  while(env->signature->isPredicateName(cname, 0)) {
     _symElNextClauseNumber++;
     cname = "inv"+Int::toString(_symElNextClauseNumber);
   }
@@ -161,7 +161,7 @@ void SymElOutput::outputSymbolElimination(Color eliminated, Clause* c)
   //BDD::instance()->allowDefinitionOutput(true);
   _symElNextClauseNumber++;
 
-  env.endOutput();
+  env->endOutput();
 }
 
 
@@ -169,7 +169,7 @@ void SymElOutput::checkForPreprocessorSymbolElimination(Clause* cl)
 {
   CALL("SymElOutput::checkForPreprocessorSymbolElimination");
 
-  if(!env.colorUsed || cl->color()!=COLOR_TRANSPARENT || cl->skip()) {
+  if(!env->colorUsed || cl->color()!=COLOR_TRANSPARENT || cl->skip()) {
     return;
   }
 

--- a/Saturation/SymElOutput.cpp
+++ b/Saturation/SymElOutput.cpp
@@ -178,8 +178,8 @@ void SymElOutput::checkForPreprocessorSymbolElimination(Clause* cl)
 
   Color inputColor=COLOR_TRANSPARENT;
 
-  static DHMap<Unit*, Color> inputFormulaColors;
-  static Stack<Unit*> units;
+  VTHREAD_LOCAL static DHMap<Unit*, Color> inputFormulaColors;
+  VTHREAD_LOCAL static Stack<Unit*> units;
   units.reset();
   units.push(cl);
 

--- a/Shell/AnswerExtractor.cpp
+++ b/Shell/AnswerExtractor.cpp
@@ -302,7 +302,7 @@ AnswerLiteralManager* AnswerLiteralManager::getInstance()
 {
   CALL("AnswerLiteralManager::getInstance");
 
-  static AnswerLiteralManager instance;
+  VTHREAD_LOCAL static AnswerLiteralManager instance;
 
   return &instance;
 }
@@ -331,7 +331,7 @@ Literal* AnswerLiteralManager::getAnswerLiteral(VList* vars,Formula* f)
 {
   CALL("AnswerLiteralManager::getAnswerLiteral");
 
-  static Stack<TermList> litArgs;
+  VTHREAD_LOCAL static Stack<TermList> litArgs;
   litArgs.reset();
   VList::Iterator vit(vars);
   TermStack sorts;
@@ -460,7 +460,7 @@ Clause* AnswerLiteralManager::getResolverClause(unsigned pred)
     return res;
   }
 
-  static Stack<TermList> args;
+  VTHREAD_LOCAL static Stack<TermList> args;
   args.reset();
 
   Signature::Symbol* predSym = env.signature->getPredicate(pred);

--- a/Shell/AnswerExtractor.cpp
+++ b/Shell/AnswerExtractor.cpp
@@ -52,18 +52,18 @@ void AnswerExtractor::tryOutputAnswer(Clause* refutation)
       return;
     }
   }
-  env.beginOutput();
-  env.out() << "% SZS answers Tuple [[";
+  env->beginOutput();
+  env->out() << "% SZS answers Tuple [[";
   Stack<TermList>::BottomFirstIterator ait(answer);
   while(ait.hasNext()) {
     TermList aLit = ait.next();
     // try evaluating aLit
     if(aLit.isTerm()){
       InterpretedLiteralEvaluator eval;
-      unsigned p = env.signature->addFreshPredicate(1,"p"); 
+      unsigned p = env->signature->addFreshPredicate(1,"p"); 
       TermList sort = SortHelper::getResultSort(aLit.term());
       OperatorType* type = OperatorType::getPredicateType({sort});
-      env.signature->getPredicate(p)->setType(type);
+      env->signature->getPredicate(p)->setType(type);
       Literal* l = Literal::create1(p,true,aLit); 
       Literal* res =0;
       bool constant, constTrue;
@@ -74,13 +74,13 @@ void AnswerExtractor::tryOutputAnswer(Clause* refutation)
       }
     }
 
-    env.out() << aLit.toString();
+    env->out() << aLit.toString();
     if(ait.hasNext()) {
-      env.out() << ',';
+      env->out() << ',';
     }
   }
-  env.out() << "]|_] for " << env.options->problemName() << endl;
-  env.endOutput();
+  env->out() << "]|_] for " << env->options->problemName() << endl;
+  env->endOutput();
 }
 
 
@@ -344,8 +344,8 @@ Literal* AnswerLiteralManager::getAnswerLiteral(VList* vars,Formula* f)
   }
 
   unsigned vcnt = litArgs.size();
-  unsigned pred = env.signature->addFreshPredicate(vcnt,"ans");
-  Signature::Symbol* predSym = env.signature->getPredicate(pred);
+  unsigned pred = env->signature->addFreshPredicate(vcnt,"ans");
+  Signature::Symbol* predSym = env->signature->getPredicate(pred);
   predSym->setType(OperatorType::getPredicateType(sorts.size(), sorts.begin()));
   predSym->markAnswerPredicate();
   return Literal::create(pred, vcnt, true, false, litArgs.begin());
@@ -421,7 +421,7 @@ bool AnswerLiteralManager::isAnswerLiteral(Literal* lit)
   CALL("AnswerLiteralManager::isAnswerLiteral");
 
   unsigned pred = lit->functor();
-  Signature::Symbol* sym = env.signature->getPredicate(pred);
+  Signature::Symbol* sym = env->signature->getPredicate(pred);
   return sym->answerPredicate();
 }
 
@@ -446,9 +446,9 @@ void AnswerLiteralManager::onNewClause(Clause* cl)
 
   throw MainLoop::RefutationFoundException(refutation);
 
-//  env.beginOutput();
-//  env.out()<<cl->toString()<<endl;
-//  env.endOutput();
+//  env->beginOutput();
+//  env->out()<<cl->toString()<<endl;
+//  env->endOutput();
 }
 
 Clause* AnswerLiteralManager::getResolverClause(unsigned pred)
@@ -463,7 +463,7 @@ Clause* AnswerLiteralManager::getResolverClause(unsigned pred)
   VTHREAD_LOCAL static Stack<TermList> args;
   args.reset();
 
-  Signature::Symbol* predSym = env.signature->getPredicate(pred);
+  Signature::Symbol* predSym = env->signature->getPredicate(pred);
   ASS(predSym->answerPredicate());
   unsigned arity = predSym->arity();
 

--- a/Shell/BlockedClauseElimination.cpp
+++ b/Shell/BlockedClauseElimination.cpp
@@ -267,9 +267,9 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
   unsigned n = lit->arity();
 
   IntUnionFind uf(n ? 2*n : 1); // IntUnionFind does not like 0
-  static Lib::DHMap<TermList, unsigned>  litArgIds;
+  VTHREAD_LOCAL static Lib::DHMap<TermList, unsigned>  litArgIds;
   litArgIds.reset();
-  static Lib::DHMap<TermList, unsigned> plitArgIds;
+  VTHREAD_LOCAL static Lib::DHMap<TermList, unsigned> plitArgIds;
   plitArgIds.reset();
 
   int varMax = -1;
@@ -312,7 +312,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
 
   // to do replacements in cl, we need a mapping for all lit's arguments.
   // As a bonus we also allow ground arguments of plit
-  static Lib::DHMap<TermList, TermList> replacements;
+  VTHREAD_LOCAL static Lib::DHMap<TermList, TermList> replacements;
   replacements.reset();
   for(unsigned i = 0; i<n; i++) {
     TermList arg = *lit->nthArgument(i);
@@ -336,7 +336,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
 
   VarMaxUpdatingNormalizer clNormalizer(replacements,varMax);
 
-  static DHSet<Literal*> norm_lits;
+  VTHREAD_LOCAL static DHSet<Literal*> norm_lits;
   norm_lits.reset();
 
   for (unsigned i = 0; i < cl->length(); i++) {
@@ -383,11 +383,11 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
     }
   }
 
-  static Lib::DHMap<unsigned, unsigned> varMap;
+  VTHREAD_LOCAL static Lib::DHMap<unsigned, unsigned> varMap;
   varMap.reset();
   RenanigApartNormalizer pclNormalizer(replacements,varMax,varMap);
 
-  static DHSet<Literal*> pcl_lits;
+  VTHREAD_LOCAL static DHSet<Literal*> pcl_lits;
   pcl_lits.reset();
 
   for (unsigned i = 0; i < pcl->length(); i++) {
@@ -503,13 +503,13 @@ bool BlockedClauseElimination::resolvesToTautologyUn(Clause* cl, Literal* lit, C
   // cout << "lit: " << lit->toString() << endl;
   // cout << "plit: " << plit->toString() << endl;
 
-  static RobSubstitution subst_main;
+  VTHREAD_LOCAL static RobSubstitution subst_main;
   subst_main.reset();
   if(!subst_main.unifyArgs(lit,0,plit,1)) {
     return true; // since they don't resolve
   }
 
-  static DHSet<Literal*> cl_lits;
+  VTHREAD_LOCAL static DHSet<Literal*> cl_lits;
   cl_lits.reset();
 
   Literal* opslit = 0;
@@ -535,10 +535,10 @@ bool BlockedClauseElimination::resolvesToTautologyUn(Clause* cl, Literal* lit, C
 
   ASS_NEQ(opslit,0);
 
-  static DHSet<Literal*> pcl_lits;
+  VTHREAD_LOCAL static DHSet<Literal*> pcl_lits;
   pcl_lits.reset();
 
-  static RobSubstitution subst_aux;
+  VTHREAD_LOCAL static RobSubstitution subst_aux;
   subst_aux.reset();
 
   for (unsigned i = 0; i < pcl->length(); i++) {

--- a/Shell/BlockedClauseElimination.cpp
+++ b/Shell/BlockedClauseElimination.cpp
@@ -57,8 +57,8 @@ void BlockedClauseElimination::apply(Problem& prb)
   bool modified = false;
   bool equationally = prb.hasEquality() && prb.getProperty()->positiveEqualityAtoms();
 
-  DArray<Stack<Candidate*>> positive(env.signature->predicates());
-  DArray<Stack<Candidate*>> negative(env.signature->predicates());
+  DArray<Stack<Candidate*>> positive(env->signature->predicates());
+  DArray<Stack<Candidate*>> negative(env->signature->predicates());
 
   Stack<ClWrapper*> wrappers; // just to delete easily in the end
 
@@ -75,7 +75,7 @@ void BlockedClauseElimination::apply(Problem& prb)
     for(unsigned i=0; i<cl->length(); i++) {
       Literal* lit = (*cl)[i];
       unsigned pred = lit->functor();
-      if (!env.signature->getPredicate(pred)->protectedSymbol()) { // don't index on interpreted or otherwise protected predicates (=> the cannot be ``flipped'')
+      if (!env->signature->getPredicate(pred)->protectedSymbol()) { // don't index on interpreted or otherwise protected predicates (=> the cannot be ``flipped'')
         ASS(pred); // equality predicate is protected
 
         (lit->isPositive() ? positive : negative)[pred].push(new Candidate {clw,i,0,0});
@@ -144,11 +144,11 @@ void BlockedClauseElimination::apply(Problem& prb)
     }
 
     // resolves to tautology with all partners -- blocked!
-    if (env.options->showPreprocessing()) {
+    if (env->options->showPreprocessing()) {
       cout << "[PP] Blocked clause[" << cand->litIdx << "]: " << cl->toString() << endl;
     }
 
-    env.statistics->blockedClauses++;
+    env->statistics->blockedClauses++;
     modified = true;
 
     clw->blocked = true;
@@ -256,7 +256,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
   CALL("BlockedClauseElimination::resolvesToTautologyEq");
 
   // With polymorphism, some intermediate terms created here are not well sorted, but that's OK
-  TermSharing::WellSortednessCheckingLocalDisabler disableInScope(env.sharing);
+  TermSharing::WellSortednessCheckingLocalDisabler disableInScope(env->sharing);
   // cout << "cl: " << cl->toString() << endl;
   // cout << "lit: " << lit->toString() << endl;
   // cout << "pcl: " << pcl->toString() << endl;

--- a/Shell/CommandLine.cpp
+++ b/Shell/CommandLine.cpp
@@ -70,9 +70,9 @@ void CommandLine::interpret (Options& options)
       ){ 
       // cout << _next << " " << _last << endl;
       options.set("help","on");
-      env.beginOutput();
-      options.output(env.out());
-      env.endOutput();
+      env->beginOutput();
+      options.output(env->out());
+      env->endOutput();
       exit(0);
     }
     if (arg[0] == '-') {

--- a/Shell/ConstantRemover.cpp
+++ b/Shell/ConstantRemover.cpp
@@ -29,7 +29,7 @@ using namespace Lib;
 using namespace Kernel;
 
 ConstantRemover::ConstantRemover()
-  : _varCnt(env.signature->vars())
+  : _varCnt(env->signature->vars())
 {
   reset();
 }
@@ -60,7 +60,7 @@ bool ConstantRemover::apply(ConstraintRCList*& lst)
       c = ConstraintRCPtr(Constraint::resolve(v, *c, needsLeft ? *d.left : *d.right, false));
     }
     if(c!=c0) {
-      env.statistics->updatedByConstantPropagation++;
+      env->statistics->updatedByConstantPropagation++;
       anyUpdated = true;
       if(c->isTautology()) {
         cit.del();
@@ -119,7 +119,7 @@ bool ConstantRemover::scan(ConstraintRCList* lst)
     }
     d.isTight = true;
     haveConstant = true;
-    env.statistics->constantVariables++;
+    env->statistics->constantVariables++;
   }
 
   return haveConstant;

--- a/Shell/ConstraintReaderBack.cpp
+++ b/Shell/ConstraintReaderBack.cpp
@@ -42,7 +42,7 @@ using namespace Parse;
 using namespace std;
 
 SMTLib2ConstraintReader::SMTLib2ConstraintReader(Parse::SMTLIB2& parser)
-  :_sig(*env.signature), _parser(parser) {
+  :_sig(*env->signature), _parser(parser) {
   CALL("SMTLib2ConstraintReader::SMTLib2ConstraintReader(Parse::SMTLIB2)");
 }
 
@@ -249,7 +249,7 @@ ConstraintRCList* SMTConstraintReader::constraints(){
 }
 
 ConstraintReader::ConstraintReader(SMTParser& parser)
- : _sig(*env.signature), _parser(parser) {}
+ : _sig(*env->signature), _parser(parser) {}
  
 /**
  * Return list of constraints from @c _parser
@@ -364,7 +364,7 @@ void ConstraintReader::readCoefs(SMTParser::Term* term, CoeffStack& coeffs, Coef
 }
 
 MpsConstraintReader::MpsConstraintReader(Model& model)
-    : _sig(*env.signature), _model(model){ }
+    : _sig(*env->signature), _model(model){ }
 
 MpsConstraintReader::~MpsConstraintReader()
 {

--- a/Shell/DistinctGroupExpansion.cpp
+++ b/Shell/DistinctGroupExpansion.cpp
@@ -60,11 +60,11 @@ bool DistinctGroupExpansion::apply(UnitList*& units)
 
   bool added=false;
 
-  Stack<Signature::DistinctGroupMembers>& group_members = env.signature->distinctGroupMembers();
+  Stack<Signature::DistinctGroupMembers>& group_members = env->signature->distinctGroupMembers();
 
   // If this is updated then make sure you update the check in
   // Kernel::Signature::Symol::addToDistinctGroup as well
-  bool expandEverything = env.options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING;
+  bool expandEverything = env->options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING;
 
   bool someLeft = false;
 
@@ -74,8 +74,8 @@ bool DistinctGroupExpansion::apply(UnitList*& units)
       if( members->size()>1 && (members->size() <= EXPAND_UP_TO_SIZE || expandEverything)) {
         added=true;
         Formula* expansion = expand(*members);
-        if(env.options->showPreprocessing()){
-          env.out() << "  expansion adding " << expansion->toString() << endl;
+        if(env->options->showPreprocessing()){
+          env->out() << "  expansion adding " << expansion->toString() << endl;
         }
         // Currently we just say that these are from the Input, not $distinct or theory of ints
         UnitList::push(
@@ -87,7 +87,7 @@ bool DistinctGroupExpansion::apply(UnitList*& units)
   } 
 
   if(!someLeft){
-    env.signature->noDistinctGroupsLeft();
+    env->signature->noDistinctGroupsLeft();
   }
 
   return added;

--- a/Shell/DistinctProcessor.cpp
+++ b/Shell/DistinctProcessor.cpp
@@ -53,7 +53,7 @@ bool DistinctProcessor::apply(FormulaUnit* unit, Unit*& res)
   Formula* form = unit->formula();
 
 
-  static Stack<unsigned> distConsts;
+  VTHREAD_LOCAL static Stack<unsigned> distConsts;
   if(form->connective()==LITERAL) {
     Literal* tlLit = form->literal();
     if(isDistinctPred(tlLit) && tlLit->isPositive()) {

--- a/Shell/DistinctProcessor.cpp
+++ b/Shell/DistinctProcessor.cpp
@@ -70,9 +70,9 @@ bool DistinctProcessor::apply(FormulaUnit* unit, Unit*& res)
       }
 
       if(justConsts) {
-	unsigned grpIdx = env.signature->createDistinctGroup(unit);
+	unsigned grpIdx = env->signature->createDistinctGroup(unit);
 	while(distConsts.isNonEmpty()) {
-	  env.signature->addToDistinctGroup(distConsts.pop(), grpIdx);
+	  env->signature->addToDistinctGroup(distConsts.pop(), grpIdx);
 	}
       }else{
         USER_ERROR("$distinct should only be used positively with constants");

--- a/Shell/EqResWithDeletion.cpp
+++ b/Shell/EqResWithDeletion.cpp
@@ -76,7 +76,7 @@ start_applying:
 
   _subst.reset();
 
-  static Stack<Literal*> resLits(8);
+  VTHREAD_LOCAL static Stack<Literal*> resLits(8);
   resLits.reset();
 
   bool foundResolvable=false;

--- a/Shell/EqualityAxiomatizer.cpp
+++ b/Shell/EqualityAxiomatizer.cpp
@@ -68,10 +68,10 @@ void EqualityAxiomatizer::scan(Literal* lit)
   if(lit->isEquality()) {
     unsigned eqSort = SortHelper::getEqualityArgumentSort(lit);
     _eqSorts.insert(eqSort);
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "eq sort "<<env.sorts->sortName(eqSort)<<" added because of "<<(*lit) << std::endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "eq sort "<<env->sorts->sortName(eqSort)<<" added because of "<<(*lit) << std::endl;
+      env->endOutput();
     }    
   }
   else {
@@ -109,7 +109,7 @@ void EqualityAxiomatizer::saturateEqSorts()
   SymbolSet::Iterator fit(_fns);
   while(fit.hasNext()) {
     unsigned fn = fit.next();
-    FunctionType* ft = env.signature->getFunction(fn)->fnType();
+    FunctionType* ft = env->signature->getFunction(fn)->fnType();
     unsigned rngSort = ft->result();
     unsigned arity = ft->arity();
     for(unsigned ai = 0; ai<arity; ++ai) {
@@ -125,10 +125,10 @@ void EqualityAxiomatizer::saturateEqSorts()
   while(implIt.hasNext()) {
     unsigned eqSort = implIt.next();
     if(_eqSorts.insert(eqSort)) {
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "eq sort "<<env.sorts->sortName(eqSort)<<" added by implications" << std::endl;
-        env.endOutput();
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "eq sort "<<env->sorts->sortName(eqSort)<<" added by implications" << std::endl;
+        env->endOutput();
       }
     }
   }
@@ -188,15 +188,15 @@ UnitList* EqualityAxiomatizer::getAxioms()
     addCongruenceAxioms(res);
   }
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    ostream& out = env.out();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    ostream& out = env->out();
     out << "Sorts using equality:" << endl;
     
     SortSet::Iterator sit2(_eqSorts);
     while(sit2.hasNext()) {
       unsigned srt = sit2.next();
-      out << env.sorts->sortName(srt);
+      out << env->sorts->sortName(srt);
       if(sit2.hasNext()) {
         out << ", ";
       }
@@ -209,7 +209,7 @@ UnitList* EqualityAxiomatizer::getAxioms()
       out << (*uit.next()) << endl;
     }
         
-    env.endOutput();
+    env->endOutput();
   }
                  
   return res;
@@ -239,19 +239,19 @@ bool EqualityAxiomatizer::getArgumentEqualityLiterals(BaseType* symbolType, Lite
       lits.push(Literal::createEquality(false, v1, v2, sort));
       vars1.push(v1);
       vars2.push(v2);
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "sort "<<env.sorts->sortName(sort)<<" lead to equality "<<(*lits.top()) << std::endl;
-        env.endOutput();
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "sort "<<env->sorts->sortName(sort)<<" lead to equality "<<(*lits.top()) << std::endl;
+        env->endOutput();
       }            
     }
     else {
       vars1.push(v1);
       vars2.push(v1);
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "sort "<<env.sorts->sortName(sort)<<" did not use equality" << std::endl;
-        env.endOutput();
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "sort "<<env->sorts->sortName(sort)<<" did not use equality" << std::endl;
+        env->endOutput();
       }
     }
   }
@@ -271,7 +271,7 @@ Clause* EqualityAxiomatizer::getFnCongruenceAxiom(unsigned fn)
   vars2.reset();
   lits.reset();
 
-  Signature::Symbol* fnSym = env.signature->getFunction(fn);
+  Signature::Symbol* fnSym = env->signature->getFunction(fn);
   FunctionType* fnType = fnSym->fnType();
 
   if(!_eqSorts.contains(fnType->result())) {
@@ -304,7 +304,7 @@ Clause* EqualityAxiomatizer::getPredCongruenceAxiom(unsigned pred)
   vars2.reset();
   lits.reset();
 
-  Signature::Symbol* predSym = env.signature->getPredicate(pred);
+  Signature::Symbol* predSym = env->signature->getPredicate(pred);
   unsigned arity = predSym->arity();
   ASS_G(arity,0);
   if(!getArgumentEqualityLiterals(predSym->predType(), lits, vars1, vars2)) {

--- a/Shell/EqualityAxiomatizer.cpp
+++ b/Shell/EqualityAxiomatizer.cpp
@@ -263,9 +263,9 @@ Clause* EqualityAxiomatizer::getFnCongruenceAxiom(unsigned fn)
 {
   CALL("EqualityAxiomatizer::getFnCongruenceAxiom");
 
-  static Stack<TermList> vars1;
-  static Stack<TermList> vars2;
-  static LiteralStack lits;
+  VTHREAD_LOCAL static Stack<TermList> vars1;
+  VTHREAD_LOCAL static Stack<TermList> vars2;
+  VTHREAD_LOCAL static LiteralStack lits;
 
   vars1.reset();
   vars2.reset();
@@ -296,9 +296,9 @@ Clause* EqualityAxiomatizer::getPredCongruenceAxiom(unsigned pred)
   CALL("EqualityAxiomatizer::getPredCongruenceAxiom");
   ASS_NEQ(pred,0);
 
-  static Stack<TermList> vars1;
-  static Stack<TermList> vars2;
-  static LiteralStack lits;
+  VTHREAD_LOCAL static Stack<TermList> vars1;
+  VTHREAD_LOCAL static Stack<TermList> vars2;
+  VTHREAD_LOCAL static LiteralStack lits;
 
   vars1.reset();
   vars2.reset();

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -188,7 +188,7 @@ void EqualityProxy::getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits
 }
 
 /**
- * For every symbol occurring in env.signature, add to the units equality congruence axioms
+ * For every symbol occurring in env->signature, add to the units equality congruence axioms
  * for this symbol.
  * @author Andrei Voronkov
  * @since 16/05/2014 Manchester
@@ -204,9 +204,9 @@ void EqualityProxy::addCongruenceAxioms(UnitList*& units)
   LiteralStack lits;
   TermList srt;
 
-  unsigned funs = env.signature->functions();
+  unsigned funs = env->signature->functions();
   for (unsigned i=0; i<funs; i++) {
-    Signature::Symbol* fnSym = env.signature->getFunction(i);
+    Signature::Symbol* fnSym = env->signature->getFunction(i);
     if(fnSym->super()){
       continue;
     }
@@ -225,9 +225,9 @@ void EqualityProxy::addCongruenceAxioms(UnitList*& units)
     UnitList::push(cl,units);
   }
 
-  unsigned preds = env.signature->predicates();
+  unsigned preds = env->signature->predicates();
   for (unsigned i = 1; i < preds; i++) {
-    Signature::Symbol* predSym = env.signature->getPredicate(i);
+    Signature::Symbol* predSym = env->signature->getPredicate(i);
     unsigned arity = predSym->arity();
     if (predSym->equalityProxy() || predSym->arity() == 0) {
       continue;
@@ -315,13 +315,13 @@ unsigned EqualityProxy::getProxyPredicate()
 
   if(_addedPred){ return _proxyPredicate; }
 
-  unsigned newPred = env.signature->addFreshPredicate(3,"sQ","eqProxy");
+  unsigned newPred = env->signature->addFreshPredicate(3,"sQ","eqProxy");
   
   TermList sort = TermList(0,false);
   TermList var1 = TermList(1,false);
   TermList var2 = TermList(2,false);
 
-  Signature::Symbol* predSym = env.signature->getPredicate(newPred);
+  Signature::Symbol* predSym = env->signature->getPredicate(newPred);
   OperatorType* predType = OperatorType::getPredicateType({sort, sort}, 1);
   predSym->setType(predType);
   predSym->markEqualityProxy();

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -167,7 +167,7 @@ void EqualityProxy::getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits
   vars1.reset();
   vars2.reset();
 
-  static Substitution localSubst;
+  VTHREAD_LOCAL static Substitution localSubst;
   localSubst.reset();
 
   for (unsigned i=0; i<cnt; i++) {
@@ -326,7 +326,7 @@ unsigned EqualityProxy::getProxyPredicate()
   predSym->setType(predType);
   predSym->markEqualityProxy();
 
-  static TermStack args;
+  VTHREAD_LOCAL static TermStack args;
   args.reset();
 
   args.push(sort);

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -38,7 +38,6 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
-
 /**
  * Constructor, simply memorizes the value of the equality proxy option.
  */

--- a/Shell/EqualityProxyMono.cpp
+++ b/Shell/EqualityProxyMono.cpp
@@ -159,7 +159,7 @@ void EqualityProxyMono::addAxioms(UnitList*& units)
   unsigned proxyPredArrSz = s_proxyPredicates.size();
   for (unsigned sort=0; sort<proxyPredArrSz; sort++) {
     if (haveProxyPredicate(sort)) {
-      addLocalAxioms(units, env.sorts->getSortTerm(sort));
+      addLocalAxioms(units, env->sorts->getSortTerm(sort));
     }
   }
 } // addAxioms
@@ -184,7 +184,7 @@ bool EqualityProxyMono::getArgumentEqualityLiterals(unsigned cnt, LiteralStack& 
     TermList v1(2*i, false);
     TermList v2(2*i+1, false);
     TermList sort = symbolType->arg(i);
-    if (!skipSortsWithoutEquality || haveProxyPredicate(env.sorts->getSortNum(sort))) {
+    if (!skipSortsWithoutEquality || haveProxyPredicate(env->sorts->getSortNum(sort))) {
       lits.push(makeProxyLiteral(false, v1, v2, sort));
       vars1.push(v1);
       vars2.push(v2);
@@ -198,7 +198,7 @@ bool EqualityProxyMono::getArgumentEqualityLiterals(unsigned cnt, LiteralStack& 
 }
 
 /**
- * For every symbol occurring in env.signature, add to the units equality congruence axioms
+ * For every symbol occurring in env->signature, add to the units equality congruence axioms
  * for this symbol.
  * @author Andrei Voronkov
  * @since 16/05/2014 Manchester
@@ -213,9 +213,9 @@ void EqualityProxyMono::addCongruenceAxioms(UnitList*& units)
   Stack<TermList> vars2;
   LiteralStack lits;
 
-  unsigned funs = env.signature->functions();
+  unsigned funs = env->signature->functions();
   for (unsigned i=0; i<funs; i++) {
-    Signature::Symbol* fnSym = env.signature->getFunction(i);
+    Signature::Symbol* fnSym = env->signature->getFunction(i);
     if(fnSym->super()){
       continue;
     }
@@ -233,9 +233,9 @@ void EqualityProxyMono::addCongruenceAxioms(UnitList*& units)
     UnitList::push(cl,units);
   }
 
-  unsigned preds = env.signature->predicates();
+  unsigned preds = env->signature->predicates();
   for (unsigned i = 1; i < preds; i++) {
-    Signature::Symbol* predSym = env.signature->getPredicate(i);
+    Signature::Symbol* predSym = env->signature->getPredicate(i);
     unsigned arity = predSym->arity();
     if (predSym->equalityProxy() || predSym->arity() == 0) {
       continue;
@@ -275,7 +275,7 @@ Clause* EqualityProxyMono::apply(Clause* cl)
       ASS(lit->isEquality());
       modified = true;
       TermList srt = s_proxyPredicateSorts.get(rlit->functor());
-      Unit* prem = s_proxyPremises[env.sorts->getSortNum(srt)];
+      Unit* prem = s_proxyPremises[env->sorts->getSortNum(srt)];
       proxyPremises.push(prem);
     }
   }
@@ -348,16 +348,16 @@ unsigned EqualityProxyMono::getProxyPredicate(TermList sort)
 {
   CALL("EqualityProxyMono::getProxyPredicate");
 
-  if (s_proxyPredicates[env.sorts->getSortNum(sort)] != 0) {
-    return s_proxyPredicates[env.sorts->getSortNum(sort)];
+  if (s_proxyPredicates[env->sorts->getSortNum(sort)] != 0) {
+    return s_proxyPredicates[env->sorts->getSortNum(sort)];
   }
-  unsigned newPred = env.signature->addFreshPredicate(2,"sQ","eqProxy");
-  Signature::Symbol* predSym = env.signature->getPredicate(newPred);
+  unsigned newPred = env->signature->addFreshPredicate(2,"sQ","eqProxy");
+  Signature::Symbol* predSym = env->signature->getPredicate(newPred);
   OperatorType* predType = OperatorType::getPredicateType({sort, sort});
   predSym->setType(predType);
   predSym->markEqualityProxy();
 
-  s_proxyPredicates[env.sorts->getSortNum(sort)] = newPred;
+  s_proxyPredicates[env->sorts->getSortNum(sort)] = newPred;
   s_proxyPredicateSorts.insert(newPred,sort);
 
   Literal* proxyLit = Literal::create2(newPred,true,TermList(0,false),TermList(1,false));
@@ -367,7 +367,7 @@ unsigned EqualityProxyMono::getProxyPredicate(TermList sort)
 
   FormulaUnit* defUnit = new FormulaUnit(quantDefForm,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::EQUALITY_PROXY_AXIOM1));
 
-  s_proxyPremises[env.sorts->getSortNum(sort)] = defUnit;
+  s_proxyPremises[env->sorts->getSortNum(sort)] = defUnit;
   InferenceStore::instance()->recordIntroducedSymbol(defUnit, false, newPred);
   return newPred;
 }
@@ -395,7 +395,7 @@ Clause* EqualityProxyMono::createEqProxyAxiom(const LiteralStack& literalStack)
     if (!sorts.insert(srt)) {
       continue;
     }
-    Unit* prem = s_proxyPremises[env.sorts->getSortNum(srt)];
+    Unit* prem = s_proxyPremises[env->sorts->getSortNum(srt)];
     ASS(prem);
     UnitList::push(prem, prems);
   }

--- a/Shell/EqualityVariableRemover.cpp
+++ b/Shell/EqualityVariableRemover.cpp
@@ -163,13 +163,13 @@ void EqualityVariableRemover::eliminate(Constraint* c, ConstraintRCList*& lst)
       }
     }
   }
-  env.statistics->equalityPropagationVariables++;
+  env->statistics->equalityPropagationVariables++;
 
   VTHREAD_LOCAL static DHSet<Constraint*> toRemove;
   toRemove.reset();
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(posId));
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(negId));
-  env.statistics->equalityPropagationConstraints += toRemove.size();
+  env->statistics->equalityPropagationConstraints += toRemove.size();
 
   ConstraintRCList::DelIterator cit(lst);
   while(cit.hasNext()) {
@@ -194,7 +194,7 @@ bool EqualityVariableRemover::allowedEquality(Constraint& c)
   CALL("EqualityVariableRemover::allowedEquality");
 
 //  return true;
-  return c.coeffCnt()<=env.options->bpMaximalPropagatedEqualityLength();
+  return c.coeffCnt()<=env->options->bpMaximalPropagatedEqualityLength();
 }
 
 void EqualityVariableRemover::scan(ConstraintRCList* lst)

--- a/Shell/EqualityVariableRemover.cpp
+++ b/Shell/EqualityVariableRemover.cpp
@@ -165,7 +165,7 @@ void EqualityVariableRemover::eliminate(Constraint* c, ConstraintRCList*& lst)
   }
   env.statistics->equalityPropagationVariables++;
 
-  static DHSet<Constraint*> toRemove;
+  VTHREAD_LOCAL static DHSet<Constraint*> toRemove;
   toRemove.reset();
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(posId));
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(negId));

--- a/Shell/EquivalentVariableRemover.cpp
+++ b/Shell/EquivalentVariableRemover.cpp
@@ -31,7 +31,7 @@ using namespace Lib;
 using namespace Kernel;
 
 EquivalentVariableRemover::EquivalentVariableRemover()
- : _eqClasses(env.signature->vars())
+ : _eqClasses(env->signature->vars())
 {
   CALL("EquivalentVariableRemover::EquivalentVariableRemover");
 
@@ -129,7 +129,7 @@ void EquivalentVariableRemover::scan(ConstraintRCList* lst)
 	_pairs.set(vp, BOTH);
 	_haveEquivalences = true;
 	if(_eqClasses.doUnion(vp.first, vp.second)) {
-	  env.statistics->equivalentVariables++;
+	  env->statistics->equivalentVariables++;
 	}
       }
     }

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -163,11 +163,11 @@ FormulaUnit* FOOLElimination::apply(FormulaUnit* unit) {
   FormulaUnit* processedUnit = new FormulaUnit(processedFormula,
       NonspecificInference1(InferenceRule::FOOL_ELIMINATION, rectifiedUnit));
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] " << unit->toString() << endl;
-    env.out() << "[PP] " << processedUnit->toString()  << endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] " << unit->toString() << endl;
+    env->out() << "[PP] " << processedUnit->toString()  << endl;
+    env->endOutput();
   }
 
   return processedUnit;
@@ -176,13 +176,13 @@ FormulaUnit* FOOLElimination::apply(FormulaUnit* unit) {
 Formula* FOOLElimination::process(Formula* formula) {
   CALL("FOOLElimination::process(Formula*)");
 
-  if(env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
+  if(env->options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
      !_polymorphic){
     LambdaElimination le = LambdaElimination();
     TermList proxifiedFormula = le.elimLambda(formula);
     Formula* processedFormula = toEquality(proxifiedFormula);
 
-    if (env.options->showPreprocessing()) {
+    if (env->options->showPreprocessing()) {
       reportProcessed(formula->toString(), processedFormula->toString());
     }
 
@@ -212,7 +212,7 @@ Formula* FOOLElimination::process(Formula* formula) {
        */
 
       if (literal->isEquality() && 
-         (!env.statistics->higherOrder || env.options->equalityToEquivalence())) { 
+         (!env->statistics->higherOrder || env->options->equalityToEquivalence())) { 
         ASS_EQ(literal->arity(), 2);
         TermList lhs = *literal->nthArgument(0);
         TermList rhs = *literal->nthArgument(1);
@@ -227,7 +227,7 @@ Formula* FOOLElimination::process(Formula* formula) {
           Connective connective = literal->polarity() ? IFF : XOR;
           Formula* processedFormula = new BinaryFormula(connective, lhsFormula, rhsFormula);
 
-          if (env.options->showPreprocessing()) {
+          if (env->options->showPreprocessing()) {
             reportProcessed(formula->toString(), processedFormula->toString());
           }
 
@@ -243,7 +243,7 @@ Formula* FOOLElimination::process(Formula* formula) {
 
       Formula* processedFormula = new AtomicFormula(Literal::create(literal, arguments.begin()));
 
-      if (env.options->showPreprocessing()) {
+      if (env->options->showPreprocessing()) {
         reportProcessed(formula->toString(), processedFormula->toString());
       }
 
@@ -275,7 +275,7 @@ Formula* FOOLElimination::process(Formula* formula) {
         Literal* equality = Literal::createEquality(polarity, process(lhsTerm), process(rhsTerm), Term::boolSort());
         Formula* processedFormula = new AtomicFormula(equality);
 
-        if (env.options->showPreprocessing()) {
+        if (env->options->showPreprocessing()) {
           reportProcessed(formula->toString(), processedFormula->toString());
         }
 
@@ -301,7 +301,7 @@ Formula* FOOLElimination::process(Formula* formula) {
     case BOOL_TERM: {
       Formula* processedFormula = processAsFormula(formula->getBooleanTerm());
 
-      if (env.options->showPreprocessing()) {
+      if (env->options->showPreprocessing()) {
         reportProcessed(formula->toString(), processedFormula->toString());
       }
 
@@ -645,8 +645,8 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
          * If the symbol is not marked as introduced then this means it was used
          * in the input after introduction, therefore it should be renamed here
          */
-        if(bindingContext == TERM_CONTEXT && !env.signature->getFunction(symbol)->introduced()) renameSymbol = true;
-        if(bindingContext == FORMULA_CONTEXT && !env.signature->getPredicate(symbol)->introduced()) renameSymbol = true;
+        if(bindingContext == TERM_CONTEXT && !env->signature->getFunction(symbol)->introduced()) renameSymbol = true;
+        if(bindingContext == FORMULA_CONTEXT && !env->signature->getPredicate(symbol)->introduced()) renameSymbol = true;
 
         // create a fresh function or predicate symbol g
         unsigned freshSymbol = renameSymbol ? introduceFreshSymbol(bindingContext, LET_PREFIX, termVarSorts, bindingSort, typeVars.size()) : symbol;
@@ -682,10 +682,10 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         // replace occurrences of f(s1, ..., sj,t1, ..., tk) by 
         // g(A1, ..., Am, s1, ..., sj,X1, ..., Xn, t1, ..., tk)
         if (renameSymbol) {
-          if (env.options->showPreprocessing()) {
-            env.beginOutput();
-            env.out() << "[PP] FOOL replace in:  " << contents.toString() << endl;
-            env.endOutput();
+          if (env->options->showPreprocessing()) {
+            env->beginOutput();
+            env->out() << "[PP] FOOL replace in:  " << contents.toString() << endl;
+            env->endOutput();
           }
 
           SymbolOccurrenceReplacement replacement(bindingContext == FORMULA_CONTEXT, 
@@ -693,10 +693,10 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
           contents = replacement.process(contents);
 
-          if (env.options->showPreprocessing()) {
-            env.beginOutput();
-            env.out() << "[PP] FOOL replace out: " << contents.toString() << endl;
-            env.endOutput();
+          if (env->options->showPreprocessing()) {
+            env->beginOutput();
+            env->out() << "[PP] FOOL replace out: " << contents.toString() << endl;
+            env->endOutput();
           }
         }
 
@@ -775,7 +775,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 #endif
     }
 
-    if (env.options->showPreprocessing()) {
+    if (env->options->showPreprocessing()) {
       reportProcessed(term->toString(), context == FORMULA_CONTEXT ? formulaResult->toString() : termResult.toString());
     }
   }
@@ -920,10 +920,10 @@ void FOOLElimination::addDefinition(FormulaUnit* def) {
 
   _defs = new UnitList(def, _defs);
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] FOOL added definition: " << def->toString() << endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] FOOL added definition: " << def->toString() << endl;
+    env->endOutput();
   }
 }
 
@@ -947,23 +947,23 @@ unsigned FOOLElimination::introduceFreshSymbol(Context context, const char* pref
 
   unsigned symbol;
   if (context == FORMULA_CONTEXT) {
-    symbol = env.signature->addFreshPredicate(arity + typeArgsArity, prefix);
-    env.signature->getPredicate(symbol)->setType(type);
+    symbol = env->signature->addFreshPredicate(arity + typeArgsArity, prefix);
+    env->signature->getPredicate(symbol)->setType(type);
   } else {
-    symbol = env.signature->addFreshFunction(arity + typeArgsArity, prefix);
-    env.signature->getFunction(symbol)->setType(type);
+    symbol = env->signature->addFreshFunction(arity + typeArgsArity, prefix);
+    env->signature->getFunction(symbol)->setType(type);
   }
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] FOOL: introduced fresh ";
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] FOOL: introduced fresh ";
     if (context == FORMULA_CONTEXT) {
-      env.out() << "predicate symbol " << env.signature->predicateName(symbol);
+      env->out() << "predicate symbol " << env->signature->predicateName(symbol);
     } else {
-      env.out() << "function symbol " << env.signature->functionName(symbol);
+      env->out() << "function symbol " << env->signature->functionName(symbol);
     }
-    env.out() << " of the sort " << type->toString() << endl;
-    env.endOutput();
+    env->out() << " of the sort " << type->toString() << endl;
+    env->endOutput();
   }
 
   return symbol;
@@ -981,9 +981,9 @@ void FOOLElimination::reportProcessed(vstring inputRepr, vstring outputRepr) {
      * the output seeming the same, we will not log such processings at
      * all. Setting show_fool to on, however, will display everything.
      */
-    env.beginOutput();
-    env.out() << "[PP] FOOL in:  " << inputRepr  << endl;
-    env.out() << "[PP] FOOL out: " << outputRepr << endl;
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "[PP] FOOL in:  " << inputRepr  << endl;
+    env->out() << "[PP] FOOL out: " << outputRepr << endl;
+    env->endOutput();
   }
 }

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -72,11 +72,11 @@ FormulaUnit* Flattening::flatten (FormulaUnit* unit)
 
   FormulaUnit* res = new FormulaUnit(g,
       FormulaTransformation(InferenceRule::FLATTEN,unit));
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] flatten in: " << unit->toString() << std::endl;
-    env.out() << "[PP] flatten out: " << res->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] flatten in: " << unit->toString() << std::endl;
+    env->out() << "[PP] flatten out: " << res->toString() << std::endl;
+    env->endOutput();
   }
   return res;
 } // Flattening::flatten
@@ -104,8 +104,8 @@ Formula* Flattening::flatten (Formula* f)
     {
       Literal* lit = f->literal();
 
-      if (env.options->newCNF() && !env.statistics->higherOrder &&
-          !env.property->hasPolymorphicSym()) {
+      if (env->options->newCNF() && !env->statistics->higherOrder &&
+          !env->property->hasPolymorphicSym()) {
         // Convert equality between boolean FOOL terms to equivalence
         if (lit->isEquality()) {
           TermList lhs = *lit->nthArgument(0);

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -398,13 +398,13 @@ void FunctionDefinition::checkDefinitions(Def* def0)
 
   //Next argument of the current-level term to be processed.
   //An empty term means we've processed all arguments of the term.
-  static Stack<TermList*> stack(4);
+  VTHREAD_LOCAL static Stack<TermList*> stack(4);
   //Definition whose rhs is the current-level term (or zero if none).
-  static Stack<Def*> defCheckingStack(4);
+  VTHREAD_LOCAL static Stack<Def*> defCheckingStack(4);
   //Definition whose lhs is the current-level term (or zero if none).
-  static Stack<Def*> defArgStack(4);
+  VTHREAD_LOCAL static Stack<Def*> defArgStack(4);
   //Current-level term.
-  static Stack<Term*> termArgStack(4);
+  VTHREAD_LOCAL static Stack<Term*> termArgStack(4);
 
   //loop invariant: the four above stacks contain the same number of elements
   for(;;) {
@@ -502,7 +502,7 @@ void FunctionDefinition::assignArgOccursData(Def* updDef)
 	    "FunctionDefinition::Def::argOccurs"));
   BitUtils::zeroMemory(updDef->argOccurs, updDef->lhs->arity()*sizeof(bool));
 
-  static DHMap<unsigned, unsigned, IdentityHash> var2argIndex;
+  VTHREAD_LOCAL static DHMap<unsigned, unsigned, IdentityHash> var2argIndex;
   var2argIndex.reset();
   int argIndex=0;
   for (TermList* ts = updDef->lhs->args(); ts->isNonEmpty(); ts=ts->next()) {
@@ -512,9 +512,9 @@ void FunctionDefinition::assignArgOccursData(Def* updDef)
   }
 
   TermList t=TermList(updDef->rhs);
-  static Stack<TermList*> stack(4);
-  static Stack<Def*> defArgStack(4);
-  static Stack<Term*> termArgStack(4);
+  VTHREAD_LOCAL static Stack<TermList*> stack(4);
+  VTHREAD_LOCAL static Stack<Def*> defArgStack(4);
+  VTHREAD_LOCAL static Stack<Term*> termArgStack(4);
   for(;;) {
     Def* d;
     if(t.isEmpty()) {
@@ -720,8 +720,8 @@ Clause* FunctionDefinition::applyDefinitions(Clause* cl)
 
   unsigned clen=cl->length();
 
-  static Stack<Def*> usedDefs(8);
-  static Stack<Literal*> resLits(8);
+  VTHREAD_LOCAL static Stack<Def*> usedDefs(8);
+  VTHREAD_LOCAL static Stack<Literal*> resLits(8);
   ASS(usedDefs.isEmpty());
   resLits.reset();
 

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -87,8 +87,8 @@ struct FunctionDefinition::Def
   IntList* dependentFns;
 
   bool lhsIsBool(){
-    return (env.signature->isFoolConstantSymbol(true , fun) ||
-            env.signature->isFoolConstantSymbol(false, fun));
+    return (env->signature->isFoolConstantSymbol(true , fun) ||
+            env->signature->isFoolConstantSymbol(false, fun));
   }
 
   /**
@@ -162,7 +162,7 @@ bool FunctionDefinition::removeUnusedDefinitions(UnitList*& units, Problem* prb)
 {
   CALL("FunctionDefinition::removeUnusedDefinitions");
 
-  unsigned funs=env.signature->functions();
+  unsigned funs=env->signature->functions();
 
   Stack<Def*> defStack;
   DArray<Def*> def;
@@ -365,12 +365,12 @@ bool FunctionDefinition::removeAllDefinitions(UnitList*& units)
       _processedProblem->addEliminatedFunction(d->fun, (*d->defCl)[0]);
     }
 
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] fn def discovered: "<<(*d->defCl)<<"\n  unfolded: "<<(*d->rhs) << std::endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] fn def discovered: "<<(*d->defCl)<<"\n  unfolded: "<<(*d->rhs) << std::endl;
+      env->endOutput();
     }
-    env.statistics->functionDefinitions++;
+    env->statistics->functionDefinitions++;
   }
 
   UnitList::DelIterator unfoldIterator(units);
@@ -569,10 +569,10 @@ Term* FunctionDefinition::applyDefinitions(Literal* lit, Stack<Def*>* usedDefs)
 
   //cout << "applying definitions to " + lit->toString() << endl;
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] applying function definitions to literal "<<(*lit) << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] applying function definitions to literal "<<(*lit) << std::endl;
+    env->endOutput();
   }
   BindingMap bindings;
   UnfoldedSet unfolded;
@@ -670,10 +670,10 @@ Term* FunctionDefinition::applyDefinitions(Literal* lit, Stack<Def*>* usedDefs)
     if( !defIndex && _defs.find(t->functor(), d) && d->mark!=Def::BLOCKED) {
       ASS_EQ(d->mark, Def::UNFOLDED);
       usedDefs->push(d);
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] definition of "<<(*t)<<"\n  expanded to "<<(*d->rhs) << std::endl;
-        env.endOutput();
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "[PP] definition of "<<(*t)<<"\n  expanded to "<<(*d->rhs) << std::endl;
+        env->endOutput();
       }
 
       defIndex=nextDefIndex++;
@@ -777,7 +777,7 @@ FunctionDefinition::Def*
 FunctionDefinition::isFunctionDefinition (Unit& unit)
 {
   CALL("FunctionDefinition::isFunctionDefinition(const Unit&)");
-  if(unit.derivedFromGoal() && env.options->ignoreConjectureInPreprocessing()){
+  if(unit.derivedFromGoal() && env->options->ignoreConjectureInPreprocessing()){
     return 0;
   }
 
@@ -866,10 +866,10 @@ FunctionDefinition::defines (Term* lhs, Term* rhs)
     return 0;
   }
   unsigned f = lhs->functor();
-  if(env.signature->getFunction(f)->protectedSymbol()) {
+  if(env->signature->getFunction(f)->protectedSymbol()) {
     return 0;
   }
-  if(env.signature->getFunction(f)->distinctGroups()!=0) {
+  if(env->signature->getFunction(f)->distinctGroups()!=0) {
     return 0;
   }
   if(lhs->color()==COLOR_TRANSPARENT && rhs->color()!=COLOR_TRANSPARENT) {
@@ -880,19 +880,19 @@ FunctionDefinition::defines (Term* lhs, Term* rhs)
     return 0;
   }
   if (!lhs->arity()) {
-    if(env.signature->isFoolConstantSymbol(true , f) ||
-       env.signature->isFoolConstantSymbol(false, f)){
+    if(env->signature->isFoolConstantSymbol(true , f) ||
+       env->signature->isFoolConstantSymbol(false, f)){
       return 0;
     }
     //Higher-order often contains definitions of the form
     //f = ^x^y...
-    if (rhs->arity() && !env.statistics->higherOrder) { // c = f(...)
+    if (rhs->arity() && !env->statistics->higherOrder) { // c = f(...)
       return 0;
     }
     if (rhs->functor() == f) {
       return 0;
     }
-    if(!env.statistics->higherOrder){
+    if(!env->statistics->higherOrder){
       return new Def(lhs,rhs,true,true);
     }
   }

--- a/Shell/GeneralSplitting.cpp
+++ b/Shell/GeneralSplitting.cpp
@@ -206,9 +206,9 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
     }
   }
 
-  static TermStack args;
+  VTHREAD_LOCAL static TermStack args;
   args.reset();
-  static TermStack argSorts;
+  VTHREAD_LOCAL static TermStack argSorts;
   argSorts.reset();
 
   DHMap<unsigned,TermList> varSorts;

--- a/Shell/GeneralSplitting.cpp
+++ b/Shell/GeneralSplitting.cpp
@@ -233,16 +233,16 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
   }
 
 
-  unsigned namingPred=env.signature->addNamePredicate(minDeg);
+  unsigned namingPred=env->signature->addNamePredicate(minDeg);
   OperatorType* npredType = OperatorType::getPredicateType(minDeg, argSorts.begin());
-  env.signature->getPredicate(namingPred)->setType(npredType);
+  env->signature->getPredicate(namingPred)->setType(npredType);
 
   if(mdvColor!=COLOR_TRANSPARENT && otherColor!=COLOR_TRANSPARENT) {
     ASS_EQ(mdvColor, otherColor);
-    env.signature->getPredicate(namingPred)->addColor(mdvColor);
+    env->signature->getPredicate(namingPred)->addColor(mdvColor);
   }
-  if(env.colorUsed && cl->skip()) {
-    env.signature->getPredicate(namingPred)->markSkip();
+  if(env->colorUsed && cl->skip()) {
+    env->signature->getPredicate(namingPred)->markSkip();
   }
 
 

--- a/Shell/GoalGuessing.cpp
+++ b/Shell/GoalGuessing.cpp
@@ -37,12 +37,12 @@ void GoalGuessing::apply(Problem& prb)
 {
   CALL("GoalGuessing::apply(Problem&)");
 
-  _lookInside = env.options->guessTheGoal() != Options::GoalGuess::POSITION;
-  _checkTop = env.options->guessTheGoal() == Options::GoalGuess::EXISTS_TOP || env.options->guessTheGoal() == Options::GoalGuess::EXISTS_ALL;
-  _checkSymbols = env.options->guessTheGoal() == Options::GoalGuess::EXISTS_SYM || env.options->guessTheGoal() == Options::GoalGuess::EXISTS_ALL;
-  _checkPosition = env.options->guessTheGoal() == Options::GoalGuess::POSITION;
+  _lookInside = env->options->guessTheGoal() != Options::GoalGuess::POSITION;
+  _checkTop = env->options->guessTheGoal() == Options::GoalGuess::EXISTS_TOP || env->options->guessTheGoal() == Options::GoalGuess::EXISTS_ALL;
+  _checkSymbols = env->options->guessTheGoal() == Options::GoalGuess::EXISTS_SYM || env->options->guessTheGoal() == Options::GoalGuess::EXISTS_ALL;
+  _checkPosition = env->options->guessTheGoal() == Options::GoalGuess::POSITION;
 
-  if(env.options->guessTheGoal() == Options::GoalGuess::ALL){
+  if(env->options->guessTheGoal() == Options::GoalGuess::ALL){
     _lookInside=true;
     _checkSymbols=true;
     _checkPosition=true;
@@ -142,12 +142,12 @@ bool GoalGuessing::apply(Literal* lit)
     it.next(); // to move past the lit symbol 
     while(it.hasNext()){
       unsigned f = it.next();
-      if(f > env.signature->functions()){ continue; }
-      unsigned unitUsageCnt = env.signature->getFunction(f)->unitUsageCnt();
-      unsigned unitUsageCntLimit = env.options->gtgLimit();
+      if(f > env->signature->functions()){ continue; }
+      unsigned unitUsageCnt = env->signature->getFunction(f)->unitUsageCnt();
+      unsigned unitUsageCntLimit = env->options->gtgLimit();
       if(unitUsageCnt <= unitUsageCntLimit){
-        //cout << "IDENTIFIED AS GOAL symbol " << env.signature->functionName(f) << endl;
-        env.signature->getFunction(f)->markInGoal();
+        //cout << "IDENTIFIED AS GOAL symbol " << env->signature->functionName(f) << endl;
+        env->signature->getFunction(f)->markInGoal();
         found = true;
       }
     }

--- a/Shell/GoalGuessing.cpp
+++ b/Shell/GoalGuessing.cpp
@@ -144,7 +144,7 @@ bool GoalGuessing::apply(Literal* lit)
       unsigned f = it.next();
       if(f > env.signature->functions()){ continue; }
       unsigned unitUsageCnt = env.signature->getFunction(f)->unitUsageCnt();
-      static unsigned unitUsageCntLimit = env.options->gtgLimit();
+      unsigned unitUsageCntLimit = env.options->gtgLimit();
       if(unitUsageCnt <= unitUsageCntLimit){
         //cout << "IDENTIFIED AS GOAL symbol " << env.signature->functionName(f) << endl;
         env.signature->getFunction(f)->markInGoal();

--- a/Shell/Grounding.cpp
+++ b/Shell/Grounding.cpp
@@ -31,11 +31,11 @@ using namespace Kernel;
 
 Grounding::GroundingApplicator::GroundingApplicator()
 {
-  int funcs=env.signature->functions();
+  int funcs=env->signature->functions();
   for(int i=0;i<funcs;i++) {
-    if(env.signature->functionArity(i)==0) {
-      if(env.signature->getFunction(i)->fnType()->result()!= Term::defaultSort()){
-        USER_ERROR("grounding mode can (currently) only be used on unsorted problems, problem with "+env.signature->functionName(i));
+    if(env->signature->functionArity(i)==0) {
+      if(env->signature->getFunction(i)->fnType()->result()!= Term::defaultSort()){
+        USER_ERROR("grounding mode can (currently) only be used on unsorted problems, problem with "+env->signature->functionName(i));
       }
       _constants.push(TermList(Term::create(i,0,0)));
     }
@@ -154,7 +154,7 @@ ClauseList* Grounding::getEqualityAxioms(bool otherThanReflexivity)
   ClauseList* res=0;
 
 /*
-  unsigned sortCnt = env.sorts->sorts();
+  unsigned sortCnt = env->sorts->sorts();
   for(unsigned i=0; i<sortCnt; ++i) {
     getLocalEqualityAxioms(i, otherThanReflexivity, res);
   }
@@ -164,14 +164,14 @@ ClauseList* Grounding::getEqualityAxioms(bool otherThanReflexivity)
   if(otherThanReflexivity) {
 
     DArray<TermList> args;
-    int preds=env.signature->predicates();
+    int preds=env->signature->predicates();
     for(int pred=1;pred<preds;pred++) { //we skip equality predicate, as transitivity was added above
-      unsigned arity=env.signature->predicateArity(pred);
+      unsigned arity=env->signature->predicateArity(pred);
       if(arity==0) {
         continue;
       }
 
-      OperatorType* predType = env.signature->getPredicate(pred)->predType();
+      OperatorType* predType = env->signature->getPredicate(pred)->predType();
 
       args.ensure(arity);
       for(unsigned i=0;i<arity;i++) {

--- a/Shell/HalfBoundingRemover.cpp
+++ b/Shell/HalfBoundingRemover.cpp
@@ -50,9 +50,9 @@ bool HalfBoundingRemover::apply(ConstraintRCList*& lst)
   //now we need to apply eliminations one step at a time since they depend
   //on content of _posVars and _negVars which gets invalidated by every change
   //of the constraint list 
-  if (env.options->bpAlmostHalfBoundingRemoval()!=Options::AHR_OFF) {
+  if (env->options->bpAlmostHalfBoundingRemoval()!=Options::AHR_OFF) {
     anyRemoved |= applyAlmostHalfBoundingRemoval(lst,
-						 env.options->bpAlmostHalfBoundingRemoval()==Options::AHR_BOUNDS_ONLY);
+						 env->options->bpAlmostHalfBoundingRemoval()==Options::AHR_BOUNDS_ONLY);
   }
 
   if (anyRemoved) {
@@ -60,7 +60,7 @@ bool HalfBoundingRemover::apply(ConstraintRCList*& lst)
     return true;
   }
 
-  if (env.options->bpFmElimination()) {
+  if (env->options->bpFmElimination()) {
     anyRemoved |= applyFMElimination(lst);
   }
 
@@ -80,13 +80,13 @@ bool HalfBoundingRemover::applyHalfBoundingRemoval(ConstraintRCList*& lst)
   VTHREAD_LOCAL static DHSet<Var> halfBounding;
   halfBounding.reset();
 
-  unsigned varCnt = env.signature->vars();
+  unsigned varCnt = env->signature->vars();
   for(Var v=0; v<varCnt; v++) {
     size_t posCnt = _v2c.getConstraintCnt(BoundId(v, true));
     size_t negCnt = _v2c.getConstraintCnt(BoundId(v, false));
     if ( (posCnt==0) != (negCnt==0) ) {
       halfBounding.insert(v);
-      env.statistics->halfBoundingVariables++;
+      env->statistics->halfBoundingVariables++;
     }
   }
 
@@ -107,7 +107,7 @@ bool HalfBoundingRemover::applyHalfBoundingRemoval(ConstraintRCList*& lst)
 
     if (hasHalfBounding) {
       cit.del();
-      env.statistics->halfBoundingConstraints++;
+      env->statistics->halfBoundingConstraints++;
       anyRemoved = true;
     }
   }
@@ -126,7 +126,7 @@ bool HalfBoundingRemover::applyAlmostHalfBoundingRemoval(ConstraintRCList*& lst,
 {
   CALL("HalfBoundingRemover::applyAlmostHalfBoundingRemoval");
 
-  unsigned varCnt = env.signature->vars();
+  unsigned varCnt = env->signature->vars();
   for(Var v=0; v<varCnt; v++) {
     Constraint* posSingleton = _v2c.getOnlyConstraint(BoundId(v, true));
     Constraint* negSingleton = _v2c.getOnlyConstraint(BoundId(v, false));
@@ -138,8 +138,8 @@ bool HalfBoundingRemover::applyAlmostHalfBoundingRemoval(ConstraintRCList*& lst,
 	     || (negSingleton && negSingleton->coeffCnt()==1) )) {
       continue;
     }
-    env.statistics->almostHalfBoundingVariables++;
-    env.statistics->almostHalfBoundingConstraints += _v2c.getConstraintCnt(v);
+    env->statistics->almostHalfBoundingVariables++;
+    env->statistics->almostHalfBoundingConstraints += _v2c.getConstraintCnt(v);
 
     doFMReduction(v, lst);
     return true;
@@ -156,8 +156,8 @@ bool HalfBoundingRemover::applyFMElimination(ConstraintRCList*& lst)
 {
   CALL("HalfBoundingRemover::applyFMElimination");
 
-  unsigned allowedBalance = env.options->bpAllowedFMBalance();
-  unsigned varCnt = env.signature->vars();
+  unsigned allowedBalance = env->options->bpAllowedFMBalance();
+  unsigned varCnt = env->signature->vars();
   for(Var v=0; v<varCnt; v++) {
     size_t posCnt = _v2c.getConstraintCnt(BoundId(v, true));
     size_t negCnt = _v2c.getConstraintCnt(BoundId(v, false));
@@ -167,7 +167,7 @@ bool HalfBoundingRemover::applyFMElimination(ConstraintRCList*& lst)
     if (posCnt*negCnt-posCnt-negCnt>allowedBalance) {
       continue;
     }
-    env.statistics->fmRemovedVariables++;
+    env->statistics->fmRemovedVariables++;
 
     doFMReduction(v, lst);
     return true;
@@ -191,7 +191,7 @@ void HalfBoundingRemover::doFMReduction(Var v, ConstraintRCList*& constraints)
       ConstraintRCPtr newConstr(Constraint::resolve(v, posConstr, negConstr, false));
       if (!newConstr->isTautology()) {
 	ConstraintRCList::push(newConstr, constraints);
-	env.statistics->preprocessingFMIntroduced++;
+	env->statistics->preprocessingFMIntroduced++;
       }
     }
   }
@@ -200,7 +200,7 @@ void HalfBoundingRemover::doFMReduction(Var v, ConstraintRCList*& constraints)
   toRemove.reset();
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(posId));
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(negId));
-  env.statistics->preprocessingFMRemoved += toRemove.size();
+  env->statistics->preprocessingFMRemoved += toRemove.size();
 
   ConstraintRCList::DelIterator cit(constraints);
   while(cit.hasNext()) {

--- a/Shell/HalfBoundingRemover.cpp
+++ b/Shell/HalfBoundingRemover.cpp
@@ -77,7 +77,7 @@ bool HalfBoundingRemover::applyHalfBoundingRemoval(ConstraintRCList*& lst)
 {
   CALL("HalfBoundingRemover::applyHalfBoundingRemoval");
 
-  static DHSet<Var> halfBounding;
+  VTHREAD_LOCAL static DHSet<Var> halfBounding;
   halfBounding.reset();
 
   unsigned varCnt = env.signature->vars();
@@ -196,7 +196,7 @@ void HalfBoundingRemover::doFMReduction(Var v, ConstraintRCList*& constraints)
     }
   }
 
-  static DHSet<Constraint*> toRemove;
+  VTHREAD_LOCAL static DHSet<Constraint*> toRemove;
   toRemove.reset();
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(posId));
   toRemove.loadFromIterator(_v2c.getConsraintsWithBound(negId));

--- a/Shell/HalfBoundingRemover.hpp
+++ b/Shell/HalfBoundingRemover.hpp
@@ -29,7 +29,7 @@ using namespace Kernel;
 /**
  * Preprocessing rule that performs half-bounding, almost-half bounding and
  * FM variable elimination according to the options specified in
- * @c env.options.
+ * @c env->options.
  */
 class HalfBoundingRemover {
 public:

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -162,20 +162,20 @@ Literal* InequalitySplitting::splitLiteral(Literal* lit, UnitInputType inpType, 
   unsigned fun;
   OperatorType* type;
   if(!_appify){
-    fun=env.signature->addNamePredicate(vars.size() + 1);
+    fun=env->signature->addNamePredicate(vars.size() + 1);
     type = OperatorType::getPredicateType({srt}, vars.size());
   } else {
     srt = Term::arrowSort(srt, Term::boolSort());
-    fun=env.signature->addNameFunction(vars.size());
+    fun=env->signature->addNameFunction(vars.size());
     type = OperatorType::getConstantsType(srt, vars.size());
   }
 
 
   Signature::Symbol* sym;
   if(_appify){
-    sym = env.signature->getFunction(fun);    
+    sym = env->signature->getFunction(fun);    
   } else {
-    sym = env.signature->getPredicate(fun);    
+    sym = env->signature->getPredicate(fun);    
   }
   sym->setType(type);
 
@@ -191,10 +191,10 @@ Literal* InequalitySplitting::splitLiteral(Literal* lit, UnitInputType inpType, 
   }
 
   ASS(t.isTerm());
-  if(env.colorUsed && t.term()->color()!=COLOR_TRANSPARENT) {
+  if(env->colorUsed && t.term()->color()!=COLOR_TRANSPARENT) {
     sym->addColor(t.term()->color());
   }
-  if(env.colorUsed && t.term()->skip()) {
+  if(env->colorUsed && t.term()->skip()) {
     sym->markSkip();
   }
 
@@ -206,7 +206,7 @@ Literal* InequalitySplitting::splitLiteral(Literal* lit, UnitInputType inpType, 
 
   premise=defCl;
 
-  env.statistics->splitInequalities++;
+  env->statistics->splitInequalities++;
 
   return makeNameLiteral(fun, s, true, vars);
 }

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -100,7 +100,7 @@ Clause* InequalitySplitting::trySplitClause(Clause* cl)
     return cl;
   }
 
-  static DArray<Literal*> resLits(8);
+  VTHREAD_LOCAL static DArray<Literal*> resLits(8);
   resLits.ensure(clen);
 
   UnitInputType inpType = cl->inputType();

--- a/Shell/InterpolantMinimizer.cpp
+++ b/Shell/InterpolantMinimizer.cpp
@@ -72,9 +72,9 @@ Formula* InterpolantMinimizer::getInterpolant(Unit* refutation)
   }
 
   if(_showStats) {
-    env.beginOutput();
-    env.out() << _statsPrefix << " cost: " <<res.assignment.get(costFunction()) << endl;
-    env.endOutput();
+    env->beginOutput();
+    env->out() << _statsPrefix << " cost: " <<res.assignment.get(costFunction()) << endl;
+    env->endOutput();
   }
 
   collectSlicedOffNodes(res, slicedOff);
@@ -91,7 +91,7 @@ void InterpolantMinimizer::prettyPrint(Formula* formula, ostream& out)
 {
   CALL("SMTLibPrinter::prettyPrint");
         
-  Signature *sig = env.signature;
+  Signature *sig = env->signature;
   unsigned symbNum;
   Symbol* symb;
   TermList* args;
@@ -179,7 +179,7 @@ void InterpolantMinimizer::prettyPrint(Formula* formula, ostream& out)
 /*print terms in SMT*/    
 void InterpolantMinimizer::prettyPrint(Term* term, ostream& out)
 {
-    Signature *sig = env.signature;
+    Signature *sig = env->signature;
     unsigned int symbNum = term->functor();
     Symbol* symb = sig->getFunction(symbNum);
         

--- a/Shell/InterpolantMinimizer.cpp
+++ b/Shell/InterpolantMinimizer.cpp
@@ -313,7 +313,7 @@ void InterpolantMinimizer::addNodeFormulas(Unit* u)
 {
   CALL("InterpolantMinimizer::addNodeFormulas");
 
-  static ParentSummary psum;
+  VTHREAD_LOCAL static ParentSummary psum;
   psum.reset();
 
   UnitIterator pit = InferenceStore::instance()->getParents(u);
@@ -473,7 +473,7 @@ protected:
 
   void doSplitting(Clause* cl) {
 
-    static Stack<LiteralStack> comps;
+    VTHREAD_LOCAL static Stack<LiteralStack> comps;
     comps.reset();
     // fills comps with components, returning if not splittable
     if(!Saturation::Splitter::getComponents(cl, comps)) {
@@ -623,7 +623,7 @@ void InterpolantMinimizer::collectAtoms(Unit* u, Stack<vstring>& atoms)
   
   Clause* cl = u->asClause();
     
-  static ClauseStack components;
+  VTHREAD_LOCAL static ClauseStack components;
   components.reset();
   _splitter->getComponents(cl, components);
   ASS(components.isNonEmpty());
@@ -649,7 +649,7 @@ void InterpolantMinimizer::addAtomImplicationFormula(Unit* u)
   CALL("InterpolantMinimizer::getAtomImplicationFormula");
   
   
-  static Stack<vstring> atoms;
+  VTHREAD_LOCAL static Stack<vstring> atoms;
   atoms.reset();
   
   collectAtoms(u, atoms);
@@ -991,7 +991,7 @@ void InterpolantMinimizer::traverse(Unit* refutationUnit)
 
   Unit* refutation = refutationUnit;
 
-  static Stack<TraverseStackEntry> stack;
+  VTHREAD_LOCAL static Stack<TraverseStackEntry> stack;
   stack.reset();
 
   stack.push(TraverseStackEntry(*this, refutation));

--- a/Shell/Interpolants.cpp
+++ b/Shell/Interpolants.cpp
@@ -54,8 +54,8 @@ VirtualIterator<Unit*> Interpolants::getParents(Unit* u)
     return InferenceStore::instance()->getParents(u);
   }
 
-  static Stack<Unit*> toDo;
-  static Stack<Unit*> parents;
+  VTHREAD_LOCAL static Stack<Unit*> toDo;
+  VTHREAD_LOCAL static Stack<Unit*> parents;
 
   toDo.reset();
   parents.reset();

--- a/Shell/InterpolantsNew.cpp
+++ b/Shell/InterpolantsNew.cpp
@@ -352,7 +352,7 @@ namespace Shell
 
         // do dfs on the derivation and present results in the reversed order (using stack for it)
         ProofIteratorPostOrder pipo(refutation);
-        static UnitStack buffer;
+        VTHREAD_LOCAL static UnitStack buffer;
         buffer.reset();
         buffer.loadFromIterator(pipo);
 

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -500,7 +500,7 @@ Clause* InterpretedNormalizer::apply(Clause* cl)
 {
   CALL("InterpretedNormalizer::apply(Clause* cl)");
 
-  static LiteralStack lits;
+  VTHREAD_LOCAL static LiteralStack lits;
   lits.reset();
   unsigned clen = cl->length();
   bool modified = false;

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -55,9 +55,9 @@ public:
   {
     CALL("InterpretedNormalizer::RoundingFunctionTranslator::RoundingFunctionTranslator");
 
-    _origFun = env.signature->getInterpretingSymbol(origf);
-    _newFun = env.signature->getInterpretingSymbol(newf);
-    _roundingFun = env.signature->getInterpretingSymbol(roundf);
+    _origFun = env->signature->getInterpretingSymbol(origf);
+    _newFun = env->signature->getInterpretingSymbol(newf);
+    _roundingFun = env->signature->getInterpretingSymbol(roundf);
 
   }
 
@@ -96,8 +96,8 @@ public:
   {
     CALL("InterpretedNormalizer::SuccessorTranslator::SuccessorTranslator");
 
-    _succFun = env.signature->getInterpretingSymbol(Theory::INT_SUCCESSOR);
-    _plusFun = env.signature->getInterpretingSymbol(Theory::INT_PLUS);
+    _succFun = env->signature->getInterpretingSymbol(Theory::INT_SUCCESSOR);
+    _plusFun = env->signature->getInterpretingSymbol(Theory::INT_PLUS);
     _one = TermList(theory->representConstant(IntegerConstantType(1)));
   }
 
@@ -133,9 +133,9 @@ public:
   {
     CALL("InterpretedNormalizer::BinaryMinusTranslator::BinaryMinusTranslator");
 
-    _bMinusFun = env.signature->getInterpretingSymbol(bMinus);
-    _plusFun = env.signature->getInterpretingSymbol(plus);
-    _uMinusFun = env.signature->getInterpretingSymbol(uMinus);
+    _bMinusFun = env->signature->getInterpretingSymbol(bMinus);
+    _plusFun = env->signature->getInterpretingSymbol(plus);
+    _uMinusFun = env->signature->getInterpretingSymbol(uMinus);
   }
 
   virtual TermList translate(Term* trm)
@@ -172,10 +172,10 @@ public:
    : _swapArguments(swapArguments), _reversePolarity(reversePolarity)
   {
     CALL("InterpretedNormalizer::IneqTranslator::IneqTranslator");
-    _srcPred = env.signature->getInterpretingSymbol(src);
-    _tgtPred = env.signature->getInterpretingSymbol(tgt);
-    ASS_EQ(env.signature->predicateArity(_srcPred), 2);
-    ASS_EQ(env.signature->predicateArity(_tgtPred), 2);
+    _srcPred = env->signature->getInterpretingSymbol(src);
+    _tgtPred = env->signature->getInterpretingSymbol(tgt);
+    ASS_EQ(env->signature->predicateArity(_srcPred), 2);
+    ASS_EQ(env->signature->predicateArity(_tgtPred), 2);
 
   }
 
@@ -211,8 +211,8 @@ public:
   USE_ALLOCATOR(InterpretedNormalizer::NLiteralTransformer);
   
   NLiteralTransformer()
-  : _ineqTransls(env.signature->predicates()),
-    _fnTransfs(env.signature->functions())
+  : _ineqTransls(env->signature->predicates()),
+    _fnTransfs(env->signature->functions())
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::NLiteralTransformer");
 
@@ -306,7 +306,7 @@ private:
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::addMinusTransformer");
 
-    if(!env.signature->haveInterpretingSymbol(bMinus)) {
+    if(!env->signature->haveInterpretingSymbol(bMinus)) {
       return; //the symbol to be transformed doesn't exist, so we don't need to worry
     }
     BinaryMinusTranslator* transl = new BinaryMinusTranslator(bMinus, plus, uMinus);
@@ -322,7 +322,7 @@ private:
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::addSuccessorTransformer");
 
-    if(!env.signature->haveInterpretingSymbol(Theory::INT_SUCCESSOR)) {
+    if(!env->signature->haveInterpretingSymbol(Theory::INT_SUCCESSOR)) {
       return; //the symbol to be transformed doesn't exist, so we don't need to worry
     }
     SuccessorTranslator* transl = new SuccessorTranslator();
@@ -338,7 +338,7 @@ private:
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::addRoundingFunctionTransformer");
 
-    if(!env.signature->haveInterpretingSymbol(origF)) {
+    if(!env->signature->haveInterpretingSymbol(origF)) {
       return; //the symbol to be transformed doesn't exist, so we don't need to worry
     }
     RoundingFunctionTranslator* transl = new RoundingFunctionTranslator(origF,newF,roundF);
@@ -356,7 +356,7 @@ private:
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::addIneqTransformer");
 
-    if(!env.signature->haveInterpretingSymbol(from)) {
+    if(!env->signature->haveInterpretingSymbol(from)) {
       return; //the symbol to be transformed doesn't exist, so we don't need to worry
     }
     IneqTranslator* transl = new IneqTranslator(from, to, swapArguments, reversePolarity);

--- a/Shell/LaTeX.cpp
+++ b/Shell/LaTeX.cpp
@@ -399,13 +399,13 @@ vstring LaTeX::symbolToString (unsigned num, bool pred) const
   vstring symbolName; // the name of this symbol, if any
 
   if(pred) {
-    symbolName = env.signature->predicateName(num);
+    symbolName = env->signature->predicateName(num);
   }
   else {
 //    if (f.isSkolemFunction()) {
 //      return (vstring)"\\sigma_{" + Int::toString(f.number()) + "}";
 //    }
-    symbolName = env.signature->functionName(num);
+    symbolName = env->signature->functionName(num);
   }
 
   // cut names longer than 8000 symbols

--- a/Shell/LambdaElimination.cpp
+++ b/Shell/LambdaElimination.cpp
@@ -132,12 +132,12 @@ TermList LambdaElimination::elimLambda(Formula* formula)
                 
       TermList equalsSort = SortHelper::getEqualityArgumentSort(lit);
       
-      unsigned eqProxy = env.signature->getEqualityProxy();
+      unsigned eqProxy = env->signature->getEqualityProxy();
       constant = TermList(Term::create1(eqProxy, equalsSort));             
       appTerm = AH::createAppTerm3(sortOf(constant), constant, lhs, rhs);
       
       if(!lit->polarity()){
-        constant = TermList(Term::createConstant(env.signature->getNotProxy()));
+        constant = TermList(Term::createConstant(env->signature->getNotProxy()));
         appTerm = AH::createAppTerm(sortOf(constant), constant, appTerm);
       }
       return appTerm;
@@ -149,7 +149,7 @@ TermList LambdaElimination::elimLambda(Formula* formula)
       Formula* rhs = formula->right();
                     
       vstring name = (conn == IFF ? "vIFF" : (conn == IMP ? "vIMP" : "vXOR"));
-      constant = TermList(Term::createConstant(env.signature->getBinaryProxy(name)));
+      constant = TermList(Term::createConstant(env->signature->getBinaryProxy(name)));
 
       TermList form1 = elimLambda(lhs);
       TermList form2 = elimLambda(rhs);
@@ -168,7 +168,7 @@ TermList LambdaElimination::elimLambda(Formula* formula)
       FormulaList::Iterator argsIt(formula->args());
       
       vstring name = (conn == AND ? "vAND" : "vOR");
-      constant = TermList(Term::createConstant(env.signature->getBinaryProxy(name)));
+      constant = TermList(Term::createConstant(env->signature->getBinaryProxy(name)));
       
       /*TermListComparator tlc;
       unsigned length = FormulaList::length(formula->args());
@@ -199,7 +199,7 @@ TermList LambdaElimination::elimLambda(Formula* formula)
       return appTerm;                           
     }
     case NOT: {
-      constant = TermList(Term::createConstant(env.signature->getNotProxy()));
+      constant = TermList(Term::createConstant(env->signature->getNotProxy()));
       TermList form = elimLambda(formula->uarg());
       return  AH::createAppTerm(sortOf(constant), constant, form);                                                    
     }
@@ -212,7 +212,7 @@ TermList LambdaElimination::elimLambda(Formula* formula)
 
       TermList form = elimLambda(formula->qarg());
       vstring name = (conn == FORALL ? "vPI" : "vSIGMA");
-      unsigned proxy = env.signature->getPiSigmaProxy(name);
+      unsigned proxy = env->signature->getPiSigmaProxy(name);
 
       TermList s;
       while(vit.hasNext()){
@@ -322,7 +322,7 @@ TermList LambdaElimination::elimLambda(int var, TermList varSort,
 
   if(body.isVar()){
     ASS(body.var() == (unsigned)var);
-    return TermList(Term::create1(env.signature->getCombinator(Signature::I_COMB), varSort));
+    return TermList(Term::create1(env->signature->getCombinator(Signature::I_COMB), varSort));
   }
 
   Term* t = body.term();
@@ -375,7 +375,7 @@ TermList LambdaElimination::createKTerm(TermList s1, TermList s2, TermList arg1)
 {
   CALL("LambdaElimination::createKTerm");
   
-  unsigned kcomb = env.signature->getCombinator(Signature::K_COMB);
+  unsigned kcomb = env->signature->getCombinator(Signature::K_COMB);
   TermList res = TermList(Term::create2(kcomb, s1, s2));
   return AH::createAppTerm(sortOf(res), res, arg1);             
 }   
@@ -386,7 +386,7 @@ TermList LambdaElimination::createSCorBTerm(TermList arg1, TermList arg1sort,
   CALL("LambdaElimination::createSCorBTerm");
   
   TermList s1, s2, s3;
-  unsigned cb = env.signature->getCombinator(comb);
+  unsigned cb = env->signature->getCombinator(comb);
   
   if(comb == Signature::S_COMB || comb == Signature::C_COMB){
     s1 = AH::getNthArg(arg1sort, 1);
@@ -428,7 +428,7 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   TermList z = TermList(5, false);
   TermList args[] = {s1, s2, s3};
   
-  unsigned s_comb = env.signature->getCombinator(Signature::S_COMB);
+  unsigned s_comb = env->signature->getCombinator(Signature::S_COMB);
   TermList constant = TermList(Term::create(s_comb, 3, args));
   TermList lhs = AH::createAppTerm(srtOf(constant), constant, x, y, z); //TODO fix
   TermList rhs = AH::createAppTerm3(Term::arrowSort(s1, s2, s3), x, z, AH::createAppTerm(Term::arrowSort(s1, s2), y, z));
@@ -438,7 +438,7 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   sAxiom->inference().setCombAxiomsDescendant(true);
   UnitList::push(sAxiom, prb.units());
 
-  unsigned c_comb = env.signature->getCombinator(Signature::C_COMB);
+  unsigned c_comb = env->signature->getCombinator(Signature::C_COMB);
   constant = TermList(Term::create(c_comb, 3, args));
   lhs = AH::createAppTerm(srtOf(constant), constant, x, y, z); //TODO fix
   rhs = AH::createAppTerm3(Term::arrowSort(s1, s2, s3), x, z, y);
@@ -448,7 +448,7 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   cAxiom->inference().setCombAxiomsDescendant(true);
   UnitList::push(cAxiom, prb.units());
      
-  unsigned b_comb = env.signature->getCombinator(Signature::B_COMB);
+  unsigned b_comb = env->signature->getCombinator(Signature::B_COMB);
   constant = TermList(Term::create(b_comb, 3, args));
   lhs = AH::createAppTerm(srtOf(constant), constant, x, y, z); //TODO fix
   rhs = AH::createAppTerm(Term::arrowSort(s2, s3), x, AH::createAppTerm(Term::arrowSort(s1, s2), y, z));
@@ -458,7 +458,7 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   bAxiom->inference().setCombAxiomsDescendant(true);
   UnitList::push(bAxiom, prb.units());
 
-  unsigned k_comb = env.signature->getCombinator(Signature::K_COMB);
+  unsigned k_comb = env->signature->getCombinator(Signature::K_COMB);
   constant = TermList(Term::create2(k_comb, s1, s2));
   lhs = AH::createAppTerm3(srtOf(constant), constant, x, y);
   
@@ -467,7 +467,7 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   bAxiom->inference().setCombAxiomsDescendant(true);
   UnitList::push(kAxiom, prb.units());
 
-  unsigned i_comb = env.signature->getCombinator(Signature::I_COMB);
+  unsigned i_comb = env->signature->getCombinator(Signature::I_COMB);
   constant = TermList(Term::create1(i_comb, s1));
   lhs = AH::createAppTerm(srtOf(constant), constant, x);
   
@@ -476,13 +476,13 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   iAxiom->inference().setCombAxiomsDescendant(true);  
   UnitList::push(iAxiom, prb.units());
 
-  if (env.options->showPreprocessing()) {
-    env.out() << "Added combinator axioms: " << std::endl;
-    env.out() << sAxiom->toString() << std::endl;
-    env.out() << cAxiom->toString() << std::endl;
-    env.out() << bAxiom->toString() << std::endl;
-    env.out() << kAxiom->toString() << std::endl;  
-    env.out() << iAxiom->toString() << std::endl;        
+  if (env->options->showPreprocessing()) {
+    env->out() << "Added combinator axioms: " << std::endl;
+    env->out() << sAxiom->toString() << std::endl;
+    env->out() << cAxiom->toString() << std::endl;
+    env->out() << bAxiom->toString() << std::endl;
+    env->out() << kAxiom->toString() << std::endl;  
+    env->out() << iAxiom->toString() << std::endl;        
   }
 }
 
@@ -500,7 +500,7 @@ void LambdaElimination::addFunctionExtensionalityAxiom(Problem& prb)
   TermList beta = TermList(1, false);
   TermList x = TermList(2, false);
   TermList y = TermList(3, false);
-  unsigned diff = env.signature->getDiff();
+  unsigned diff = env->signature->getDiff();
 
   TermList diffT = TermList(Term::create2(diff, alpha, beta));
   TermList diffTApplied = AH::createAppTerm3(srtOf(diffT), diffT, x, y);
@@ -513,9 +513,9 @@ void LambdaElimination::addFunctionExtensionalityAxiom(Problem& prb)
   UnitList::push(funcExtAx, prb.units());
 
 
-  if (env.options->showPreprocessing()) {
-    env.out() << "Added functional extensionality axiom: " << std::endl;
-    env.out() << funcExtAx->toString() << std::endl;       
+  if (env->options->showPreprocessing()) {
+    env->out() << "Added functional extensionality axiom: " << std::endl;
+    env->out() << funcExtAx->toString() << std::endl;       
   }
 }
 
@@ -528,7 +528,7 @@ void LambdaElimination::addChoiceAxiom(Problem& prb)
   TermList alphaBool = Term::arrowSort(alpha, Term::boolSort());
   TermList p = TermList(1, false);
   TermList x = TermList(2, false);
-  unsigned choice = env.signature->getChoice();
+  unsigned choice = env->signature->getChoice();
 
   TermList choiceT = TermList(Term::create1(choice, alpha));
   TermList choiceTApplied = AH::createAppTerm(alphaBool, alpha, choiceT, p);
@@ -541,9 +541,9 @@ void LambdaElimination::addChoiceAxiom(Problem& prb)
   UnitList::push(choiceAx, prb.units());
 
 
-  if (env.options->showPreprocessing()) {
-    env.out() << "Added Hilbert choice axiom: " << std::endl;
-    env.out() << choiceAx->toString() << std::endl;       
+  if (env->options->showPreprocessing()) {
+    env->out() << "Added Hilbert choice axiom: " << std::endl;
+    env->out() << choiceAx->toString() << std::endl;       
   }
 }
 
@@ -565,7 +565,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   TermList sk1 = TermList(Term::create1(skolem1, s1));
   TermList sk2 = TermList(Term::create1(skolem2, s1));
 
-  unsigned eqProxy = env.signature->getEqualityProxy();
+  unsigned eqProxy = env->signature->getEqualityProxy();
   TermList constant = TermList(Term::create1(eqProxy, s1));
 
   Clause* eqAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::EQUALITY_PROXY_AXIOM));
@@ -580,7 +580,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   eqAxiom2->inference().setProxyAxiomsDescendant(true);   
   UnitList::push(eqAxiom2, prb.units());
 
-  unsigned notProxy = env.signature->getNotProxy();
+  unsigned notProxy = env->signature->getNotProxy();
   constant = TermList(Term::createConstant(notProxy));
 
   Clause* notAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::NOT_PROXY_AXIOM));
@@ -595,7 +595,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   notAxiom2->inference().setProxyAxiomsDescendant(true);    
   UnitList::push(notAxiom2, prb.units());  
 
-  unsigned piProxy = env.signature->getPiSigmaProxy("vPI");
+  unsigned piProxy = env->signature->getPiSigmaProxy("vPI");
   constant = TermList(Term::create1(piProxy, s1));
 
   Clause* piAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::PI_PROXY_AXIOM));
@@ -610,7 +610,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   piAxiom2->inference().setProxyAxiomsDescendant(true);      
   UnitList::push(piAxiom2, prb.units());  
 
-  unsigned sigmaProxy = env.signature->getPiSigmaProxy("vSIGMA");
+  unsigned sigmaProxy = env->signature->getPiSigmaProxy("vSIGMA");
   constant = TermList(Term::create1(sigmaProxy, s1));
 
   Clause* sigmaAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::SIGMA_PROXY_AXIOM));
@@ -625,7 +625,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   sigmaAxiom2->inference().setProxyAxiomsDescendant(true);    
   UnitList::push(sigmaAxiom2, prb.units()); 
 
-  unsigned impProxy = env.signature->getBinaryProxy("vIMP");
+  unsigned impProxy = env->signature->getBinaryProxy("vIMP");
   constant = TermList(Term::createConstant(impProxy));
 
   Clause* impAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::IMPLIES_PROXY_AXIOM));
@@ -647,7 +647,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   impAxiom3->inference().setProxyAxiomsDescendant(true);
   UnitList::push(impAxiom3, prb.units());
 
-  unsigned andProxy = env.signature->getBinaryProxy("vAND");
+  unsigned andProxy = env->signature->getBinaryProxy("vAND");
   constant = TermList(Term::createConstant(andProxy));
 
   Clause* andAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::AND_PROXY_AXIOM));
@@ -669,7 +669,7 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   andAxiom3->inference().setProxyAxiomsDescendant(true);  
   UnitList::push(andAxiom3, prb.units());
 
-  unsigned orProxy = env.signature->getBinaryProxy("vOR");
+  unsigned orProxy = env->signature->getBinaryProxy("vOR");
   constant = TermList(Term::createConstant(orProxy));
 
   Clause* orAxiom1 = new(2) Clause(2, TheoryAxiom(InferenceRule::OR_PROXY_AXIOM));
@@ -694,25 +694,25 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
 
   //TODO iff and xor
 
-  if (env.options->showPreprocessing()) {
-    env.out() << "Added proxy axioms: " << std::endl;
-    env.out() << eqAxiom1->toString() << std::endl;
-    env.out() << eqAxiom2->toString() << std::endl;
-    env.out() << notAxiom1->toString() << std::endl;
-    env.out() << notAxiom2->toString() << std::endl;  
-    env.out() << piAxiom1->toString() << std::endl;
-    env.out() << piAxiom2->toString() << std::endl;            
-    env.out() << sigmaAxiom1->toString() << std::endl;
-    env.out() << sigmaAxiom2->toString() << std::endl;
-    env.out() << impAxiom1->toString() << std::endl;  
-    env.out() << impAxiom2->toString() << std::endl;
-    env.out() << impAxiom3->toString() << std::endl;  
-    env.out() << andAxiom1->toString() << std::endl;  
-    env.out() << andAxiom2->toString() << std::endl;
-    env.out() << andAxiom3->toString() << std::endl;   
-    env.out() << orAxiom1->toString() << std::endl;  
-    env.out() << orAxiom2->toString() << std::endl;
-    env.out() << orAxiom3->toString() << std::endl;      
+  if (env->options->showPreprocessing()) {
+    env->out() << "Added proxy axioms: " << std::endl;
+    env->out() << eqAxiom1->toString() << std::endl;
+    env->out() << eqAxiom2->toString() << std::endl;
+    env->out() << notAxiom1->toString() << std::endl;
+    env->out() << notAxiom2->toString() << std::endl;  
+    env->out() << piAxiom1->toString() << std::endl;
+    env->out() << piAxiom2->toString() << std::endl;            
+    env->out() << sigmaAxiom1->toString() << std::endl;
+    env->out() << sigmaAxiom2->toString() << std::endl;
+    env->out() << impAxiom1->toString() << std::endl;  
+    env->out() << impAxiom2->toString() << std::endl;
+    env->out() << impAxiom3->toString() << std::endl;  
+    env->out() << andAxiom1->toString() << std::endl;  
+    env->out() << andAxiom2->toString() << std::endl;
+    env->out() << andAxiom3->toString() << std::endl;   
+    env->out() << orAxiom1->toString() << std::endl;  
+    env->out() << orAxiom2->toString() << std::endl;
+    env->out() << orAxiom3->toString() << std::endl;      
   }
     
 }

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -45,11 +45,11 @@ FormulaUnit* NNF::ennf(FormulaUnit* unit)
 
   FormulaUnit* res = new FormulaUnit(g,FormulaTransformation(InferenceRule::ENNF,unit));
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] ennf in: " << unit->toString() << std::endl;
-    env.out() << "[PP] ennf out: " << res->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] ennf in: " << unit->toString() << std::endl;
+    env->out() << "[PP] ennf out: " << res->toString() << std::endl;
+    env->endOutput();
   }
 
   return res;
@@ -238,11 +238,11 @@ TermList NNF::ennf(TermList ts, bool polarity)
 
   Term* term = ts.term();
 
-  if (env.signature->isFoolConstantSymbol(true, term->functor())) {
+  if (env->signature->isFoolConstantSymbol(true, term->functor())) {
     return polarity ? ts : TermList(Term::foolFalse());
   }
 
-  if (env.signature->isFoolConstantSymbol(false, term->functor())) {
+  if (env->signature->isFoolConstantSymbol(false, term->functor())) {
     return polarity ? ts : TermList(Term::foolTrue());
   }
 

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1113,10 +1113,10 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
 
   unsigned arity = VList::length(freeVars);
 
-  static TermStack termVarSorts;
-  static TermStack termVars;
-  static TermStack typeVars;
-  static DHMap<unsigned, TermList> varSorts;
+  VTHREAD_LOCAL static TermStack termVarSorts;
+  VTHREAD_LOCAL static TermStack termVars;
+  VTHREAD_LOCAL static TermStack typeVars;
+  VTHREAD_LOCAL static DHMap<unsigned, TermList> varSorts;
   termVarSorts.reset();
   termVars.reset();
   typeVars.reset();

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -69,10 +69,10 @@ FormulaUnit* Naming::apply(FormulaUnit* unit, UnitList*& defs) {
   ASS_REP(unit->formula()->freeVariables() == 0, *unit);
   ASS(!_varsInScope); //_varsInScope can be true only when traversing inside a formula
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] naming args: " << unit->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] naming args: " << unit->toString() << std::endl;
+    env->endOutput();
   }
 
   Formula* f = unit->formula();
@@ -1146,10 +1146,10 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
   }
 
   if(!_appify){
-    unsigned pred = env.signature->addNamePredicate(arity);
-    Signature::Symbol* predSym = env.signature->getPredicate(pred);
+    unsigned pred = env->signature->addNamePredicate(arity);
+    Signature::Symbol* predSym = env->signature->getPredicate(pred);
 
-    if (env.colorUsed) {
+    if (env->colorUsed) {
       Color fc = f->getColor();
       if (fc != COLOR_TRANSPARENT) {
         predSym->addColor(fc);
@@ -1162,9 +1162,9 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
     predSym->setType(OperatorType::getPredicateType(arity - typeArgArity, termVarSorts.begin(), typeArgArity));
     return Literal::create(pred, arity, true, false, allVars.begin());
   } else {
-    unsigned fun = env.signature->addNameFunction(typeVars.size());
+    unsigned fun = env->signature->addNameFunction(typeVars.size());
     TermList sort = Term::arrowSort(termVarSorts, Term::boolSort());
-    Signature::Symbol* sym = env.signature->getFunction(fun);
+    Signature::Symbol* sym = env->signature->getFunction(fun);
     sym->setType(OperatorType::getConstantsType(sort, typeArgArity)); 
     TermList head = TermList(Term::create(fun, typeVars.size(), typeVars.begin()));
     TermList t = ApplicativeHelper::createAppTerm(sort, head, termVars);
@@ -1215,13 +1215,13 @@ Formula* Naming::introduceDefinition(Formula* f, bool iff) {
   InferenceStore::instance()->recordIntroducedSymbol(definition, false,
       atom->functor());
 
-  env.statistics->formulaNames++;
+  env->statistics->formulaNames++;
   UnitList::push(definition, _defs);
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] naming defs: " << definition->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] naming defs: " << definition->toString() << std::endl;
+    env->endOutput();
   }
 
   return name;

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -516,8 +516,8 @@ void NewCNF::processBoolVar(SIGN sign, unsigned var, Occurrences &occurrences)
       continue;
     }
 
-    bool isTrue  = env.signature->isFoolConstantSymbol(true,  skolem->functor());
-    bool isFalse = env.signature->isFoolConstantSymbol(false, skolem->functor());
+    bool isTrue  = env->signature->isFoolConstantSymbol(true,  skolem->functor());
+    bool isFalse = env->signature->isFoolConstantSymbol(false, skolem->functor());
 
     if (isTrue || isFalse) {
       SIGN bindingSign = isTrue ? POSITIVE : NEGATIVE;
@@ -584,7 +584,7 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
     VList* symbols = sd->getTupleSymbols();
     TermList bodySort = sd->getSort();
 
-    OperatorType* tupleType = env.signature->getFunction(tupleFunctor)->fnType();
+    OperatorType* tupleType = env->signature->getFunction(tupleFunctor)->fnType();
 
     Term* bindingTuple = binding.term()->getSpecialData()->getTupleTerm();
     unsigned arity = VList::length(symbols);
@@ -606,13 +606,13 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
     ASS(!sit.hasNext());
     ASS(!bit.hasNext());
 
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
       Term* tupleLet = Term::createTupleLet(tupleFunctor, symbols, binding, contents, tupleType->result());
-      env.out() << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << endl;
+      env->out() << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << endl;
       Term* processedLet = Term::createLet(symbol, 0, processedBinding, processedContents, bodySort);
-      env.out() << "[PP] clausify (detuplify let) out: " << processedLet->toString() << endl;
-      env.endOutput();
+      env->out() << "[PP] clausify (detuplify let) out: " << processedLet->toString() << endl;
+      env->endOutput();
     }
 
     variables = VList::empty();
@@ -623,13 +623,13 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
     VList* symbols = sd->getTupleSymbols();
     TermList bodySort = sd->getSort();
 
-    OperatorType* tupleType = env.signature->getFunction(tupleFunctor)->fnType();
+    OperatorType* tupleType = env->signature->getFunction(tupleFunctor)->fnType();
     TermList tupleSort = tupleType->result();
 
     ASS_EQ(tupleType->arity(), VList::length(symbols));
 
-    unsigned tuple = env.signature->addFreshFunction(0, "tuple");
-    env.signature->getFunction(tuple)->setType(OperatorType::getConstantsType(tupleSort));
+    unsigned tuple = env->signature->addFreshFunction(0, "tuple");
+    env->signature->getFunction(tuple)->setType(OperatorType::getConstantsType(tupleSort));
 
     TermList tupleTerm = TermList(Term::createConstant(tuple));
 
@@ -651,13 +651,13 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
       detupledContents = inlining.process(detupledContents);
     }
 
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
       Term* tupleLet = Term::createTupleLet(tupleFunctor, symbols, binding, contents, tupleType->result());
-      env.out() << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << endl;
+      env->out() << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << endl;
       Term* processedLet = Term::createLet(tuple, 0, binding, detupledContents, bodySort);
-      env.out() << "[PP] clausify (detuplify let) out: " << processedLet->toString() << endl;
-      env.endOutput();
+      env->out() << "[PP] clausify (detuplify let) out: " << processedLet->toString() << endl;
+      env->endOutput();
     }
 
     symbol = tuple;
@@ -665,7 +665,7 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
     contents = detupledContents;
   }
 
-  bool inlineLet = env.options->getIteInlineLet();
+  bool inlineLet = env->options->getIteInlineLet();
 
   if (binding.isVar()) {
     inlineLet = true;
@@ -696,21 +696,21 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
   TermList processedContents;
   if (inlineLet) {
     processedContents = inlineLetBinding(symbol, variables, binding, contents);
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify (inline let) binding: " << binding.toString() << endl;
-      env.out() << "[PP] clausify (inline let) in:  " << contents.toString() << endl;
-      env.out() << "[PP] clausify (inline let) out: " << processedContents.toString() << endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] clausify (inline let) binding: " << binding.toString() << endl;
+      env->out() << "[PP] clausify (inline let) in:  " << contents.toString() << endl;
+      env->out() << "[PP] clausify (inline let) out: " << processedContents.toString() << endl;
+      env->endOutput();
     }
   } else {
     processedContents = nameLetBinding(symbol, variables, binding, contents);
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify (name let) binding: " << binding.toString() << endl;
-      env.out() << "[PP] clausify (name let) in:  " << contents.toString() << endl;
-      env.out() << "[PP] clausify (name let) out: " << processedContents.toString() << endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] clausify (name let) binding: " << binding.toString() << endl;
+      env->out() << "[PP] clausify (name let) in:  " << contents.toString() << endl;
+      env->out() << "[PP] clausify (name let) out: " << processedContents.toString() << endl;
+      env->endOutput();
     }
   }
 
@@ -749,7 +749,7 @@ TermList NewCNF::nameLetBinding(unsigned symbol, VList* bindingVariables, TermLi
   unsigned nameArity = VList::length(bindingVariables) + VList::length(bindingFreeVars);
   TermList nameSort;
   if (!isPredicate) {
-    nameSort = env.signature->getFunction(symbol)->fnType()->result();
+    nameSort = env->signature->getFunction(symbol)->fnType()->result();
   }
 
   unsigned freshSymbol = symbol;
@@ -769,12 +769,12 @@ TermList NewCNF::nameLetBinding(unsigned symbol, VList* bindingVariables, TermLi
 
     if (isPredicate) {
       OperatorType* type = OperatorType::getPredicateType(nameArity, sorts.begin());
-      freshSymbol = env.signature->addFreshPredicate(nameArity, "lG");
-      env.signature->getPredicate(freshSymbol)->setType(type);
+      freshSymbol = env->signature->addFreshPredicate(nameArity, "lG");
+      env->signature->getPredicate(freshSymbol)->setType(type);
     } else {
       OperatorType* type = OperatorType::getFunctionType(nameArity, sorts.begin(), nameSort);
-      freshSymbol = env.signature->addFreshFunction(nameArity, "lG");
-      env.signature->getFunction(freshSymbol)->setType(type);
+      freshSymbol = env->signature->addFreshFunction(nameArity, "lG");
+      env->signature->getFunction(freshSymbol)->setType(type);
     }
   }
 
@@ -900,16 +900,16 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free)
   if (isPredicate) {
     unsigned pred = Skolem::addSkolemPredicate(arity, domainSorts.begin(), var);
     if(_beingClausified->derivedFromGoal()){
-      env.signature->getPredicate(pred)->markInGoal();
+      env->signature->getPredicate(pred)->markInGoal();
     }
     res = Term::createFormula(new AtomicFormula(Literal::create(pred, arity, true, false, fnArgs.begin())));
   } else {
     unsigned fun = Skolem::addSkolemFunction(arity, domainSorts.begin(), rangeSort, var);
     if(_beingClausified->derivedFromGoal()){
-      env.signature->getFunction(fun)->markInGoal();
+      env->signature->getFunction(fun)->markInGoal();
     }
     if(_forInduction){
-      env.signature->getFunction(fun)->markInductionSkolem();
+      env->signature->getFunction(fun)->markInductionSkolem();
     }
     res = Term::create(fun, arity, fnArgs.begin());
   }
@@ -982,7 +982,7 @@ void NewCNF::skolemise(QuantifiedFormula* g, BindingList*& bindings, BindingList
         unsigned var = vs.next();
         Term* skolem = createSkolemTerm(var, unboundFreeVars);
 
-        env.statistics->skolemFunctions++;
+        env->statistics->skolemFunctions++;
 
         Binding binding(var, skolem);
         if (skolem->isSpecial()) {
@@ -1110,10 +1110,10 @@ Literal* NewCNF::createNamingLiteral(Formula* f, VList* free)
   CALL("NewCNF::createNamingLiteral");
 
   unsigned length = VList::length(free);
-  unsigned pred = env.signature->addNamePredicate(length);
-  Signature::Symbol* predSym = env.signature->getPredicate(pred);
+  unsigned pred = env->signature->addNamePredicate(length);
+  Signature::Symbol* predSym = env->signature->getPredicate(pred);
 
-  if (env.colorUsed) {
+  if (env->colorUsed) {
     Color fc = f->getColor();
     if (fc != COLOR_TRANSPARENT) {
       predSym->addColor(fc);
@@ -1163,7 +1163,7 @@ void NewCNF::nameSubformula(Formula* g, Occurrences &occurrences)
   Literal* naming = createNamingLiteral(g, fv);
   Formula* name = new AtomicFormula(naming);
 
-  env.statistics->formulaNames++;
+  env->statistics->formulaNames++;
 
   occurrences.replaceBy(name);
 

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -423,11 +423,11 @@ void NewCNF::BindingStore::pushAndRememberWhileApplying(Binding b, BindingList* 
   CALL("NewCNF::pushAndRememberWhileApplying");
 
   // turn b into a singleton substitution
-  static Substitution subst;
+  VTHREAD_LOCAL static Substitution subst;
   subst.bind(b.first,b.second);
 
   // to go through the bindings from the end, put them on a stack...
-  static Stack<BindingList*> st(5);
+  VTHREAD_LOCAL static Stack<BindingList*> st(5);
   BindingList* traverse = lst;
   while (BindingList::isNonEmpty(traverse)) {
     st.push(traverse);
@@ -756,7 +756,7 @@ TermList NewCNF::nameLetBinding(unsigned symbol, VList* bindingVariables, TermLi
 
   bool renameSymbol = VList::isNonEmpty(bindingFreeVars);
   if (renameSymbol) {
-    static Stack<TermList> sorts;
+    VTHREAD_LOCAL static Stack<TermList> sorts;
     sorts.reset();
 
     ensureHavingVarSorts();
@@ -883,8 +883,8 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free)
 
   ensureHavingVarSorts();
   TermList rangeSort=_varSorts.get(var, Term::defaultSort());
-  static Stack<TermList> domainSorts;
-  static Stack<TermList> fnArgs;
+  VTHREAD_LOCAL static Stack<TermList> domainSorts;
+  VTHREAD_LOCAL static Stack<TermList> fnArgs;
   ASS(domainSorts.isEmpty());
   ASS(fnArgs.isEmpty());
 
@@ -941,9 +941,9 @@ void NewCNF::skolemise(QuantifiedFormula* g, BindingList*& bindings, BindingList
 
     VarSet* frees = freeVars(g);
 
-    static Stack<unsigned> toSubtract;
+    VTHREAD_LOCAL static Stack<unsigned> toSubtract;
     toSubtract.reset();
-    static Stack<unsigned> toAddOnTop;
+    VTHREAD_LOCAL static Stack<unsigned> toAddOnTop;
     toAddOnTop.reset();
 
     BindingList::Iterator bIt(bindings);
@@ -1123,8 +1123,8 @@ Literal* NewCNF::createNamingLiteral(Formula* f, VList* free)
     }
   }
 
-  static Stack<TermList> domainSorts;
-  static Stack<TermList> predArgs;
+  VTHREAD_LOCAL static Stack<TermList> domainSorts;
+  VTHREAD_LOCAL static Stack<TermList> predArgs;
   domainSorts.reset();
   predArgs.reset();
 
@@ -1428,7 +1428,7 @@ Clause* NewCNF::toClause(SPGenClause gc)
     _substitutionsByBindings.insert(gc->bindings, subst);
   }
 
-  static Stack<Literal*> properLiterals;
+  VTHREAD_LOCAL static Stack<Literal*> properLiterals;
   ASS(properLiterals.isEmpty());
 
   GenClause::Iterator lit = gc->genLiterals();

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -31,7 +31,7 @@ using namespace Kernel;
 using namespace Shell;
 
 Normalisation::Normalisation ()
-  : _counter(*env.signature)
+  : _counter(*env->signature)
 {
 } // Normalisation::Normalisation
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -110,6 +110,9 @@ void Options::init()
                                         "model_check",
                                         "output",
                                         "portfolio",
+#if VTHREADED
+                                        "threaded",
+#endif
                                         "preprocess",
                                         "preprocess2",
                                         "profile",
@@ -124,6 +127,9 @@ void Options::init()
     "  -vampire: the standard mode of operation for first-order theorem proving\n"
     "  -portfolio: a portfolio mode running a specified schedule (see schedule)\n"
     "  -casc, casc_sat, smtcomp - like portfolio mode, with competition specific\n     presets for schedule, etc.\n"
+#if VTHREADED
+    "  -threaded: like portfolio, but in thread-parallel (experimental)\n"
+#endif
     "  -preprocess,axiom_selection,clausify,grounding: modes for producing output\n      for other solvers.\n"
     "  -tpreprocess,tclausify: output modes for theory input (clauses are quantified\n      with sort information).\n"
     "  -output,profile: output information about the problem\n"
@@ -152,7 +158,15 @@ void Options::init()
          "struct_induction"});
     _schedule.description = "Schedule to be run by the portfolio mode. casc and smtcomp usually point to the most recent schedule in that category. Note that some old schedules may contain option values that are no longer supported - see ignore_missing.";
     _lookup.insert(&_schedule);
-    _schedule.reliesOnHard(Or(_mode.is(equal(Mode::CASC)),_mode.is(equal(Mode::CASC_SAT)),_mode.is(equal(Mode::SMTCOMP)),_mode.is(equal(Mode::PORTFOLIO))));
+    _schedule.reliesOnHard(Or(
+      _mode.is(equal(Mode::CASC)),
+      _mode.is(equal(Mode::CASC_SAT)),
+      _mode.is(equal(Mode::SMTCOMP)),
+#if VTHREADED
+      _mode.is(equal(Mode::THREADED)),
+#endif
+      _mode.is(equal(Mode::PORTFOLIO))
+    ));
 
     _multicore = UnsignedOptionValue("cores","",1);
     _multicore.description = "When running in portfolio modes (including casc or smtcomp modes) specify the number of cores, set to 0 to use maximum";

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2275,10 +2275,10 @@ void Options::set(const char* name,const char* value, bool longOpt)
         break;
       case IgnoreMissing::WARN:
         if (outputAllowed()) {
-          env.beginOutput();
-          addCommentSignForSZS(env.out());
-          env.out() << "WARNING: invalid value "<< value << " for option " << name << endl;
-          env.endOutput();
+          env->beginOutput();
+          addCommentSignForSZS(env->out());
+          env->out() << "WARNING: invalid value "<< value << " for option " << name << endl;
+          env->endOutput();
         }
         break;
       case IgnoreMissing::ON:
@@ -2291,10 +2291,10 @@ void Options::set(const char* name,const char* value, bool longOpt)
       vstring msg = (vstring)name + (longOpt ? " is not a valid option" : " is not a valid short option (did you mean --?)");
       if (_ignoreMissing.actualValue == IgnoreMissing::WARN) {
         if (outputAllowed()) {
-          env.beginOutput();
-          addCommentSignForSZS(env.out());
-          env.out() << "WARNING: " << msg << endl;
-          env.endOutput();
+          env->beginOutput();
+          addCommentSignForSZS(env->out());
+          env->out() << "WARNING: " << msg << endl;
+          env->endOutput();
         }
         return;
       } // else:
@@ -2325,7 +2325,7 @@ void Options::set(const vstring& name,const vstring& value)
 
 bool Options::OptionHasValue::check(Property*p){
           CALL("Options::OptionHasValue::check");
-          AbstractOptionValue* opt = env.options->getOptionValueByName(option_value);
+          AbstractOptionValue* opt = env->options->getOptionValueByName(option_value);
           ASS(opt);
           return opt->getStringOfActual()==value;
 }
@@ -2543,10 +2543,10 @@ bool Options::OptionValue<T>::randomize(Property* prop){
   CALL("Options::OptionValue::randomize()");
 
   DArray<vstring>* choices = nullptr;
-  if(env.options->randomStrategy()==RandomStrategy::NOCHECK) prop=0;
+  if(env->options->randomStrategy()==RandomStrategy::NOCHECK) prop=0;
 
   // Only randomize if we have a property and need it or don't have one and don't need it!
-  if( env.options->randomStrategy()!=RandomStrategy::NOCHECK && 
+  if( env->options->randomStrategy()!=RandomStrategy::NOCHECK && 
       ((prop && !hasProblemConstraints()) || (!prop && hasProblemConstraints()))
     ){
     return false;
@@ -2571,7 +2571,7 @@ bool Options::OptionValue<T>::randomize(Property* prop){
   return true;
 }
 
-//TODO should not use cout, should use env.out
+//TODO should not use cout, should use env->out
 template<typename T>
 bool Options::OptionValue<T>::checkConstraints(){
      CALL("Options::OptionValue::checkConstraints");
@@ -2580,17 +2580,17 @@ bool Options::OptionValue<T>::checkConstraints(){
        const OptionValueConstraintUP<T>& con = it.next();
        if(!con->check(*this)){
 
-         if(env.options->mode()==Mode::SPIDER){
+         if(env->options->mode()==Mode::SPIDER){
            reportSpiderFail();
            USER_ERROR("\nBroken Constraint: "+con->msg(*this));
          }
 
          if(con->isHard()){ 
-           if(env.options->randomStrategy()!=RandomStrategy::OFF)
+           if(env->options->randomStrategy()!=RandomStrategy::OFF)
               return false; // Skip warning for Hard
            USER_ERROR("\nBroken Constraint: "+con->msg(*this));
          }
-         switch(env.options->getBadOptionChoice()){
+         switch(env->options->getBadOptionChoice()){
            case BadOption::HARD :
                USER_ERROR("\nBroken Constraint: "+con->msg(*this));
            case BadOption::SOFT :
@@ -2622,12 +2622,12 @@ bool Options::OptionValue<T>::checkProblemConstraints(Property* prop){
       // Constraint should hold whenever the option is set
       if(is_set && !con->check(prop)){
 
-         if(env.options->mode()==Mode::SPIDER){
+         if(env->options->mode()==Mode::SPIDER){
            reportSpiderFail();
            USER_ERROR("WARNING: " + longName + con->msg());
          }
 
-         switch(env.options->getBadOptionChoice()){
+         switch(env->options->getBadOptionChoice()){
          case BadOption::OFF: break;
          default:
            cout << "WARNING: " << longName << con->msg() << endl;
@@ -2972,12 +2972,12 @@ void Options::readOptionsString(vstring optionsString,bool assign)
                 USER_ERROR("value "+value+" for option "+ param +" not known");
                 break;
               case IgnoreMissing::WARN:
-                env.beginOutput();
+                env->beginOutput();
                 if (outputAllowed()) {
-                  env.beginOutput();
-                  addCommentSignForSZS(env.out());
-                  env.out() << "WARNING: value " << value << " for option "<< param <<" not known" << endl;
-                  env.endOutput();
+                  env->beginOutput();
+                  addCommentSignForSZS(env->out());
+                  env->out() << "WARNING: value " << value << " for option "<< param <<" not known" << endl;
+                  env->endOutput();
                 }
                 break;
               case IgnoreMissing::ON:
@@ -2998,12 +2998,12 @@ void Options::readOptionsString(vstring optionsString,bool assign)
         USER_ERROR("option "+param+" not known");
         break;
       case IgnoreMissing::WARN:
-        env.beginOutput();
+        env->beginOutput();
         if (outputAllowed()) {
-          env.beginOutput();
-          addCommentSignForSZS(env.out());
-          env.out() << "WARNING: option "<< param << " not known." << endl;
-          env.endOutput();
+          env->beginOutput();
+          addCommentSignForSZS(env->out());
+          env->out() << "WARNING: option "<< param << " not known." << endl;
+          env->endOutput();
         }
         break;
       case IgnoreMissing::ON:
@@ -3189,7 +3189,7 @@ bool Options::complete(const Problem& prb) const
 {
   CALL("Options::complete");
 
-  if(env.statistics->higherOrder){
+  if(env->statistics->higherOrder){
     //safer for competition
     return false;
   }
@@ -3218,7 +3218,7 @@ bool Options::complete(const Problem& prb) const
   }
 
   // preprocessing
-  if (env.signature->hasDistinctGroups()) {
+  if (env->signature->hasDistinctGroups()) {
     return false;
   }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -171,7 +171,15 @@ void Options::init()
     _multicore = UnsignedOptionValue("cores","",1);
     _multicore.description = "When running in portfolio modes (including casc or smtcomp modes) specify the number of cores, set to 0 to use maximum";
     _lookup.insert(&_multicore);
-    _multicore.reliesOnHard(Or(_mode.is(equal(Mode::CASC)),_mode.is(equal(Mode::CASC_SAT)),_mode.is(equal(Mode::SMTCOMP)),_mode.is(equal(Mode::PORTFOLIO))));
+    _multicore.reliesOnHard(Or(
+      _mode.is(equal(Mode::CASC)),
+      _mode.is(equal(Mode::CASC_SAT)),
+      _mode.is(equal(Mode::SMTCOMP)),
+#if VTHREADED
+      _mode.is(equal(Mode::THREADED)),
+#endif
+      _mode.is(equal(Mode::PORTFOLIO))
+    ));
 
     _ltbLearning = ChoiceOptionValue<LTBLearning>("ltb_learning","ltbl",LTBLearning::OFF,{"on","off","biased"});
     _ltbLearning.description = "Perform learning in LTB mode";

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1049,6 +1049,12 @@ void Options::init()
       _lookup.insert(&_simulatedTimeLimit);
       _simulatedTimeLimit.tag(OptionTag::LRS);
 
+#if VTHREADED
+      _persistentGrounding = BoolOptionValue("persistent_grounding", "pg", false);
+      _persistentGrounding.description = "Ground all clauses and feed them into a SAT solver. SAT solver persists across proof attempts.";
+      _persistentGrounding.tag(OptionTag::SATURATION);
+      _lookup.insert(&_persistentGrounding);
+#endif
 
   //*********************** Inferences  ***********************
 

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1861,7 +1861,7 @@ bool _hard;
     }
 
 
-    //Cheating - we refer to env.options to ask about option values
+    //Cheating - we refer to env->options to ask about option values
     // There is an assumption that the option values used have been
     // set to their final values
     // These are used in randomisation where we guarantee a certain

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -414,6 +414,9 @@ public:
     /** this mode only outputs the input problem, without any preprocessing */
     OUTPUT,
     PORTFOLIO,
+#if VTHREADED
+    THREADED,
+#endif
     PREPROCESS,
     PREPROCESS2,
     PROFILE,

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2241,6 +2241,10 @@ public:
   SplittingCongruenceClosure splittingCongruenceClosure() const { return _splittingCongruenceClosure.actualValue; }
   CCUnsatCores ccUnsatCores() const { return _ccUnsatCores.actualValue; }
 
+#if VTHREADED
+  bool persistentGrounding() const { return _persistentGrounding.actualValue; }
+#endif
+
   void setProof(Proof p) { _proof.actualValue = p; }
   bool bpEquivalentVariableRemoval() const { return _equivalentVariableRemoval.actualValue; }
   unsigned bpMaximalPropagatedEqualityLength() const { return _maximalPropagatedEqualityLength.actualValue; }
@@ -2648,6 +2652,10 @@ private:
   ChoiceOptionValue<SplittingDeleteDeactivated> _splittingDeleteDeactivated;
   BoolOptionValue _splittingFastRestart;
   BoolOptionValue _splittingBufferedSolver;
+
+#if VTHREADED
+  BoolOptionValue _persistentGrounding;
+#endif
 
   ChoiceOptionValue<Statistics> _statistics;
   BoolOptionValue _superpositionFromVariables;

--- a/Shell/PDUtils.cpp
+++ b/Shell/PDUtils.cpp
@@ -34,7 +34,7 @@ bool PDUtils::isDefinitionHead(Literal* l)
 {
   CALL("PDUtils::isDefinitionHead");
 
-  Signature::Symbol* sym = env.signature->getPredicate(l->functor());
+  Signature::Symbol* sym = env->signature->getPredicate(l->functor());
   if(sym->protectedSymbol()) {
     return false;
   }

--- a/Shell/PDUtils.cpp
+++ b/Shell/PDUtils.cpp
@@ -307,7 +307,7 @@ bool PDUtils::hasDefinitionShape(Literal* lhs, Formula* rhs)
     counter.inc(w);
   }
 
-  static Stack<unsigned> bodyPredicates;
+  VTHREAD_LOCAL static Stack<unsigned> bodyPredicates;
   bodyPredicates.reset();
 
   rhs->collectPredicates(bodyPredicates);

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -115,20 +115,20 @@ struct PredicateDefinition::PredData
       ASS(!enqueuedForReplacement);
       pdObj->_eliminable.push(pred);
       enqueuedForDefEl=true;
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] pred marked for removing unused predicate definition: " 
-                << env.signature->predicateName(pred) << std::endl;
-        env.endOutput();
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "[PP] pred marked for removing unused predicate definition: " 
+                << env->signature->predicateName(pred) << std::endl;
+        env->endOutput();
       }            
     } else if(!enqueuedForReplacement && isPure()) {
       pdObj->_pureToReplace.push(pred);
       enqueuedForReplacement=true;
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] " << stateToString() << " to be replaced by " 
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "[PP] " << stateToString() << " to be replaced by " 
                 << ((nocc==0) ? "$false" : "$true") << std::endl;
-        env.endOutput();
+        env->endOutput();
       }
     }
   }
@@ -143,7 +143,7 @@ struct PredicateDefinition::PredData
   }
 
   vstring stateToString() const {
-    return env.signature->predicateName(pred) + ": +(" + Int::toString(pocc)
+    return env->signature->predicateName(pred) + ": +(" + Int::toString(pocc)
 	+ ") -(" + Int::toString(nocc) + ") 0(" + Int::toString(docc) + ")";
   }
 
@@ -152,9 +152,9 @@ struct PredicateDefinition::PredData
 };
 
 PredicateDefinition::PredicateDefinition()
-: _processedPrb(0), _predCnt(env.signature->predicates())
+: _processedPrb(0), _predCnt(env->signature->predicates())
 {
-  int predCnt=env.signature->predicates();
+  int predCnt=env->signature->predicates();
 
   _preds = new PredData[predCnt];
   for(int i=0;i<predCnt;i++) {
@@ -163,7 +163,7 @@ PredicateDefinition::PredicateDefinition()
 
   //mark built-in
   for(int i=0;i<predCnt;i++) {
-    if(env.signature->getPredicate(i)->protectedSymbol()) {
+    if(env->signature->getPredicate(i)->protectedSymbol()) {
       addBuiltInPredicate(i);
     }
   }
@@ -184,11 +184,11 @@ void PredicateDefinition::addBuiltInPredicate(unsigned pred)
 
   _preds[pred].builtIn = true;
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] pred marked as built-in: " 
-            << env.signature->predicateName(pred) << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] pred marked as built-in: " 
+            << env->signature->predicateName(pred) << std::endl;
+    env->endOutput();
   }  
 }
 
@@ -229,10 +229,10 @@ void PredicateDefinition::eliminatePredicateDefinition(unsigned pred, ReplMap& r
   if(pd.pocc==0 && pd.nocc==0) {
     //pred does not occur anywhere else, hence can be deleted
     repl = 0;
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] definition " << (*def) << " removed" << std::endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] definition " << (*def) << " removed" << std::endl;
+      env->endOutput();
     }
     _processedPrb->addEliminatedPredicate(pred,def);
   }
@@ -247,25 +247,25 @@ void PredicateDefinition::eliminatePredicateDefinition(unsigned pred, ReplMap& r
     if(!repl) {
       //the definition formula was simplified by other transformation to the      
       //point it is no longer definition that can be eliminated
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] Formula " << (*def) 
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "[PP] Formula " << (*def) 
                 << " is no longer in the shape of definition of "
-                << env.signature->predicateName(pred) 
+                << env->signature->predicateName(pred) 
                 << ". The original definition was " << (*def0) 
                 << "." << std::endl;
-        env.endOutput();
+        env->endOutput();
       }
       
       return;
     }
     _processedPrb->addPartiallyEliminatedPredicate(pred,def);
 
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] definition " << (*def) << " replaced by " 
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] definition " << (*def) << " replaced by " 
               << (*repl) << std::endl;
-      env.endOutput();
+      env->endOutput();
     }    
   }
   if(repl) {
@@ -274,7 +274,7 @@ void PredicateDefinition::eliminatePredicateDefinition(unsigned pred, ReplMap& r
   count(def, -1);
   ALWAYS(replacements.insert(def, repl));
 
-  env.statistics->unusedPredicateDefinitions++;
+  env->statistics->unusedPredicateDefinitions++;
 }
 
 void PredicateDefinition::replacePurePred(unsigned pred, ReplMap& replacements)
@@ -298,14 +298,14 @@ void PredicateDefinition::replacePurePred(unsigned pred, ReplMap& replacements)
     Unit* v=replacePurePredicates(u);
 
     ASS_NEQ(u,v);
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
         if (v) {
-          env.out() << "unit " << (*u) << " replaced by " << (*v) << endl;
+          env->out() << "unit " << (*u) << " replaced by " << (*v) << endl;
         } else {
-          env.out() << "unit " << (*u) << " removed" << endl;
+          env->out() << "unit " << (*u) << " removed" << endl;
         }
-      env.endOutput();
+      env->endOutput();
     }
     
     count(v,1);
@@ -313,7 +313,7 @@ void PredicateDefinition::replacePurePred(unsigned pred, ReplMap& replacements)
     ALWAYS(replacements.insert(u,v));
   }
 
-  env.statistics->purePredicates++;
+  env->statistics->purePredicates++;
 }
 
 /**
@@ -329,14 +329,14 @@ void PredicateDefinition::collectReplacements(UnitList* units, ReplMap& replacem
     scan(scanIterator.next());
   }
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
     for (unsigned i = 0; i < _predCnt; ++i) {
       if (!_preds[i].pocc && !_preds[i].nocc && !_preds[i].docc)
         continue;      
-      env.out() << _preds[i].stateToString() << endl;
+      env->out() << _preds[i].stateToString() << endl;
     }    
-    env.endOutput();
+    env->endOutput();
   }  
 
   for(unsigned pred=1; pred<_predCnt; pred++) {
@@ -353,13 +353,13 @@ void PredicateDefinition::collectReplacements(UnitList* units, ReplMap& replacem
       replacePurePred(pred, replacements);
     }
   }
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
     for(unsigned i=0; i<_predCnt; ++i) {
       if(!_preds[i].pocc && !_preds[i].nocc  && !_preds[i].docc ) { continue; }
-      env.out() << _preds[i].stateToString() << endl;
+      env->out() << _preds[i].stateToString() << endl;
     }    
-    env.endOutput();
+    env->endOutput();
   }
 }
 
@@ -423,7 +423,7 @@ Clause* PredicateDefinition::replacePurePredicates(Clause* cl)
 
 Unit* PredicateDefinition::replacePurePredicates(Unit* u)
 {
-  if(u->derivedFromGoal() && env.options->ignoreConjectureInPreprocessing()){
+  if(u->derivedFromGoal() && env->options->ignoreConjectureInPreprocessing()){
     return u;
   }
   if(u->isClause()) {
@@ -727,7 +727,7 @@ FormulaUnit* PredicateDefinition::makeImplFromDef(FormulaUnit* def, unsigned pre
 
 void PredicateDefinition::scan(Unit* u)
 {
-  if(!(u->derivedFromGoal() && env.options->ignoreConjectureInPreprocessing())){
+  if(!(u->derivedFromGoal() && env->options->ignoreConjectureInPreprocessing())){
     if(u->isClause()) {
       scan(static_cast<Clause*>(u));
     } else {

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -375,7 +375,7 @@ void PredicateDefinition::removeUnusedDefinitionsAndPurePredicates(UnitList*& un
 {
   CALL("PredicateDefinition::removeUnusedDefinitionsAndPurePredicates");
 
-  static DHMap<Unit*, Unit*> replacements;
+  VTHREAD_LOCAL static DHMap<Unit*, Unit*> replacements;
   replacements.reset();
 
   collectReplacements(units, replacements);

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -158,17 +158,17 @@ void Preprocess::preprocess(Problem& prb)
 {
   CALL("Preprocess::preprocess");
 
-  if(env.options->choiceReasoning()){
-    env.signature->addChoiceOperator(env.signature->getChoice());
+  if(env->options->choiceReasoning()){
+    env->signature->addChoiceOperator(env->signature->getChoice());
   }
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "preprocessing started" << std::endl;
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "preprocessing started" << std::endl;
     UnitList::Iterator uit(prb.units());
     while(uit.hasNext()) {
       Unit* u = uit.next();
-      env.out() << "[PP] input: " << u->toString() << std::endl;
+      env->out() << "[PP] input: " << u->toString() << std::endl;
     }
   }
 
@@ -182,15 +182,15 @@ void Preprocess::preprocess(Problem& prb)
    * in profileMode() in vampire.cpp and PortfolioMode::searchForProof()
    * to preserve reproducibility out of casc mode when using --decode */
   if (_options.normalize()) { // reorder units
-    env.statistics->phase=Statistics::NORMALIZATION;
-    if (env.options->showPreprocessing())
-      env.out() << "normalization" << std::endl;
+    env->statistics->phase=Statistics::NORMALIZATION;
+    if (env->options->showPreprocessing())
+      env->out() << "normalization" << std::endl;
 
     Normalisation().normalise(prb);
   }
 
   if (prb.hasInterpretedOperations()) {
-    env.interpretedOperationsUsed = true;
+    env->interpretedOperationsUsed = true;
   }
 
   if(_options.guessTheGoal() != Options::GoalGuess::OFF){
@@ -200,89 +200,89 @@ void Preprocess::preprocess(Problem& prb)
   }
 
   // If there are interpreted operations
-  if (prb.hasInterpretedOperations() || env.signature->hasTermAlgebras()){
+  if (prb.hasInterpretedOperations() || env->signature->hasTermAlgebras()){
     // Normalizer is needed, because the TheoryAxioms code assumes Normalized problem
     InterpretedNormalizer().apply(prb);
    
     // Add theory axioms if needed
     if( _options.theoryAxioms() != Options::TheoryAxiomLevel::OFF){
-      env.statistics->phase=Statistics::INCLUDING_THEORY_AXIOMS;
-      if (env.options->showPreprocessing())
-        env.out() << "adding theory axioms" << std::endl;
+      env->statistics->phase=Statistics::INCLUDING_THEORY_AXIOMS;
+      if (env->options->showPreprocessing())
+        env->out() << "adding theory axioms" << std::endl;
 
       TheoryAxioms(prb).apply();
     }
   }
 
-  if (prb.hasFOOL() || env.statistics->higherOrder) {//or lambda
+  if (prb.hasFOOL() || env->statistics->higherOrder) {//or lambda
 
     // This is the point to extend the signature with $$true and $$false
     // If we don't have fool then these constants get in the way (a lot)
 
-    if (!_options.newCNF() || env.statistics->polymorphic || env.statistics->higherOrder) {
-      if (env.options->showPreprocessing())
-        env.out() << "FOOL elimination" << std::endl;
+    if (!_options.newCNF() || env->statistics->polymorphic || env->statistics->higherOrder) {
+      if (env->options->showPreprocessing())
+        env->out() << "FOOL elimination" << std::endl;
   
       TheoryAxioms(prb).applyFOOL();
       FOOLElimination().apply(prb);
     }
   }
 
-  if(env.options->functionExtensionality() == Options::FunctionExtensionality::AXIOM){
+  if(env->options->functionExtensionality() == Options::FunctionExtensionality::AXIOM){
     LambdaElimination::addFunctionExtensionalityAxiom(prb);
   }
 
-  if(env.options->choiceAxiom()){
+  if(env->options->choiceAxiom()){
     LambdaElimination::addChoiceAxiom(prb);    
   }
 
   prb.getProperty();
 
-  if ((prb.hasCombs() || prb.hasAppliedVar()) && env.options->addCombAxioms()){
+  if ((prb.hasCombs() || prb.hasAppliedVar()) && env->options->addCombAxioms()){
     LambdaElimination::addCombinatorAxioms(prb);
   }
 
-  if ((prb.hasLogicalProxy() || prb.hasBoolVar()) && env.options->addProxyAxioms()){
+  if ((prb.hasLogicalProxy() || prb.hasBoolVar()) && env->options->addProxyAxioms()){
     LambdaElimination::addProxyAxioms(prb);
   }
   
-  if (prb.hasInterpretedOperations() || env.signature->hasTermAlgebras()){
+  if (prb.hasInterpretedOperations() || env->signature->hasTermAlgebras()){
     // Some axioms needed to be normalized, so we call InterpretedNormalizer twice
     InterpretedNormalizer().apply(prb);
   }
 
   // Expansion of distinct groups happens before other preprocessing
   // If a distinct group is small enough it will add inequality to describe it
-  if(env.signature->hasDistinctGroups()){
-    if(env.options->showPreprocessing())
-      env.out() << "distinct group expansion" << std::endl;
+  if(env->signature->hasDistinctGroups()){
+    if(env->options->showPreprocessing())
+      env->out() << "distinct group expansion" << std::endl;
     DistinctGroupExpansion().apply(prb);
   }
 
   if (_options.sineToAge() || _options.useSineLevelSplitQueues() || (_options.sineToPredLevels() != Options::PredicateSineLevels::OFF)) {
-    env.statistics->phase=Statistics::SINE_SELECTION;
+    env->statistics->phase=Statistics::SINE_SELECTION;
 
     if (_options.sineToPredLevels() != Options::PredicateSineLevels::OFF) {
-      env.predicateSineLevels = new DHMap<unsigned,unsigned>();
+      env->predicateSineLevels = new DHMap<unsigned,unsigned>();
     }
 
-    // just to initialize ``env.clauseSineLevels'' or ``env.predicateSineLevels''
+    // just to initialize ``env->clauseSineLevels'' or ``env->predicateSineLevels''
     SineSelector(false,_options.sineToAgeTolerance(),0,
         _options.sineToAgeGeneralityThreshold(),true).perform(prb);
   }
 
   if (_options.sineSelection()!=Options::SineSelection::OFF) {
-    env.statistics->phase=Statistics::SINE_SELECTION;
-    if (env.options->showPreprocessing())
-      env.out() << "sine selection" << std::endl;
+    env->statistics->phase=Statistics::SINE_SELECTION;
+    if (env->options->showPreprocessing())
+      env->out() << "sine selection" << std::endl;
 
     SineSelector(_options).perform(prb);
   }
 
   if (_options.questionAnswering()==Options::QuestionAnsweringMode::ANSWER_LITERAL) {
-    env.statistics->phase=Statistics::UNKNOWN_PHASE;
-    if (env.options->showPreprocessing())
-      env.out() << "answer literal addition" << std::endl;
+    env->statistics->phase=Statistics::UNKNOWN_PHASE;
+    if (env->options->showPreprocessing())
+      env->out() << "answer literal addition" << std::endl;
 
     AnswerLiteralManager::getInstance()->addAnswerLiterals(prb);
   }
@@ -293,8 +293,8 @@ void Preprocess::preprocess(Problem& prb)
   }
 
   if (prb.mayHaveFormulas()) {
-    if (env.options->showPreprocessing())
-      env.out() << "preprocess1 (rectify, simplify false true, flatten)" << std::endl;
+    if (env->options->showPreprocessing())
+      env->out() << "preprocess1 (rectify, simplify false true, flatten)" << std::endl;
 
     preprocess1(prb);
   }
@@ -311,55 +311,55 @@ void Preprocess::preprocess(Problem& prb)
   // - unused definitions
   // I think TrivialPredicateRemoval just removes pures
   if (_options.unusedPredicateDefinitionRemoval()) {
-    env.statistics->phase=Statistics::UNUSED_PREDICATE_DEFINITION_REMOVAL;
-    if (env.options->showPreprocessing())
-      env.out() << "unused predicate definition removal" << std::endl;
+    env->statistics->phase=Statistics::UNUSED_PREDICATE_DEFINITION_REMOVAL;
+    if (env->options->showPreprocessing())
+      env->out() << "unused predicate definition removal" << std::endl;
 
     PredicateDefinition pdRemover;
     pdRemover.removeUnusedDefinitionsAndPurePredicates(prb);
   }
 
   if (prb.mayHaveFormulas()) {
-    if (env.options->showPreprocessing())
-      env.out() << "preprocess 2 (ennf,flatten)" << std::endl;
+    if (env->options->showPreprocessing())
+      env->out() << "preprocess 2 (ennf,flatten)" << std::endl;
 
     preprocess2(prb);
   }
 
   if (prb.mayHaveFormulas() && _options.newCNF() && 
-     !prb.hasPolymorphicSym() && !env.statistics->higherOrder) {
-    if (env.options->showPreprocessing())
-      env.out() << "newCnf" << std::endl;
+     !prb.hasPolymorphicSym() && !env->statistics->higherOrder) {
+    if (env->options->showPreprocessing())
+      env->out() << "newCnf" << std::endl;
 
     newCnf(prb);
   } else {
     if (prb.mayHaveFormulas() && _options.newCNF()) { // TODO: update newCNF to deal with polymorphism / higher-order
-      ASS(prb.hasPolymorphicSym() || env.statistics->higherOrder);
+      ASS(prb.hasPolymorphicSym() || env->statistics->higherOrder);
       if (outputAllowed()) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out());
-        env.out() << "WARNING: Not using newCnf currently not compatible with polymorphic/higher-order inputs." << endl;
-        env.endOutput();
+        env->beginOutput();
+        addCommentSignForSZS(env->out());
+        env->out() << "WARNING: Not using newCnf currently not compatible with polymorphic/higher-order inputs." << endl;
+        env->endOutput();
       }
     }
 
     if (prb.mayHaveFormulas() && _options.naming()) {
-      if (env.options->showPreprocessing())
-        env.out() << "naming" << std::endl;
+      if (env->options->showPreprocessing())
+        env->out() << "naming" << std::endl;
 
       naming(prb);
     }
 
     if (prb.mayHaveFormulas()) {
-      if (env.options->showPreprocessing())
-        env.out() << "preprocess3 (nnf, flatten, skolemize)" << std::endl;
+      if (env->options->showPreprocessing())
+        env->out() << "preprocess3 (nnf, flatten, skolemize)" << std::endl;
 
       preprocess3(prb);
     }
 
     if (prb.mayHaveFormulas()) {
-      if (env.options->showPreprocessing())
-        env.out() << "clausify" << std::endl;
+      if (env->options->showPreprocessing())
+        env->out() << "clausify" << std::endl;
 
       clausify(prb);
     }
@@ -368,9 +368,9 @@ void Preprocess::preprocess(Problem& prb)
   prb.getProperty();
 
   if (prb.mayHaveFunctionDefinitions()) {
-    env.statistics->phase=Statistics::FUNCTION_DEFINITION_ELIMINATION;
-    if (env.options->showPreprocessing())
-      env.out() << "function definition elimination" << std::endl;
+    env->statistics->phase=Statistics::FUNCTION_DEFINITION_ELIMINATION;
+    if (env->options->showPreprocessing())
+      env->out() << "function definition elimination" << std::endl;
 
     if (_options.functionDefinitionElimination() == Options::FunctionDefinitionElimination::ALL) {
       FunctionDefinition fd;
@@ -383,10 +383,10 @@ void Preprocess::preprocess(Problem& prb)
 
 
   if (prb.mayHaveEquality() && _options.inequalitySplitting() != 0) {
-    if (env.options->showPreprocessing())
-      env.out() << "inequality splitting" << std::endl;
+    if (env->options->showPreprocessing())
+      env->out() << "inequality splitting" << std::endl;
 
-    env.statistics->phase=Statistics::INEQUALITY_SPLITTING;
+    env->statistics->phase=Statistics::INEQUALITY_SPLITTING;
     InequalitySplitting is(_options);
     is.perform(prb);
   }
@@ -411,9 +411,9 @@ void Preprocess::preprocess(Problem& prb)
 
    if (_options.equalityResolutionWithDeletion()!=Options::RuleActivity::OFF &&
 	   prb.mayHaveInequalityResolvableWithDeletion() ) {
-     env.statistics->phase=Statistics::EQUALITY_RESOLUTION_WITH_DELETION;
-     if (env.options->showPreprocessing())
-      env.out() << "equality resolution with deletion" << std::endl;
+     env->statistics->phase=Statistics::EQUALITY_RESOLUTION_WITH_DELETION;
+     if (env->options->showPreprocessing())
+      env->out() << "equality resolution with deletion" << std::endl;
 
      EqResWithDeletion resolver;
      resolver.apply(prb);
@@ -422,36 +422,36 @@ void Preprocess::preprocess(Problem& prb)
 /*
    //TODO consider using this in conjunction with unused predicate removal i.e. when it is off
    if (_options.trivialPredicateRemoval()) {
-     env.statistics->phase=Statistics::UNKNOWN_PHASE;
-     if (env.options->showPreprocessing())
-      env.out() << "trivial predicate removal" << std::endl;
+     env->statistics->phase=Statistics::UNKNOWN_PHASE;
+     if (env->options->showPreprocessing())
+      env->out() << "trivial predicate removal" << std::endl;
 
      TrivialPredicateRemover().apply(prb);
    }
 */
 
    if (_options.generalSplitting()!=Options::RuleActivity::OFF) {
-     if (env.statistics->higherOrder || prb.hasPolymorphicSym()) {  // TODO: extend GeneralSplitting to support polymorphism (would higher-order make sense?)
+     if (env->statistics->higherOrder || prb.hasPolymorphicSym()) {  // TODO: extend GeneralSplitting to support polymorphism (would higher-order make sense?)
        if (outputAllowed()) {
-         env.beginOutput();
-         addCommentSignForSZS(env.out());
-         env.out() << "WARNING: Not using GeneralSplitting currently not compatible with polymorphic/higher-order inputs." << endl;
-         env.endOutput();
+         env->beginOutput();
+         addCommentSignForSZS(env->out());
+         env->out() << "WARNING: Not using GeneralSplitting currently not compatible with polymorphic/higher-order inputs." << endl;
+         env->endOutput();
        }
      } else {
-       env.statistics->phase=Statistics::GENERAL_SPLITTING;
-       if (env.options->showPreprocessing())
-         env.out() << "general splitting" << std::endl;
+       env->statistics->phase=Statistics::GENERAL_SPLITTING;
+       if (env->options->showPreprocessing())
+         env->out() << "general splitting" << std::endl;
 
        GeneralSplitting gs;
        gs.apply(prb);
      }
    }
 
-   if (!env.statistics->higherOrder && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
-     env.statistics->phase=Statistics::EQUALITY_PROXY;
-     if (env.options->showPreprocessing())
-       env.out() << "equality proxy" << std::endl;
+   if (!env->statistics->higherOrder && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
+     env->statistics->phase=Statistics::EQUALITY_PROXY;
+     if (env->options->showPreprocessing())
+       env->out() << "equality proxy" << std::endl;
 
      if(_options.useMonoEqualityProxy() && !prb.hasPolymorphicSym()){
        EqualityProxyMono proxy(_options.equalityProxy());
@@ -467,14 +467,14 @@ void Preprocess::preprocess(Problem& prb)
    if(_options.theoryFlattening()) {
      if (prb.hasPolymorphicSym()) { // TODO: extend theoryFlattening to support polymorphism?
        if (outputAllowed()) {
-         env.beginOutput();
-         addCommentSignForSZS(env.out());
-         env.out() << "WARNING: Not using TheoryFlattening currently not compatible with polymorphic inputs." << endl;
-         env.endOutput();
+         env->beginOutput();
+         addCommentSignForSZS(env->out());
+         env->out() << "WARNING: Not using TheoryFlattening currently not compatible with polymorphic inputs." << endl;
+         env->endOutput();
        }
      } else {
-       if(env.options->showPreprocessing())
-         env.out() << "theory flattening" << std::endl;
+       if(env->options->showPreprocessing())
+         env->out() << "theory flattening" << std::endl;
 
        TheoryFlattening tf;
        tf.apply(prb);
@@ -482,19 +482,19 @@ void Preprocess::preprocess(Problem& prb)
    }
 
    if (_options.blockedClauseElimination()) {
-     env.statistics->phase=Statistics::BLOCKED_CLAUSE_ELIMINATION;
-     if(env.options->showPreprocessing())
-       env.out() << "blocked clause elimination" << std::endl;
+     env->statistics->phase=Statistics::BLOCKED_CLAUSE_ELIMINATION;
+     if(env->options->showPreprocessing())
+       env->out() << "blocked clause elimination" << std::endl;
 
      BlockedClauseElimination bce;
      bce.apply(prb);
    }
 
-   if (env.options->showPreprocessing()) {
+   if (env->options->showPreprocessing()) {
      UnitList::Iterator uit(prb.units());
      while(uit.hasNext()) {
       Unit* u = uit.next();
-      env.out() << "[PP] final: " << u->toString() << std::endl;
+      env->out() << "[PP] final: " << u->toString() << std::endl;
      }
    }
 
@@ -502,9 +502,9 @@ void Preprocess::preprocess(Problem& prb)
      UIHelper::outputAllPremises(cerr, prb.units());
    }
 
-   if (env.options->showPreprocessing()) {
-     env.out() << "preprocessing finished" << std::endl;
-     env.endOutput();
+   if (env->options->showPreprocessing()) {
+     env->out() << "preprocessing finished" << std::endl;
+     env->endOutput();
    }
 } // Preprocess::preprocess ()
 
@@ -527,7 +527,7 @@ void Preprocess::preprocess1 (Problem& prb)
 {
   CALL("Preprocess::preprocess1");
 
-  ScopedLet<Statistics::ExecutionPhase> epLet(env.statistics->phase, Statistics::PREPROCESS_1);
+  ScopedLet<Statistics::ExecutionPhase> epLet(env->statistics->phase, Statistics::PREPROCESS_1);
 
   bool formulasSimplified = false;
 
@@ -546,7 +546,7 @@ void Preprocess::preprocess1 (Problem& prb)
     fu = Rectify::rectify(fu);
     FormulaUnit* rectFu = fu;
     // Simplify the formula if it contains true or false
-    if (!_options.newCNF() || env.statistics->higherOrder || prb.hasPolymorphicSym()) {
+    if (!_options.newCNF() || env->statistics->higherOrder || prb.hasPolymorphicSym()) {
       // NewCNF effectively implements this simplification already (but could have been skipped if higherOrder || hasPolymorphicSym)
       fu = SimplifyFalseTrue::simplify(fu);
     }
@@ -580,7 +580,7 @@ void Preprocess::preprocess2(Problem& prb)
 {
   CALL("Preprocess::preprocess2");
 
-  env.statistics->phase=Statistics::PREPROCESS_2;
+  env->statistics->phase=Statistics::PREPROCESS_2;
 
   UnitList::DelIterator us(prb.units());
   while (us.hasNext()) {
@@ -610,10 +610,10 @@ void Preprocess::naming(Problem& prb)
   CALL("Preprocess::naming");
   ASS(_options.naming());
 
-  env.statistics->phase=Statistics::NAMING;
+  env->statistics->phase=Statistics::NAMING;
   UnitList::DelIterator us(prb.units());
   //TODO fix the below
-  Naming naming(_options.naming(),false, env.statistics->higherOrder); // For now just force eprPreservingNaming to be false, should update Naming
+  Naming naming(_options.naming(),false, env->statistics->higherOrder); // For now just force eprPreservingNaming to be false, should update Naming
   while (us.hasNext()) {
     Unit* u = us.next();
     if (u->isClause()) {
@@ -638,7 +638,7 @@ void Preprocess::newCnf(Problem& prb)
 {
   CALL("Preprocess::newCnf");
 
-  env.statistics->phase=Statistics::NEW_CNF;
+  env->statistics->phase=Statistics::NEW_CNF;
 
   // TODO: this is an ugly copy-paste of "Preprocess::clausify"
 
@@ -648,14 +648,14 @@ void Preprocess::newCnf(Problem& prb)
   bool modified = false;
 
   UnitList::DelIterator us(prb.units());
-  NewCNF cnf(env.options->naming());
+  NewCNF cnf(env->options->naming());
   Stack<Clause*> clauses(32);
   while (us.hasNext()) {
     Unit* u = us.next();
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify: " << u->toString() << std::endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] clausify: " << u->toString() << std::endl;
+      env->endOutput();
     }
     if (u->isClause()) {
       if (static_cast<Clause*>(u)->isEmpty()) {
@@ -739,11 +739,11 @@ void Preprocess::preprocess3 (Problem& prb)
 
   bool modified = false;
 
-  env.statistics->phase=Statistics::PREPROCESS_3;
+  env->statistics->phase=Statistics::PREPROCESS_3;
   UnitList::DelIterator us(prb.units());
   while (us.hasNext()) {
     Unit* u = us.next();
-    Unit* v = preprocess3(u, env.statistics->higherOrder);
+    Unit* v = preprocess3(u, env->statistics->higherOrder);
     if (u!=v) {
       us.replace(v);
       modified = true;
@@ -759,7 +759,7 @@ void Preprocess::clausify(Problem& prb)
 {
   CALL("Preprocess::clausify");
 
-  env.statistics->phase=Statistics::CLAUSIFICATION;
+  env->statistics->phase=Statistics::CLAUSIFICATION;
 
   //we check if we haven't discovered an empty clause during preprocessing
   Unit* emptyClause = 0;
@@ -771,10 +771,10 @@ void Preprocess::clausify(Problem& prb)
   Stack<Clause*> clauses(32);
   while (us.hasNext()) {
     Unit* u = us.next();
-    if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify: " << u->toString() << std::endl;
-      env.endOutput();
+    if (env->options->showPreprocessing()) {
+      env->beginOutput();
+      env->out() << "[PP] clausify: " << u->toString() << std::endl;
+      env->endOutput();
     }
     if (u->isClause()) {
       if (static_cast<Clause*>(u)->isEmpty()) {

--- a/Shell/Profile.cpp
+++ b/Shell/Profile.cpp
@@ -75,8 +75,8 @@ void Profile::output(const Literal* lit,ostream& str,char pred)
 
 void Profile::output(const Clause* clause,ostream& str)
 {
-  static int lastPredicate = -1;
-  static bool nonUnitFound;
+  VTHREAD_LOCAL static int lastPredicate = -1;
+  VTHREAD_LOCAL static bool nonUnitFound;
 
   int length = clause->length();
   const Literal* head = (*clause)[0];

--- a/Shell/Profile.cpp
+++ b/Shell/Profile.cpp
@@ -190,7 +190,7 @@ Profile::Profile ()
     _lits[i] = 0;
   }
 
-  Signature* sig = env.signature;
+  Signature* sig = env->signature;
   int fn = sig->functions();
   _funs = (int*)ALLOC_UNKNOWN(sizeof(int)*fn,"Profile::funs");
   _funClauses = (const Clause**)ALLOC_UNKNOWN(sizeof(Clause*)*fn,
@@ -222,7 +222,7 @@ void Profile::scan(const UnitList* units)
 {
   CALL("Profile::scan(UnitList*)");
 
-  Signature* sig = env.signature;
+  Signature* sig = env->signature;
   int fn = sig->functions();
   for (int i = fn-1;i >= 0;i--) {
     _funs[i] = 0;
@@ -426,7 +426,7 @@ vstring Profile::toString () const
   result += vstring(" >") + Int::toString(HOW_MANY-2) + ':'
     + Int::toString(_lits[HOW_MANY-1]) + '\n';
 
-  Signature* sig = env.signature;
+  Signature* sig = env->signature;
 
   result += "Functions with more than 10 occurrences:\n";
   int fn = sig->functions();

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -602,7 +602,7 @@ void Property::scan(Literal* lit, int polarity, unsigned cLen, bool goal)
       _maxPredArity = arity;
     }
     Signature::Symbol* pred = env.signature->getPredicate(lit->functor());
-    static bool weighted = env.options->symbolPrecedence() == Options::SymbolPrecedence::WEIGHTED_FREQUENCY ||
+    bool weighted = env.options->symbolPrecedence() == Options::SymbolPrecedence::WEIGHTED_FREQUENCY ||
                            env.options->symbolPrecedence() == Options::SymbolPrecedence::REVERSE_WEIGHTED_FREQUENCY;
     unsigned w = weighted ? cLen : 1; 
     for(unsigned i=0;i<w;i++){pred->incUsageCnt();}

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -90,7 +90,7 @@ Property::Property()
     _smtlibLogic(SMTLIBLogic::SMT_UNDEFINED)
 {
   _interpretationPresence.init(Theory::instance()->numberOfFixedInterpretations(), false);
-  env.property = this;
+  env->property = this;
 } // Property::Property
 
 /**
@@ -102,13 +102,13 @@ Property* Property::scan(UnitList* units)
   CALL("Property::scan");
 
   // a bit of a hack, these counts belong in Property
-  for(unsigned f=0;f<env.signature->functions();f++){ 
-    env.signature->getFunction(f)->resetUsageCnt(); 
-    env.signature->getFunction(f)->resetUnitUsageCnt(); 
+  for(unsigned f=0;f<env->signature->functions();f++){ 
+    env->signature->getFunction(f)->resetUsageCnt(); 
+    env->signature->getFunction(f)->resetUnitUsageCnt(); 
    }
-  for(unsigned p=0;p<env.signature->predicates();p++){ 
-    env.signature->getPredicate(p)->resetUsageCnt(); 
-    env.signature->getPredicate(p)->resetUnitUsageCnt(); 
+  for(unsigned p=0;p<env->signature->predicates();p++){ 
+    env->signature->getPredicate(p)->resetUsageCnt(); 
+    env->signature->getPredicate(p)->resetUnitUsageCnt(); 
    }
 
   Property* prop = new Property;
@@ -117,15 +117,15 @@ Property* Property::scan(UnitList* units)
 } // Property::scan
 
 /**
- * Destroy the property. If this property is used as env.property, set env.property to null.
+ * Destroy the property. If this property is used as env->property, set env->property to null.
  * @since 22/07/2011 Manchester
  */
 Property::~Property()
 {
   CALL("Property::~Property");
 
-  if (this == env.property) {
-    env.property = 0;
+  if (this == env->property) {
+    env->property = 0;
   }
 }
 
@@ -149,21 +149,21 @@ void Property::add(UnitList* units)
   }
 
   // information about sorts is read from the environment, not from the problem
-  if (env.sorts->hasSort()) {
+  if (env->sorts->hasSort()) {
     addProp(PR_SORTS);
   }
     
   // information about interpreted constant is read from the signature
-  if (env.signature->strings()) {
+  if (env->signature->strings()) {
     addProp(PR_HAS_STRINGS);
   }
-  if (env.signature->integers()) {
+  if (env->signature->integers()) {
     addProp(PR_HAS_INTEGERS);
   }
-  if (env.signature->rationals()) {
+  if (env->signature->rationals()) {
     addProp(PR_HAS_RATS);
   }
-  if (env.signature->reals()) {
+  if (env->signature->reals()) {
     addProp(PR_HAS_REALS);
   }
 
@@ -251,10 +251,10 @@ void Property::scan(Unit* unit)
   while(it.hasNext()){
     int symbol = it.next();
     if(symbol >= 0){
-      env.signature->getFunction(symbol)->incUnitUsageCnt();
+      env->signature->getFunction(symbol)->incUnitUsageCnt();
     }else{
       symbol = -symbol;
-      env.signature->getPredicate(symbol)->incUnitUsageCnt();
+      env->signature->getPredicate(symbol)->incUnitUsageCnt();
     }
   }
 
@@ -476,7 +476,7 @@ void Property::scan(Formula* f, int polarity)
         while(vit.hasNext()){
           int v = vit.next();
           if(SortHelper::tryGetVariableSort(v, f->qarg(), s)){
-            if(s.isTerm() && env.signature->getFunction(s.term()->functor())->super()){
+            if(s.isTerm() && env->signature->getFunction(s.term()->functor())->super()){
               _quantifiesOverPolymorphicVar = true;
               break;
             }
@@ -505,7 +505,7 @@ void Property::scanSort(TermList sort)
     return;
   }
 
-  if(!env.statistics->higherOrder && !_hasPolymorphicSym){
+  if(!env->statistics->higherOrder && !_hasPolymorphicSym){
     //used sorts is for FMB which is not compatible with 
     //higher-order or polymorphism
     unsigned sortU = SortHelper::sortNum(sort);
@@ -519,7 +519,7 @@ void Property::scanSort(TermList sort)
     return;
   }
   _hasNonDefaultSorts = true;
-  env.statistics->hasTypes=true;
+  env->statistics->hasTypes=true;
 
   if(SortHelper::isArraySort(sort)){
     // an array sort is infinite, if the index or value sort is infinite
@@ -532,8 +532,8 @@ void Property::scanSort(TermList sort)
     addProp(PR_HAS_ARRAYS);
     return;
   }
-  if (env.signature->isTermAlgebraSort(sort)) {
-    TermAlgebra* ta = env.signature->getTermAlgebraOfSort(sort);
+  if (env->signature->isTermAlgebraSort(sort)) {
+    TermAlgebra* ta = env->signature->getTermAlgebraOfSort(sort);
     if (!ta->finiteDomain()) {
       _onlyFiniteDomainDatatypes = false;
     }
@@ -601,9 +601,9 @@ void Property::scan(Literal* lit, int polarity, unsigned cLen, bool goal)
     if (arity > _maxPredArity) {
       _maxPredArity = arity;
     }
-    Signature::Symbol* pred = env.signature->getPredicate(lit->functor());
-    bool weighted = env.options->symbolPrecedence() == Options::SymbolPrecedence::WEIGHTED_FREQUENCY ||
-                           env.options->symbolPrecedence() == Options::SymbolPrecedence::REVERSE_WEIGHTED_FREQUENCY;
+    Signature::Symbol* pred = env->signature->getPredicate(lit->functor());
+    bool weighted = env->options->symbolPrecedence() == Options::SymbolPrecedence::WEIGHTED_FREQUENCY ||
+                           env->options->symbolPrecedence() == Options::SymbolPrecedence::REVERSE_WEIGHTED_FREQUENCY;
     unsigned w = weighted ? cLen : 1; 
     for(unsigned i=0;i<w;i++){pred->incUsageCnt();}
     if(cLen==1){
@@ -685,7 +685,7 @@ void Property::scan(TermList ts,bool unit,bool goal)
     scanForInterpreted(t);
 
     _symbolsInFormula.insert(t->functor());
-    Signature::Symbol* func = env.signature->getFunction(t->functor());
+    Signature::Symbol* func = env->signature->getFunction(t->functor());
     func->incUsageCnt();
     if(unit){ func->markInUnit();}
     if(goal){ func->markInGoal();}
@@ -763,7 +763,7 @@ void Property::scanForInterpreted(Term* t)
 
   if (Theory::isPolymorphic(itp)) {
     OperatorType* type = t->isLiteral() ?
-        env.signature->getPredicate(t->functor())->predType() : env.signature->getFunction(t->functor())->fnType();
+        env->signature->getPredicate(t->functor())->predType() : env->signature->getFunction(t->functor())->fnType();
 
     _polymorphicInterpretations.insert(std::make_pair(itp,type));
     return;

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -270,7 +270,7 @@ Term* Rectify::rectify (Term* t)
   Term* s = new(t->arity()) Term(*t);
   if (rectify(t->args(),s->args())) {
     if(TermList::allShared(s->args())) {
-      return env.sharing->insert(s);
+      return env->sharing->insert(s);
     }
     else {
       return s;
@@ -341,10 +341,10 @@ Literal* Rectify::rectify (Literal* l)
     if(TermList::allShared(m->args())) {
       if(l->isEquality() && m->nthArgument(0)->isVar() && m->nthArgument(1)->isVar()) {
         ASS(l->shared());
-        return env.sharing->insertVariableEquality(m, rectifiedSrt);
+        return env->sharing->insertVariableEquality(m, rectifiedSrt);
       }
       else {
-        return env.sharing->insert(m);
+        return env->sharing->insert(m);
       }
     }
     else {

--- a/Shell/SMTFormula.cpp
+++ b/Shell/SMTFormula.cpp
@@ -142,7 +142,7 @@ void SMTBenchmark::output(ostream& out)
     out << ":extrafuns ((" << func << " " << fType << "))" <<endl;
   }
 
-  static Stack<vstring> predDeclStack;
+  VTHREAD_LOCAL static Stack<vstring> predDeclStack;
   predDeclStack.reset();
   predDeclStack.loadFromIterator(_predDecls.iterator());
   sort<DefaultComparator>(predDeclStack.begin(), predDeclStack.end());
@@ -250,7 +250,7 @@ void YicesSolver::run(SMTBenchmark& problem, SMTSolverResult& res, unsigned time
   vostringstream problemStm;
   problem.output(problemStm);
 
-  static Stack<vstring> proverOut;
+  VTHREAD_LOCAL static Stack<vstring> proverOut;
   proverOut.reset();
 
   vstring execName = System::guessExecutableDirectory()+"/yices";

--- a/Shell/SMTPrinter.cpp
+++ b/Shell/SMTPrinter.cpp
@@ -58,7 +58,7 @@ void SMTPrinter::smtPrint(Formula* formula, ostream& out)
 {
   CALL("SMTPrinter::smtPrint");
         
-  Signature *sig = env.signature;
+  Signature *sig = env->signature;
   unsigned symbNum;
   Symbol* symb;
   TermList* args;
@@ -152,7 +152,7 @@ void SMTPrinter::smtPrint(Formula* formula, ostream& out)
 /*print terms in SMT format*/    
 void SMTPrinter::smtPrint(Term* term, ostream& out)
 {
-  Signature *sig = env.signature;
+  Signature *sig = env->signature;
   unsigned int symbNum = term->functor();
   Symbol* symb = sig->getFunction(symbNum);
         

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -51,11 +51,11 @@ FormulaUnit* SimplifyFalseTrue::simplify (FormulaUnit* unit)
 
   FormulaUnit* res = new FormulaUnit(g,FormulaTransformation(InferenceRule::REDUCE_FALSE_TRUE,unit));
 
-  if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] simplify in: " << unit->toString() << std::endl;
-    env.out() << "[PP] simplify out: " << res->toString() << std::endl;
-    env.endOutput();
+  if (env->options->showPreprocessing()) {
+    env->beginOutput();
+    env->out() << "[PP] simplify in: " << unit->toString() << std::endl;
+    env->out() << "[PP] simplify out: " << res->toString() << std::endl;
+    env->endOutput();
   }
   return res;
 } // SimplifyFalseTrue::simplify
@@ -85,7 +85,7 @@ Formula* SimplifyFalseTrue::simplify (Formula* f)
       TermList ts = simplify(f->getBooleanTerm());
       if (ts.isTerm()) {
         for (bool constant : { true, false }) {
-          if (env.signature->isFoolConstantSymbol(constant, ts.term()->functor())) {
+          if (env->signature->isFoolConstantSymbol(constant, ts.term()->functor())) {
             return new Formula(constant);
           }
         }
@@ -116,8 +116,8 @@ Formula* SimplifyFalseTrue::simplify (Formula* f)
         if (literal->isEquality() && !literal->isTwoVarEquality()) {
           for (unsigned argument : { 0u, 1u }) {
             if (arguments[argument].isTerm()) {
-              bool isTrue  = env.signature->isFoolConstantSymbol(true,  arguments[argument].term()->functor());
-              bool isFalse = env.signature->isFoolConstantSymbol(false, arguments[argument].term()->functor());
+              bool isTrue  = env->signature->isFoolConstantSymbol(true,  arguments[argument].term()->functor());
+              bool isFalse = env->signature->isFoolConstantSymbol(false, arguments[argument].term()->functor());
               if (isTrue || isFalse) {
                 Formula* simplifiedFormula = BoolTermFormula::create(arguments[argument == 0 ? 1 : 0]);
                 return (isTrue == literal->polarity()) ? simplifiedFormula
@@ -388,8 +388,8 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
          */
         for (BRANCH branch : { THEN, ELSE }) {
           bool isTerm = branches[branch].isTerm();
-          isTrue[branch]  = isTerm && env.signature->isFoolConstantSymbol(true,  branches[branch].term()->functor());
-          isFalse[branch] = isTerm && env.signature->isFoolConstantSymbol(false, branches[branch].term()->functor());
+          isTrue[branch]  = isTerm && env->signature->isFoolConstantSymbol(true,  branches[branch].term()->functor());
+          isFalse[branch] = isTerm && env->signature->isFoolConstantSymbol(false, branches[branch].term()->functor());
         }
 
         for (BRANCH branch : {THEN, ELSE }) {

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -220,7 +220,7 @@ SineSymbolExtractor::SymIdIterator SineSymbolExtractor::extractSymIds(Unit* u)
 {
   CALL("SineSymbolExtractor::extractSymIds");
 
-  static Stack<SymId> itms;
+  VTHREAD_LOCAL static Stack<SymId> itms;
   itms.reset();
 
   if (u->isClause()) {
@@ -305,7 +305,7 @@ void SineSelector::updateDefRelation(Unit* u)
     return;
   }
 
-  static Stack<SymId> equalGenerality;
+  VTHREAD_LOCAL static Stack<SymId> equalGenerality;
   equalGenerality.reset();
 
   SymId leastGenSym=sit.next();
@@ -555,7 +555,7 @@ void SineTheorySelector::updateDefRelation(Unit* u)
     return;
   }
 
-  static Stack<SymId> symIds;
+  VTHREAD_LOCAL static Stack<SymId> symIds;
   symIds.reset();
   symIds.loadFromIterator(sit0);
 

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -54,7 +54,7 @@ using namespace Kernel;
  */
 SineSymbolExtractor::SymId SineSymbolExtractor::getSymIdBound()
 {
-  return max(env.signature->predicates()*2-1, env.signature->functions()*2);
+  return max(env->signature->predicates()*2-1, env->signature->functions()*2);
 }
 
 void SineSymbolExtractor::addSymIds(Term* term, Stack<SymId>& ids)
@@ -145,12 +145,12 @@ bool SineSymbolExtractor::validSymId(SymId s)
   unsigned functor;
   decodeSymId(s, pred, functor);
   if (pred) {
-    if (functor>=static_cast<unsigned>(env.signature->predicates())) {
+    if (functor>=static_cast<unsigned>(env->signature->predicates())) {
       return false;
     }
   }
   else {
-    if (functor>=static_cast<unsigned>(env.signature->functions())) {
+    if (functor>=static_cast<unsigned>(env->signature->functions())) {
       return false;
     }
   }
@@ -399,7 +399,7 @@ bool SineSelector::perform(UnitList*& units)
     numberUnitsLeftOut++;
     Unit* u=uit2.next();
     bool performSelection= _onIncluded ? u->included() : ((u->inputType()==UnitInputType::AXIOM)
-                            || (env.options->guessTheGoal() != Options::GoalGuess::OFF && u->inputType()==UnitInputType::ASSUMPTION));
+                            || (env->options->guessTheGoal() != Options::GoalGuess::OFF && u->inputType()==UnitInputType::ASSUMPTION));
     if (performSelection) { // register the unit for later
       updateDefRelation(u);
     }
@@ -418,7 +418,7 @@ bool SineSelector::perform(UnitList*& units)
   unsigned depth=0;
   newlySelected.push_back(0);
 
-  // cout << "env.maxClausePriority starts as" << env.maxClausePriority << endl;
+  // cout << "env->maxClausePriority starts as" << env->maxClausePriority << endl;
 
   //select required axiom formulas
   while (newlySelected.isNonEmpty()) {
@@ -433,8 +433,8 @@ bool SineSelector::perform(UnitList*& units)
       }
       ASS(!_depthLimit || depth<_depthLimit);
       if(_justForSineLevels){
-        if (env.maxSineLevel < std::numeric_limits<decltype(env.maxSineLevel)>::max()) { // saturate at 255 or something
-          env.maxSineLevel++;
+        if (env->maxSineLevel < std::numeric_limits<decltype(env->maxSineLevel)>::max()) { // saturate at 255 or something
+          env->maxSineLevel++;
         }
       }
       // cout << "Time to inc" << endl;
@@ -450,13 +450,13 @@ bool SineSelector::perform(UnitList*& units)
     while (sit.hasNext()) {
       SymId sym=sit.next();
 
-      if (env.predicateSineLevels) {
+      if (env->predicateSineLevels) {
         bool pred;
         unsigned functor;
         SineSymbolExtractor::decodeSymId(sym,pred,functor);
-        if (pred && !env.predicateSineLevels->find(functor)) {
-          env.predicateSineLevels->insert(functor,env.maxSineLevel);
-          // cout << "set level of predicate " << functor << " i.e. " << env.signature->predicateName(functor) << " to " << env.maxClausePriority << endl;
+        if (pred && !env->predicateSineLevels->find(functor)) {
+          env->predicateSineLevels->insert(functor,env->maxSineLevel);
+          // cout << "set level of predicate " << functor << " i.e. " << env->signature->predicateName(functor) << " to " << env->maxClausePriority << endl;
         }
       }
 
@@ -471,8 +471,8 @@ bool SineSelector::perform(UnitList*& units)
         newlySelected.push_back(du);
 
         if(_justForSineLevels){
-          du->inference().setSineLevel(env.maxSineLevel);
-          //cout << "set level for " << du->toString() << " in iteration as " << env.maxClausePriority << endl;
+          du->inference().setSineLevel(env->maxSineLevel);
+          //cout << "set level for " << du->toString() << " in iteration as " << env->maxClausePriority << endl;
         }
       }
       //all defining units for the symbol sym were selected,
@@ -487,10 +487,10 @@ bool SineSelector::perform(UnitList*& units)
     return false;
   }
 
-  env.statistics->sineIterations=depth;
-  env.statistics->selectedBySine=_unitsWithoutSymbols.size() + selectedStack.size();
+  env->statistics->sineIterations=depth;
+  env->statistics->selectedBySine=_unitsWithoutSymbols.size() + selectedStack.size();
 
-  numberUnitsLeftOut -= env.statistics->selectedBySine;
+  numberUnitsLeftOut -= env->statistics->selectedBySine;
 
   UnitList::destroy(units);
   units=0;
@@ -653,7 +653,7 @@ void SineTheorySelector::perform(UnitList*& units)
   while (uit2.hasNext()) {
     Unit* u=uit2.next();
     bool performSelection= sineOnIncluded ? u->included() : ((u->inputType()==UnitInputType::AXIOM)
-                   || (env.options->guessTheGoal() != Options::GoalGuess::OFF && u->inputType()==UnitInputType::ASSUMPTION));
+                   || (env->options->guessTheGoal() != Options::GoalGuess::OFF && u->inputType()==UnitInputType::ASSUMPTION));
 
     if (performSelection) {
       updateDefRelation(u);
@@ -717,8 +717,8 @@ void SineTheorySelector::perform(UnitList*& units)
 //  units=res->reverse(); //we want to resemble the original SInE as much as possible
   units=res;
 
-  env.statistics->sineIterations=depth;
-  env.statistics->selectedBySine=_unitsWithoutSymbols.size() + selected.size();
+  env->statistics->sineIterations=depth;
+  env->statistics->selectedBySine=_unitsWithoutSymbols.size() + selected.size();
 
 #if SINE_PRINT_SELECTED
   UnitList::Iterator selIt(units);

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -64,7 +64,7 @@ FormulaUnit* Skolem::skolemise (FormulaUnit* unit, bool appify)
     break;
   }
 
-  static Skolem skol;
+  VTHREAD_LOCAL static Skolem skol;
   return skol.skolemiseImpl(unit, appify);
 } // Skolem::skolemise
 
@@ -253,8 +253,8 @@ void Skolem::preskolemise (Formula* f)
         _varOccs.remove(vs.next());
       }
 
-      static Stack<unsigned> univ_dep_stack;
-      static Stack<unsigned> exists_deps_stack;
+      VTHREAD_LOCAL static Stack<unsigned> univ_dep_stack;
+      VTHREAD_LOCAL static Stack<unsigned> exists_deps_stack;
       ASS(univ_dep_stack.isEmpty());
       ASS(exists_deps_stack.isEmpty());
 
@@ -363,10 +363,10 @@ Formula* Skolem::skolemise (Formula* f)
       // and bind them in _subst
       unsigned arity = 0;
       ensureHavingVarSorts();
-      static TermStack allVars;
-      static TermStack typeVars;
-      static TermStack termVars;
-      static TermStack termVarSorts;
+      VTHREAD_LOCAL static TermStack allVars;
+      VTHREAD_LOCAL static TermStack typeVars;
+      VTHREAD_LOCAL static TermStack termVars;
+      VTHREAD_LOCAL static TermStack termVarSorts;
       termVarSorts.reset();
       termVars.reset();
       allVars.reset();

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -104,7 +104,7 @@ FormulaUnit* Skolem::skolemiseImpl (FormulaUnit* unit, bool appify)
     unsigned fn = _introducedSkolemFuns.pop();
     InferenceStore::instance()->recordIntroducedSymbol(res,true,fn);
     if(unit->derivedFromGoal()){
-      env.signature->getFunction(fn)->markInGoal();
+      env->signature->getFunction(fn)->markInGoal();
     }
   }
 
@@ -131,8 +131,8 @@ unsigned Skolem::addSkolemFunction(unsigned arity, unsigned taArity, TermList* d
   CALL("Skolem::addSkolemFunction(unsigned,TermList*,TermList,const char*)");
   //ASS(arity==0 || domainSorts!=0);
 
-  unsigned fun = env.signature->addSkolemFunction(arity, suffix);
-  Signature::Symbol* fnSym = env.signature->getFunction(fun);
+  unsigned fun = env->signature->addSkolemFunction(arity, suffix);
+  Signature::Symbol* fnSym = env->signature->getFunction(fun);
   OperatorType* ot = OperatorType::getFunctionType(arity - taArity, domainSorts, rangeSort, taArity);
   fnSym->setType(ot);
   return fun;
@@ -156,8 +156,8 @@ unsigned Skolem::addSkolemPredicate(unsigned arity, unsigned taArity, TermList* 
   CALL("Skolem::addSkolemPredicate(unsigned,unsigned*,unsigned,const char*)");
   //ASS(arity==0 || domainSorts!=0);
 
-  unsigned pred = env.signature->addSkolemPredicate(arity, suffix);
-  Signature::Symbol* pSym = env.signature->getPredicate(pred);
+  unsigned pred = env->signature->addSkolemPredicate(arity, suffix);
+  Signature::Symbol* pSym = env->signature->getPredicate(pred);
   OperatorType* ot = OperatorType::getPredicateType(arity - taArity, domainSorts, taArity);
   pSym->setType(ot);
   return pred;
@@ -459,20 +459,20 @@ Formula* Skolem::skolemise (Formula* f)
           skolemTerm = ApplicativeHelper::createAppTerm(skSymSort, head, termVars).term();
         }
 
-        env.statistics->skolemFunctions++;
+        env->statistics->skolemFunctions++;
 
         _subst.bind(v,skolemTerm);
 
-        if (env.options->showSkolemisations()) {
-          env.beginOutput();
-          env.out() << "Skolemising: "<<skolemTerm->toString()<<" for X"<< v
+        if (env->options->showSkolemisations()) {
+          env->beginOutput();
+          env->out() << "Skolemising: "<<skolemTerm->toString()<<" for X"<< v
             <<" in "<<f->toString()<<" in formula "<<_beingSkolemised->toString() << endl;
-          env.endOutput();
+          env->endOutput();
         }
 
-        if (env.options->showNonconstantSkolemFunctionTrace() && arity!=0) {
-          env.beginOutput();
-          ostream& out = env.out();
+        if (env->options->showNonconstantSkolemFunctionTrace() && arity!=0) {
+          env->beginOutput();
+          ostream& out = env->out();
             out <<"Nonconstant skolem function introduced: "
             <<skolemTerm->toString()<<" for X"<<v<<" in "<<f->toString()
             <<" in formula "<<_beingSkolemised->toString()<<endl;
@@ -481,7 +481,7 @@ Formula* Skolem::skolemise (Formula* f)
           Refutation ref(_beingSkolemised, true);
           ref.output(out);
           */
-          env.endOutput();
+          env->endOutput();
         }
       }
 

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -202,7 +202,7 @@ void Statistics::explainRefutationNotFound(ostream& out)
 
 void Statistics::print(ostream& out)
 {
-  if (env.options->statistics()==Options::Statistics::NONE) {
+  if (env->options->statistics()==Options::Statistics::NONE) {
     return;
   }
 
@@ -265,7 +265,7 @@ void Statistics::print(ostream& out)
   }
   out << endl;
 
-  if (env.options->statistics()==Options::Statistics::FULL) {
+  if (env->options->statistics()==Options::Statistics::FULL) {
 
   HEADING("Input",inputClauses+inputFormulas);
   COND_OUT("Input clauses", inputClauses);
@@ -446,7 +446,7 @@ void Statistics::print(ostream& out)
 
   addCommentSignForSZS(out);
   out << "Time elapsed: ";
-  Timer::printMSString(out,env.timer->elapsedMilliseconds());
+  Timer::printMSString(out,env->timer->elapsedMilliseconds());
   out << endl;
   addCommentSignForSZS(out);
   out << "------------------------------\n";
@@ -458,7 +458,7 @@ void Statistics::print(ostream& out)
 #undef SEPARATOR
 #undef COND_OUT
 
-  if (env.options && env.options->timeStatistics()) {
+  if (env->options && env->options->timeStatistics()) {
     TimeCounter::printReport(out);
   }
 }

--- a/Shell/SubsumptionRemover.cpp
+++ b/Shell/SubsumptionRemover.cpp
@@ -88,7 +88,7 @@ bool SubsumptionRemover::apply(ConstraintRCList*& lst)
     if(map.get(&c->coeffArray())!=c) {
       dcit.del();
       someRemoved = true;
-      env.statistics->subsumedConstraints++;
+      env->statistics->subsumedConstraints++;
     }
   }
   pinned->destroy();

--- a/Shell/SymbolDefinitionInlining.cpp
+++ b/Shell/SymbolDefinitionInlining.cpp
@@ -169,7 +169,7 @@ TermList SymbolDefinitionInlining::process(TermList ts) {
 
 bool SymbolDefinitionInlining::mirroredTuple(Term* tuple, TermList &tupleConstant) {
   bool foundTupleConstant = false;
-  TermList tupleSort = env.signature->getFunction(tuple->functor())->fnType()->result();
+  TermList tupleSort = env->signature->getFunction(tuple->functor())->fnType()->result();
   ASS(SortHelper::isTupleSort(tupleSort));
   for (unsigned i = 0; i < tuple->arity(); i++) {
     if (!tuple->nthArgument(i)->isTerm()) {

--- a/Shell/SymbolOccurrenceReplacement.hpp
+++ b/Shell/SymbolOccurrenceReplacement.hpp
@@ -37,13 +37,13 @@ class SymbolOccurrenceReplacement {
             : _isPredicate(isPredicate), _freshApplication(freshApplication), _symbol(symbol), _argVars(argVars) {
         
         if(isPredicate){
-          ASS(VList::length(argVars) == env.signature->getPredicate(symbol)->arity());
+          ASS(VList::length(argVars) == env->signature->getPredicate(symbol)->arity());
         } else {
-          ASS(VList::length(argVars) == env.signature->getFunction(symbol)->arity());            
+          ASS(VList::length(argVars) == env->signature->getFunction(symbol)->arity());            
         }
         // The implementation of this class doesn't requite argVars to be
         // non-empty, however, its use case expects this constraint
-        //ASS(argVars || !env.signature->getFunction(symbol)->introduced());
+        //ASS(argVars || !env->signature->getFunction(symbol)->introduced());
     }
     Formula* process(Formula* formula);
     FormulaList* process(FormulaList* formulas);

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -96,7 +96,7 @@ vstring TPTPPrinter::getBodyStr(Unit* u, bool includeSplitLevels)
   vostringstream res;
 
   typedef DHMap<unsigned,TermList> SortMap;
-  static SortMap varSorts;
+  VTHREAD_LOCAL static SortMap varSorts;
   varSorts.reset();
   SortHelper::collectVariableSorts(u, varSorts);
 

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -201,7 +201,7 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   bool function = symType == SymbolType::FUNC;
 
   Signature::Symbol* sym = function ?
-      env.signature->getFunction(symNumber) : env.signature->getPredicate(symNumber);
+      env->signature->getFunction(symNumber) : env->signature->getPredicate(symNumber);
   OperatorType* type = function ? sym->fnType() : sym->predType();
 
   if(type->isAllDefault()) {
@@ -225,7 +225,7 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   }
 
   vstring cat = "tff(";
-  if(env.statistics->higherOrder){
+  if(env->statistics->higherOrder){
     cat = "thf(";
   }
 
@@ -260,11 +260,11 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   List<TermList> *_usedSorts(0);
   OperatorType* type;
   Signature::Symbol* sym;
-  unsigned sorts = env.sorts->count();
+  unsigned sorts = env->sorts->count();
   //check the sorts of the function symbols and collect information about used sorts
-  for (i = 0; i < env.signature->functions(); i++) {
-    if(env.signature->isTypeConOrSup(f)){ continue; }
-    sym = env.signature->getFunction(i);
+  for (i = 0; i < env->signature->functions(); i++) {
+    if(env->signature->isTypeConOrSup(f)){ continue; }
+    sym = env->signature->getFunction(i);
     type = sym->fnType();
     unsigned arity = sym->arity();
     // NOTE: for function types, the last entry (i.e., type->arg(arity)) contains the type of the result
@@ -274,8 +274,8 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
     }
   }
   //check the sorts of the predicates and collect information about used sorts
-  for (i = 0; i < env.signature->predicates(); i++) {
-    sym = env.signature->getPredicate(i);
+  for (i = 0; i < env->signature->predicates(); i++) {
+    sym = env->signature->getPredicate(i);
     type = sym->predType();
     unsigned arity = sym->arity();
     if (arity > 0) {
@@ -288,7 +288,7 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   //output the sort definition for the used sorts, but not for the built-in sorts
   for (i = Sorts::FIRST_USER_SORT; i < sorts; i++) {
     if (List<unsigned>::member(i, _usedSorts))
-      tgt() << "tff(sort_def_" << i << ",type, " << env.sorts->sortName(i)
+      tgt() << "tff(sort_def_" << i << ",type, " << env->sorts->sortName(i)
             	      << ": $tType" << " )." << endl;
 
   }
@@ -307,13 +307,13 @@ void TPTPPrinter::ensureHeadersPrinted(Unit* u)
   
   //ensureNecesarySorts();
 
-  unsigned funs = env.signature->functions();
+  unsigned funs = env->signature->functions();
   for(unsigned i=0; i<funs; i++) {
     SymbolType st = SymbolType::FUNC;
-    if(env.signature->isTypeConOrSup(i)){ st = SymbolType::TYPE_CON; }
+    if(env->signature->isTypeConOrSup(i)){ st = SymbolType::TYPE_CON; }
     outputSymbolTypeDefinitions(i, st);
   }
-  unsigned preds = env.signature->predicates();
+  unsigned preds = env->signature->predicates();
   for(unsigned i=1; i<preds; i++) {
     outputSymbolTypeDefinitions(i, SymbolType::PRED);
   }
@@ -332,26 +332,26 @@ ostream& TPTPPrinter::tgt()
     return *_tgtStream;
   }
   else {
-    return env.out();
+    return env->out();
   }
 }
 
 /**
  * In case there is no specified output stream, than print to the one
- * specified in the env.beginOutput();
+ * specified in the env->beginOutput();
  */
 void TPTPPrinter::beginOutput()
 {
   CALL("TPTPPrinter::beginOutput");
 
-  if(!_tgtStream) { env.beginOutput(); }
+  if(!_tgtStream) { env->beginOutput(); }
 }
 
 void TPTPPrinter::endOutput()
 {
   CALL("TPTPPrinter::endOutput");
 
-  if(!_tgtStream) { env.endOutput(); }
+  if(!_tgtStream) { env->endOutput(); }
 }
 
 /**

--- a/Shell/TPTPPrinter.hpp
+++ b/Shell/TPTPPrinter.hpp
@@ -59,7 +59,7 @@ private:
   void endOutput();
   ostream& tgt();
 
-  /** if zero, we print to env.out() */
+  /** if zero, we print to env->out() */
   ostream* _tgtStream;
 
   bool _headersPrinted;

--- a/Shell/TermAlgebra.cpp
+++ b/Shell/TermAlgebra.cpp
@@ -20,16 +20,16 @@ namespace Shell {
 TermAlgebraConstructor::TermAlgebraConstructor(unsigned functor, Lib::Array<unsigned> destructors)
   : _functor(functor), _hasDiscriminator(false), _destructors(destructors)
 {
-  _type = env.signature->getFunction(_functor)->fnType();
-  ASS_REP(env.signature->getFunction(_functor)->termAlgebraCons(), env.signature->functionName(_functor));
+  _type = env->signature->getFunction(_functor)->fnType();
+  ASS_REP(env->signature->getFunction(_functor)->termAlgebraCons(), env->signature->functionName(_functor));
   ASS_EQ(_type->arity(), destructors.size());
 }
 
 TermAlgebraConstructor::TermAlgebraConstructor(unsigned functor, unsigned discriminator, Lib::Array<unsigned> destructors)
   : _functor(functor), _hasDiscriminator(true), _discriminator(discriminator), _destructors(destructors)
 {
-  _type = env.signature->getFunction(_functor)->fnType();
-  ASS_REP(env.signature->getFunction(_functor)->termAlgebraCons(), env.signature->functionName(_functor));
+  _type = env->signature->getFunction(_functor)->fnType();
+  ASS_REP(env->signature->getFunction(_functor)->termAlgebraCons(), env->signature->functionName(_functor));
   ASS_EQ(_type->arity(), destructors.size());
 }
 
@@ -55,7 +55,7 @@ Lib::vstring TermAlgebraConstructor::discriminatorName()
 {
   CALL("TermAlgebraConstructor::discriminatorName");
 
-  return "$is" + env.signature->functionName(_functor);
+  return "$is" + env->signature->functionName(_functor);
 }
 
 TermAlgebra::TermAlgebra(TermList sort,
@@ -127,14 +127,14 @@ unsigned TermAlgebra::getSubtermPredicate() {
   CALL("TermAlgebra::getSubtermPredicate");
 
   bool added;
-  unsigned s = env.signature->addPredicate(getSubtermPredicateName(), 2, added);
+  unsigned s = env->signature->addPredicate(getSubtermPredicateName(), 2, added);
 
   if (added) {
     // declare a binary predicate subterm
     TermStack args;
     args.push(_sort); 
     args.push(_sort);
-    env.signature->getPredicate(s)->setType(OperatorType::getPredicateType(args.size(),args.begin()));
+    env->signature->getPredicate(s)->setType(OperatorType::getPredicateType(args.size(),args.begin()));
   }
 
   return s;

--- a/Shell/TheoryAxioms.cpp
+++ b/Shell/TheoryAxioms.cpp
@@ -48,7 +48,7 @@ void TheoryAxioms::addAndOutputTheoryUnit(Unit* unit, unsigned level)
 {
   CALL("TheoryAxioms::addAndOutputTheoryUnit");
 
-  static Options::TheoryAxiomLevel opt_level = env.options->theoryAxioms();
+  Options::TheoryAxiomLevel opt_level = env.options->theoryAxioms();
   // if the theory axioms are some or off (want this case for some things like fool) and the axiom is not
   // a cheap one then don't add it
   if(opt_level != Options::TheoryAxiomLevel::ON && level != CHEAP){ return; }
@@ -1333,7 +1333,7 @@ void TheoryAxioms::addAcyclicityAxiom(TermAlgebra* ta)
     return;
   }
 
-  static TermList x(0, false);
+  VTHREAD_LOCAL static TermList x(0, false);
 
   Literal* sub = Literal::create2(pred, false, x, x);
   addTheoryClauseFromLits({sub}, InferenceRule::TERM_ALGEBRA_ACYCLICITY_AXIOM,CHEAP);

--- a/Shell/TheoryAxioms.cpp
+++ b/Shell/TheoryAxioms.cpp
@@ -48,12 +48,12 @@ void TheoryAxioms::addAndOutputTheoryUnit(Unit* unit, unsigned level)
 {
   CALL("TheoryAxioms::addAndOutputTheoryUnit");
 
-  Options::TheoryAxiomLevel opt_level = env.options->theoryAxioms();
+  Options::TheoryAxiomLevel opt_level = env->options->theoryAxioms();
   // if the theory axioms are some or off (want this case for some things like fool) and the axiom is not
   // a cheap one then don't add it
   if(opt_level != Options::TheoryAxiomLevel::ON && level != CHEAP){ return; }
 
-  if (env.options->showTheoryAxioms()) {
+  if (env->options->showTheoryAxioms()) {
     Unit* qunit = unit;
     Formula* f = 0;
     if(unit->isClause()){
@@ -97,7 +97,7 @@ void TheoryAxioms::addCommutativity(Interpretation op)
   ASS(theory->isFunction(op));
   ASS_EQ(theory->getArity(op),2);
 
-  unsigned f = env.signature->getInterpretingSymbol(op);
+  unsigned f = env->signature->getInterpretingSymbol(op);
   TermList srt = theory->getOperationSort(op);
   TermList x(0,false);
   TermList y(1,false);
@@ -118,7 +118,7 @@ void TheoryAxioms::addAssociativity(Interpretation op)
   ASS(theory->isFunction(op));
   ASS_EQ(theory->getArity(op),2);
 
-  unsigned f = env.signature->getInterpretingSymbol(op);
+  unsigned f = env->signature->getInterpretingSymbol(op);
   TermList srt = theory->getOperationSort(op);
   TermList x(0,false);
   TermList y(1,false);
@@ -143,7 +143,7 @@ void TheoryAxioms::addRightIdentity(Interpretation op, TermList e)
   ASS(theory->isFunction(op));
   ASS_EQ(theory->getArity(op),2);
 
-  unsigned f = env.signature->getInterpretingSymbol(op);
+  unsigned f = env->signature->getInterpretingSymbol(op);
   TermList srt = theory->getOperationSort(op);
   TermList x(0,false);
   TermList fxe(Term::create2(f,x,e));
@@ -160,7 +160,7 @@ void TheoryAxioms::addLeftIdentity(Interpretation op, TermList e)
   ASS(theory->isFunction(op));
   ASS_EQ(theory->getArity(op),2);
 
-  unsigned f = env.signature->getInterpretingSymbol(op);
+  unsigned f = env->signature->getInterpretingSymbol(op);
   TermList srt = theory->getOperationSort(op);
   TermList x(0,false);
   TermList fex(Term::create2(f,e,x));
@@ -194,8 +194,8 @@ void TheoryAxioms::addCommutativeGroupAxioms(Interpretation op, Interpretation i
   addRightIdentity(op,e);
 
   // i(f(x,y)) = f(i(y),i(x))
-  unsigned f = env.signature->getInterpretingSymbol(op);
-  unsigned i = env.signature->getInterpretingSymbol(inverse);
+  unsigned f = env->signature->getInterpretingSymbol(op);
+  unsigned i = env->signature->getInterpretingSymbol(inverse);
   TermList srt = theory->getOperationSort(op);
   ASS_EQ(srt, theory->getOperationSort(inverse));
 
@@ -223,8 +223,8 @@ void TheoryAxioms::addRightInverse(Interpretation op, Interpretation inverse)
 {
   TermList x(0,false);
   TermList y(0,false);
-  unsigned f = env.signature->getInterpretingSymbol(op);
-  unsigned i = env.signature->getInterpretingSymbol(inverse);
+  unsigned f = env->signature->getInterpretingSymbol(op);
+  unsigned i = env->signature->getInterpretingSymbol(inverse);
   TermList srt = theory->getOperationSort(op);
   ASS_EQ(srt, theory->getOperationSort(inverse));
 
@@ -245,7 +245,7 @@ void TheoryAxioms::addNonReflexivity(Interpretation op)
   ASS(!theory->isFunction(op));
   ASS_EQ(theory->getArity(op),2);
 
-  unsigned opPred = env.signature->getInterpretingSymbol(op);
+  unsigned opPred = env->signature->getInterpretingSymbol(op);
   TermList x(0,false);
   Literal* l11 = Literal::create2(opPred, false, x, x);
   addTheoryClauseFromLits({l11}, InferenceRule::THA_NONREFLEX, CHEAP);
@@ -260,7 +260,7 @@ void TheoryAxioms::addTransitivity(Interpretation op)
   ASS(!theory->isFunction(op));
   ASS_EQ(theory->getArity(op),2);
 
-  unsigned opPred = env.signature->getInterpretingSymbol(op);
+  unsigned opPred = env->signature->getInterpretingSymbol(op);
   TermList x(0,false);
   TermList y(1,false);
   TermList v3(2,false);
@@ -281,7 +281,7 @@ void TheoryAxioms::addOrderingTotality(Interpretation less)
   ASS(!theory->isFunction(less));
   ASS_EQ(theory->getArity(less),2);
 
-  unsigned opPred = env.signature->getInterpretingSymbol(less);
+  unsigned opPred = env->signature->getInterpretingSymbol(less);
   TermList x(0,false);
   TermList y(1,false);
 
@@ -317,8 +317,8 @@ void TheoryAxioms::addMonotonicity(Interpretation less, Interpretation addition)
   ASS(theory->isFunction(addition));
   ASS_EQ(theory->getArity(addition),2);
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned addFun = env.signature->getInterpretingSymbol(addition);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned addFun = env->signature->getInterpretingSymbol(addition);
   TermList x(0,false);
   TermList y(1,false);
   TermList v3(2,false);
@@ -344,8 +344,8 @@ void TheoryAxioms::addPlusOneGreater(Interpretation plus, TermList oneElement,
   ASS(theory->isFunction(plus));
   ASS_EQ(theory->getArity(plus),2);
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned addFun = env.signature->getInterpretingSymbol(plus);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned addFun = env->signature->getInterpretingSymbol(plus);
   TermList x(0,false);
 
   TermList xPo(Term::create2(addFun,x,oneElement));
@@ -366,8 +366,8 @@ void TheoryAxioms::addAdditionAndOrderingAxioms(Interpretation plus, Interpretat
   addMonotonicity(less, plus);
 
   // y < x+one | x<y
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
   TermList x(0,false);
   TermList y(1,false);
   Literal* xLy = Literal::create2(lessPred,true,x,y);
@@ -378,7 +378,7 @@ void TheoryAxioms::addAdditionAndOrderingAxioms(Interpretation plus, Interpretat
 
   // add that --x = x
   TermList varSort = theory->getOperationSort(unaryMinus);
-  unsigned unaryMinusFun = env.signature->getInterpretingSymbol(unaryMinus);
+  unsigned unaryMinusFun = env->signature->getInterpretingSymbol(unaryMinus);
   TermList mx(Term::create1(unaryMinusFun,x));
   TermList mmx(Term::create1(unaryMinusFun,mx));
   Literal* mmxEqx = Literal::createEquality(true,mmx,x,varSort);
@@ -405,7 +405,7 @@ void TheoryAxioms::addAdditionOrderingAndMultiplicationAxioms(Interpretation plu
   addRightIdentity(multiply, oneElement);
 
   //axiom( X0*zero==zero );
-  unsigned mulFun = env.signature->getInterpretingSymbol(multiply);
+  unsigned mulFun = env->signature->getInterpretingSymbol(multiply);
   TermList x(0,false);
   TermList xMulZero(Term::create2(mulFun, x, zeroElement));
   Literal* xEqXMulZero = Literal::createEquality(true, xMulZero, zeroElement, srt);
@@ -414,7 +414,7 @@ void TheoryAxioms::addAdditionOrderingAndMultiplicationAxioms(Interpretation plu
   // Distributivity
   //axiom x*(y+z) = (x*y)+(x*z)
 
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
   TermList y(1,false);
   TermList z(2,false);
 
@@ -462,13 +462,13 @@ void TheoryAxioms::addIntegerDivisionWithModuloAxioms(Interpretation plus, Inter
   ASS_EQ(srt, theory->getOperationSort(modulo));
   ASS_EQ(srt, theory->getOperationSort(abs));
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned umFun = env.signature->getInterpretingSymbol(unaryMinus);
-  unsigned mulFun = env.signature->getInterpretingSymbol(multiply);
-  unsigned divFun = env.signature->getInterpretingSymbol(divide);
-  unsigned modFun = env.signature->getInterpretingSymbol(modulo);
-  unsigned absFun = env.signature->getInterpretingSymbol(abs);
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned umFun = env->signature->getInterpretingSymbol(unaryMinus);
+  unsigned mulFun = env->signature->getInterpretingSymbol(multiply);
+  unsigned divFun = env->signature->getInterpretingSymbol(divide);
+  unsigned modFun = env->signature->getInterpretingSymbol(modulo);
+  unsigned absFun = env->signature->getInterpretingSymbol(abs);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
 
   addIntegerAbsAxioms(abs,less,unaryMinus,zeroElement);
 
@@ -520,8 +520,8 @@ void TheoryAxioms::addIntegerDividesAxioms(Interpretation divides, Interpretatio
   TermList srt = theory->getOperationSort(divides);
   ASS_EQ(srt, theory->getOperationSort(multiply));
 
-  unsigned divsPred = env.signature->getInterpretingSymbol(divides);
-  unsigned mulFun   = env.signature->getInterpretingSymbol(multiply);
+  unsigned divsPred = env->signature->getInterpretingSymbol(divides);
+  unsigned mulFun   = env->signature->getInterpretingSymbol(multiply);
 
   TermList y(1,false);
   TermList z(2,false);
@@ -536,8 +536,8 @@ void TheoryAxioms::addIntegerDividesAxioms(Interpretation divides, Interpretatio
   Literal* ndivsXY = Literal::create2(divsPred,false,n,y);
   
   // create a skolem function with signature srt*srt>srt
-  unsigned skolem = env.signature->addSkolemFunction(2);
-  Signature::Symbol* sym = env.signature->getFunction(skolem);
+  unsigned skolem = env->signature->addSkolemFunction(2);
+  Signature::Symbol* sym = env->signature->getFunction(skolem);
   sym->setType(OperatorType::getFunctionType({srt,srt},srt));
   TermList skXY(Term::create2(skolem,n,y));
   TermList msxX(Term::create2(mulFun,skXY,n));
@@ -555,9 +555,9 @@ void TheoryAxioms::addIntegerAbsAxioms(Interpretation abs, Interpretation less,
   ASS_EQ(srt, theory->getOperationSort(less));
   ASS_EQ(srt, theory->getOperationSort(unaryMinus));
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned absFun = env.signature->getInterpretingSymbol(abs);
-  unsigned umFun = env.signature->getInterpretingSymbol(unaryMinus);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned absFun = env->signature->getInterpretingSymbol(abs);
+  unsigned umFun = env->signature->getInterpretingSymbol(unaryMinus);
 
   TermList x(1,false);
   TermList absX(Term::create1(absFun,x));
@@ -593,8 +593,8 @@ void TheoryAxioms::addQuotientAxioms(Interpretation quotient, Interpretation mul
   TermList x(1,false);
   TermList y(2,false);
 
-  unsigned mulFun = env.signature->getInterpretingSymbol(multiply);
-  unsigned divFun = env.signature->getInterpretingSymbol(quotient);
+  unsigned mulFun = env->signature->getInterpretingSymbol(multiply);
+  unsigned divFun = env->signature->getInterpretingSymbol(quotient);
 
   Literal* guardx = Literal::createEquality(true,x,zeroElement,srt); 
 
@@ -631,8 +631,8 @@ void TheoryAxioms::addExtraIntegerOrderingAxiom(Interpretation plus, TermList on
 {
   CALL("TheoryAxioms::addExtraIntegerOrderingAxiom");
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
   TermList x(0,false);
   TermList y(1,false);
   Literal* nxLy = Literal::create2(lessPred, false, x, y);
@@ -651,10 +651,10 @@ void TheoryAxioms::addFloorAxioms(Interpretation floor, Interpretation less, Int
 {
   CALL("TheoryAxioms::addFloorAxioms");
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
-  unsigned umFun = env.signature->getInterpretingSymbol(unaryMinus);
-  unsigned floorFun = env.signature->getInterpretingSymbol(floor);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
+  unsigned umFun = env->signature->getInterpretingSymbol(unaryMinus);
+  unsigned floorFun = env->signature->getInterpretingSymbol(floor);
   TermList x(0,false);
   TermList floorX(Term::create1(floorFun,x));
 
@@ -680,9 +680,9 @@ void TheoryAxioms::addCeilingAxioms(Interpretation ceiling, Interpretation less,
 {
   CALL("TheoryAxioms::addCeilingAxioms");
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
-  unsigned ceilingFun = env.signature->getInterpretingSymbol(ceiling);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
+  unsigned ceilingFun = env->signature->getInterpretingSymbol(ceiling);
   TermList x(0,false);
   TermList ceilingX(Term::create1(ceilingFun,x));
 
@@ -735,10 +735,10 @@ void TheoryAxioms::addTruncateAxioms(Interpretation truncate, Interpretation les
 {
   CALL("TheoryAxioms::addTruncateAxioms");
 
-  unsigned lessPred = env.signature->getInterpretingSymbol(less);
-  unsigned plusFun = env.signature->getInterpretingSymbol(plus);
-  unsigned umFun = env.signature->getInterpretingSymbol(unaryMinus);
-  unsigned truncateFun = env.signature->getInterpretingSymbol(truncate);
+  unsigned lessPred = env->signature->getInterpretingSymbol(less);
+  unsigned plusFun = env->signature->getInterpretingSymbol(plus);
+  unsigned umFun = env->signature->getInterpretingSymbol(unaryMinus);
+  unsigned truncateFun = env->signature->getInterpretingSymbol(truncate);
   TermList x(0,false);
   TermList truncateX(Term::create1(truncateFun,x));
 
@@ -781,7 +781,7 @@ void TheoryAxioms::addArrayExtensionalityAxioms(TermList arraySort, unsigned sko
 {
   CALL("TheoryAxioms::addArrayExtenstionalityAxioms");
 
-  unsigned sel = env.signature->getInterpretingSymbol(Theory::ARRAY_SELECT,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_SELECT));
+  unsigned sel = env->signature->getInterpretingSymbol(Theory::ARRAY_SELECT,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_SELECT));
 
   TermList rangeSort = SortHelper::getInnerSort(arraySort);
 
@@ -810,7 +810,7 @@ void TheoryAxioms::addBooleanArrayExtensionalityAxioms(TermList arraySort, unsig
 
   OperatorType* selectType = Theory::getArrayOperatorType(arraySort,Theory::ARRAY_BOOL_SELECT);
 
-  unsigned sel = env.signature->getInterpretingSymbol(Theory::ARRAY_BOOL_SELECT,selectType);
+  unsigned sel = env->signature->getInterpretingSymbol(Theory::ARRAY_BOOL_SELECT,selectType);
 
   TermList x(0,false);
   TermList y(1,false);
@@ -838,8 +838,8 @@ void TheoryAxioms::addArrayWriteAxioms(TermList arraySort)
 {
   CALL("TheoryAxioms::addArrayWriteAxioms");
         
-  unsigned func_select = env.signature->getInterpretingSymbol(Theory::ARRAY_SELECT,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_SELECT));
-  unsigned func_store = env.signature->getInterpretingSymbol(Theory::ARRAY_STORE,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_STORE));
+  unsigned func_select = env->signature->getInterpretingSymbol(Theory::ARRAY_SELECT,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_SELECT));
+  unsigned func_store = env->signature->getInterpretingSymbol(Theory::ARRAY_STORE,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_STORE));
 
   TermList rangeSort = SortHelper::getInnerSort(arraySort);
   TermList domainSort = SortHelper::getIndexSort(arraySort);
@@ -874,8 +874,8 @@ void TheoryAxioms::addBooleanArrayWriteAxioms(TermList arraySort)
 {
   CALL("TheoryAxioms::addArrayWriteAxioms");
 
-  unsigned pred_select = env.signature->getInterpretingSymbol(Theory::ARRAY_BOOL_SELECT,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_BOOL_SELECT));
-  unsigned func_store = env.signature->getInterpretingSymbol(Theory::ARRAY_STORE,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_STORE));
+  unsigned pred_select = env->signature->getInterpretingSymbol(Theory::ARRAY_BOOL_SELECT,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_BOOL_SELECT));
+  unsigned func_store = env->signature->getInterpretingSymbol(Theory::ARRAY_STORE,Theory::getArrayOperatorType(arraySort,Theory::ARRAY_STORE));
 
   TermList domainSort = SortHelper::getIndexSort(arraySort);
 
@@ -971,7 +971,7 @@ void TheoryAxioms::apply()
                                  Theory::INT_REMAINDER_E, Theory::INT_ABS, zero,one);
       }
       else if(haveIntDivides){ 
-        Stack<TermList>& ns = env.signature->getDividesNvalues(); 
+        Stack<TermList>& ns = env->signature->getDividesNvalues(); 
         Stack<TermList>::Iterator nsit(ns);
         while(nsit.hasNext()){
           TermList n = nsit.next();
@@ -1082,7 +1082,7 @@ void TheoryAxioms::apply()
     modified = true;
   }
 
-  DHSet<TermList>* arraySorts = env.sorts->getArraySorts();
+  DHSet<TermList>* arraySorts = env->sorts->getArraySorts();
   DHSet<TermList>::Iterator it(*arraySorts);
   while(it.hasNext()){
     TermList arraySort = it.next();
@@ -1112,7 +1112,7 @@ void TheoryAxioms::apply()
     }
   }
 
-  VirtualIterator<TermAlgebra*> tas = env.signature->termAlgebrasIterator();
+  VirtualIterator<TermAlgebra*> tas = env->signature->termAlgebrasIterator();
   while (tas.hasNext()) {
     TermAlgebra* ta = tas.next();
 
@@ -1121,7 +1121,7 @@ void TheoryAxioms::apply()
     addInjectivityAxiom(ta);
     addDiscriminationAxiom(ta);
 
-    if (env.options->termAlgebraCyclicityCheck() == Options::TACyclicityCheck::AXIOM) {
+    if (env->options->termAlgebraCyclicityCheck() == Options::TACyclicityCheck::AXIOM) {
       addAcyclicityAxiom(ta);
     }
 
@@ -1145,8 +1145,8 @@ void TheoryAxioms::applyFOOL() {
   addTheoryClauseFromLits({tneqf},InferenceRule::FOOL_AXIOM_TRUE_NEQ_FALSE,CHEAP);
 
   // Do not add the finite domain axiom if --fool_paradomulation on
-  if (env.options->FOOLParamodulation() || env.options->cases() ||
-      env.options->casesSimp()) {
+  if (env->options->FOOLParamodulation() || env->options->cases() ||
+      env->options->casesSimp()) {
     return;
   }
 

--- a/Shell/TheoryFlattening.cpp
+++ b/Shell/TheoryFlattening.cpp
@@ -191,7 +191,7 @@ Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
   if(lit->isEquality()){
     interpreted=false;
     for(TermList* ts = lit->args(); ts->isNonEmpty(); ts = ts->next()){
-      if(ts->isTerm() && env.signature->getFunction(ts->term()->functor())->interpreted()){
+      if(ts->isTerm() && env->signature->getFunction(ts->term()->functor())->interpreted()){
         interpreted=true;
       }
       if(ts->isTerm() && theory->isInterpretedConstant(ts->term())){
@@ -212,13 +212,13 @@ Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
     }
     Term* t = ts->term();
 
-    //cout << "term " << t->toString() << " has interp=" << env.signature->getFunction(t->functor())->interpreted() << endl;
+    //cout << "term " << t->toString() << " has interp=" << env->signature->getFunction(t->functor())->interpreted() << endl;
 
     // if interpreted status is different factor out
     // but never factor out interpreted constants e.g. numbers
     if(
         !equalityWithNumber &&
-        (interpreted != env.signature->getFunction(t->functor())->interpreted()) && 
+        (interpreted != env->signature->getFunction(t->functor())->interpreted()) && 
         !theory->isInterpretedConstant(t) 
       ){
       //cout << "Factoring out " << t->toString() << endl;
@@ -272,7 +272,7 @@ Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
     }
     Term* t = ts->term();
 
-    bool interpretedStatus = env.signature->getFunction(t->functor())->interpreted(); 
+    bool interpretedStatus = env->signature->getFunction(t->functor())->interpreted(); 
 
     // do not abstract numbers out of uninterpreted things, no point
     if(!interpreted && interpretedStatus){

--- a/Shell/TheoryFlattening.hpp
+++ b/Shell/TheoryFlattening.hpp
@@ -37,7 +37,7 @@ public:
   bool apply(ClauseList*& units);
   Clause* apply(Clause*& cl,Stack<Literal*>& target);
   Clause* apply(Clause*& cl){
-    static Stack<Literal*> dummy;
+    VTHREAD_LOCAL static Stack<Literal*> dummy;
     return apply(cl,dummy);
   }
 private:

--- a/Shell/TrivialPredicateRemover.cpp
+++ b/Shell/TrivialPredicateRemover.cpp
@@ -59,7 +59,7 @@ bool TrivialPredicateRemover::apply(UnitList*& units)
   while(dit.hasNext()) {
     Clause* cl = static_cast<Clause*>(dit.next());
     if(_removed.contains(cl) && 
-       !(cl->derivedFromGoal() && env.options->ignoreConjectureInPreprocessing())) {
+       !(cl->derivedFromGoal() && env->options->ignoreConjectureInPreprocessing())) {
       dit.del();
       modified = true;
     }
@@ -71,14 +71,14 @@ void TrivialPredicateRemover::scan(UnitList* units)
 {
   CALL("TrivialPredicateRemover::scan");
 
-  unsigned preds = env.signature->predicates();
+  unsigned preds = env->signature->predicates();
   _posOcc.init(preds, 0);
   _negOcc.init(preds, 0);
   _predClauses.ensure(preds);
 
 
   for(unsigned i=0; i<preds; i++) {
-    if(env.signature->getPredicate(i)->protectedSymbol()) {
+    if(env->signature->getPredicate(i)->protectedSymbol()) {
       //we add a fictional positive and negative occurrence to protected
       //predicates, so that they are never considered trivial
       _posOcc[i]++;
@@ -122,12 +122,12 @@ void TrivialPredicateRemover::scan(UnitList* units)
       }
       _removed.insert(cl);
       count(cl, -1);
-      env.statistics->trivialPredicates++;
-      if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] ennf: Removed due to trivial predicate: " 
+      env->statistics->trivialPredicates++;
+      if (env->options->showPreprocessing()) {
+        env->beginOutput();
+        env->out() << "[PP] ennf: Removed due to trivial predicate: " 
                 << cl->toString() << std::endl;
-        env.endOutput();
+        env->endOutput();
       }      
     }
     while(_reachedZeroes.isNonEmpty()) {
@@ -151,7 +151,7 @@ void TrivialPredicateRemover::count(Clause* cl, int add)
 
   //1 - positive, -1 - negative, 0 - both occurrences
   VTHREAD_LOCAL static ArrayMap<int> predOccurrences;
-  predOccurrences.ensure(env.signature->predicates());
+  predOccurrences.ensure(env->signature->predicates());
   predOccurrences.reset();
 
   VTHREAD_LOCAL static Stack<unsigned> preds;

--- a/Shell/TrivialPredicateRemover.cpp
+++ b/Shell/TrivialPredicateRemover.cpp
@@ -150,11 +150,11 @@ void TrivialPredicateRemover::count(Clause* cl, int add)
   CALL("TrivialPredicateRemover::count");
 
   //1 - positive, -1 - negative, 0 - both occurrences
-  static ArrayMap<int> predOccurrences;
+  VTHREAD_LOCAL static ArrayMap<int> predOccurrences;
   predOccurrences.ensure(env.signature->predicates());
   predOccurrences.reset();
 
-  static Stack<unsigned> preds;
+  VTHREAD_LOCAL static Stack<unsigned> preds;
   preds.reset();
 
   Clause::Iterator it(*cl);

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -18,6 +18,9 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <iostream>
+#if VTHREADED
+#include <thread>
+#endif
 
 #include "Forwards.hpp"
 
@@ -116,6 +119,11 @@ ostream& addCommentSignForSZS(ostream& out)
   if (szsOutputMode()) {
     out << "% ";
     if (Lib::env.options && Lib::env.options->multicore() != 1) {
+      #if VTHREADED
+      if(Lib::env.options->mode() == Options::Mode::THREADED)
+        out << "(" << std::this_thread::get_id() << ")";
+      else
+      #endif
       out << "(" << getpid() << ")";
     }
   }

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #if VTHREADED
 #include <thread>
+#include "Saturation/PersistentGrounding.hpp"
 #endif
 
 #include "Forwards.hpp"
@@ -343,6 +344,11 @@ Problem* UIHelper::getInputProblem(const Options& opts)
 
   Problem* res = new Problem(units);
   res->setSMTLIBLogic(smtLibLogic);
+
+#if VTHREADED
+  if(env->options->persistentGrounding())
+    PersistentGrounding::instance();
+#endif
 
   env->statistics->phase=Statistics::UNKNOWN_PHASE;
   return res;

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -65,7 +65,7 @@ public:
    * A hacky global flag distinguishing the parent and the child in portfolio modes.
    * Currently affects how things are reported during timeout (see Timer.cpp)
    */
-  static bool portfolioParent;
+  VTHREAD_LOCAL static bool portfolioParent;
   /**
    * Hack not to output satisfiable status twice (we may output it earlier in
    * IGAlgorithm, before we start generating model)

--- a/Shell/VarManager.cpp
+++ b/Shell/VarManager.cpp
@@ -22,7 +22,7 @@ namespace Shell
 
 using namespace std;
 
-VarManager::VarFactory* VarManager::_fact = 0;
+VTHREAD_LOCAL VarManager::VarFactory* VarManager::_fact = 0;
 
 unsigned VarManager::getVarAlias(unsigned var)
 {

--- a/Shell/VarManager.hpp
+++ b/Shell/VarManager.hpp
@@ -39,7 +39,7 @@ public:
   static unsigned getVarAlias(unsigned var);
   static vstring getVarName(unsigned var);
 private:
-  static VarFactory* _fact;
+  VTHREAD_LOCAL static VarFactory* _fact;
 };
 
 }

--- a/Test/SyntaxSugar.hpp
+++ b/Test/SyntaxSugar.hpp
@@ -33,7 +33,7 @@ using SortType = TermList;
 
 #define __CLSR_RELATION(name, inter)                                                                          \
   auto name = [](TermWrapper lhs, TermWrapper rhs) -> Literal&  {                                             \
-    return *Literal::create2(env.signature->addInterpretedPredicate(inter, #name),                            \
+    return *Literal::create2(env->signature->addInterpretedPredicate(inter, #name),                            \
         true, lhs,rhs);                                                                                       \
   };                                                                                                          \
  
@@ -67,7 +67,7 @@ using SortType = TermList;
 #define __CLSR_FUN_INTERPRETED(arity, mul, INT, _MULTIPLY)                                                    \
     auto mul = [](__ARGS_DECL(TermWrapper, arity)) -> TermWrapper {                                           \
       return TermList(Term::create ## arity(                                                                  \
-            env.signature->addInterpretedFunction(Theory::Interpretation:: INT ## _MULTIPLY, #mul),           \
+            env->signature->addInterpretedFunction(Theory::Interpretation:: INT ## _MULTIPLY, #mul),           \
             __ARGS_EXPR(Type, arity))                                                                         \
           );                                                                                                  \
     };                                                                                                        \
@@ -89,8 +89,8 @@ using SortType = TermList;
     unsigned _functor;                                                                                        \
   public:                                                                                                     \
     __ ##  f ## __CLASS(SortType sort)                                                                        \
-     : _functor(env.signature->addFunction(#f, arity)) {                                                      \
-      env.signature->getFunction(_functor)->setType(OperatorType::getFunctionType({ __REPEAT(arity, sort) }, sort));    \
+     : _functor(env->signature->addFunction(#f, arity)) {                                                      \
+      env->signature->getFunction(_functor)->setType(OperatorType::getFunctionType({ __REPEAT(arity, sort) }, sort));    \
     }                                                                                                         \
     TermWrapper operator()(__ARGS_DECL(TermWrapper, arity)) {                                                 \
       return TermList(Term::create(_functor, {__ARGS_EXPR(TermWrapper, arity)}));                             \
@@ -104,8 +104,8 @@ using SortType = TermList;
     unsigned _functor;                                                                                        \
   public:                                                                                                     \
     __ ##  f ## __CLASS(SortType sort)                                                                        \
-     : _functor(env.signature->addPredicate(#f, arity)) {                                                     \
-      env.signature->getPredicate(_functor)->setType(OperatorType::getPredicateType({ __REPEAT(arity, sort) }));        \
+     : _functor(env->signature->addPredicate(#f, arity)) {                                                     \
+      env->signature->getPredicate(_functor)->setType(OperatorType::getPredicateType({ __REPEAT(arity, sort) }));        \
     }                                                                                                         \
     LiteralWrapper operator()(__ARGS_DECL(TermWrapper, arity)) {                                              \
       return Literal::create(_functor, true, {__ARGS_EXPR(TermWrapper, arity)});                              \
@@ -138,8 +138,8 @@ using SortType = TermList;
       operator TermList() {return _term;}                                                                     \
       TermList toTerm() {return _term;}                                                                       \
       static TermWrapper createConstant(const char* name, SortType sort) {                                    \
-        unsigned f = env.signature->addFunction(name,0);                                                      \
-        env.signature->getFunction(f)->setType(OperatorType::getFunctionType({},sort));                       \
+        unsigned f = env->signature->addFunction(name,0);                                                      \
+        env->signature->getFunction(f)->setType(OperatorType::getFunctionType({},sort));                       \
         return TermWrapper(TermList(Term::createConstant(f)));                                                \
       }                                                                                                       \
       __VA_ARGS__                                                                                             \

--- a/UnitTests/tDisagreement.cpp
+++ b/UnitTests/tDisagreement.cpp
@@ -26,7 +26,7 @@ using namespace Kernel;
 TEST_FUN(dis1)
 {
 
-  unsigned p = env.signature->addFunction("p",1);
+  unsigned p = env->signature->addFunction("p",1);
   TermList x(0,false);
   TermList y(1,false);
   Term* px = Term::create1(p,x);

--- a/UnitTests/tKBO.cpp
+++ b/UnitTests/tKBO.cpp
@@ -23,21 +23,21 @@
 //////////////////////////////////////////////////////////////////////////////// 
 
 DArray<int> funcPrec() {
-  unsigned num = env.signature->functions();
+  unsigned num = env->signature->functions();
   DArray<int> out(num);
   out.initFromIterator(getRangeIterator(0u, num));
   return out;
 }
 
 DArray<int> predPrec() {
-  unsigned num = env.signature->predicates();
+  unsigned num = env->signature->predicates();
   DArray<int> out(num);
   out.initFromIterator(getRangeIterator(0u, num));
   return out;
 }
 
 DArray<int> predLevels() {
-  DArray<int> out(env.signature->predicates());
+  DArray<int> out(env->signature->predicates());
   out.init(out.size(), 1);
   return out;
 }
@@ -71,12 +71,12 @@ KBO kbo(unsigned introducedSymbolWeight,
           ._numInt  = variableWeight,
           ._numRat  = variableWeight,
           ._numReal = variableWeight,
-        }, funcs, env.signature->functions()), 
+        }, funcs, env->signature->functions()), 
 #if __KBO__CUSTOM_PREDICATE_WEIGHTS__
              toWeightMap<PredSigTraits>(introducedSymbolWeight,
                KboSpecialWeights<PredSigTraits>::dflt(), 
                preds,
-               env.signature->predicates()), 
+               env->signature->predicates()), 
 #endif
              funcPrec(), 
              predPrec(), 

--- a/UnitTests/tSATSolver.cpp
+++ b/UnitTests/tSATSolver.cpp
@@ -105,7 +105,7 @@ void testZICert1(SATSolverWithAssumptions& s)
 
 TEST_FUN(satSolverZeroImpliedCert)
 {
-  MinisatInterfacing s(*env.options,true);
+  MinisatInterfacing s(*env->options,true);
   testZICert1(s);
 }
 */
@@ -138,7 +138,7 @@ void testProofWithAssumptions(SATSolver& s)
 
 TEST_FUN(testProofWithAssums)
 {
-  MinisatInterfacing s(*env.options,true);
+  MinisatInterfacing s(*env->options,true);
   testProofWithAssumptions(s);    
 }
 
@@ -229,14 +229,14 @@ void testInterface(SATSolverWithAssumptions &s) {
 TEST_FUN(testSATSolverInterface)
 { 
   cout << endl << "Minisat" << endl;  
-  MinisatInterfacing sMini(*env.options,true);
+  MinisatInterfacing sMini(*env->options,true);
   testInterface(sMini);
     
   /* Not fully conforming - does not support zeroImplied and resource-limited solving
   cout << endl << "Z3" << endl;
   {
     SAT2FO sat2fo;
-    Z3Interfacing sZ3(*env.options,sat2fo);
+    Z3Interfacing sZ3(*env->options,sat2fo);
     testInterface(sZ3);
   }
   */
@@ -289,13 +289,13 @@ void testAssumptions(SATSolverWithAssumptions &s) {
 TEST_FUN(testSolvingUnderAssumptions)
 {
   cout << endl << "Minisat" << endl;
-  MinisatInterfacing sMini(*env.options,true);
+  MinisatInterfacing sMini(*env->options,true);
   testAssumptions(sMini);
 
   /*cout << endl << "Z3" << endl;
   {
     SAT2FO sat2fo;
-    Z3Interfacing sZ3(*env.options,sat2fo,true);
+    Z3Interfacing sZ3(*env->options,sat2fo,true);
     testAssumptions(sZ3);
   }*/
 }

--- a/UnitTests/tTwoVampires.cpp
+++ b/UnitTests/tTwoVampires.cpp
@@ -50,11 +50,11 @@ void runChild(UnitList* units, vstring slice)
   
   int resultValue=1;
   try {    
-    env.timer->reset();
-    env.timer->start();
+    env->timer->reset();
+    env->timer->start();
     TimeCounter::reinitialize();
 
-    env.options->readFromEncodedOptions(slice);
+    env->options->readFromEncodedOptions(slice);
 
     //To make sure the outputs of the two child Vampires don't interfere,
     //the pipe allows only one process at a time to possess the output for
@@ -62,37 +62,37 @@ void runChild(UnitList* units, vstring slice)
 
     //However, not to block other processes from running, we claim the output
     //only when we actually need it -- this we announce it by calling the
-    //functions env.beginOutput() and env.endOutput().
+    //functions env->beginOutput() and env->endOutput().
 
     //As outputs can happen all over the Vampire, every (non-debugging) output
     //is now encapsulated by a call to these two functions.
 
-    //Also, to allow easy switching between cout and the pipe, the env.out
-    //member has now become a function env.out().
-    env.beginOutput();
-    env.out()<<env.options->testId()<<" on "<<env.options->problemName()<<endl;
-    env.endOutput();
+    //Also, to allow easy switching between cout and the pipe, the env->out
+    //member has now become a function env->out().
+    env->beginOutput();
+    env->out()<<env->options->testId()<<" on "<<env->options->problemName()<<endl;
+    env->endOutput();
 
     Problem prob(units);
-    ProvingHelper::runVampire(prob, *env.options);
+    ProvingHelper::runVampire(prob, *env->options);
 
     //set return value to zero if we were successful
-    if(env.statistics->terminationReason==Statistics::REFUTATION) {
+    if(env->statistics->terminationReason==Statistics::REFUTATION) {
       resultValue=0;
     }
 
-    env.beginOutput();
-    UIHelper::outputResult(env.out());
-    env.endOutput();
+    env->beginOutput();
+    UIHelper::outputResult(env->out());
+    env->endOutput();
   } 
   catch (Exception& exception) {        
-    env.beginOutput();
-    exception.cry(env.out());
-    env.endOutput();
+    env->beginOutput();
+    exception.cry(env->out());
+    env->endOutput();
   } catch (std::bad_alloc& _) {    
-    env.beginOutput();
-    env.out() << "Insufficient system memory" << '\n';
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "Insufficient system memory" << '\n';
+    env->endOutput();
   }
   
   
@@ -121,7 +121,7 @@ TEST_FUN(two_vampires1)
   if(!child1) {
     //we're in child1
     childOutputPipe.neverRead(); //we won't be reading from the pipe in children
-    env.setPipeOutput(&childOutputPipe); //direct output into the pipe
+    env->setPipeOutput(&childOutputPipe); //direct output into the pipe
       runChild(units, "dis+10_32_nwc=2.0:sac=on:spl=backtracking_20"); //start proving
   }
 
@@ -130,7 +130,7 @@ TEST_FUN(two_vampires1)
   if(!child2) {
     //we're in child2
     childOutputPipe.neverRead();
-    env.setPipeOutput(&childOutputPipe);
+    env->setPipeOutput(&childOutputPipe);
     runChild(units, "dis+4_8_30");
   }
 

--- a/UnitTests/tUnificationWithAbstraction.cpp
+++ b/UnitTests/tUnificationWithAbstraction.cpp
@@ -37,7 +37,7 @@ using SortType = TermList;
 
 TermList number(vstring n)
 {
-  return TermList(Term::create(env.signature->addIntegerConstant(n,false),0,0));
+  return TermList(Term::create(env->signature->addIntegerConstant(n,false),0,0));
 }
 TermList var(unsigned i)
 {
@@ -46,9 +46,9 @@ TermList var(unsigned i)
 unsigned function_symbol(vstring name,unsigned arity,SortType srt)
 {
   bool added;
-  unsigned f = env.signature->addFunction(name,arity,added);
+  unsigned f = env->signature->addFunction(name,arity,added);
   if(added){
-    Signature::Symbol* symbol = env.signature->getFunction(f);
+    Signature::Symbol* symbol = env->signature->getFunction(f);
     OperatorType* ot = OperatorType::getFunctionTypeUniformRange(arity,srt,srt);
     symbol->setType(ot); 
   }
@@ -66,7 +66,7 @@ TermList int_constant(vstring name)
 }
 TermList binary(Interpretation fun, TermList n1, TermList n2)
 {
-  return TermList(Term::create2(env.signature->getInterpretingSymbol(fun),n1,n2));
+  return TermList(Term::create2(env->signature->getInterpretingSymbol(fun),n1,n2));
 }
 TermList int_plus(TermList n1, TermList n2)
 {
@@ -84,9 +84,9 @@ Literal* equals(TermList t1, TermList t2)
 Literal* pred(vstring p, TermList t, SortType srt)
 {
   bool added;
-  unsigned ps = env.signature->addPredicate(p,1,added);
+  unsigned ps = env->signature->addPredicate(p,1,added);
   if(added){
-    Signature::Symbol* symbol = env.signature->getPredicate(ps);
+    Signature::Symbol* symbol = env->signature->getPredicate(ps);
     OperatorType* ot = OperatorType::getPredicateTypeUniformRange(1,srt);
     symbol->setType(ot);
   }
@@ -155,7 +155,7 @@ void reportMatches(LiteralIndexingStructure* index, Literal* qlit)
 // This test demonstrates the current issue. The constraints produced depend on
 TEST_FUN(current_issue)
 {
-  env.options->setUWA(Options::UnificationWithAbstraction::ALL); 
+  env->options->setUWA(Options::UnificationWithAbstraction::ALL); 
 
   LiteralIndexingStructure* index = getBasicIndex();
 
@@ -227,7 +227,7 @@ void reportRobUnify(TermList a, TermList b)
 
 TEST_FUN(using_robsub)
 {
-  env.options->setUWA(Options::UnificationWithAbstraction::ALL);
+  env->options->setUWA(Options::UnificationWithAbstraction::ALL);
 
   TermList b_plus_two = int_plus(int_constant("b"),number("2"));
   TermList one_plus_a = int_plus(number("1"),int_constant("a"));
@@ -241,7 +241,7 @@ TEST_FUN(using_robsub)
 
 TEST_FUN(complex_case)
 {
-  env.options->setUWA(Options::UnificationWithAbstraction::ALL);
+  env->options->setUWA(Options::UnificationWithAbstraction::ALL);
 
   // The complex case is where we have a variable that needs to be instantiated elsewhere
   // e.g. unifying f(f(g(X),X),f(Y,a)) with f(f(1,2),(3,g(Z)))

--- a/test_vapi.cpp
+++ b/test_vapi.cpp
@@ -119,7 +119,7 @@ void inlineTest(const char* fname)
 
 void assymmetricRewriteTest(const char* fname)
 {
-  Lib::env.options->set("protected_prefix","aaa__");
+  Lib::env->options->set("protected_prefix","aaa__");
 
   ifstream fs(fname);
   Problem p;
@@ -260,8 +260,8 @@ void readAndFilterGlobalOpts(Stack<char*>& args) {
       if(!Int::stringToUnsignedInt(memLimitStr, memLimit)) {
 	USER_ERROR("unsigned number expected as value of -m option");
       }
-      env.options->setMemoryLimit(memLimit);
-      Allocator::setMemoryLimit(env.options->memoryLimit()*1048576ul);
+      env->options->setMemoryLimit(memLimit);
+      Allocator::setMemoryLimit(env->options->memoryLimit()*1048576ul);
     }
     else {
       break;

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -892,13 +892,15 @@ int main(int argc, char* argv[])
       break;
 
     case Options::Mode::PORTFOLIO:
+#if VTHREADED
+    case Options::Mode::THREADED:
+#endif
       env.options->setIgnoreMissing(Options::IgnoreMissing::WARN);
 
       if (CASC::PortfolioMode::perform(1.0)) {
         vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
       }
       break;
-
     case Options::Mode::CASC_LTB: {
       bool learning = env.options->ltbLearning()!=Options::LTBLearning::OFF;
       try {

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -151,11 +151,11 @@ Problem* getPreprocessedProblem()
 {
   CALL("getPreprocessedProblem");
 
-  Problem* prb = UIHelper::getInputProblem(*env.options);
+  Problem* prb = UIHelper::getInputProblem(*env->options);
 
   TimeCounter tc2(TC_PREPROCESSING);
 
-  Shell::Preprocess prepro(*env.options);
+  Shell::Preprocess prepro(*env->options);
   //phases for preprocessing are being set inside the preprocess method
   prepro.preprocess(*prb);
   
@@ -167,45 +167,45 @@ Problem* getPreprocessedProblem()
 
 void explainException(Exception& exception)
 {
-  env.beginOutput();
-  exception.cry(env.out());
-  env.endOutput();
+  env->beginOutput();
+  exception.cry(env->out());
+  env->endOutput();
 } // explainException
 
 void getRandomStrategy()
 {
   CALL("getRandomStrategy()");
   // We might have set random_strategy sat
-  if(env.options->randomStrategy()==Options::RandomStrategy::OFF){
-    env.options->setRandomStrategy(Options::RandomStrategy::ON);
+  if(env->options->randomStrategy()==Options::RandomStrategy::OFF){
+    env->options->setRandomStrategy(Options::RandomStrategy::ON);
   }
 
   // One call to randomize before preprocessing (see Options)
-  env.options->randomizeStrategy(0); 
+  env->options->randomizeStrategy(0); 
   ScopedPtr<Problem> prb(getPreprocessedProblem());
   // Then again when the property is here
-  env.options->randomizeStrategy(prb->getProperty()); 
+  env->options->randomizeStrategy(prb->getProperty()); 
 
   // It is possible that the random strategy is still incorrect as we don't
   // have access to the Property when setting preprocessing
-  env.options->checkProblemOptionConstraints(prb->getProperty());
+  env->options->checkProblemOptionConstraints(prb->getProperty());
 }
 
 void doProving()
 {
   CALL("doProving()");
   // One call to randomize before preprocessing (see Options)
-  env.options->randomizeStrategy(0);
+  env->options->randomizeStrategy(0);
 
   ScopedPtr<Problem> prb(getPreprocessedProblem());
 
   // Then again when the property is here (this will only randomize non-default things if an option is set to do so)
-  env.options->randomizeStrategy(prb->getProperty()); 
+  env->options->randomizeStrategy(prb->getProperty()); 
 
   // this will provide warning if options don't make sense for problem
-  //env.options->checkProblemOptionConstraints(prb->getProperty()); 
+  //env->options->checkProblemOptionConstraints(prb->getProperty()); 
 
-  ProvingHelper::runVampireSaturation(*prb, *env.options);
+  ProvingHelper::runVampireSaturation(*prb, *env->options);
 }
 
 /**
@@ -216,7 +216,7 @@ void profileMode()
 {
   CALL("profileMode()");
 
-  ScopedPtr<Problem> prb(UIHelper::getInputProblem(*env.options));
+  ScopedPtr<Problem> prb(UIHelper::getInputProblem(*env->options));
 
   /* CAREFUL: Make sure that the order
    * 1) getProperty, 2) normalise, 3) TheoryFinder::search
@@ -226,10 +226,10 @@ void profileMode()
   Normalisation().normalise(*prb);
   TheoryFinder(prb->units(), property).search();
 
-  env.beginOutput();
-  env.out() << property->categoryString() << ' ' << property->props() << ' '
+  env->beginOutput();
+  env->out() << property->categoryString() << ' ' << property->props() << ' '
 	  << property->atoms() << "\n";
-  env.endOutput();
+  env->endOutput();
 
   //we have succeeded with the profile mode, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -238,7 +238,7 @@ void profileMode()
 void outputResult(ostream& out) {
   CALL("outputResult");
 
-  switch(env.statistics->terminationReason) {
+  switch(env->statistics->terminationReason) {
   case Statistics::UNKNOWN:
     cout<<"unknown"<<endl;
     break;
@@ -248,7 +248,7 @@ void outputResult(ostream& out) {
   case Statistics::SATISFIABLE:
     cout<<"sat"<<endl;
 #if GNUMP
-    UIHelper::outputAssignment(*env.statistics->satisfyingAssigment, cout);
+    UIHelper::outputAssignment(*env->statistics->satisfyingAssigment, cout);
 #endif //GNUMP
     break;
   case Statistics::REFUTATION:
@@ -258,8 +258,8 @@ void outputResult(ostream& out) {
     //these outcomes are not reachable with the current implementation
     ASSERTION_VIOLATION;
   }
-  if(env.options->mode()!=Options::Mode::SPIDER){
-    env.statistics->print(env.out());
+  if(env->options->mode()!=Options::Mode::SPIDER){
+    env->statistics->print(env->out());
   }
 }
 
@@ -270,28 +270,28 @@ void boundPropagationMode(){
   CALL("boundPropagationMode::doSolving()");
 
   //adjust vampire options in order to serve the purpose of bound propagation
-  if ( env.options->proof() == env.options->PROOF_ON ) {
-    env.options->setProof(env.options->PROOF_OFF);
+  if ( env->options->proof() == env->options->PROOF_ON ) {
+    env->options->setProof(env->options->PROOF_OFF);
   }
 
   //this ensures the fact that int's read in smtlib file are treated as reals
-  env.options->setSmtlibConsiderIntsReal(true);
+  env->options->setSmtlibConsiderIntsReal(true);
 
-  if (env.options->bpStartWithPrecise()) {
+  if (env->options->bpStartWithPrecise()) {
 	  switchToPreciseNumbers();
   }
-  if (env.options->bpStartWithRational()){
+  if (env->options->bpStartWithRational()){
 	  switchToRationalNumbers();
   }
 
-  ConstraintRCList* constraints(UIHelper::getPreprocessedConstraints(*env.options));
+  ConstraintRCList* constraints(UIHelper::getPreprocessedConstraints(*env->options));
 
   start:
   try
   {
-    env.statistics->phase = Statistics::SOLVING;
+    env->statistics->phase = Statistics::SOLVING;
     TimeCounter tc(TC_SOLVING);
-    Solver solver(env.signature->vars(), *env.options, *env.statistics);
+    Solver solver(env->signature->vars(), *env->options, *env->statistics);
     solver.load(constraints);
     solver.solve();
   }
@@ -300,7 +300,7 @@ void boundPropagationMode(){
       INVALID_OPERATION("Imprecision error when using precise numbers.");
     }
     else {
-      env.statistics->switchToPreciseTimeInMs = env.timer->elapsedMilliseconds();
+      env->statistics->switchToPreciseTimeInMs = env->timer->elapsedMilliseconds();
       switchToPreciseNumbers();
       //switchToRationalNumbers();
       ASS(usingPreciseNumbers());
@@ -308,18 +308,18 @@ void boundPropagationMode(){
     }
   }
   catch (TimeLimitExceededException){
-      env.statistics->phase = Statistics::FINALIZATION;
-      env.statistics->terminationReason = Statistics::TIME_LIMIT;
+      env->statistics->phase = Statistics::FINALIZATION;
+      env->statistics->terminationReason = Statistics::TIME_LIMIT;
     }
-  env.statistics->phase = Statistics::FINALIZATION;
+  env->statistics->phase = Statistics::FINALIZATION;
 
 
-  env.beginOutput();
-  outputResult(env.out());
-  env.endOutput();
+  env->beginOutput();
+  outputResult(env->out());
+  env->endOutput();
 
-  if (env.statistics->terminationReason==Statistics::REFUTATION
-      || env.statistics->terminationReason==Statistics::SATISFIABLE) {
+  if (env->statistics->terminationReason==Statistics::REFUTATION
+      || env->statistics->terminationReason==Statistics::SATISFIABLE) {
     g_returnValue=0;
   }
 
@@ -347,14 +347,14 @@ void outputUnitToLaTeX(LaTeX& latex, ofstream& latexOut, Unit* u,unsigned index)
 void outputClausesToLaTeX(Problem* prb)
 {
   CALL("outputClausesToLaTeX");
-  ASS(env.options->latexOutput()!="off");
+  ASS(env->options->latexOutput()!="off");
 
   BYPASSING_ALLOCATOR; // not sure why we need this yet, ofstream?
 
   LaTeX latex;
-  ofstream latexOut(env.options->latexOutput().c_str());
+  ofstream latexOut(env->options->latexOutput().c_str());
   latexOut << latex.header() << endl;
-  latexOut << "\\section{Problem "<<env.options->problemName() << "}" << endl;
+  latexOut << "\\section{Problem "<<env->options->problemName() << "}" << endl;
   //TODO output more header
   latexOut << "\\[\n\\begin{array}{ll}" << endl;
 
@@ -382,20 +382,20 @@ void outputClausesToLaTeX(Problem* prb)
 void outputProblemToLaTeX(Problem* prb)
 {
   CALL("outputProblemToLaTeX");
-  ASS(env.options->latexOutput()!="off");
+  ASS(env->options->latexOutput()!="off");
 
   BYPASSING_ALLOCATOR; // not sure why we need this yet, ofstream?
 
   LaTeX latex;
-  ofstream latexOut(env.options->latexOutput().c_str());
+  ofstream latexOut(env->options->latexOutput().c_str());
   latexOut << latex.header() << endl;
-  latexOut << "\\section{Problem "<<env.options->problemName() << "}" << endl;
+  latexOut << "\\section{Problem "<<env->options->problemName() << "}" << endl;
   //TODO output more header
   latexOut << "\\[\n\\begin{array}{ll}" << endl;
 
   //TODO  get symbol and sort declarations into LaTeX
-  //UIHelper::outputSortDeclarations(env.out());
-  //UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(env->out());
+  //UIHelper::outputSymbolDeclarations(env->out());
 
   UnitList::Iterator units(prb->units());
 
@@ -423,26 +423,26 @@ void preprocessMode(bool theory)
 {
   CALL("preprocessMode()");
 
-  Problem* prb = UIHelper::getInputProblem(*env.options);
+  Problem* prb = UIHelper::getInputProblem(*env->options);
 
   TimeCounter tc2(TC_PREPROCESSING);
 
   // preprocess without clausification
-  Shell::Preprocess prepro(*env.options);
+  Shell::Preprocess prepro(*env->options);
   prepro.turnClausifierOff();
-  if(env.options->mode() == Options::Mode::PREPROCESS2){
+  if(env->options->mode() == Options::Mode::PREPROCESS2){
     prepro.keepSimplifyStep();
   }
   prepro.preprocess(*prb);
 
-  env.beginOutput();
+  env->beginOutput();
   //outputSymbolDeclarations also deals with sorts for now
-  //UIHelper::outputSortDeclarations(env.out());
-  UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(env->out());
+  UIHelper::outputSymbolDeclarations(env->out());
   UnitList::Iterator units(prb->units());
   while (units.hasNext()) {
     Unit* u = units.next();
-    if (!env.options->showFOOL()) {
+    if (!env->options->showFOOL()) {
       if (u->inference().rule() == InferenceRule::FOOL_AXIOM_TRUE_NEQ_FALSE || u->inference().rule() == InferenceRule::FOOL_AXIOM_ALL_IS_TRUE_OR_FALSE) {
         continue;
       }
@@ -457,14 +457,14 @@ void preprocessMode(bool theory)
       }
 
       FormulaUnit* fu = new FormulaUnit(f,u->inference()); // we are stealing u's inference which is not nice
-      env.out() << TPTPPrinter::toString(fu) << "\n";
+      env->out() << TPTPPrinter::toString(fu) << "\n";
     } else {
-      env.out() << TPTPPrinter::toString(u) << "\n";
+      env->out() << TPTPPrinter::toString(u) << "\n";
     }
   }
-  env.endOutput();
+  env->endOutput();
 
-  if(env.options->latexOutput()!="off"){ outputProblemToLaTeX(prb); }
+  if(env->options->latexOutput()!="off"){ outputProblemToLaTeX(prb); }
 
   //we have successfully output all clauses, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -479,10 +479,10 @@ void modelCheckMode()
 {
   CALL("modelCheckMode");
 
-  env.options->setOutputAxiomNames(true);
-  Problem* prb = UIHelper::getInputProblem(*env.options);
+  env->options->setOutputAxiomNames(true);
+  Problem* prb = UIHelper::getInputProblem(*env->options);
 
-  if(env.statistics->polymorphic || env.statistics->higherOrder){
+  if(env->statistics->polymorphic || env->statistics->higherOrder){
     USER_ERROR("Polymorphic Vampire is not yet compatible with theory reasoning");
   }
 
@@ -501,21 +501,21 @@ void outputMode()
 {
   CALL("outputMode()");
 
-  Problem* prb = UIHelper::getInputProblem(*env.options);
+  Problem* prb = UIHelper::getInputProblem(*env->options);
 
-  env.beginOutput();
+  env->beginOutput();
   //outputSymbolDeclarations also deals with sorts for now
-  //UIHelper::outputSortDeclarations(env.out());
-  UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(env->out());
+  UIHelper::outputSymbolDeclarations(env->out());
   UnitList::Iterator units(prb->units());
 
   while (units.hasNext()) {
     Unit* u = units.next();
-    env.out() << TPTPPrinter::toString(u) << "\n";
+    env->out() << TPTPPrinter::toString(u) << "\n";
   }
-  env.endOutput();
+  env->endOutput();
 
-  if(env.options->latexOutput()!="off"){ outputProblemToLaTeX(prb); }
+  if(env->options->latexOutput()!="off"){ outputProblemToLaTeX(prb); }
 
   //we have successfully output all clauses, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -525,18 +525,18 @@ void vampireMode()
 {
   CALL("vampireMode()");
 
-  if (env.options->mode() == Options::Mode::CONSEQUENCE_ELIMINATION) {
-    env.options->setUnusedPredicateDefinitionRemoval(false);
+  if (env->options->mode() == Options::Mode::CONSEQUENCE_ELIMINATION) {
+    env->options->setUnusedPredicateDefinitionRemoval(false);
   }
 
   doProving();
 
-  env.beginOutput();
-  UIHelper::outputResult(env.out());
-  env.endOutput();
+  env->beginOutput();
+  UIHelper::outputResult(env->out());
+  env->endOutput();
 
-  if (env.statistics->terminationReason == Statistics::REFUTATION
-      || env.statistics->terminationReason == Statistics::SATISFIABLE) {
+  if (env->statistics->terminationReason == Statistics::REFUTATION
+      || env->statistics->terminationReason == Statistics::SATISFIABLE) {
       vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
   }
 } // vampireMode
@@ -544,8 +544,8 @@ void vampireMode()
 void spiderMode()
 {
   CALL("spiderMode()");
-  env.options->setBadOptionChoice(Options::BadOption::HARD);
-  env.options->setOutputMode(Options::Output::SPIDER);
+  env->options->setBadOptionChoice(Options::BadOption::HARD);
+  env->options->setOutputMode(Options::Output::SPIDER);
   Exception* exception = 0;
 #if VZ3
   z3::exception* z3_exception = 0;
@@ -565,9 +565,9 @@ void spiderMode()
     noException = false;
   }
 
-  env.beginOutput();
+  env->beginOutput();
   if (noException) {
-    switch (env.statistics->terminationReason) {
+    switch (env->statistics->terminationReason) {
     case Statistics::REFUTATION:
       reportSpiderStatus('+');
       vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -580,7 +580,7 @@ void spiderMode()
     case Statistics::INAPPROPRIATE:
       reportSpiderStatus('u');
     case Statistics::REFUTATION_NOT_FOUND:
-      if(env.statistics->discardedNonRedundantClauses>0){
+      if(env->statistics->discardedNonRedundantClauses>0){
         reportSpiderStatus('n');
       }
       else{
@@ -594,7 +594,7 @@ void spiderMode()
     default:
       ASSERTION_VIOLATION;
     }
-    // env.statistics->print(env.out());
+    // env->statistics->print(env->out());
   } else {
 #if VZ3
     if(z3_exception){
@@ -613,7 +613,7 @@ void spiderMode()
 #endif
     vampireReturnValue = VAMP_RESULT_STATUS_UNHANDLED_EXCEPTION;
   }
-  env.endOutput();
+  env->endOutput();
 } // spiderMode
 
 void clausifyMode(bool theory)
@@ -627,10 +627,10 @@ void clausifyMode(bool theory)
 
   ScopedPtr<Problem> prb(getPreprocessedProblem());
 
-  env.beginOutput();
+  env->beginOutput();
   //outputSymbolDeclarations deals with sorts as well for now
-  //UIHelper::outputSortDeclarations(env.out());
-  UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(env->out());
+  UIHelper::outputSymbolDeclarations(env->out());
 
   ClauseIterator cit = prb->clauseIterator();
   bool printed_conjecture = false;
@@ -650,21 +650,21 @@ void clausifyMode(bool theory)
       }
 
       FormulaUnit* fu = new FormulaUnit(f,cl->inference()); // we are stealing cl's inference, which is not nice!
-      env.out() << TPTPPrinter::toString(fu) << "\n";
+      env->out() << TPTPPrinter::toString(fu) << "\n";
     } else {
-      env.out() << TPTPPrinter::toString(cl) << "\n";
+      env->out() << TPTPPrinter::toString(cl) << "\n";
     }
   }
   if(!printed_conjecture && UIHelper::haveConjecture()){
-    unsigned p = env.signature->addFreshPredicate(0,"p");
+    unsigned p = env->signature->addFreshPredicate(0,"p");
     Clause* c = new(2) Clause(2,NonspecificInference0(UnitInputType::NEGATED_CONJECTURE,InferenceRule::INPUT));
     (*c)[0] = Literal::create(p,0,true,false,0);
     (*c)[1] = Literal::create(p,0,false,false,0);
-    env.out() << TPTPPrinter::toString(c) << "\n";
+    env->out() << TPTPPrinter::toString(c) << "\n";
   }
-  env.endOutput();
+  env->endOutput();
 
-  if (env.options->latexOutput() != "off") { outputClausesToLaTeX(prb.ptr()); }
+  if (env->options->latexOutput() != "off") { outputClausesToLaTeX(prb.ptr()); }
 
   //we have successfully output all clauses, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -674,33 +674,33 @@ void axiomSelectionMode()
 {
   CALL("axiomSelectionMode()");
 
-  env.options->setSineSelection(Options::SineSelection::AXIOMS);
+  env->options->setSineSelection(Options::SineSelection::AXIOMS);
 
-  ScopedPtr<Problem> prb(UIHelper::getInputProblem(*env.options));
+  ScopedPtr<Problem> prb(UIHelper::getInputProblem(*env->options));
 
   if (prb->hasFOOL()) {
     FOOLElimination().apply(*prb);
   }
 
   // reorder units
-  if (env.options->normalize()) {
-    env.statistics->phase = Statistics::NORMALIZATION;
+  if (env->options->normalize()) {
+    env->statistics->phase = Statistics::NORMALIZATION;
     Normalisation norm;
     norm.normalise(*prb);
   }
 
-  env.statistics->phase = Statistics::SINE_SELECTION;
-  SineSelector(*env.options).perform(*prb);
+  env->statistics->phase = Statistics::SINE_SELECTION;
+  SineSelector(*env->options).perform(*prb);
 
-  env.statistics->phase = Statistics::FINALIZATION;
+  env->statistics->phase = Statistics::FINALIZATION;
 
   UnitList::Iterator uit(prb->units());
-  env.beginOutput();
+  env->beginOutput();
   while (uit.hasNext()) {
     Unit* u = uit.next();
-    env.out() << TPTPPrinter::toString(u) << "\n";
+    env->out() << TPTPPrinter::toString(u) << "\n";
   }
-  env.endOutput();
+  env->endOutput();
 
   //we have successfully output the selected units, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -711,9 +711,9 @@ void groundingMode()
   CALL("groundingMode()");
 
   try {
-    ScopedPtr<Problem> prb(UIHelper::getInputProblem(*env.options));
+    ScopedPtr<Problem> prb(UIHelper::getInputProblem(*env->options));
 
-    Shell::Preprocess prepro(*env.options);
+    Shell::Preprocess prepro(*env->options);
     prepro.preprocess(*prb);
 
     ClauseIterator clauses = prb->clauseIterator();
@@ -740,18 +740,18 @@ void groundingMode()
       }
       insts.pushManyToKey(cl, sGrounded);
     }
-    env.beginOutput();
-    DIMACS::outputGroundedProblem(insts, nameCtx, env.out());
-    env.endOutput();
+    env->beginOutput();
+    DIMACS::outputGroundedProblem(insts, nameCtx, env->out());
+    env->endOutput();
 
   } catch (MemoryLimitExceededException&) {
-    env.beginOutput();
-    env.out() << "Memory limit exceeded\n";
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "Memory limit exceeded\n";
+    env->endOutput();
   } catch (TimeLimitExceededException&) {
-    env.beginOutput();
-    env.out() << "Time limit exceeded\n";
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "Time limit exceeded\n";
+    env->endOutput();
   }
 } // groundingMode
 
@@ -775,27 +775,27 @@ int main(int argc, char* argv[])
   try {
     // read the command line and interpret it
     Shell::CommandLine cl(argc, argv);
-    cl.interpret(*env.options);
+    cl.interpret(*env->options);
 
     // If any of these options are set then we just need to output and exit
-    if (env.options->showHelp() ||
-        env.options->showOptions() ||
-        env.options->showExperimentalOptions() ||
-        !env.options->explainOption().empty() ||
-        env.options->printAllTheoryAxioms()) {
-      env.beginOutput();
-      env.options->output(env.out());
-      env.endOutput();
+    if (env->options->showHelp() ||
+        env->options->showOptions() ||
+        env->options->showExperimentalOptions() ||
+        !env->options->explainOption().empty() ||
+        env->options->printAllTheoryAxioms()) {
+      env->beginOutput();
+      env->options->output(env->out());
+      env->endOutput();
       exit(0);
     }
 
     //having read option reinitialize the counter
     TimeCounter::reinitialize();
 
-    Allocator::setMemoryLimit(env.options->memoryLimit() * 1048576ul);
-    Lib::Random::setSeed(env.options->randomSeed());
+    Allocator::setMemoryLimit(env->options->memoryLimit() * 1048576ul);
+    Lib::Random::setSeed(env->options->randomSeed());
 
-    switch (env.options->mode())
+    switch (env->options->mode())
     {
     case Options::Mode::AXIOM_SELECTION:
       axiomSelectionMode();
@@ -824,13 +824,13 @@ int main(int argc, char* argv[])
       break;
 
     case Options::Mode::CASC:
-      env.options->setIgnoreMissing(Options::IgnoreMissing::WARN);
-      env.options->setSchedule(Options::Schedule::CASC);
-      env.options->setOutputMode(Options::Output::SZS);
-      env.options->setProof(Options::Proof::TPTP);
-      env.options->setOutputAxiomNames(true);
-      //env.options->setTimeLimitInSeconds(300);
-      env.options->setMemoryLimit(128000);
+      env->options->setIgnoreMissing(Options::IgnoreMissing::WARN);
+      env->options->setSchedule(Options::Schedule::CASC);
+      env->options->setOutputMode(Options::Output::SZS);
+      env->options->setProof(Options::Proof::TPTP);
+      env->options->setOutputAxiomNames(true);
+      //env->options->setTimeLimitInSeconds(300);
+      env->options->setMemoryLimit(128000);
 
       if (CASC::PortfolioMode::perform(1.30)) {
         vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -838,13 +838,13 @@ int main(int argc, char* argv[])
       break;
 
     case Options::Mode::CASC_HOL: {
-      env.options->setIgnoreMissing(Options::IgnoreMissing::WARN);
-      env.options->setSchedule(Options::Schedule::CASC_HOL_2020);
-      env.options->setOutputMode(Options::Output::SZS);
-      env.options->setProof(Options::Proof::TPTP);
-      env.options->setMulticore(0); // use all available cores
-      env.options->setOutputAxiomNames(true);
-      env.options->setMemoryLimit(128000);
+      env->options->setIgnoreMissing(Options::IgnoreMissing::WARN);
+      env->options->setSchedule(Options::Schedule::CASC_HOL_2020);
+      env->options->setOutputMode(Options::Output::SZS);
+      env->options->setProof(Options::Proof::TPTP);
+      env->options->setMulticore(0); // use all available cores
+      env->options->setOutputAxiomNames(true);
+      env->options->setMemoryLimit(128000);
 
       unsigned int nthreads = std::thread::hardware_concurrency();
       float slowness = 1.00 + (0.03 * nthreads);
@@ -855,13 +855,13 @@ int main(int argc, char* argv[])
       break;
     }
     case Options::Mode::CASC_SAT:
-      env.options->setIgnoreMissing(Options::IgnoreMissing::WARN);
-      env.options->setSchedule(Options::Schedule::CASC_SAT);
-      env.options->setOutputMode(Options::Output::SZS);
-      env.options->setProof(Options::Proof::TPTP);
-      env.options->setOutputAxiomNames(true);
-      //env.options->setTimeLimitInSeconds(300);
-      env.options->setMemoryLimit(128000);
+      env->options->setIgnoreMissing(Options::IgnoreMissing::WARN);
+      env->options->setSchedule(Options::Schedule::CASC_SAT);
+      env->options->setOutputMode(Options::Output::SZS);
+      env->options->setProof(Options::Proof::TPTP);
+      env->options->setOutputAxiomNames(true);
+      //env->options->setTimeLimitInSeconds(300);
+      env->options->setMemoryLimit(128000);
 
       if (CASC::PortfolioMode::perform(1.30)) {
         vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -869,19 +869,19 @@ int main(int argc, char* argv[])
       break;
 
     case Options::Mode::SMTCOMP:
-      env.options->setIgnoreMissing(Options::IgnoreMissing::OFF);
-      env.options->setInputSyntax(Options::InputSyntax::SMTLIB2);
-      env.options->setOutputMode(Options::Output::SMTCOMP);
-      env.options->setSchedule(Options::Schedule::SMTCOMP);
-      env.options->setProof(Options::Proof::OFF);
-      env.options->setMulticore(0); // use all available cores
-      env.options->setTimeLimitInSeconds(1800);
-      env.options->setMemoryLimit(128000);
-      env.options->setStatistics(Options::Statistics::NONE);
+      env->options->setIgnoreMissing(Options::IgnoreMissing::OFF);
+      env->options->setInputSyntax(Options::InputSyntax::SMTLIB2);
+      env->options->setOutputMode(Options::Output::SMTCOMP);
+      env->options->setSchedule(Options::Schedule::SMTCOMP);
+      env->options->setProof(Options::Proof::OFF);
+      env->options->setMulticore(0); // use all available cores
+      env->options->setTimeLimitInSeconds(1800);
+      env->options->setMemoryLimit(128000);
+      env->options->setStatistics(Options::Statistics::NONE);
 
       //TODO needed?
       // to prevent from terminating by time limit
-      env.options->setTimeLimitInSeconds(100000);
+      env->options->setTimeLimitInSeconds(100000);
 
       if (CASC::PortfolioMode::perform(1.3)){
         vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -895,14 +895,14 @@ int main(int argc, char* argv[])
 #if VTHREADED
     case Options::Mode::THREADED:
 #endif
-      env.options->setIgnoreMissing(Options::IgnoreMissing::WARN);
+      env->options->setIgnoreMissing(Options::IgnoreMissing::WARN);
 
       if (CASC::PortfolioMode::perform(1.0)) {
         vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
       }
       break;
     case Options::Mode::CASC_LTB: {
-      bool learning = env.options->ltbLearning()!=Options::LTBLearning::OFF;
+      bool learning = env->options->ltbLearning()!=Options::LTBLearning::OFF;
       try {
         if(learning){
           CASC::CLTBModeLearning::perform();
@@ -952,8 +952,8 @@ int main(int argc, char* argv[])
       USER_ERROR("Unsupported mode");
     }
 #if CHECK_LEAKS
-    delete env.signature;
-    env.signature = 0;
+    delete env->signature;
+    env->signature = 0;
 #endif
   }
 #if VZ3
@@ -986,21 +986,21 @@ catch (Parse::TPTP::ParseErrorException& exception) {
 #if CHECK_LEAKS
     MemoryLeak::cancelReport();
 #endif
-    env.beginOutput();
+    env->beginOutput();
     explainException(exception);
-    //env.statistics->print(env.out());
-    env.endOutput();
+    //env->statistics->print(env->out());
+    env->endOutput();
   } catch (std::bad_alloc& _) {
     vampireReturnValue = VAMP_RESULT_STATUS_UNHANDLED_EXCEPTION;
     reportSpiderFail();
 #if CHECK_LEAKS
     MemoryLeak::cancelReport();
 #endif
-    env.beginOutput();
-    env.out() << "Insufficient system memory" << '\n';
-    env.endOutput();
+    env->beginOutput();
+    env->out() << "Insufficient system memory" << '\n';
+    env->endOutput();
   }
-//   delete env.allocator;
+//   delete env->allocator;
 
   return vampireReturnValue;
 } // main

--- a/vltb.cpp
+++ b/vltb.cpp
@@ -92,7 +92,7 @@ ClauseIterator getProblemClauses()
   {
     TimeCounter tc1(TC_PARSING);
 
-    vstring inputFile = env.options->inputFile();
+    vstring inputFile = env->options->inputFile();
 
     istream* input;
     if(inputFile=="") {
@@ -104,8 +104,8 @@ ClauseIterator getProblemClauses()
       }
     }
 
-    env.statistics->phase=Statistics::PARSING;
-    if(env.options->inputSyntax()!=Options::IS_TPTP) {
+    env->statistics->phase=Statistics::PARSING;
+    if(env->options->inputSyntax()!=Options::IS_TPTP) {
       USER_ERROR("Unsupported input syntax");
     }
 
@@ -129,9 +129,9 @@ ClauseIterator getProblemClauses()
 
   TimeCounter tc2(TC_PREPROCESSING);
 
-  env.statistics->phase=Statistics::PROPERTY_SCANNING;
+  env->statistics->phase=Statistics::PROPERTY_SCANNING;
   property.scan(units);
-  Preprocess prepro(property,*env.options);
+  Preprocess prepro(property,*env->options);
   //phases for preprocessing are being set inside the proprocess method
   prepro.preprocess(units);
 
@@ -144,67 +144,67 @@ void outputResult()
 {
   CALL("outputResult()");
 
-  switch (env.statistics->terminationReason) {
+  switch (env->statistics->terminationReason) {
   case Statistics::REFUTATION:
-    env.out << "Refutation found. Thanks to "
-	    << env.options->thanks() << "!\n";
-    if (env.options->proof() != Options::PROOF_OFF) {
-//	Shell::Refutation refutation(env.statistics->refutation,
-//		env.options->proof() == Options::PROOF_ON);
-//	refutation.output(env.out);
-      InferenceStore::instance()->outputProof(env.out, env.statistics->refutation);
+    env->out << "Refutation found. Thanks to "
+	    << env->options->thanks() << "!\n";
+    if (env->options->proof() != Options::PROOF_OFF) {
+//	Shell::Refutation refutation(env->statistics->refutation,
+//		env->options->proof() == Options::PROOF_ON);
+//	refutation.output(env->out);
+      InferenceStore::instance()->outputProof(env->out, env->statistics->refutation);
     }
-    if(env.options->showInterpolant()!=Options::INTERP_OFF) {
-      ASS(env.statistics->refutation->isClause());
-      Formula* interpolant=Interpolants::getInterpolant(static_cast<Clause*>(env.statistics->refutation));
-      env.out << "Interpolant: " << interpolant->toString() << endl;
+    if(env->options->showInterpolant()!=Options::INTERP_OFF) {
+      ASS(env->statistics->refutation->isClause());
+      Formula* interpolant=Interpolants::getInterpolant(static_cast<Clause*>(env->statistics->refutation));
+      env->out << "Interpolant: " << interpolant->toString() << endl;
     }
-    if(env.options->latexOutput()!="off") {
-      ofstream latexOut(env.options->latexOutput().c_str());
+    if(env->options->latexOutput()!="off") {
+      ofstream latexOut(env->options->latexOutput().c_str());
 
       LaTeX formatter;
-      latexOut<<formatter.refutationToString(env.statistics->refutation);
+      latexOut<<formatter.refutationToString(env->statistics->refutation);
     }
     break;
   case Statistics::TIME_LIMIT:
-    env.out << "Time limit reached!\n";
+    env->out << "Time limit reached!\n";
     break;
   case Statistics::MEMORY_LIMIT:
 #if VDEBUG
     Allocator::reportUsageByClasses();
 #endif
-    env.out << "Memory limit exceeded!\n";
+    env->out << "Memory limit exceeded!\n";
     break;
   case Statistics::REFUTATION_NOT_FOUND:
-    if(env.options->complete()) {
-      ASS_EQ(env.options->saturationAlgorithm(), Options::LRS);
-      env.out << "Refutation not found, LRS age and weight limit was active for some time!\n";
+    if(env->options->complete()) {
+      ASS_EQ(env->options->saturationAlgorithm(), Options::LRS);
+      env->out << "Refutation not found, LRS age and weight limit was active for some time!\n";
     } else {
-      env.out << "Refutation not found with incomplete strategy!\n";
+      env->out << "Refutation not found with incomplete strategy!\n";
     }
     break;
   case Statistics::SATISFIABLE:
-    env.out << "Refutation not found!\n";
+    env->out << "Refutation not found!\n";
     break;
   case Statistics::UNKNOWN:
-    env.out << "Unknown reason of termination!\n";
+    env->out << "Unknown reason of termination!\n";
     break;
   default:
     ASSERTION_VIOLATION;
   }
-  env.statistics->print();
+  env->statistics->print();
 }
 
 void explainException (Exception& exception)
 {
-  exception.cry(env.out);
+  exception.cry(env->out);
 } // explainException
 
 void ltbBuildMode()
 {
   CALL("ltbBuildMode");
 
-  vstring inputFile = env.options->inputFile();
+  vstring inputFile = env->options->inputFile();
 
   istream* input0;
   if(inputFile=="") {
@@ -243,31 +243,31 @@ void ltbSolveMode()
 {
   CALL("ltbSolveMode");
 
-  env.beginOutput();
-  env.out()<<env.options->testId()<<" on "<<env.options->problemName()<<endl;
-  env.endOutput();
+  env->beginOutput();
+  env->out()<<env->options->testId()<<" on "<<env->options->problemName()<<endl;
+  env->endOutput();
   try {
     ClauseIterator clauses=getProblemClauses();
     Unit::onPreprocessingEnd();
 
-    env.statistics->phase=Statistics::SATURATION;
+    env->statistics->phase=Statistics::SATURATION;
     MainLoopSP salg=MainLoop::createFromOptions();
     salg->addInputClauses(clauses);
 
     MainLoopResult sres(salg->saturate());
-    env.statistics->phase=Statistics::FINALIZATION;
+    env->statistics->phase=Statistics::FINALIZATION;
     sres.updateStatistics();
   }
   catch(MemoryLimitExceededException) {
-    env.statistics->terminationReason=Statistics::MEMORY_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::MEMORY_LIMIT;
+    env->statistics->refutation=0;
     size_t limit=Allocator::getMemoryLimit();
     //add extra 1 MB to allow proper termination
     Allocator::setMemoryLimit(limit+1000000);
   }
   catch(TimeLimitExceededException) {
-    env.statistics->terminationReason=Statistics::TIME_LIMIT;
-    env.statistics->refutation=0;
+    env->statistics->terminationReason=Statistics::TIME_LIMIT;
+    env->statistics->refutation=0;
   }
   outputResult();
 }
@@ -289,12 +289,12 @@ int main(int argc, char* argv [])
   try {
     // read the command line and interpret it
     Shell::CommandLine cl(argc,argv);
-    cl.interpret(*env.options);
+    cl.interpret(*env->options);
 
-    Allocator::setMemoryLimit(env.options->memoryLimit()*1048576ul);
-    Lib::Random::setSeed(env.options->randomSeed());
+    Allocator::setMemoryLimit(env->options->memoryLimit()*1048576ul);
+    Lib::Random::setSeed(env->options->randomSeed());
 
-    switch (env.options->mode())
+    switch (env->options->mode())
     {
     case Options::MODE_LTB_BUILD:
       ltbBuildMode();
@@ -311,8 +311,8 @@ int main(int argc, char* argv [])
       MemoryLeak leak;
       leak.release(globUnitList);
     }
-    delete env.signature;
-    env.signature = 0;
+    delete env->signature;
+    env->signature = 0;
 #endif
   }
 #if VDEBUG
@@ -336,16 +336,16 @@ int main(int argc, char* argv [])
     MemoryLeak::cancelReport();
 #endif
     explainException(exception);
-    env.statistics->print();
+    env->statistics->print();
   }
   catch (std::bad_alloc& _) {
     reportSpiderFail();
 #if CHECK_LEAKS
     MemoryLeak::cancelReport();
 #endif
-    env.out << "Insufficient system memory" << '\n';
+    env->out << "Insufficient system memory" << '\n';
   }
-//   delete env.allocator;
+//   delete env->allocator;
 
   return EXIT_SUCCESS;
 } // main


### PR DESCRIPTION
The following provides an experimental `--mode threaded` which works in much the same way as the current process-based portfolio modes, but running in thread-parallel rather than process-parallel. For our purposes, threads are processes which share memory, allowing some powerful future techniques not implemented here, such as sharing SAT state between threads.

Generally this now almost-works, but there a number of bugs to work out. However, I want to get this work merged into master regularly to avoid the dreaded Merge, so all changes are safely guarded with a compile-time flag. _The behaviour of default-built Vampire should be identical post-merge._

Limitations/Bugs:
- definitely some bugs remaining, mostly data races in less-used parts of Vampire: not found any for a while though?
- neither the `SIGALRM` or the `getrusage` implementation of `Lib::Timer` plays nicely with threads: currently we use the less-broken `getrusage`, but at some point this needs fixing properly
  - this has now been "fixed" by (yet another) a new `Timer` implementation, which just uses `std::chrono` - this doesn't always exit on time (might be a few seconds late) but does work and counts accurately...
- when a thread succeeds, it acquires a global lock and then calls `exit()` to halt immediately, similar to the process-based version - this works, but is not very nice to the other threads
- signal handling is a bit broken somehow: `SIGINT` needs several attempts on Linux, for example - not quite sure how best to fix this
- some logic has to be changed when in threaded mode, e.g. caching ordering queries in terms doesn't work in the multi-threaded case

Most of the above can be fixed with lots of effort or more invasive changes, but I think it's probably best to get this merged and fix these later.

--------------------------

Summary of major changes:
- reshuffle some of the portfolio-mode stuff around, producing `ProcessScheduleExecutor` and `ThreadScheduleExecutor`
- compile-time flag `VTHREADED` for threaded Vampire builds: all of following is guarded by `VTHREADED`
- new option and supporting machinery for `--mode threaded`
- introduction of `VTHREAD_LOCAL`, `VATOMIC` macros, compiling to `thread_local`, `std::atomic` if `VTHREADED`, or no-op
- support for [ThreadSanitizer](https://clang.llvm.org/docs/ThreadSanitizer.html) in Vampire builds, associated `TSAN` compile-time flag
- copy `Options` and `Signature` (`Options` might be OK to share in future, `Signature` seems like it's designed for destructive modification)
- coarse-grained locks where required for `Allocator` and `Sharing`
- `static` can in most cases be fixed with a suitable `VTHREAD_LOCAL`
- `std::atomic`s for counters
- changes to program logic where absolutely necessary, guarded