### PR TITLE
SMT-LIB 2.6 new keywords

### DIFF
--- a/Kernel/Formula.hpp
+++ b/Kernel/Formula.hpp
@@ -328,7 +328,8 @@ class BoolTermFormula
       _ts(ts)
   {
     // only boolean terms in formula context are expected here
-    ASS_REP(ts.isVar() || ts.term()->isITE() || ts.term()->isLet() || ts.term()->isTupleLet() || 
+    ASS_REP(ts.isVar() || ts.term()->isITE() || ts.term()->isLet() ||
+            ts.term()->isTupleLet() || ts.term()->isMatch() ||
             SortHelper::getResultSort(ts.term()) == Term::boolSort(), ts.toString());
   }
 

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -126,6 +126,14 @@ TermList FormulaTransformer::apply(TermList ts) {
       case Term::SF_TUPLE:
         return TermList(Term::createTuple(apply(TermList(sd->getTupleTerm())).term()));
 
+      case Term::SF_MATCH: {
+        DArray<TermList> terms(term->arity());
+        for (unsigned i = 0; i < term->arity(); i++) {
+          terms[i] = apply(*term->nthArgument(i));
+        }
+        return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
+      }
+
       default:
         ASSERTION_VIOLATION_REP(ts.toString());
     }

--- a/Kernel/FormulaVarIterator.cpp
+++ b/Kernel/FormulaVarIterator.cpp
@@ -216,6 +216,15 @@ bool FormulaVarIterator::hasNext()
               _vars.push(sd->getLambdaVars());
               break;
             }
+
+            case Term::SF_MATCH: {
+              for (unsigned int i = 0; i < t->arity(); i++) {
+                _instructions.push(FVI_TERM_LIST);
+                _termLists.push(*t->nthArgument(i));
+              }
+              break;
+            }
+
 #if VDEBUG
             default:
               ASSERTION_VIOLATION;

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -657,6 +657,8 @@ vstring Kernel::ruleName(InferenceRule rule)
     return "fool $ite elimination";
   case InferenceRule::FOOL_LET_ELIMINATION:
     return "fool $let elimination";
+  case InferenceRule::FOOL_MATCH_ELIMINATION:
+    return "fool $match elimination";
   case InferenceRule::FOOL_PARAMODULATION:
     return "fool paramodulation";
 //  case CHOICE_AXIOM:

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -393,6 +393,8 @@ enum class InferenceRule : unsigned char {
   FOOL_ITE_ELIMINATION,
   /** Elimination of $let expressions */
   FOOL_LET_ELIMINATION,
+  /** Elimination of $match expressions */
+  FOOL_MATCH_ELIMINATION,
   /** result of general splitting */
   GENERAL_SPLITTING,
   /** component introduced by general splitting */

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -690,6 +690,10 @@ void SortHelper::collectVariableSorts(TermList ts, TermList contextSort, DHMap<u
       collectVariableSorts(sd->getTupleTerm(), map);
       break;
 
+    case Term::SF_MATCH:
+      // args are handled below
+      break;
+
 #if VDEBUG
     default:
       ASSERTION_VIOLATION;

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -482,16 +482,16 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
 
             // there are two sorts here, one is the sort
             // of matched term and patterns, the other is
-            // the sort of the match block and of each case 
+            // the sort of the match block and of each case
             newTask.ts = *term->nthArgument(0);
             newTask.contextSort = matchedSort;
             todo.push(newTask);
-            for (unsigned int i = 1; i < term->arity(); i+=2) {
+            for (unsigned int i = 1; i < term->arity(); i += 2) {
               newTask.ts = *term->nthArgument(i);
               newTask.contextSort = matchedSort;
               todo.push(newTask);
 
-              newTask.ts = *term->nthArgument(i+1);
+              newTask.ts = *term->nthArgument(i + 1);
               newTask.contextSort = task.contextSort;
               todo.push(newTask);
             }

--- a/Kernel/SubformulaIterator.cpp
+++ b/Kernel/SubformulaIterator.cpp
@@ -216,6 +216,11 @@ bool SubformulaIterator::hasNext ()
             _reserve = new Element(tupleTerm, polarity, rest);
             break;
           }*/
+          case Term::SF_MATCH: {
+            delete _reserve;
+            _reserve = rest;
+            break;
+          }
 #if VDEBUG
           default:
             ASSERTION_VIOLATION;

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -317,6 +317,13 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
         );
     case Term::SF_TUPLE:
       return Term::createTuple(applyImpl<ProcessSpecVars>(sd->getTupleTerm(), applicator, noSharing));
+    case Term::SF_MATCH: {
+      DArray<TermList> terms(trm->arity());
+      for (unsigned i = 0; i < trm->arity(); i++) {
+        terms[i] = applyImpl<ProcessSpecVars>(*trm->nthArgument(i), applicator, noSharing);
+      }
+      return Term::createMatch(sd->getSort(), sd->getMatchedSort(), trm->arity(), terms.begin());
+    }
     }
     ASSERTION_VIOLATION;
   }

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1394,9 +1394,17 @@ bool Term::isBoolean() const {
         return false;
       case SF_ITE:
       case SF_LET:
-      case SF_LET_TUPLE:
-      case SF_MATCH: {
+      case SF_LET_TUPLE: {
         const TermList *ts = term->nthArgument(0);
+        if (!ts->isTerm()) {
+          return false;
+        } else {
+          term = ts->term();
+          break;
+        }
+      }
+      case SF_MATCH: {
+        const TermList *ts = term->nthArgument(2);
         if (!ts->isTerm()) {
           return false;
         } else {

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1130,11 +1130,11 @@ Term* Term::createTuple(Term* tupleTerm) {
   return s;
 }
 
-Term* Term::createMatch(TermList sort, TermList matchedSort, unsigned int arity, TermList* elements) {
+Term *Term::createMatch(TermList sort, TermList matchedSort, unsigned int arity, TermList *elements) {
   CALL("Term::createMatch");
-  Term* s = new(arity, sizeof(SpecialTermData)) Term;
+  Term *s = new (arity, sizeof(SpecialTermData)) Term;
   s->makeSymbol(SF_MATCH, arity);
-  TermList* ss = s->args();
+  TermList *ss = s->args();
   s->getSpecialData()->_matchData.sort = sort;
   s->getSpecialData()->_matchData.matchedSort = matchedSort;
 

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -564,6 +564,10 @@ vstring Term::headToString() const
         varList += "]";        
         return "(^" + varList + " : (" + lambdaExp.toString() + "))";
       }
+      case Term::SF_MATCH: {
+        // we simply let the arguments be written out
+        return "$match(";
+      }
       default:
         ASSERTION_VIOLATION;
     }
@@ -1126,6 +1130,24 @@ Term* Term::createTuple(Term* tupleTerm) {
   return s;
 }
 
+Term* Term::createMatch(TermList sort, TermList matchedSort, unsigned int arity, TermList* elements) {
+  CALL("Term::createMatch");
+  Term* s = new(arity, sizeof(SpecialTermData)) Term;
+  s->makeSymbol(SF_MATCH, arity);
+  TermList* ss = s->args();
+  s->getSpecialData()->_matchData.sort = sort;
+  s->getSpecialData()->_matchData.matchedSort = matchedSort;
+
+  for (unsigned i = 0; i < arity; i++) {
+    ASS(!elements[i].isEmpty());
+    *ss = elements[i];
+    ss = ss->next();
+  }
+  ASS(ss->isEmpty());
+
+  return s;
+}
+
 /** Create a new complex term, copy from @b t its function symbol and arity.
  *  Initialize its arguments by a dummy special variable.
  */
@@ -1372,7 +1394,8 @@ bool Term::isBoolean() const {
         return false;
       case SF_ITE:
       case SF_LET:
-      case SF_LET_TUPLE: {
+      case SF_LET_TUPLE:
+      case SF_MATCH: {
         const TermList *ts = term->nthArgument(0);
         if (!ts->isTerm()) {
           return false;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -230,7 +230,8 @@ public:
   static const unsigned SF_TUPLE = 0xFFFFFFFC;
   static const unsigned SF_LET_TUPLE = 0xFFFFFFFB;
   static const unsigned SF_LAMBDA = 0xFFFFFFFA;
-  static const unsigned SPECIAL_FUNCTOR_LOWER_BOUND = 0xFFFFFFFA;
+  static const unsigned SF_MATCH = 0xFFFFFFF9;
+  static const unsigned SPECIAL_FUNCTOR_LOWER_BOUND = 0xFFFFFFF9;
 
   class SpecialTermData
   {
@@ -270,6 +271,10 @@ public:
         TermList sort; 
         TermList expSort;//TODO is this needed?
       } _lambdaData;
+      struct {
+        TermList sort;
+        TermList matchedSort;
+      } _matchData;
     };
     /** Return pointer to the term to which this object is attached */
     const Term* getTerm() const { return reinterpret_cast<const Term*>(this+1); }
@@ -304,12 +309,15 @@ public:
           return _letTupleData.sort;
         case SF_LAMBDA:
           return _lambdaData.sort;
+        case SF_MATCH:
+          return _matchData.sort;
         default:
           ASSERTION_VIOLATION_REP(getType());
       }
     }
     Formula* getFormula() const { ASS_EQ(getType(), SF_FORMULA); return _formulaData.formula; }
     Term* getTupleTerm() const { return _tupleData.term; }
+    TermList getMatchedSort() const { return _matchData.matchedSort; }
   };
 
 
@@ -333,6 +341,7 @@ public:
   static Term* createFormula(Formula* formula);
   static Term* createTuple(unsigned arity, TermList* sorts, TermList* elements);
   static Term* createTuple(Term* tupleTerm);
+  static Term* createMatch(TermList sort, TermList matchedSort, unsigned int arity, TermList* elements);
   static Term* create1(unsigned fn, TermList arg);
   static Term* create2(unsigned fn, TermList arg1, TermList arg2);
 
@@ -608,6 +617,7 @@ public:
   bool isTuple() const { return functor() == SF_TUPLE; }
   bool isFormula() const { return functor() == SF_FORMULA; }
   bool isLambda() const { return functor() == SF_LAMBDA; }
+  bool isMatch() const { return functor() == SF_MATCH; }
   bool isBoolean() const;
   bool isSuper() const; 
   

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -197,6 +197,21 @@ Term* TermTransformer::transformSpecial(Term* term)
       }
     }
 
+    case Term::SF_MATCH: {
+      DArray<TermList> terms(term->arity());
+      bool unchanged = true;
+      for (unsigned i = 0; i < term->arity(); i++) {
+        TermList subterm = transform(*term->nthArgument(i));
+        unchanged = unchanged && (subterm == *term->nthArgument(i));
+        terms[i] = subterm;
+      }
+
+      if (unchanged) {
+        return term;
+      }
+      return Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin());
+    }
+
   }
   ASSERTION_VIOLATION_REP(term->toString()); 
   return nullptr;

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -201,9 +201,8 @@ Term* TermTransformer::transformSpecial(Term* term)
       DArray<TermList> terms(term->arity());
       bool unchanged = true;
       for (unsigned i = 0; i < term->arity(); i++) {
-        TermList subterm = transform(*term->nthArgument(i));
-        unchanged = unchanged && (subterm == *term->nthArgument(i));
-        terms[i] = subterm;
+        terms[i] = transform(*term->nthArgument(i));
+        unchanged = unchanged && (terms[i] == *term->nthArgument(i));
       }
 
       if (unchanged) {

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -165,8 +165,8 @@ void SMTLIB2::readBenchmark(LExprList* bench)
     // TODO(mhajdu): is it possible that codatatypes are
     // declared this way?
     if (ibRdr.tryAcceptAtom("declare-datatype")) {
-      LExpr* sort = ibRdr.readNext();
-      LExprList* datatype = ibRdr.readList();
+      LExpr *sort = ibRdr.readNext();
+      LExprList *datatype = ibRdr.readList();
 
       readDeclareDatatype(sort, datatype, false);
 
@@ -223,11 +223,11 @@ void SMTLIB2::readBenchmark(LExprList* bench)
 
     if (ibRdr.tryAcceptAtom("define-fun-rec")) {
       vstring name = ibRdr.readAtom();
-      LExprList* iArgs = ibRdr.readList();
-      LExpr* oSort = ibRdr.readNext();
-      LExpr* body = ibRdr.readNext();
+      LExprList *iArgs = ibRdr.readList();
+      LExpr *oSort = ibRdr.readNext();
+      LExpr *body = ibRdr.readNext();
 
-      readDefineFun(name,iArgs,oSort,body,true/*recursive*/);
+      readDefineFun(name, iArgs, oSort, body, true /*recursive*/);
 
       ibRdr.acceptEOL();
 
@@ -926,7 +926,7 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
 
   DeclaredFunction fun;
   if (recursive) {
-    fun = declareFunctionOrPredicate(name,rangeSort,argSorts);
+    fun = declareFunctionOrPredicate(name, rangeSort, argSorts);
   }
 
   ParseResult res = parseTermOrFormula(body);
@@ -939,7 +939,7 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
   }
 
   if (!recursive) {
-    fun = declareFunctionOrPredicate(name,rangeSort,argSorts);
+    fun = declareFunctionOrPredicate(name, rangeSort, argSorts);
   }
 
   unsigned symbIdx = fun.first;
@@ -960,17 +960,17 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
   UnitList::push(fu, _formulas);
 }
 
-void SMTLIB2::readDeclareDatatype(LExpr* sort, LExprList* datatype, bool codatatype)
+void SMTLIB2::readDeclareDatatype(LExpr *sort, LExprList *datatype, bool codatatype)
 {
   CALL("SMTLIB2::readDeclareDatatype");
 
   // first declare the sort
   vstring dtypeName = sort->str;
   if (isAlreadyKnownSortSymbol(dtypeName)) {
-    USER_ERROR("Redeclaring built-in, declared or defined sort symbol as datatype: "+dtypeName);
+    USER_ERROR("Redeclaring built-in, declared or defined sort symbol as datatype: " + dtypeName);
   }
   ALWAYS(_declaredSorts.insert(dtypeName, 0));
-  Stack<TermAlgebraConstructor*> constructors;
+  Stack<TermAlgebraConstructor *> constructors;
   TermStack argSorts;
   Stack<vstring> destructorNames;
 
@@ -993,9 +993,10 @@ void SMTLIB2::readDeclareDatatype(LExpr* sort, LExprList* datatype, bool codatat
       // atom, constructor of arity 0
       constrName = constr->str;
       if (constrName == "par") {
-        USER_ERROR("Datatype '"+dtypeName+"' is declared parametric which is unsupported");
+        USER_ERROR("Datatype '" + dtypeName + "' is declared parametric which is unsupported");
       }
-    } else {
+    }
+    else {
       ASS(constr->isList());
       LispListReader constrRdr(constr);
       constrName = constrRdr.readAtom();
@@ -1497,65 +1498,65 @@ void SMTLIB2::parseLetEnd(LExpr* exp)
   delete lookup;
 }
 
-static const char* UNDERSCORE = "_";
+static const char *UNDERSCORE = "_";
 
-bool SMTLIB2::isTermAlgebraConstructor(const vstring& name)
+bool SMTLIB2::isTermAlgebraConstructor(const vstring &name)
 {
   CALL("SMTLIB2::isTermAlgebraConstructor");
 
   if (_declaredFunctions.find(name)) {
-    DeclaredFunction& f = _declaredFunctions.get(name);
+    DeclaredFunction &f = _declaredFunctions.get(name);
     return (f.second && env.signature->getTermAlgebraConstructor(f.first));
   }
 
   return false;
 }
 
-void SMTLIB2::parseMatchBegin(LExpr* exp)
+void SMTLIB2::parseMatchBegin(LExpr *exp)
 {
   CALL("SMTLIB2::parseMatchBegin");
 
-  LOG2("parseMatchBegin  ",exp->toString());
+  LOG2("parseMatchBegin  ", exp->toString());
 
   ASS(exp->isList());
   LispListReader lRdr(exp->list);
 
   // the match atom
-  const vstring& theMatchAtom = lRdr.readAtom();
-  ASS_EQ(theMatchAtom,MATCH);
+  const vstring &theMatchAtom = lRdr.readAtom();
+  ASS_EQ(theMatchAtom, MATCH);
 
   // next is the matched term
   if (!lRdr.hasNext()) {
-    complainAboutArgShortageOrWrongSorts(MATCH,exp);
+    complainAboutArgShortageOrWrongSorts(MATCH, exp);
   }
-  LExpr* matchedAtom = lRdr.readNext();
+  LExpr *matchedAtom = lRdr.readNext();
 
   // and the list of cases
   if (!lRdr.hasNext()) {
-    complainAboutArgShortageOrWrongSorts(MATCH,exp);
+    complainAboutArgShortageOrWrongSorts(MATCH, exp);
   }
   LispListReader casesRdr(lRdr.readList());
 
   lRdr.acceptEOL();
 
-  _todo.push(make_pair(PO_MATCH_END,exp));
+  _todo.push(make_pair(PO_MATCH_END, exp));
   // this is the last thing we parse so that it pops
   // first when the result is created
-  _todo.push(make_pair(PO_PARSE,matchedAtom));
+  _todo.push(make_pair(PO_PARSE, matchedAtom));
 
   while (casesRdr.hasNext()) {
     LispListReader pRdr(casesRdr.readList());
 
     if (!pRdr.hasNext()) {
-      complainAboutArgShortageOrWrongSorts(MATCH,exp);
+      complainAboutArgShortageOrWrongSorts(MATCH, exp);
     }
-    LExpr* pattern = pRdr.readNext();
+    LExpr *pattern = pRdr.readNext();
     if (!pRdr.hasNext()) {
-      complainAboutArgShortageOrWrongSorts(MATCH,exp);
+      complainAboutArgShortageOrWrongSorts(MATCH, exp);
     }
-    LExpr* body = pRdr.readNext();
+    LExpr *body = pRdr.readNext();
 
-    LExpr* l = new LExpr(LispParser::LIST);
+    LExpr *l = new LExpr(LispParser::LIST);
     LExprList::push(body, l->list);
     LExprList::push(pattern, l->list);
     LExprList::push(matchedAtom, l->list);
@@ -1565,17 +1566,19 @@ void SMTLIB2::parseMatchBegin(LExpr* exp)
   }
 }
 
-void SMTLIB2::parseMatchCaseStart(LExpr* exp)
+void SMTLIB2::parseMatchCaseStart(LExpr *exp)
 {
+  CALL("SMTLIB2::parseMatchCaseStart");
+
   ASS(exp->isList());
   LispListReader eRdr(exp->list);
 
   ASS(eRdr.hasNext());
   auto matched = eRdr.readNext();
   ASS(eRdr.hasNext());
-  LExpr* pattern = eRdr.readNext();
+  LExpr *pattern = eRdr.readNext();
   ASS(eRdr.hasNext());
-  LExpr* body = eRdr.readNext();
+  LExpr *body = eRdr.readNext();
   eRdr.acceptEOL();
 
   // find the matched term -- it must
@@ -1584,19 +1587,19 @@ void SMTLIB2::parseMatchCaseStart(LExpr* exp)
   Scopes::Iterator sIt(_scopes);
   bool foundMatched = false;
   while (sIt.hasNext()) {
-    if (sIt.next()->find(matched->str,matchedTerm)) {
+    if (sIt.next()->find(matched->str, matchedTerm)) {
       foundMatched = true;
       break;
     }
   }
 
   if (!foundMatched) {
-    complainAboutArgShortageOrWrongSorts(MATCH,exp);
+    complainAboutArgShortageOrWrongSorts(MATCH, exp);
   }
 
   // now parse the match pattern which
   // potentially declares new variables
-  TermLookup* lookup = new TermLookup;
+  TermLookup *lookup = new TermLookup;
   if (pattern->isList()) {
     LispListReader tRdr(pattern);
     auto ctorName = tRdr.readAtom();
@@ -1606,21 +1609,22 @@ void SMTLIB2::parseMatchCaseStart(LExpr* exp)
     while (tRdr.hasNext()) {
       auto arg = tRdr.readNext();
       if (!arg->isAtom() || isAlreadyKnownFunctionSymbol(arg->str)) {
-        USER_ERROR("Nested ctors in match patterns are disallowed: '"+exp->toString()+"'");
+        USER_ERROR("Nested ctors in match patterns are disallowed: '" + exp->toString() + "'");
       }
       if (!lookup->insert(arg->str, make_pair(TermList(_nextVar++, false), fn->fnType()->arg(argcnt++)))) {
-        USER_ERROR("Variable '"+arg->str+"' has already been defined");
+        USER_ERROR("Variable '" + arg->str + "' has already been defined");
       }
     }
+  }
   // non-ctor atom
-  } else if (!isTermAlgebraConstructor(pattern->str)) {
+  else if (!isTermAlgebraConstructor(pattern->str)) {
     if (isAlreadyKnownFunctionSymbol(pattern->str)) {
-      USER_ERROR("Constant symbol found in match pattern: '"+exp->toString()+"'");
+      USER_ERROR("Constant symbol found in match pattern: '" + exp->toString() + "'");
     }
     // in case of _ nothing to add to lookup
     if (pattern->str != UNDERSCORE) {
       if (!lookup->insert(pattern->str, make_pair(TermList(_nextVar++, false), matchedTerm.second))) {
-        USER_ERROR("Variable '"+pattern->str+"' has already been defined");
+        USER_ERROR("Variable '" + pattern->str + "' has already been defined");
       }
     }
   }
@@ -1628,37 +1632,40 @@ void SMTLIB2::parseMatchCaseStart(LExpr* exp)
   _scopes.push(lookup);
   // only parse pattern if it's not _
   if (pattern->isList() || pattern->str != UNDERSCORE) {
-    _todo.push(make_pair(PO_PARSE,pattern));
+    _todo.push(make_pair(PO_PARSE, pattern));
   }
-  _todo.push(make_pair(PO_PARSE,body));
+  _todo.push(make_pair(PO_PARSE, body));
 }
 
-void SMTLIB2::parseMatchCaseEnd(LExpr* exp)
+void SMTLIB2::parseMatchCaseEnd(LExpr *exp)
 {
+  CALL("SMTLIB2::parseMatchCaseEnd");
+
   LExprList::destroy(exp->list);
   delete exp;
   delete _scopes.pop();
 }
 
-void SMTLIB2::parseMatchEnd(LExpr* exp)
+void SMTLIB2::parseMatchEnd(LExpr *exp)
 {
   CALL("SMTLIB2::parseMatchEnd");
-  LOG2("PO_MATCH_END ",exp->toString());
+
+  LOG2("PO_MATCH_END ", exp->toString());
 
   ASS(exp->isList());
   LispListReader lRdr(exp->list);
-  const vstring& theMatchAtom = lRdr.readAtom();
-  ASS_EQ(getBuiltInTermSymbol(theMatchAtom),TS_MATCH);
+  const vstring &theMatchAtom = lRdr.readAtom();
+  ASS_EQ(getBuiltInTermSymbol(theMatchAtom), TS_MATCH);
 
   vstring matched = lRdr.readAtom();
   TermList matchedTerm;
   auto matchedTermSort = _results.pop().asTerm(matchedTerm);
   LOG2("CASE matched ", matchedTerm.toString());
 
-  vmap<unsigned, TermAlgebraConstructor*> ctorFunctors;
+  vmap<unsigned, TermAlgebraConstructor *> ctorFunctors;
   TermAlgebra *ta = env.signature->getTermAlgebraOfSort(matchedTermSort);
   if (ta == nullptr) {
-    USER_ERROR("Match term '"+matched+"' is not of a term algebra type in expression '"+exp->toString()+"'");
+    USER_ERROR("Match term '" + matched + "' is not of a term algebra type in expression '" + exp->toString() + "'");
   }
   for (unsigned int i = 0; i < ta->nConstructors(); i++) {
     ctorFunctors.insert(make_pair(ta->constructor(i)->functor(), ta->constructor(i)));
@@ -1674,32 +1681,34 @@ void SMTLIB2::parseMatchEnd(LExpr* exp)
   LispListReader cRdr(lRdr.readList());
   while (cRdr.hasNext()) {
     LispListReader pRdr(cRdr.readList());
-    LExpr* pattern = pRdr.readNext();
+    LExpr *pattern = pRdr.readNext();
     pRdr.readNext(); // body
     pRdr.acceptEOL();
     TermList p;
     if (pattern->isAtom() && pattern->str == UNDERSCORE) {
       p = TermList(_nextVar++, false);
-    } else {
+    }
+    else {
       ALWAYS(_results.pop().asTerm(p) == matchedTermSort);
     }
     TermList b;
     sort = _results.pop().asTerm(b);
 
-    LOG2("CASE pattern ",p.toString());
-    LOG2("CASE body    ",b.toString());
+    LOG2("CASE pattern ", p.toString());
+    LOG2("CASE body    ", b.toString());
 
     if (p.isVar()) {
       if (varUsed) {
-        USER_ERROR("Else branch cannot be used twice in match in '"+exp->toString()+"'");
+        USER_ERROR("Else branch cannot be used twice in match in '" + exp->toString() + "'");
       }
       varUsed = true;
       varPattern = p;
       varBody = b;
-    } else {
+    }
+    else {
       auto functor = p.term()->functor();
       if (ctorFunctors.erase(functor) != 1) {
-        USER_ERROR("Match pattern '"+p.toString()+"' is either not ctor or was listed twice in '"+exp->toString()+"'");
+        USER_ERROR("Match pattern '" + p.toString() + "' is either not ctor or was listed twice in '" + exp->toString() + "'");
       }
       elements.push(p);
       elements.push(b);
@@ -1711,23 +1720,24 @@ void SMTLIB2::parseMatchEnd(LExpr* exp)
   // we add the missing ctors
   if (varUsed) {
     Stack<TermList> argTerms;
-    for (const auto& kv : ctorFunctors) {
+    for (const auto &kv : ctorFunctors) {
       argTerms.reset();
       for (unsigned j = 0; j < kv.second->arity(); j++) {
         argTerms.push(TermList(_nextVar++, false));
       }
       TermList pattern(Term::create(kv.second->functor(), argTerms.size(), argTerms.begin()));
-      LOG2("CASE missing ",pattern);
+      LOG2("CASE missing ", pattern);
       elements.push(pattern);
       if (varPattern.isVar()) {
         Substitution subst;
-        subst.bind(varPattern.var(),pattern);
+        subst.bind(varPattern.var(), pattern);
         varBody = SubstHelper::apply<Substitution>(varBody, subst);
       }
       elements.push(varBody);
     }
-  } else if (ctorFunctors.size() > 0) {
-    USER_ERROR("Missing ctors in match expression '"+exp->toString()+"'");
+  }
+  else if (ctorFunctors.size() > 0) {
+    USER_ERROR("Missing ctors in match expression '" + exp->toString() + "'");
   }
 
   auto match = TermList(Term::createMatch(sort, matchedTermSort, elements.size(), elements.begin()));

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -25,6 +25,8 @@
 #include "Kernel/Inference.hpp"
 #include "Kernel/Signature.hpp"
 #include "Kernel/SortHelper.hpp"
+#include "Kernel/SubstHelper.hpp"
+#include "Kernel/Substitution.hpp"
 
 #include "Shell/LispLexer.hpp"
 #include "Shell/Options.hpp"
@@ -160,6 +162,19 @@ void SMTLIB2::readBenchmark(LExprList* bench)
       continue;
     }
 
+    // TODO(mhajdu): is it possible that codatatypes are
+    // declared this way?
+    if (ibRdr.tryAcceptAtom("declare-datatype")) {
+      LExpr* sort = ibRdr.readNext();
+      LExprList* datatype = ibRdr.readList();
+
+      readDeclareDatatype(sort, datatype, false);
+
+      ibRdr.acceptEOL();
+
+      continue;
+    }
+
     if (ibRdr.tryAcceptAtom("declare-datatypes")) {
       LExprList* sorts = ibRdr.readList();
       LExprList* datatypes = ibRdr.readList();
@@ -200,6 +215,19 @@ void SMTLIB2::readBenchmark(LExprList* bench)
       LExpr* body = ibRdr.readNext();
 
       readDefineFun(name,iArgs,oSort,body);
+
+      ibRdr.acceptEOL();
+
+      continue;
+    }
+
+    if (ibRdr.tryAcceptAtom("define-fun-rec")) {
+      vstring name = ibRdr.readAtom();
+      LExprList* iArgs = ibRdr.readList();
+      LExpr* oSort = ibRdr.readNext();
+      LExpr* body = ibRdr.readNext();
+
+      readDefineFun(name,iArgs,oSort,body,true/*recursive*/);
 
       ibRdr.acceptEOL();
 
@@ -734,6 +762,7 @@ SMTLIB2::FormulaSymbol SMTLIB2::getBuiltInFormulaSymbol(const vstring& str)
 }
 
 static const char* LET = "let";
+static const char* MATCH = "match";
 
 const char * SMTLIB2::s_termSymbolNameStrings[] = {
     "*",
@@ -744,6 +773,7 @@ const char * SMTLIB2::s_termSymbolNameStrings[] = {
     "div",
     "ite",
     LET,
+    MATCH,
     "mod",
     "select",
     "store",
@@ -852,7 +882,7 @@ SMTLIB2::DeclaredFunction SMTLIB2::declareFunctionOrPredicate(const vstring& nam
 
 //  ----------------------------------------------------------------------
 
-void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort, LExpr* body)
+void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort, LExpr* body, bool recursive)
 {
   CALL("SMTLIB2::readDefineFun");
 
@@ -894,6 +924,11 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
 
   _scopes.push(lookup);
 
+  DeclaredFunction fun;
+  if (recursive) {
+    fun = declareFunctionOrPredicate(name,rangeSort,argSorts);
+  }
+
   ParseResult res = parseTermOrFormula(body);
 
   delete _scopes.pop();
@@ -903,8 +938,9 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
     USER_ERROR("Defined function body "+body->toString()+" has different sort than declared "+oSort->toString());
   }
 
-  // Only after parsing, so that the definition cannot be recursive
-  DeclaredFunction fun = declareFunctionOrPredicate(name,rangeSort,argSorts);
+  if (!recursive) {
+    fun = declareFunctionOrPredicate(name,rangeSort,argSorts);
+  }
 
   unsigned symbIdx = fun.first;
   bool isTrueFun = fun.second;
@@ -922,6 +958,69 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
   FormulaUnit* fu = new FormulaUnit(fla, FromInput(UnitInputType::ASSUMPTION));
 
   UnitList::push(fu, _formulas);
+}
+
+void SMTLIB2::readDeclareDatatype(LExpr* sort, LExprList* datatype, bool codatatype)
+{
+  CALL("SMTLIB2::readDeclareDatatype");
+
+  // first declare the sort
+  vstring dtypeName = sort->str;
+  if (isAlreadyKnownSortSymbol(dtypeName)) {
+    USER_ERROR("Redeclaring built-in, declared or defined sort symbol as datatype: "+dtypeName);
+  }
+  ALWAYS(_declaredSorts.insert(dtypeName, 0));
+  Stack<TermAlgebraConstructor*> constructors;
+  TermStack argSorts;
+  Stack<vstring> destructorNames;
+
+  bool added = false;
+  auto taName = dtypeName + "()";
+  unsigned srt = TPTP::addUninterpretedConstant(taName, _overflow, added);
+  ASS(added);
+  env.signature->getFunction(srt)->setType(OperatorType::getConstantsType(Term::superSort()));
+  TermList taSort = TermList(Term::createConstant(srt));
+  env.sorts->addSort(taSort);
+
+  LispListReader dtypeRdr(datatype);
+  while (dtypeRdr.hasNext()) {
+    argSorts.reset();
+    destructorNames.reset();
+    // read each constructor declaration
+    vstring constrName;
+    LExpr *constr = dtypeRdr.next();
+    if (constr->isAtom()) {
+      // atom, constructor of arity 0
+      constrName = constr->str;
+      if (constrName == "par") {
+        USER_ERROR("Datatype '"+dtypeName+"' is declared parametric which is unsupported");
+      }
+    } else {
+      ASS(constr->isList());
+      LispListReader constrRdr(constr);
+      constrName = constrRdr.readAtom();
+
+      while (constrRdr.hasNext()) {
+        LExpr *arg = constrRdr.next();
+        LispListReader argRdr(arg);
+        destructorNames.push(argRdr.readAtom());
+        argSorts.push(declareSort(argRdr.next()));
+        if (argRdr.hasNext()) {
+          USER_ERROR("Bad constructor argument:" + arg->toString());
+        }
+      }
+    }
+    constructors.push(buildTermAlgebraConstructor(constrName, taSort, destructorNames, argSorts));
+  }
+
+  ASS(!env.signature->isTermAlgebraSort(taSort));
+  TermAlgebra* ta = new TermAlgebra(taSort, constructors.size(), constructors.begin(), codatatype);
+
+  if (ta->emptyDomain()) {
+    USER_ERROR("Datatype " + taName + " defines an empty sort");
+  }
+
+  env.signature->addTermAlgebra(ta);
 }
 
 void SMTLIB2::readDeclareDatatypes(LExprList* sorts, LExprList* datatypes, bool codatatype)
@@ -1396,6 +1495,238 @@ void SMTLIB2::parseLetEnd(LExpr* exp)
   _results.push(ParseResult(letSort,let));
 
   delete lookup;
+}
+
+static const char* UNDERSCORE = "_";
+
+bool SMTLIB2::isTermAlgebraConstructor(const vstring& name)
+{
+  CALL("SMTLIB2::isTermAlgebraConstructor");
+
+  if (_declaredFunctions.find(name)) {
+    DeclaredFunction& f = _declaredFunctions.get(name);
+    return (f.second && env.signature->getTermAlgebraConstructor(f.first));
+  }
+
+  return false;
+}
+
+void SMTLIB2::parseMatchBegin(LExpr* exp)
+{
+  CALL("SMTLIB2::parseMatchBegin");
+
+  LOG2("parseMatchBegin  ",exp->toString());
+
+  ASS(exp->isList());
+  LispListReader lRdr(exp->list);
+
+  // the match atom
+  const vstring& theMatchAtom = lRdr.readAtom();
+  ASS_EQ(theMatchAtom,MATCH);
+
+  // next is the matched term
+  if (!lRdr.hasNext()) {
+    complainAboutArgShortageOrWrongSorts(MATCH,exp);
+  }
+  LExpr* matchedAtom = lRdr.readNext();
+
+  // and the list of cases
+  if (!lRdr.hasNext()) {
+    complainAboutArgShortageOrWrongSorts(MATCH,exp);
+  }
+  LispListReader casesRdr(lRdr.readList());
+
+  lRdr.acceptEOL();
+
+  _todo.push(make_pair(PO_MATCH_END,exp));
+  // this is the last thing we parse so that it pops
+  // first when the result is created
+  _todo.push(make_pair(PO_PARSE,matchedAtom));
+
+  while (casesRdr.hasNext()) {
+    LExprList* pair = casesRdr.readList();
+    LispListReader pRdr(pair);
+
+    if (!pRdr.hasNext()) {
+      complainAboutArgShortageOrWrongSorts(MATCH,exp);
+    }
+    LExpr* pattern = pRdr.readNext();
+    if (!pRdr.hasNext()) {
+      complainAboutArgShortageOrWrongSorts(MATCH,exp);
+    }
+    LExpr* body = pRdr.readNext();
+
+    LExpr* l = new LExpr(LispParser::LIST);
+    l->list = LExprList::cons(body, l->list);
+    l->list = LExprList::cons(pattern, l->list);
+    l->list = LExprList::cons(matchedAtom, l->list);
+    _todo.push(make_pair(PO_MATCH_CASE_END, l));
+    _todo.push(make_pair(PO_MATCH_CASE_START, l));
+    pRdr.acceptEOL();
+  }
+}
+
+void SMTLIB2::parseMatchCaseStart(LExpr* exp)
+{
+  ASS(exp->isList());
+  LispListReader eRdr(exp->list);
+
+  ASS(eRdr.hasNext());
+  auto matched = eRdr.readNext();
+  ASS(eRdr.hasNext());
+  LExpr* pattern = eRdr.readNext();
+  ASS(eRdr.hasNext());
+  LExpr* body = eRdr.readNext();
+  eRdr.acceptEOL();
+
+  // find the matched term -- it must
+  // be a variable already in some scope
+  SortedTerm matchedTerm;
+  Scopes::Iterator sIt(_scopes);
+  bool foundMatched = false;
+  while (sIt.hasNext()) {
+    if (sIt.next()->find(matched->str,matchedTerm)) {
+      foundMatched = true;
+      break;
+    }
+  }
+
+  if (!foundMatched) {
+    complainAboutArgShortageOrWrongSorts(MATCH,exp);
+  }
+
+  // now parse the match pattern which
+  // potentially declares new variables
+  TermLookup* lookup = new TermLookup;
+  if (pattern->isList()) {
+    LispListReader tRdr(pattern);
+    auto ctorName = tRdr.readAtom();
+    // whether it is a ctor we check in MATCH_END
+    auto fn = env.signature->getFunction(_declaredFunctions.get(ctorName).first);
+    unsigned argcnt = 0;
+    while (tRdr.hasNext()) {
+      auto arg = tRdr.readNext();
+      if (!arg->isAtom() || isAlreadyKnownFunctionSymbol(arg->str)) {
+        USER_ERROR("Nested ctors in match patterns are disallowed: '"+exp->toString()+"'");
+      }
+      if (!lookup->insert(arg->str, make_pair(TermList(_nextVar++, false), fn->fnType()->arg(argcnt++)))) {
+        USER_ERROR("Variable '"+arg->str+"' has already been defined");
+      }
+    }
+  // non-ctor atom
+  } else if (!isTermAlgebraConstructor(pattern->str)) {
+    if (isAlreadyKnownFunctionSymbol(pattern->str)) {
+      USER_ERROR("Constant symbol found in match pattern: '"+exp->toString()+"'");
+    }
+    // TODO(mhajdu): now _ is added to the lookup but
+    // this has to be dealt with some other way since
+    // _ cannot be used in inner lookups anymore
+
+    // in case of _ nothing to add to lookup
+    // if (pattern->str != UNDERSCORE) {
+      if (!lookup->insert(pattern->str, make_pair(TermList(_nextVar++, false), matchedTerm.second))) {
+        USER_ERROR("Variable '"+pattern->str+"' has already been defined");
+      }
+    // }
+  }
+
+  _scopes.push(lookup);
+  _todo.push(make_pair(PO_PARSE,pattern));
+  _todo.push(make_pair(PO_PARSE,body));
+}
+
+void SMTLIB2::parseMatchCaseEnd(LExpr* exp)
+{
+  LExprList::destroy(exp->list);
+  delete exp;
+  delete _scopes.pop();
+}
+
+void SMTLIB2::parseMatchEnd(LExpr* exp)
+{
+  CALL("SMTLIB2::parseMatchEnd");
+  LOG2("PO_MATCH_END ",exp->toString());
+
+  ASS(exp->isList());
+  LispListReader lRdr(exp->list);
+  const vstring& theMatchAtom = lRdr.readAtom();
+  ASS_EQ(getBuiltInTermSymbol(theMatchAtom),TS_MATCH);
+
+  vstring matched = lRdr.readAtom();
+  auto numCases = LExprList::length(lRdr.readList());
+  lRdr.acceptEOL();
+
+  TermList matchedTerm;
+  auto matchedTermSort = _results.pop().asTerm(matchedTerm);
+  LOG2("CASE matched ", matchedTerm.toString());
+
+  vmap<unsigned, TermAlgebraConstructor*> ctorFunctors;
+  TermAlgebra *ta = env.signature->getTermAlgebraOfSort(matchedTermSort);
+  if (ta == nullptr) {
+    USER_ERROR("Match term '"+matched+"' is not of a term algebra type in expression '"+exp->toString()+"'");
+  }
+  for (unsigned int i = 0; i < ta->nConstructors(); i++) {
+    ctorFunctors.insert(make_pair(ta->constructor(i)->functor(), ta->constructor(i)));
+  }
+
+  TermList varPattern;
+  TermList varBody;
+  bool varUsed = false;
+  Stack<TermList> elements;
+  elements.push(matchedTerm);
+  TermList sort = Term::defaultSort();
+  for (unsigned j = 0; j < numCases; j++) {
+    TermList pattern;
+    TermList patternSort = _results.pop().asTerm(pattern);
+    TermList body;
+    sort = _results.pop().asTerm(body);
+
+    LOG2("CASE pattern ",pattern.toString());
+    LOG2("CASE body    ",body.toString());
+
+    ASS_EQ(patternSort, matchedTermSort);
+    if (pattern.isVar()) {
+      if (varUsed) {
+        USER_ERROR("Else branch cannot be used twice in match in '"+exp->toString()+"'");
+      }
+      varUsed = true;
+      varPattern = pattern;
+      varBody = body;
+    } else {
+      auto functor = pattern.term()->functor();
+      if (ctorFunctors.erase(functor) != 1) {
+        USER_ERROR("Match pattern '"+pattern.toString()+"' is either not ctor or was listed twice in '"+exp->toString()+"'");
+      }
+      elements.push(pattern);
+      elements.push(body);
+    }
+  }
+
+  // if there is a variable pattern,
+  // we add the missing ctors
+  if (varUsed) {
+    Stack<TermList> argTerms;
+    for (const auto& kv : ctorFunctors) {
+      argTerms.reset();
+      for (unsigned j = 0; j < kv.second->arity(); j++) {
+        argTerms.push(TermList(_nextVar++, false));
+      }
+      TermList pattern(Term::create(kv.second->functor(), argTerms.size(), argTerms.begin()));
+      LOG2("CASE missing ",pattern);
+      elements.push(pattern);
+      if (varPattern.isVar()) {
+        Substitution subst;
+        subst.bind(varPattern.var(),pattern);
+        varBody = SubstHelper::apply<Substitution>(varBody, subst);
+      }
+      elements.push(varBody);
+    }
+  } else if (ctorFunctors.size() > 0) {
+    USER_ERROR("Missing ctors in match expression '"+exp->toString()+"'");
+  }
+
+  auto match = TermList(Term::createMatch(sort, matchedTermSort, elements.size(), elements.begin()));
+  _results.push(ParseResult(sort,match));
 }
 
 void SMTLIB2::parseQuantBegin(LExpr* exp)
@@ -2061,8 +2392,6 @@ bool SMTLIB2::parseAsBuiltinTermSymbol(const vstring& id, LExpr* exp)
   }
 }
 
-static const char* UNDERSCORE = "_";
-
 void SMTLIB2::parseRankedFunctionApplication(LExpr* exp)
 {
   CALL("SMTLIB2::parseRankedFunctionApplication");
@@ -2185,6 +2514,11 @@ SMTLIB2::ParseResult SMTLIB2::parseTermOrFormula(LExpr* body)
               continue;
             }
 
+            if (id == MATCH) {
+              parseMatchBegin(exp);
+              continue;
+            }
+
             if (id == EXCLAMATION) {
               parseAnnotatedTerm(exp);
               continue;
@@ -2272,6 +2606,18 @@ SMTLIB2::ParseResult SMTLIB2::parseTermOrFormula(LExpr* body)
       case PO_LET_END:
         parseLetEnd(exp);
         continue;
+      case PO_MATCH_CASE_START: {
+        parseMatchCaseStart(exp);
+        continue;
+      }
+      case PO_MATCH_CASE_END: {
+        parseMatchCaseEnd(exp);
+        continue;
+      }
+      case PO_MATCH_END: {
+        parseMatchEnd(exp);
+        continue;
+      }
     }
   }
 

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -162,13 +162,11 @@ void SMTLIB2::readBenchmark(LExprList* bench)
       continue;
     }
 
-    // TODO(mhajdu): is it possible that codatatypes are
-    // declared this way?
     if (ibRdr.tryAcceptAtom("declare-datatype")) {
       LExpr *sort = ibRdr.readNext();
       LExprList *datatype = ibRdr.readList();
 
-      readDeclareDatatype(sort, datatype, false);
+      readDeclareDatatype(sort, datatype);
 
       ibRdr.acceptEOL();
 
@@ -960,7 +958,7 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
   UnitList::push(fu, _formulas);
 }
 
-void SMTLIB2::readDeclareDatatype(LExpr *sort, LExprList *datatype, bool codatatype)
+void SMTLIB2::readDeclareDatatype(LExpr *sort, LExprList *datatype)
 {
   CALL("SMTLIB2::readDeclareDatatype");
 
@@ -1015,7 +1013,7 @@ void SMTLIB2::readDeclareDatatype(LExpr *sort, LExprList *datatype, bool codatat
   }
 
   ASS(!env.signature->isTermAlgebraSort(taSort));
-  TermAlgebra* ta = new TermAlgebra(taSort, constructors.size(), constructors.begin(), codatatype);
+  TermAlgebra* ta = new TermAlgebra(taSort, constructors.size(), constructors.begin(), false);
 
   if (ta->emptyDomain()) {
     USER_ERROR("Datatype " + taName + " defines an empty sort");

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -265,7 +265,7 @@ private:
    */
   void readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort, LExpr* body, bool recursive = false);
 
-  void readDeclareDatatype(LExpr* sort, LExprList* datatype, bool codatatype = false);
+  void readDeclareDatatype(LExpr* sort, LExprList* datatype);
 
   void readDeclareDatatypes(LExprList* sorts, LExprList* datatypes, bool codatatype = false);
 

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -217,6 +217,7 @@ private:
     TS_DIV,
     TS_ITE,
     TS_LET,
+    TS_MATCH,
     TS_MOD,
     TS_SELECT,
     TS_STORE,
@@ -262,7 +263,9 @@ private:
    *
    * Defining a function extends the signature and adds the new function's definition into _formulas.
    */
-  void readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort, LExpr* body);
+  void readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort, LExpr* body, bool recursive = false);
+
+  void readDeclareDatatype(LExpr* sort, LExprList* datatype, bool codatatype = false);
 
   void readDeclareDatatypes(LExprList* sorts, LExprList* datatypes, bool codatatype = false);
 
@@ -352,7 +355,10 @@ private:
     PO_CHECK_ARITY,        // takes LExpr* (again the whole, just for error reporting)
     // these two are intermediate cases for handling let
     PO_LET_PREPARE_LOOKUP, // takes LExpr* (the whole let expression again, why not)
-    PO_LET_END             // takes LExpr* (the whole let expression again, why not)
+    PO_LET_END,            // takes LExpr* (the whole let expression again, why not)
+    PO_MATCH_CASE_START,   // takes LExpr*, a list containing the matched term, pattern, case
+    PO_MATCH_CASE_END,     // takes LExpr*, a list containing the matched term, pattern, case
+    PO_MATCH_END           // takes LExpr* (the whole match again)
   };
   /**
    * Main smtlib term parsing stack.
@@ -368,6 +374,12 @@ private:
   void parseLetBegin(LExpr* exp);
   void parseLetPrepareLookup(LExpr* exp);
   void parseLetEnd(LExpr* exp);
+
+  bool isTermAlgebraConstructor(const vstring& name);
+  void parseMatchBegin(LExpr* exp);
+  void parseMatchCaseStart(LExpr* exp);
+  void parseMatchCaseEnd(LExpr* exp);
+  void parseMatchEnd(LExpr* exp);
 
   void parseQuantBegin(LExpr* exp);
 

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -785,9 +785,8 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
          */
 
         TermList matchedTerm;
-        Formula* matchedFormula;
-        Context matchedContext = term->nthArgument(0)->isTerm()
-          && term->nthArgument(0)->term()->isBoolean() ? FORMULA_CONTEXT : TERM_CONTEXT;
+        Formula *matchedFormula;
+        Context matchedContext = term->nthArgument(0)->isTerm() && term->nthArgument(0)->term()->isBoolean() ? FORMULA_CONTEXT : TERM_CONTEXT;
         process(*term->nthArgument(0), matchedContext, matchedTerm, matchedFormula);
 
         TermList resultSort = Term::defaultSort();
@@ -802,37 +801,38 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
         // build g(X1, ..., Xn)
         TermList freshFunctionApplication;
-        Formula* freshPredicateApplication;
+        Formula *freshPredicateApplication;
         buildApplication(freshSymbol, context, allVars, freshFunctionApplication, freshPredicateApplication);
 
-        for (unsigned int i = 1; i < term->arity(); i+=2) {
+        for (unsigned int i = 1; i < term->arity(); i += 2) {
           TermList patternTerm;
-          Formula* patternFormula;
+          Formula *patternFormula;
           process(*term->nthArgument(i), matchedContext, patternTerm, patternFormula);
           // build v = pi
-          Formula* head = buildEq(matchedContext, matchedFormula, patternFormula,
+          Formula *head = buildEq(matchedContext, matchedFormula, patternFormula,
                                   matchedTerm, patternTerm, sd->getMatchedSort());
 
           TermList bodyTerm;
-          Formula* bodyFormula;
-          process(*term->nthArgument(i+1), context, bodyTerm, bodyFormula);
+          Formula *bodyFormula;
+          process(*term->nthArgument(i + 1), context, bodyTerm, bodyFormula);
           // build g(X1, ..., Xn) == bi
-          Formula* body = buildEq(context, freshPredicateApplication, bodyFormula,
+          Formula *body = buildEq(context, freshPredicateApplication, bodyFormula,
                                   freshFunctionApplication, bodyTerm, resultSort);
           // build (v = pi => g(X1, ..., Xn) == bi)
-          Formula* impl = new BinaryFormula(IMP, head, body);
+          Formula *impl = new BinaryFormula(IMP, head, body);
 
           // build ![X1, ..., Xn]: (f => g(X1, ..., Xn) == s)
           if (VList::length(freeVars) > 0) {
             //TODO do we know the sorts of freeVars?
-            impl = new QuantifiedFormula(FORALL, freeVars,0, impl);
+            impl = new QuantifiedFormula(FORALL, freeVars, 0, impl);
           }
           addDefinition(new FormulaUnit(impl, NonspecificInference1(InferenceRule::FOOL_MATCH_ELIMINATION, _unit)));
         }
 
         if (context == FORMULA_CONTEXT) {
           formulaResult = freshPredicateApplication;
-        } else {
+        }
+        else {
           termResult = freshFunctionApplication;
         }
         break;

--- a/Shell/FOOLElimination.hpp
+++ b/Shell/FOOLElimination.hpp
@@ -101,6 +101,7 @@ private:
   static const char* ITE_PREFIX;
   static const char* LET_PREFIX;
   static const char* BOOL_PREFIX;
+  static const char* MATCH_PREFIX;
 
   // Report that a given formula or a term has been rewritten during defooling
   // The term or formula is passed as its string representation

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -328,9 +328,8 @@ TermList Flattening::flatten (TermList ts)
         DArray<TermList> terms(term->arity());
         bool unchanged = true;
         for (unsigned i = 0; i < term->arity(); i++) {
-          TermList subterm = flatten(*term->nthArgument(i));
-          unchanged = unchanged && (subterm == *term->nthArgument(i));
-          terms[i] = subterm;
+          terms[i] = flatten(*term->nthArgument(i));
+          unchanged = unchanged && (terms[i] == *term->nthArgument(i));
         }
 
         if (unchanged) {

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -324,6 +324,21 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
+      case Term::SF_MATCH: {
+        DArray<TermList> terms(term->arity());
+        bool unchanged = true;
+        for (unsigned i = 0; i < term->arity(); i++) {
+          TermList subterm = flatten(*term->nthArgument(i));
+          unchanged = unchanged && (subterm == *term->nthArgument(i));
+          terms[i] = subterm;
+        }
+
+        if (unchanged) {
+          return ts;
+        }
+        return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
+      }
+
       default:
         ASSERTION_VIOLATION;
     }

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -334,6 +334,21 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
+      case Term::SF_MATCH: {
+        DArray<TermList> terms(term->arity());
+        bool unchanged = true;
+        for (unsigned i = 0; i < term->arity(); i++) {
+          TermList subterm = ennf(*term->nthArgument(i), polarity);
+          unchanged = unchanged && (subterm == *term->nthArgument(i));
+          terms[i] = subterm;
+        }
+
+        if (unchanged) {
+          return ts;
+        }
+        return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
+      }
+
       default:
         ASSERTION_VIOLATION;
     }

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -338,9 +338,8 @@ TermList NNF::ennf(TermList ts, bool polarity)
         DArray<TermList> terms(term->arity());
         bool unchanged = true;
         for (unsigned i = 0; i < term->arity(); i++) {
-          TermList subterm = ennf(*term->nthArgument(i), polarity);
-          unchanged = unchanged && (subterm == *term->nthArgument(i));
-          terms[i] = subterm;
+          terms[i] = ennf(*term->nthArgument(i), polarity);
+          unchanged = unchanged && (terms[i] == *term->nthArgument(i));
         }
 
         if (unchanged) {

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -243,19 +243,19 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
   LOG3("Replacing it by", processedLiteral->toString(), "with variable substitutions");
 
   while (matchVariables.isNonEmpty()) {
-    unsigned matchVar          = matchVariables.pop();
-    List<Formula*>* conditions = matchConditions.pop();
-    List<TermList>* branches   = matchBranches.pop();
+    unsigned matchVar = matchVariables.pop();
+    List<Formula *> *conditions = matchConditions.pop();
+    List<TermList> *branches = matchBranches.pop();
 
-    List<LPair>* processedLiterals(0);
+    List<LPair> *processedLiterals(0);
 
-    List<Formula*>::Iterator condIt(conditions);
+    List<Formula *>::Iterator condIt(conditions);
     List<TermList>::Iterator branchIt(branches);
 
     while (List<LPair>::isNonEmpty(literals)) {
       LPair p = List<LPair>::pop(literals);
-      Literal* literal = p.first;
-      List<GenLit>* gls = p.second;
+      Literal *literal = p.first;
+      List<GenLit> *gls = p.second;
 
       while (condIt.hasNext()) {
         ASS(branchIt.hasNext());
@@ -269,10 +269,11 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
         Substitution subst;
         subst.bind(matchVar, branch);
 
-        Literal* branchLiteral = SubstHelper::apply(literal, subst);
+        Literal *branchLiteral = SubstHelper::apply(literal, subst);
 
         List<LPair>::push(make_pair(
-          branchLiteral, List<GenLit>::cons(negCondition, gls)), processedLiterals);
+                              branchLiteral, List<GenLit>::cons(negCondition, gls)),
+                          processedLiterals);
       }
     }
     literals = processedLiterals;
@@ -363,22 +364,22 @@ TermList NewCNF::findITEs(TermList ts, Stack<unsigned> &variables, Stack<Formula
     case Term::SF_TUPLE: {
       TermList tupleTerm = TermList(sd->getTupleTerm());
       return findITEs(tupleTerm, variables, conditions, thenBranches,
-        elseBranches, matchVariables, matchConditions, matchBranches);
+                      elseBranches, matchVariables, matchConditions, matchBranches);
     }
 
     case Term::SF_MATCH: {
       sort = sd->getSort();
       auto matched = *term->nthArgument(0);
-      List<Formula*>* mconditions(0);
-      List<TermList>* mbranches(0);
+      List<Formula *> *mconditions(0);
+      List<TermList> *mbranches(0);
       // for each case (p, t) with matched term m,
       // we create a condition m=p and a branch t
-      for (unsigned int i = 1; i < term->arity(); i+=2) {
+      for (unsigned int i = 1; i < term->arity(); i += 2) {
         auto pattern = *term->nthArgument(i);
-        auto body = *term->nthArgument(i+1);
-        Formula* condition = new AtomicFormula(
-          Literal::createEquality(POSITIVE, matched, pattern, sd->getMatchedSort()));
-        List<Formula*>::push(condition, mconditions);
+        auto body = *term->nthArgument(i + 1);
+        Formula *condition = new AtomicFormula(
+            Literal::createEquality(POSITIVE, matched, pattern, sd->getMatchedSort()));
+        List<Formula *>::push(condition, mconditions);
         List<TermList>::push(body, mbranches);
       }
       matchConditions.push(mconditions);
@@ -640,16 +641,16 @@ void NewCNF::processITE(Formula* condition, Formula* thenBranch, Formula* elseBr
   }
 }
 
-void NewCNF::processMatch(Term::SpecialTermData* sd, Term* term, Occurrences &occurrences)
+void NewCNF::processMatch(Term::SpecialTermData *sd, Term *term, Occurrences &occurrences)
 {
   CALL("NewCNF::processMatch");
   auto matched = *term->nthArgument(0);
 
-  for (unsigned int i = 1; i < term->arity(); i+=2) {
+  for (unsigned int i = 1; i < term->arity(); i += 2) {
     auto pattern = *term->nthArgument(i);
-    auto body = *term->nthArgument(i+1);
-    Formula* condition = new AtomicFormula(
-      Literal::createEquality(POSITIVE, matched, pattern, sd->getMatchedSort()));
+    auto body = *term->nthArgument(i + 1);
+    Formula *condition = new AtomicFormula(
+        Literal::createEquality(POSITIVE, matched, pattern, sd->getMatchedSort()));
     auto branch = BoolTermFormula::create(body);
 
     enqueue(condition);
@@ -661,7 +662,9 @@ void NewCNF::processMatch(Term::SpecialTermData* sd, Term* term, Occurrences &oc
       introduceExtendedGenClause(occ, GenLit(condition, NEGATIVE), GenLit(branch, occ.sign()));
     }
   }
-  while (occurrences.isNonEmpty()) { pop(occurrences); }
+  while (occurrences.isNonEmpty()) {
+    pop(occurrences);
+  }
 }
 
 TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -143,10 +143,15 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
   Stack<TermList> thenBranches;
   Stack<TermList> elseBranches;
 
+  Stack<unsigned> matchVariables;
+  Stack<List<Formula*>*> matchConditions;
+  Stack<List<TermList>*> matchBranches;
+
   Stack<TermList> arguments;
   Term::Iterator ait(literal);
   while (ait.hasNext()) {
-    arguments.push(findITEs(ait.next(), variables, conditions, thenBranches, elseBranches));
+    arguments.push(findITEs(ait.next(), variables, conditions, thenBranches,
+      elseBranches, matchVariables, matchConditions, matchBranches));
   }
   Literal* processedLiteral = Literal::create(literal, arguments.begin());
 
@@ -154,7 +159,7 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
   List<LPair>::push(make_pair(processedLiteral, List<GenLit>::empty()),
                     literals);
 
-  LOG4("Found", variables.size(), "variable(s) inside", literal->toString());
+  LOG4("Found", variables.size(), "variable(s) for ITEs inside", literal->toString());
   LOG3("Replacing it by", processedLiteral->toString(), "with variable substitutions");
 
   unsigned iteCounter = 0;
@@ -234,6 +239,49 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
   ASS(thenBranches.isEmpty());
   ASS(elseBranches.isEmpty());
 
+  LOG4("Found", matchVariables.size(), "variable(s) for matches inside", literal->toString());
+  LOG3("Replacing it by", processedLiteral->toString(), "with variable substitutions");
+
+  while (matchVariables.isNonEmpty()) {
+    unsigned matchVar          = matchVariables.pop();
+    List<Formula*>* conditions = matchConditions.pop();
+    List<TermList>* branches   = matchBranches.pop();
+
+    List<LPair>* processedLiterals(0);
+
+    List<Formula*>::Iterator condIt(conditions);
+    List<TermList>::Iterator branchIt(branches);
+
+    while (List<LPair>::isNonEmpty(literals)) {
+      LPair p = List<LPair>::pop(literals);
+      Literal* literal = p.first;
+      List<GenLit>* gls = p.second;
+
+      while (condIt.hasNext()) {
+        ASS(branchIt.hasNext());
+
+        auto condition = condIt.next();
+        auto branch = branchIt.next();
+        enqueue(condition);
+
+        GenLit negCondition = GenLit(condition, NEGATIVE);
+
+        Substitution subst;
+        subst.bind(matchVar, branch);
+
+        Literal* branchLiteral = SubstHelper::apply(literal, subst);
+
+        List<LPair>::push(make_pair(
+          branchLiteral, List<GenLit>::cons(negCondition, gls)), processedLiterals);
+      }
+    }
+    literals = processedLiterals;
+  }
+
+  ASS(matchVariables.isEmpty());
+  ASS(matchConditions.isEmpty());
+  ASS(matchBranches.isEmpty());
+
   while (occurrences.isNonEmpty()) {
     Occurrence occ = pop(occurrences);
 
@@ -253,7 +301,9 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
 }
 
 TermList NewCNF::findITEs(TermList ts, Stack<unsigned> &variables, Stack<Formula*> &conditions,
-                          Stack<TermList> &thenBranches, Stack<TermList> &elseBranches)
+                          Stack<TermList> &thenBranches, Stack<TermList> &elseBranches,
+                          Stack<unsigned> &matchVariables, Stack<List<Formula*>*> &matchConditions,
+                          Stack<List<TermList>*> &matchBranches)
 {
   CALL("NewCNF::findITEs");
 
@@ -267,7 +317,8 @@ TermList NewCNF::findITEs(TermList ts, Stack<unsigned> &variables, Stack<Formula
 
     Term::Iterator it(term);
     while (it.hasNext()) {
-      arguments.push(findITEs(it.next(), variables, conditions, thenBranches, elseBranches));
+      arguments.push(findITEs(it.next(), variables, conditions, thenBranches,
+        elseBranches, matchVariables, matchConditions, matchBranches));
     }
 
     unsigned proj;
@@ -305,12 +356,37 @@ TermList NewCNF::findITEs(TermList ts, Stack<unsigned> &variables, Stack<Formula
     case Term::SF_LET_TUPLE: {
       TermList contents = *term->nthArgument(0);
       TermList processedLet = eliminateLet(sd, contents);
-      return findITEs(processedLet, variables, conditions, thenBranches, elseBranches);
+      return findITEs(processedLet, variables, conditions, thenBranches,
+        elseBranches, matchVariables, matchConditions, matchBranches);
     }
 
     case Term::SF_TUPLE: {
       TermList tupleTerm = TermList(sd->getTupleTerm());
-      return findITEs(tupleTerm, variables, conditions, thenBranches, elseBranches);
+      return findITEs(tupleTerm, variables, conditions, thenBranches,
+        elseBranches, matchVariables, matchConditions, matchBranches);
+    }
+
+    case Term::SF_MATCH: {
+      sort = sd->getSort();
+      auto matched = *term->nthArgument(0);
+      List<Formula*>* mconditions(0);
+      List<TermList>* mbranches(0);
+      // for each case (p, t) with matched term m,
+      // we create a condition m=p and a branch t
+      for (unsigned int i = 1; i < term->arity(); i+=2) {
+        auto pattern = *term->nthArgument(i);
+        auto body = *term->nthArgument(i+1);
+        Formula* condition = new AtomicFormula(
+          Literal::createEquality(POSITIVE, matched, pattern, sd->getMatchedSort()));
+        List<Formula*>::push(condition, mconditions);
+        List<TermList>::push(body, mbranches);
+      }
+      matchConditions.push(mconditions);
+      matchBranches.push(mbranches);
+
+      unsigned var = createFreshVariable(sort);
+      matchVariables.push(var);
+      return TermList(var, false);
     }
 
     default:
@@ -562,6 +638,30 @@ void NewCNF::processITE(Formula* condition, Formula* thenBranch, Formula* elseBr
       introduceExtendedGenClause(occ, GenLit(condition, conditionSign), GenLit(branch, occ.sign()));
     }
   }
+}
+
+void NewCNF::processMatch(Term::SpecialTermData* sd, Term* term, Occurrences &occurrences)
+{
+  CALL("NewCNF::processMatch");
+  auto matched = *term->nthArgument(0);
+
+  for (unsigned int i = 1; i < term->arity(); i+=2) {
+    auto pattern = *term->nthArgument(i);
+    auto body = *term->nthArgument(i+1);
+    Formula* condition = new AtomicFormula(
+      Literal::createEquality(POSITIVE, matched, pattern, sd->getMatchedSort()));
+    auto branch = BoolTermFormula::create(body);
+
+    enqueue(condition);
+    enqueue(branch);
+
+    Occurrences::Iterator occit(occurrences);
+    while (occit.hasNext()) {
+      Occurrence occ = occit.next();
+      introduceExtendedGenClause(occ, GenLit(condition, NEGATIVE), GenLit(branch, occ.sign()));
+    }
+  }
+  while (occurrences.isNonEmpty()) { pop(occurrences); }
 }
 
 TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
@@ -1095,6 +1195,10 @@ void NewCNF::processBoolterm(TermList ts, Occurrences &occurrences)
     case Term::SF_LET:
     case Term::SF_LET_TUPLE:
       processLet(sd, *term->nthArgument(0), occurrences);
+      break;
+
+    case Term::SF_MATCH:
+      processMatch(sd, term, occurrences);
       break;
 
     default:

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1200,9 +1200,10 @@ void NewCNF::processBoolterm(TermList ts, Occurrences &occurrences)
       processLet(sd, *term->nthArgument(0), occurrences);
       break;
 
-    case Term::SF_MATCH:
+    case Term::SF_MATCH: {
       processMatch(sd, term, occurrences);
       break;
+    }
 
     default:
       ASSERTION_VIOLATION_REP(term->toString());

--- a/Shell/NewCNF.hpp
+++ b/Shell/NewCNF.hpp
@@ -642,6 +642,7 @@ private:
   void processConstant(bool constant, Occurrences &occurrences);
   void processBoolVar(SIGN sign, unsigned var, Occurrences &occurrences);
   void processITE(Formula* condition, Formula* thenBranch, Formula* elseBranch, Occurrences &occurrences);
+  void processMatch(Term::SpecialTermData* sd, Term* term, Occurrences &occurrences);
   void processLet(Term::SpecialTermData* sd, TermList contents, Occurrences &occurrences);
   TermList eliminateLet(Term::SpecialTermData *sd, TermList contents);
 
@@ -649,7 +650,9 @@ private:
   TermList inlineLetBinding(unsigned symbol, VList *bindingVariables, TermList binding, TermList contents);
 
   TermList findITEs(TermList ts, Stack<unsigned> &variables, Stack<Formula*> &conditions,
-                                 Stack<TermList> &thenBranches, Stack<TermList> &elseBranches);
+                    Stack<TermList> &thenBranches, Stack<TermList> &elseBranches,
+                    Stack<unsigned> &matchVariables, Stack<List<Formula*>*> &matchConditions,
+                    Stack<List<TermList>*> &matchBranches);
 
   unsigned createFreshVariable(TermList sort);
   void createFreshVariableRenaming(unsigned oldVar, unsigned freshVar);

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -509,6 +509,10 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
         return comp;     
       }
 
+      case Term::SF_MATCH: {
+        break; // comparison by arity and pairwise by arguments is done below
+      }
+
       default:
         ASSERTION_VIOLATION;
     }

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -899,6 +899,9 @@ void PredicateDefinition::count (TermList ts,int add, Unit* unit)
         count(TermList(sd->getTupleTerm()), add, unit);
         break;
 
+      case Term::SF_MATCH:
+        break; // args are handled later
+
       default:
         ASSERTION_VIOLATION;
     }

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -678,6 +678,10 @@ void Property::scan(TermList ts,bool unit,bool goal)
         _hasFOOL = true;
         break;
 
+      case Term::SF_MATCH:
+        //TODO(mhajdu): find out whether to do anything here
+        break;
+
       default:
         break;
     }

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -679,7 +679,7 @@ void Property::scan(TermList ts,bool unit,bool goal)
         break;
 
       case Term::SF_MATCH:
-        //TODO(mhajdu): find out whether to do anything here
+        _hasFOOL = true;
         break;
 
       default:

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -244,6 +244,21 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createTuple(rectifiedTupleTerm);
   }
+  case Term::SF_MATCH:
+  {
+    DArray<TermList> terms(t->arity());
+    bool unchanged = true;
+    for (unsigned i = 0; i < t->arity(); i++) {
+      TermList subterm = rectify(*t->nthArgument(i));
+      unchanged = unchanged && (subterm == *t->nthArgument(i));
+      terms[i] = subterm;
+    }
+
+    if (unchanged) {
+      return t;
+    }
+    return Term::createMatch(sd->getSort(), sd->getMatchedSort(), t->arity(), terms.begin());
+  }
   default:
     ASSERTION_VIOLATION;
   }

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -248,9 +248,8 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     DArray<TermList> terms(t->arity());
     bool unchanged = true;
     for (unsigned i = 0; i < t->arity(); i++) {
-      TermList subterm = rectify(*t->nthArgument(i));
-      unchanged = unchanged && (subterm == *t->nthArgument(i));
-      terms[i] = subterm;
+      terms[i] = rectify(*t->nthArgument(i));
+      unchanged = unchanged && (terms[i] == *t->nthArgument(i));
     }
 
     if (unchanged) {

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -244,8 +244,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createTuple(rectifiedTupleTerm);
   }
-  case Term::SF_MATCH:
-  {
+  case Term::SF_MATCH: {
     DArray<TermList> terms(t->arity());
     bool unchanged = true;
     for (unsigned i = 0; i < t->arity(); i++) {

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -450,6 +450,19 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         ASS_REP(simplifiedTupleTerm.isTerm(), simplifiedTupleTerm.toString());
         return TermList(Term::createTuple(simplifiedTupleTerm.term()));
       }
+      case Term::SF_MATCH: {
+        DArray<TermList> terms(term->arity());
+        bool unchanged = true;
+        for (unsigned i = 0; i < term->arity(); i++) {
+          terms[i] = simplify(*term->nthArgument(i));
+          unchanged = unchanged && (terms[i] == *term->nthArgument(i));
+        }
+
+        if (unchanged) {
+          return ts;
+        }
+        return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
+      }
       default:
         ASSERTION_VIOLATION_REP(term->toString());
     }

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -83,6 +83,10 @@ void SineSymbolExtractor::addSymIds(Term* term, Stack<SymId>& ids)
           addSymIds(sd->getTupleTerm(), ids);
           break;
         }
+        case Term::SF_MATCH: {
+          // args are handled below
+          break;
+        }
         default:
           ASSERTION_VIOLATION;
       }

--- a/Shell/SubexpressionIterator.cpp
+++ b/Shell/SubexpressionIterator.cpp
@@ -156,6 +156,13 @@ namespace Shell {
               _subexpressions.push(Expression(sd->getTupleTerm()));
               break; */
 
+            case Term::SF_MATCH: {
+              for (unsigned i = 0; i < term->arity(); i++) {
+                _subexpressions.push(Expression(*term->nthArgument(i), polarity));
+              }
+              break;
+            }
+
 #if VDEBUG
             default:
               ASSERTION_VIOLATION_REP(term->toString());

--- a/Shell/SymCounter.cpp
+++ b/Shell/SymCounter.cpp
@@ -236,6 +236,9 @@ void SymCounter::count(Term* term, int polarity, int add)
           if(lambdaExp.isTerm()){
             count(lambdaExp.term(), polarity, add);
           }
+        }
+        case Term::SF_MATCH: {
+          // TODO(mhajdu): find out what to do here
           break;
         }
         default:

--- a/Shell/SymbolDefinitionInlining.cpp
+++ b/Shell/SymbolDefinitionInlining.cpp
@@ -138,6 +138,20 @@ TermList SymbolDefinitionInlining::process(TermList ts) {
         return TermList(Term::createTuple(t));
       }
 
+      case Term::SF_MATCH: {
+        DArray<TermList> terms(term->arity());
+        bool unchanged = true;
+        for (unsigned i = 0; i < term->arity(); i++) {
+          terms[i] = process(*term->nthArgument(i));
+          unchanged = unchanged && (terms[i] == *term->nthArgument(i));
+        }
+
+        if (unchanged) {
+          return ts;
+        }
+        return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
+      }
+
       default:
         ASSERTION_VIOLATION_REP(term->toString());
     }
@@ -383,6 +397,10 @@ void SymbolDefinitionInlining::collectBoundVariables(Term* t) {
       }
       case Term::SF_TUPLE: {
         collectBoundVariables(sd->getTupleTerm());
+        break;
+      }
+      case Term::SF_MATCH: {
+        // args are handled below
         break;
       }
       default:

--- a/Shell/SymbolOccurrenceReplacement.cpp
+++ b/Shell/SymbolOccurrenceReplacement.cpp
@@ -49,6 +49,14 @@ Term* SymbolOccurrenceReplacement::process(Term* term) {
       case Term::SF_TUPLE:
         return Term::createTuple(process(TermList(sd->getTupleTerm())).term());
 
+      case Term::SF_MATCH: {
+        DArray<TermList> terms(term->arity());
+        for (unsigned i = 0; i < term->arity(); i++) {
+          terms[i] = process(*term->nthArgument(i));
+        }
+        return Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin());
+      }
+
 #if VDEBUG
         default:
           ASSERTION_VIOLATION;

--- a/checks/Problems/Parse/types-funs.smt2
+++ b/checks/Problems/Parse/types-funs.smt2
@@ -1,0 +1,23 @@
+(declare-datatypes ((nat 0) (list 0))
+  (((zero) (s (s0 nat)))
+   ((nil) (cons (head nat) (tail list)))))
+(declare-datatype
+  tree ((Nil) (node (lc tree) (val nat) (rc tree))))
+(define-fun f
+    ((x list)) nat
+    (match x
+        ((nil zero)
+        ((cons x0 x1) x0))))
+(define-fun-rec r
+    ((x tree) (y nat)) nat
+    (match x
+        ((Nil zero)
+        ((node x0 x1 x2)
+            (match x0
+                ((Nil zero)
+                ((node x00 x01 x02)
+                    (match y
+                        ((zero (f nil))
+                        ((s y0) (r x2 y0)))))))))))
+(assert (not (= zero (r (node (node Nil (s zero) Nil) zero Nil) (s zero)))))
+(check-sat)

--- a/checks/sanity
+++ b/checks/sanity
@@ -23,4 +23,8 @@ szs_status 1 Theorem Problems/PUZ/PUZ001+1.p
 szs_status 1 Unsatisfiable -ind int Problems/ind/int_invariant_infinite_geq3_val3.smt2
 szs_status 1 Unsatisfiable -ind int Problems/ind/int_invariant_finite_a_to_b.smt2
 szs_status 60 Unsatisfiable --forced_options "drc=off:ind=int:intindint=infinite:sos=theory:sstl=1:to=lpo" Problems/ind/int_power_0_all_0.smt2
-szs_status 60 Unsatisfiable --forced_options "ind=int:sa=discount:sos=theory:sstl=1:to=lpo" Problems/ind/int_sum_y_geq_0.smt2 
+szs_status 60 Unsatisfiable --forced_options "ind=int:sa=discount:sos=theory:sstl=1:to=lpo" Problems/ind/int_sum_y_geq_0.smt2
+
+# Parser
+szs_status 1 Unsatisfiable --input_syntax smtlib2 Problems/Parse/types-funs.smt2
+szs_status 1 Unsatisfiable --input_syntax smtlib2 -newcnf on Problems/Parse/types-funs.smt2


### PR DESCRIPTION
This pull request extends our current SMT-LIB parsing capabilities with some useful keywords based on [this documentation](http://smtlib.cs.uiowa.edu/papers/smt-lib-reference-v2.6-r2017-07-18.pdf):
- A `match` term is a case distinction of n cases on a term algebra variable. Each case is a pair `(p t)` where `p` (the pattern) is either a constructor term, a variable, or an underscore. The term `p` can declare new variables, so we create a new variable scope for each such pair before parsing and add the new variables. E.g.: `(match x (nil y) ((cons u v) v))` contains two cases `nil` and `(cons u v)`, where the second branch declares `u` and `v`. Since the standard does not require the variables to be fresh, just to be distinct, we create a new scope for each case, just like in case of quantifier blocks.
The case distinction must be exhaustive and non-overlapping (this latter is in fact not required by the standard). The exhaustiveness is ensured by either listing all constructor terms or by adding at most one 'else' branch where `p` is a variable or an underscore. An underscore means that the variable is not used in the block and can be ignored. In accord with the standard, we disallow nested constructor terms, e.g. a pattern `(cons u (cons v w))` is not allowed, one needs to first add `(cons u u0)` to an outer case distinction and then make a case distinction on `u0` which contains `(cons v w)`.
If there is an else branch with an explicit variable `x`, we create the missing n ctor terms and substitute each for `x` into n copies of the else body.
- A `define-fun-rec` block is the same as a `define-fun` block except we declare the function before parsing its body, therefore the function can call itself.
- A `declare-datatype` is a singular datatype declaration. E.g.:
`(declare-datatype list ((nil) (cons (head nat) (tail (list nat)))))`
The first argument is the name of the datatype, the second is the list of its ctors. The keyword `par` is reserved for parametric declarations, if the ctor list contains an atom `par`, we report error (since these are not supported).

The `match` blocks are converted to special terms `$match(matched_term,p1,t1,...,pn,tn)` which are then eliminated in either FOOLElimination or NewCNF:
- In FOOLElimination, we declare a new function of arity m for each match block with m free variables, then replace the match with the function and the concrete free variables as its arguments. We also add a clause for each case. So a match occurrence:
`L[$match(matched_term,p1,t1,...,pn,tn)] v C`
becomes
`L[mG(x1,...,xm)] v C, matched_term != p1 v mG(x1,...,xm) = t1, ..., matched_term != pn v mG(x1,...,xm) = tn`
- In NewCNF, we parse any subformula/subterm similarly for matches as for ITEs TODO