### PR TITLE
Fix multicore proof printing

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -559,6 +559,11 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     } else {
       UIHelper::outputResult(output);
     }
+    if (env.options->printProofToFile() && outputAllowed()) {
+      env.beginOutput();
+      addCommentSignForSZS(env.out()) << "Proof written to " << fname << endl;
+      env.endOutput();
+    }
   }
   else{
     /*

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -387,13 +387,13 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
     vstring fname = env.options->problemName() + "-vampire.proof";    
     BYPASSING_ALLOCATOR; 
     
-    ScopedPtr<ifstream> input(new ifstream(fname.c_str()));
+    ifstream input(fname.c_str());
 
-    bool openSucceeded = !input->fail();
+    bool openSucceeded = !input.fail();
 
     if (openSucceeded) {
       env.beginOutput();
-      env.out() << input->rdbuf();
+      env.out() << input.rdbuf();
       env.endOutput();
     }
 

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -398,6 +398,12 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
       env.beginOutput();
       env.out() << input.rdbuf();
       env.endOutput();
+    } else {
+      if (outputAllowed()) {
+        env.beginOutput();
+        addCommentSignForSZS(env.out()) << "Failed to restore proof from tempfile " << outputFileName << endl;
+        env.endOutput();
+      }
     }
 
     //If for some reason, the proof could not be opened

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -50,7 +50,7 @@ PortfolioMode::PortfolioMode() : _slowness(1.0), _syncSemaphore(2) {
   // 1) dec is the only operation which is blocking
   // 2) dec is done in the mode SEM_UNDO, so is undone when a process terminates
 
-  if(env.options->printProofToFile()){
+  if(!env.options->printProofToFile()){
     outputFileName = tmpnam(NULL);
   }
   _syncSemaphore.set(SEM_LOCK,1);    // to synchronize access to the second field
@@ -560,6 +560,9 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     if (output.fail()) {
       // fallback to old printing method
       env.beginOutput();
+      // the comment below assumes that writing to temporary file never fails
+      // otherwise the comment "proof printing ..." would be confusing
+      addCommentSignForSZS(env.out()) << "Proof printing to file failed. Outputting to stdout" << fname << endl;
       UIHelper::outputResult(env.out());
       env.endOutput();
     } else {

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -51,7 +51,7 @@ PortfolioMode::PortfolioMode() : _slowness(1.0), _syncSemaphore(2) {
   // 2) dec is done in the mode SEM_UNDO, so is undone when a process terminates
 
   if(!env.options->printProofToFile()){
-    outputFileName = tmpnam(NULL);
+    _outputFileName = tmpnam(NULL);
   }
   _syncSemaphore.set(SEM_LOCK,1);    // to synchronize access to the second field
   _syncSemaphore.set(SEM_PRINTED,0); // to indicate that a child has already printed result (it should only happen once)
@@ -390,7 +390,7 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
   if(result && !env.options->printProofToFile()){  
     BYPASSING_ALLOCATOR; 
     
-    ifstream input(outputFileName);
+    ifstream input(_outputFileName);
 
     bool openSucceeded = !input.fail();
 
@@ -401,7 +401,7 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
     } else {
       if (outputAllowed()) {
         env.beginOutput();
-        addCommentSignForSZS(env.out()) << "Failed to restore proof from tempfile " << outputFileName << endl;
+        addCommentSignForSZS(env.out()) << "Failed to restore proof from tempfile " << _outputFileName << endl;
         env.endOutput();
       }
     }
@@ -409,7 +409,7 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
     //If for some reason, the proof could not be opened
     //we don't delete the proof file
     if(openSucceeded){
-      remove(outputFileName); 
+      remove(_outputFileName); 
     }
   }
 
@@ -550,7 +550,7 @@ void PortfolioMode::runSlice(Options& strategyOpt)
   if((outputAllowed() && resultValue) || outputResult) { // we can report on every failure, but only once on success
     //At the moment we only save one proof. We could potentially
     //allow multiple proofs
-    vstring fname(outputFileName);
+    vstring fname(_outputFileName);
     if(env.options->printProofToFile())
     {
       vstring fileLoc = env.options->outputFileLocation();

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -387,7 +387,7 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
     vstring fname = env.options->problemName() + "-vampire.proof";    
     BYPASSING_ALLOCATOR; 
     
-    istream* input=new ifstream(fname.c_str());
+    ScopedPtr<ifstream> input(new ifstream(fname.c_str()));
 
     bool openSucceeded = !input->fail();
 
@@ -396,9 +396,6 @@ bool PortfolioMode::runSchedule(Schedule& schedule)
       env.out() << input->rdbuf();
       env.endOutput();
     }
-
-    delete static_cast<ifstream*>(input);
-    input=0;
 
     //If for some reason, the proof could not be opened
     //we don't delete the proof file
@@ -549,7 +546,7 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     // CAREFUL: this might not be enough if the ofstream (re)allocates while being operated
     BYPASSING_ALLOCATOR; 
     
-    ostream* output=new ofstream(fname.c_str());
+    ScopedPtr<ofstream> output(new ofstream(fname.c_str()));
     if (output->fail()) {
       // fallback to old printing method
       env.beginOutput();
@@ -558,8 +555,6 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     } else {
       UIHelper::outputResult(*output);
     }
-    delete static_cast<ofstream*>(output);
-    output = 0;
   }
   else{
     /*

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -542,18 +542,22 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     //At the moment we only save one proof. We could potentially
     //allow multiple proofs
     vstring fname = env.options->problemName() + "-vampire.proof";
+    if(env.options->printProofToFile() && env.options->outputFileLocation() != "")
+    {
+      fname = env.options->outputFileLocation() + "/" + fname;
+    }
 
     // CAREFUL: this might not be enough if the ofstream (re)allocates while being operated
     BYPASSING_ALLOCATOR; 
     
-    ScopedPtr<ofstream> output(new ofstream(fname.c_str()));
-    if (output->fail()) {
+    ofstream output(fname.c_str());
+    if (output.fail()) {
       // fallback to old printing method
       env.beginOutput();
       UIHelper::outputResult(env.out());
       env.endOutput();
     } else {
-      UIHelper::outputResult(*output);
+      UIHelper::outputResult(output);
     }
   }
   else{

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -557,11 +557,9 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     BYPASSING_ALLOCATOR; 
     
     ofstream output(fname.c_str());
-    if (output.fail()) {
+    if (output.fail() && env.options->printProofToFile()) {
       // fallback to old printing method
       env.beginOutput();
-      // the comment below assumes that writing to temporary file never fails
-      // otherwise the comment "proof printing ..." would be confusing
       addCommentSignForSZS(env.out()) << "Proof printing to file failed. Outputting to stdout" << fname << endl;
       UIHelper::outputResult(env.out());
       env.endOutput();

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -87,6 +87,8 @@ private:
 
   float _slowness;
 
+  const char * outputFileName;
+
   /**
    * Problem that is being solved.
    *

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -87,7 +87,7 @@ private:
 
   float _slowness;
 
-  const char * outputFileName;
+  const char * _outputFileName;
 
   /**
    * Problem that is being solved.

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -87,7 +87,7 @@ private:
 
   float _slowness;
 
-  const char * _outputFileName;
+  const char * _tmpFileNameForProof;
 
   /**
    * Problem that is being solved.

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -516,7 +516,7 @@ struct InferenceStore::TPTPProofPrinter
   {
     //outputSymbolDeclarations also deals with sorts for now
     //UIHelper::outputSortDeclarations(env.out());
-    UIHelper::outputSymbolDeclarations(env.out());
+    UIHelper::outputSymbolDeclarations(out);
     ProofPrinter::print();
   }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -291,7 +291,7 @@ void Options::init()
 
     _outputFileLocation = StringOptionValue("proof_output_directory","pod","");
     _outputFileLocation.description="The location to which Vampire should save the proof.\n"
-                                    "If proofs are being saved to file, but this option is not set, the location of the Vampire binary is use.";
+                                    "If proofs are being saved to file, but this option is not set, the location Vampire is being run from is used.";
     _lookup.insert(&_outputFileLocation);
     _outputFileLocation.tag(OptionTag::OUTPUT);
     _outputFileLocation.reliesOnHard(_printProofToFile.is(equal(true)));

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -280,22 +280,21 @@ void Options::init()
     _lookup.insert(&_minimizeSatProofs);
     _minimizeSatProofs.tag(OptionTag::OUTPUT);
 
+    vstring emptyString = "";
     _printProofToFile = BoolOptionValue("print_proofs_to_file","pptf",false);
     _printProofToFile.description="If Vampire finds a proof, it is printed to a file instead of to stdout.\n"
                                   "The file name will be of the format <problem name>-vampire.proof.\n"
                                   "Currently, this option only works in portfolio mode.";
     _lookup.insert(&_printProofToFile);
-    _printProofToFile.reliesOn(_outputFileLocation.is(notEqual("")));
+    _printProofToFile.reliesOn(_outputFileLocation.is(notEqual(emptyString)));
     _printProofToFile.tag(OptionTag::OUTPUT);
 
-    _outputFileLocation = StringOptionValue("output_file","","");
+    _outputFileLocation = StringOptionValue("proof_output_directory","pod","");
     _outputFileLocation.description="The location to which Vampire should save the proof.\n"
-                                    "If the string does not name a valid file location, an error occurs.\n"
                                     "If proofs are being saved to file, but this option is not set, the location of the Vampire binary is use.";
     _lookup.insert(&_outputFileLocation);
     _outputFileLocation.tag(OptionTag::OUTPUT);
     _outputFileLocation.reliesOnHard(_printProofToFile.is(equal(true)));
-    _outputFileLocation.addHardConstraint(isValidSystemLocation()); // Does not work for all (any?) preprocessing steps currently
 
     _proofExtra = ChoiceOptionValue<ProofExtra>("proof_extra","",ProofExtra::OFF,{"off","free","full"});
     _proofExtra.description="Add extra detail to proofs:\n "
@@ -3103,6 +3102,8 @@ vstring Options::generateEncodedOptions() const
     forbidden.insert(&_mode);
     forbidden.insert(&_testId); // is this old version of decode?
     forbidden.insert(&_include);
+    forbidden.insert(&_printProofToFile);
+    forbidden.insert(&_outputFileLocation);
     forbidden.insert(&_problemName);
     forbidden.insert(&_inputFile);
     forbidden.insert(&_randomStrategy);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -280,27 +280,11 @@ void Options::init()
     _lookup.insert(&_minimizeSatProofs);
     _minimizeSatProofs.tag(OptionTag::OUTPUT);
 
-    vstring emptyString = "";
-    _printProofToFile = BoolOptionValue("print_proofs_to_file","pptf",false);
-    _printProofToFile.description="If Vampire finds a proof, it is printed to a file instead of to stdout.\n"
-                                  "The file name will be of the format <problem name>-vampire.proof.\n"
+    _printProofToFile = StringOptionValue("print_proofs_to_file","pptf","");
+    _printProofToFile.description="If Vampire finds a proof, it is printed to the here specified file instead of to stdout.\n"
                                   "Currently, this option only works in portfolio mode.";
     _lookup.insert(&_printProofToFile);
-    _printProofToFile.reliesOnHard(_outputFileName.is(notEqual(emptyString)));
     _printProofToFile.tag(OptionTag::OUTPUT);
-
-    _outputFileLocation = StringOptionValue("proof_output_directory","pod","");
-    _outputFileLocation.description="The location to which Vampire should save the proof.\n"
-                                    "If proofs are being saved to file, but this option is not set, the location Vampire is being run from is used.";
-    _lookup.insert(&_outputFileLocation);
-    _outputFileLocation.tag(OptionTag::OUTPUT);
-    _outputFileLocation.reliesOnHard(_printProofToFile.is(equal(true)));
-
-    _outputFileName = StringOptionValue("proof_file_name","pfn","");
-    _outputFileName.description="The name of the file to which Vampire should save the proof.";
-    _lookup.insert(&_outputFileName);
-    _outputFileName.tag(OptionTag::OUTPUT);
-    _outputFileName.reliesOnHard(_printProofToFile.is(equal(true)));
 
     _proofExtra = ChoiceOptionValue<ProofExtra>("proof_extra","",ProofExtra::OFF,{"off","free","full"});
     _proofExtra.description="Add extra detail to proofs:\n "
@@ -3109,7 +3093,6 @@ vstring Options::generateEncodedOptions() const
     forbidden.insert(&_testId); // is this old version of decode?
     forbidden.insert(&_include);
     forbidden.insert(&_printProofToFile);
-    forbidden.insert(&_outputFileLocation);
     forbidden.insert(&_problemName);
     forbidden.insert(&_inputFile);
     forbidden.insert(&_randomStrategy);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -286,7 +286,7 @@ void Options::init()
                                   "The file name will be of the format <problem name>-vampire.proof.\n"
                                   "Currently, this option only works in portfolio mode.";
     _lookup.insert(&_printProofToFile);
-    _printProofToFile.reliesOn(_outputFileLocation.is(notEqual(emptyString)));
+    // _printProofToFile.reliesOn(_outputFileLocation.is(notEqual(emptyString)));
     _printProofToFile.tag(OptionTag::OUTPUT);
 
     _outputFileLocation = StringOptionValue("proof_output_directory","pod","");

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -281,8 +281,8 @@ void Options::init()
     _minimizeSatProofs.tag(OptionTag::OUTPUT);
 
     _printProofToFile = BoolOptionValue("print_proofs_to_file","pptf",false);
-    _printProofToFile.description="If Vampire finds a proof, it is printed to a file instead of to stdout.\n";
-                                  "The file name will be of the format <problem name>-vampire.proof.\n";
+    _printProofToFile.description="If Vampire finds a proof, it is printed to a file instead of to stdout.\n"
+                                  "The file name will be of the format <problem name>-vampire.proof.\n"
                                   "Currently, this option only works in portfolio mode.";
     _lookup.insert(&_printProofToFile);
     _printProofToFile.tag(OptionTag::OUTPUT);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -285,7 +285,17 @@ void Options::init()
                                   "The file name will be of the format <problem name>-vampire.proof.\n"
                                   "Currently, this option only works in portfolio mode.";
     _lookup.insert(&_printProofToFile);
+    _printProofToFile.reliesOn(_outputFileLocation.is(notEqual("")));
     _printProofToFile.tag(OptionTag::OUTPUT);
+
+    _outputFileLocation = StringOptionValue("output_file","","");
+    _outputFileLocation.description="The location to which Vampire should save the proof.\n"
+                                    "If the string does not name a valid file location, an error occurs.\n"
+                                    "If proofs are being saved to file, but this option is not set, the location of the Vampire binary is use.";
+    _lookup.insert(&_outputFileLocation);
+    _outputFileLocation.tag(OptionTag::OUTPUT);
+    _outputFileLocation.reliesOnHard(_printProofToFile.is(equal(true)));
+    _outputFileLocation.addHardConstraint(isValidSystemLocation()); // Does not work for all (any?) preprocessing steps currently
 
     _proofExtra = ChoiceOptionValue<ProofExtra>("proof_extra","",ProofExtra::OFF,{"off","free","full"});
     _proofExtra.description="Add extra detail to proofs:\n "

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -280,6 +280,13 @@ void Options::init()
     _lookup.insert(&_minimizeSatProofs);
     _minimizeSatProofs.tag(OptionTag::OUTPUT);
 
+    _printProofToFile = BoolOptionValue("print_proofs_to_file","pptf",false);
+    _printProofToFile.description="If Vampire finds a proof, it is printed to a file instead of to stdout.\n";
+                                  "The file name will be of the format <problem name>-vampire.proof.\n";
+                                  "Currently, this option only works in portfolio mode.";
+    _lookup.insert(&_printProofToFile);
+    _printProofToFile.tag(OptionTag::OUTPUT);
+
     _proofExtra = ChoiceOptionValue<ProofExtra>("proof_extra","",ProofExtra::OFF,{"off","free","full"});
     _proofExtra.description="Add extra detail to proofs:\n "
       "- free uses known information only\n" 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -286,7 +286,7 @@ void Options::init()
                                   "The file name will be of the format <problem name>-vampire.proof.\n"
                                   "Currently, this option only works in portfolio mode.";
     _lookup.insert(&_printProofToFile);
-    // _printProofToFile.reliesOn(_outputFileLocation.is(notEqual(emptyString)));
+    _printProofToFile.reliesOnHard(_outputFileName.is(notEqual(emptyString)));
     _printProofToFile.tag(OptionTag::OUTPUT);
 
     _outputFileLocation = StringOptionValue("proof_output_directory","pod","");
@@ -295,6 +295,12 @@ void Options::init()
     _lookup.insert(&_outputFileLocation);
     _outputFileLocation.tag(OptionTag::OUTPUT);
     _outputFileLocation.reliesOnHard(_printProofToFile.is(equal(true)));
+
+    _outputFileName = StringOptionValue("proof_file_name","pfn","");
+    _outputFileName.description="The name of the file to which Vampire should save the proof.";
+    _lookup.insert(&_outputFileName);
+    _outputFileName.tag(OptionTag::OUTPUT);
+    _outputFileName.reliesOnHard(_printProofToFile.is(equal(true)));
 
     _proofExtra = ChoiceOptionValue<ProofExtra>("proof_extra","",ProofExtra::OFF,{"off","free","full"});
     _proofExtra.description="Add extra detail to proofs:\n "

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1917,9 +1917,7 @@ public:
   Proof proof() const { return _proof.actualValue; }
   bool minimizeSatProofs() const { return _minimizeSatProofs.actualValue; }
   ProofExtra proofExtra() const { return _proofExtra.actualValue; }
-  bool printProofToFile() const { return _printProofToFile.actualValue; }
-  vstring outputFileLocation() const { return _outputFileLocation.actualValue; }
-  vstring outputFileName() const { return _outputFileName.actualValue; }  
+  vstring printProofToFile() const { return _printProofToFile.actualValue; }
   bool proofChecking() const { return _proofChecking.actualValue; }
   int naming() const { return _naming.actualValue; }
 
@@ -2519,9 +2517,7 @@ private:
 
   BoolOptionValue _outputAxiomNames;
 
-  BoolOptionValue _printProofToFile;
-  StringOptionValue _outputFileLocation;
-  StringOptionValue _outputFileName;     
+  StringOptionValue _printProofToFile;
   BoolOptionValue _printClausifierPremises;
   StringOptionValue _problemName;
   ChoiceOptionValue<Proof> _proof;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1698,27 +1698,6 @@ bool _hard;
         return OptionValueConstraintUP<int>(new NotDefaultRatioConstraint());
     }
 
-    struct IsValidSystemLocation : public OptionValueConstraint<vstring>{
-        CLASS_NAME(IsValidSystemLocation);
-        USE_ALLOCATOR(IsValidSystemLocation);
-        IsValidSystemLocation() {}
-        bool check(const OptionValue<vstring>& value){
-          struct stat info;
-          if( stat(value.actualValue.c_str(), &info ) != 0 ) {
-            return false;
-          }
-          return true;
-        }
-        vstring msg(const OptionValue<vstring>& value){
-            return value.actualValue + " is not a valid directory";
-        }
-    };
-
-    // You will need to provide the type, optionally use addConstraintIfNotDefault
-    static OptionValueConstraintUP<vstring> isValidSystemLocation(){
-        return OptionValueConstraintUP<vstring>(new IsValidSystemLocation());
-    }
-
     struct isLookAheadSelectionConstraint : public OptionValueConstraint<int>{
         CLASS_NAME(isLookAheadSelectionConstraint);
         USE_ALLOCATOR(isLookAheadSelectionConstraint);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -38,6 +38,7 @@
 #include <type_traits>
 #include <cstring>
 #include <memory>
+#include <sys/stat.h>
 
 #include "Forwards.hpp"
 
@@ -1697,6 +1698,27 @@ bool _hard;
         return OptionValueConstraintUP<int>(new NotDefaultRatioConstraint());
     }
 
+    struct IsValidSystemLocation : public OptionValueConstraint<vstring>{
+        CLASS_NAME(IsValidSystemLocation);
+        USE_ALLOCATOR(IsValidSystemLocation);
+        IsValidSystemLocation() {}
+        bool check(const OptionValue<vstring>& value){
+          struct stat info;
+          if( stat(value.actualValue.c_str(), &info ) != 0 ) {
+            return false;
+          }
+          return true;
+        }
+        vstring msg(const OptionValue<vstring>& value){
+            return value.actualValue + " is not a valid directory";
+        }
+    };
+
+    // You will need to provide the type, optionally use addConstraintIfNotDefault
+    static OptionValueConstraintUP<vstring> isValidSystemLocation(){
+        return OptionValueConstraintUP<vstring>(new IsValidSystemLocation());
+    }
+
     struct isLookAheadSelectionConstraint : public OptionValueConstraint<int>{
         CLASS_NAME(isLookAheadSelectionConstraint);
         USE_ALLOCATOR(isLookAheadSelectionConstraint);
@@ -1917,6 +1939,7 @@ public:
   bool minimizeSatProofs() const { return _minimizeSatProofs.actualValue; }
   ProofExtra proofExtra() const { return _proofExtra.actualValue; }
   bool printProofToFile() const { return _printProofToFile.actualValue; }
+  vstring outputFileLocation() const { return _outputFileLocation.actualValue; }
   bool proofChecking() const { return _proofChecking.actualValue; }
   int naming() const { return _naming.actualValue; }
 
@@ -2517,6 +2540,7 @@ private:
   BoolOptionValue _outputAxiomNames;
 
   BoolOptionValue _printProofToFile;
+  StringOptionValue _outputFileLocation;  
   BoolOptionValue _printClausifierPremises;
   StringOptionValue _problemName;
   ChoiceOptionValue<Proof> _proof;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1916,6 +1916,7 @@ public:
   Proof proof() const { return _proof.actualValue; }
   bool minimizeSatProofs() const { return _minimizeSatProofs.actualValue; }
   ProofExtra proofExtra() const { return _proofExtra.actualValue; }
+  bool printProofToFile() const { return _printProofToFile.actualValue; }
   bool proofChecking() const { return _proofChecking.actualValue; }
   int naming() const { return _naming.actualValue; }
 
@@ -2515,6 +2516,7 @@ private:
 
   BoolOptionValue _outputAxiomNames;
 
+  BoolOptionValue _printProofToFile;
   BoolOptionValue _printClausifierPremises;
   StringOptionValue _problemName;
   ChoiceOptionValue<Proof> _proof;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1919,6 +1919,7 @@ public:
   ProofExtra proofExtra() const { return _proofExtra.actualValue; }
   bool printProofToFile() const { return _printProofToFile.actualValue; }
   vstring outputFileLocation() const { return _outputFileLocation.actualValue; }
+  vstring outputFileName() const { return _outputFileName.actualValue; }  
   bool proofChecking() const { return _proofChecking.actualValue; }
   int naming() const { return _naming.actualValue; }
 
@@ -2519,7 +2520,8 @@ private:
   BoolOptionValue _outputAxiomNames;
 
   BoolOptionValue _printProofToFile;
-  StringOptionValue _outputFileLocation;  
+  StringOptionValue _outputFileLocation;
+  StringOptionValue _outputFileName;     
   BoolOptionValue _printClausifierPremises;
   StringOptionValue _problemName;
   ChoiceOptionValue<Proof> _proof;


### PR DESCRIPTION
This pull requests attempts to solve an issue related to proof printing when running with multiple cores. It is possible that whilst a child process is printing a proof, another child interrupts the proof with other info (as only further proofs are locked out, not all print statements).

The attempted solution is to print the proof to a file and then, once all child processes have been killed, print the file to `env.out()` and delete the file. There is also the option to leave the proof in the file.