### PR TITLE
fixed bug causing array theory axioms not being added correctly

### DIFF
--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1263,6 +1263,7 @@ TermList Term::arraySort(TermList indexSort, TermList innerSort)
   unsigned array = env.signature->getArrayConstructor();
   TermList sort = TermList(create2(array, indexSort, innerSort));
   env.sorts->addSort(sort);
+  env.sorts->addArraySort(sort);
   return sort;
 }
 

--- a/Lib/DHSet.hpp
+++ b/Lib/DHSet.hpp
@@ -149,6 +149,19 @@ public:
   {
     return _map.domain();
   }
+
+  friend std::ostream& operator<<(std::ostream& out, DHSet const& self) 
+  {
+    auto iter = self.iterator();
+    out << "{";
+    if (iter.hasNext()) {
+      out << iter.next();
+      while (iter.hasNext()) {
+        out << ", " << iter.next();
+      }
+    }
+    return out << "}";
+  }
 private:
   /** operator= is private and without a body, because we don't want any. */
   DHSet& operator=(const DHSet& obj);


### PR DESCRIPTION
The reason for array axioms not being added was that `TheoryAxioms.cpp` adds the theory axioms only for the array sorts returned by `Sorts::getArraySorts()`. 
In the refactoring for polymorphism the call `Sorts::addArraySort()` was lost in the parsers `SMTLIB2.cpp` & friends.
All relevant places do call the function `Term::arraySort()` now, hence the fix makes up for that.