### PR TITLE
Seeded random strategies

### DIFF
--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1923,6 +1923,11 @@ void Options::init()
     _lookup.insert(&_randomSeed);
     _randomSeed.tag(OptionTag::INPUT);
 
+    _randomStrategySeed = IntOptionValue("random_strategy_seed","",time(nullptr));
+    _randomStrategySeed.description="Sets the seed for generating random strategies. This option necessary because --random_seed <value> will be included as fixed value in the generated random strategy, hence won't have any effect on the random strategy generation. The default value is derived from the current time.";
+    _lookup.insert(&_randomStrategySeed);
+    _randomStrategySeed.tag(OptionTag::INPUT);
+
     _activationLimit = IntOptionValue("activation_limit","al",0);
     _activationLimit.description="Terminate saturation after this many iterations of the main loop. 0 means no limit.";
     _lookup.insert(&_activationLimit);
@@ -2815,7 +2820,7 @@ void Options::randomizeStrategy(Property* prop)
   // By default the seed is 1
   // For this randomisation we get save the seed and try and randomize it
   int saved_seed = Random::seed();
-  Random::setSeed(time(NULL)); // TODO is this the best choice of seed?
+  Random::setSeed(randomStrategySeed());
 
   // We randomize options that have setRandomChoices
   // TODO: randomize order in which options are selected

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1955,6 +1955,7 @@ public:
   vstring inputFile() const { return _inputFile.actualValue; }
   int activationLimit() const { return _activationLimit.actualValue; }
   int randomSeed() const { return _randomSeed.actualValue; }
+  int randomStrategySeed() const { return _randomStrategySeed.actualValue; }
   bool printClausifierPremises() const { return _printClausifierPremises.actualValue; }
 
   // IMPORTANT, if you add a showX command then include showAll
@@ -2528,6 +2529,7 @@ private:
   ChoiceOptionValue<QuestionAnsweringMode> _questionAnswering;
 
   IntOptionValue _randomSeed;
+  IntOptionValue _randomStrategySeed;
 
   IntOptionValue _activationLimit;
 


### PR DESCRIPTION
Right now random strategies are seeded using the seconds of the current point in time, which means only one random strategy can be generated. Further random strategies cannot be consistently recreated. This PR adds an option that controls the random seed for random strategy generation. 
The reason why we don't use the usual ransom seed (from the option `--random_seed`), is that one might want to propagate this random seed into the random strategy.