### PR TITLE
implements splitting-disable after some fraction of allotted time

### DIFF
--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -287,7 +287,9 @@ private:
   bool _clausesAdded;
   /** true if there was a refutation added to the SAT solver */
   bool _haveBranchRefutation;
-    
+
+  unsigned _stopSplittingAt; // time elapsed in milliseconds
+
   bool _fastRestart; // option's value copy
   /**
    * We are postponing to consider these clauses for a split 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1791,6 +1791,16 @@ void Options::init()
     _splittingFlushQuotient.reliesOn(_splitting.is(equal(true)));
     _splittingFlushQuotient.setRandomChoices({"1.0","1.1","1.2","1.4","2.0"});
 
+    _splittingAvatimer = FloatOptionValue("avatar_turn_off_time_frac","atotf",0.0);
+    _splittingAvatimer.description= "Stop splitting after the specified fraction of the overall time has passed (the default 0.0 means this is disabled).\n"
+        "(the remaining time AVATAR is still switching branches and communicating with the SAT solver,\n"
+        "but not introducing new splits anymore. This fights the theoretical possibility of AVATAR's dynamic incompletness.)";
+    _lookup.insert(&_splittingAvatimer);
+    _splittingAvatimer.tag(OptionTag::AVATAR);
+    _splittingAvatimer.addConstraint(smallerThan(1.0f));
+    _splittingAvatimer.reliesOn(_splitting.is(equal(true)));
+    _splittingAvatimer.setRandomChoices({"0.0","0.5","0.7","0.9"});
+
     _splittingNonsplittableComponents = ChoiceOptionValue<SplittingNonsplittableComponents>("avatar_nonsplittable_components","anc",
                                                                                               SplittingNonsplittableComponents::KNOWN,
                                                                                               {"all","all_dependent","known","none"});

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1611,6 +1611,34 @@ bool _hard;
         return OptionValueConstraintUP<T>(new GreaterThan<T>(bv,true));
     }
     
+    // Constraint that the value should be smaller than a given value
+    // optionally we can allow it be equal to that value also
+    template<typename T>
+    struct SmallerThan : public OptionValueConstraint<T>{
+        CLASS_NAME(SmallerThan);
+        USE_ALLOCATOR(SmallerThan);
+        SmallerThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
+        bool check(const OptionValue<T>& value){
+            return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
+        }
+
+        vstring msg(const OptionValue<T>& value){
+            if(_orequal) return value.longName+"("+value.getStringOfActual()+") is smaller than or equal to " + value.getStringOfValue(_goodvalue);
+            return value.longName+"("+value.getStringOfActual()+") is smaller than "+ value.getStringOfValue(_goodvalue);
+        }
+
+        T _goodvalue;
+        bool _orequal;
+    };
+    template<typename T>
+    static OptionValueConstraintUP<T> smallerThan(T bv){
+        return OptionValueConstraintUP<T>(new SmallerThan<T>(bv,false));
+    }
+    template<typename T>
+    static OptionValueConstraintUP<T> smallerThanEq(T bv){
+        return OptionValueConstraintUP<T>(new SmallerThan<T>(bv,true));
+    }
+
     /**
      * If constraints
      */
@@ -2193,6 +2221,7 @@ public:
   bool splittingBufferedSolver() const { return _splittingBufferedSolver.actualValue; }
   int splittingFlushPeriod() const { return _splittingFlushPeriod.actualValue; }
   float splittingFlushQuotient() const { return _splittingFlushQuotient.actualValue; }
+  float splittingAvatimer() const { return _splittingAvatimer.actualValue; }
   bool splittingEagerRemoval() const { return _splittingEagerRemoval.actualValue; }
   SplittingCongruenceClosure splittingCongruenceClosure() const { return _splittingCongruenceClosure.actualValue; }
   CCUnsatCores ccUnsatCores() const { return _ccUnsatCores.actualValue; }
@@ -2594,6 +2623,7 @@ private:
   BoolOptionValue _splittingEagerRemoval;
   UnsignedOptionValue _splittingFlushPeriod;
   FloatOptionValue _splittingFlushQuotient;
+  FloatOptionValue _splittingAvatimer;
   ChoiceOptionValue<SplittingNonsplittableComponents> _splittingNonsplittableComponents;
   ChoiceOptionValue<SplittingMinimizeModel> _splittingMinimizeModel;
   ChoiceOptionValue<SplittingLiteralPolarityAdvice> _splittingLiteralPolarityAdvice;


### PR DESCRIPTION
Remotely motivated by concerns about AVATAR's dynamic completeness this PR adds an option to specify a fraction of the run time, i.e. a float x, 0.0 < x < 1.0, after which AVATAR stops splitting clauses. (This means that the SAT abstraction cannot grow anymore, and only finitely many "branch switches" lie ahead. Thus, "runaway splitting behaviours" are ruled out.) 

Experiments show that it's mildly beneficial to stop splitting before reaching the time-limit (TPTP 7.4.0, 10s runs, sac is "split at activation"):

problemsSTD_10s_rel_avatimer_5336_base.pkl 9254 0
problemsSTD_10s_rel_avatimer_5336_sac-on.pkl 9257 3
problemsSTD_10s_rel_avatimer_5336_sac-on_atotf-0.9.pkl 9259 5
problemsSTD_10s_rel_avatimer_5336_base_atotf-0.9.pkl 9261 7
problemsSTD_10s_rel_avatimer_5336_sac-on_atotf-0.7.pkl 9262 8
problemsSTD_10s_rel_avatimer_5336_base_atotf-0.7.pkl 9265 11
problemsSTD_10s_rel_avatimer_5336_sac-on_atotf-0.5.pkl 9266 12
problemsSTD_10s_rel_avatimer_5336_base_atotf-0.5.pkl 9285 31

Greedy cover:
problemsSTD_10s_rel_avatimer_5336_base_atotf-0.5.pkl contributes 9285 total 9285 uniques 7
problemsSTD_10s_rel_avatimer_5336_sac-on_atotf-0.5.pkl contributes 191 total 9266 uniques 20
problemsSTD_10s_rel_avatimer_5336_base.pkl contributes 50 total 9254 uniques 16
problemsSTD_10s_rel_avatimer_5336_base_atotf-0.9.pkl contributes 25 total 9261 uniques 18
problemsSTD_10s_rel_avatimer_5336_sac-on_atotf-0.7.pkl contributes 19 total 9262 uniques 12
problemsSTD_10s_rel_avatimer_5336_sac-on.pkl contributes 14 total 9257 uniques 11
problemsSTD_10s_rel_avatimer_5336_sac-on_atotf-0.9.pkl contributes 10 total 9259 uniques 10
problemsSTD_10s_rel_avatimer_5336_base_atotf-0.7.pkl contributes 7 total 9265 uniques 7
Total 9601

On the other hand, the experiments did not reveal any obvious "runaway splitting behaviour"... 

Given how easy this was to implement and how non-disturbing this is to the code base, this might be a "nice to have" option in the repertoire. 

Note: When turned on, vampire's behaviour becomes time-measurement-details non-deterministic, similarly to as under LRS.
