### PR TITLE
Fix race in tmpfile-based proof printing.

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -569,7 +569,7 @@ void PortfolioMode::runSlice(Options& strategyOpt)
 
     BYPASSING_ALLOCATOR; 
     
-    ofstream output(fname.c_str());
+    ofstream output(fname.c_str(), std::ios_base::app);
     if (output.fail()) {
       // fallback to old printing method
       env.beginOutput();


### PR DESCRIPTION
When running in portfolio mode with more than one core, there is currently a bug in master where the following sequence of events can happen:
1. process 1 succeeds and writes a proof to file
2. process 2 fails, opens the same file _and empties it_ and reports its failure
Therefore, we lose the proof. 

I can reproduce this ~1/2 the time on my machine with e.g.
```
$ vampire --mode portfolio --cores 3 Problems/PUZ/PUZ001+1.p
```
We can fix this by appending to the output file, rather than truncating. I believe this achieves the intended effect of reporting a number of failures but only one success.