### PR TITLE
Fixing Vampire poly parsing

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -2901,10 +2901,9 @@ void TPTP::term()
     
     case T_INTEGER_TYPE:
     case T_REAL_TYPE:
-    case T_RATIONAL_TYPE: {
-      //USER_ERROR("Polymorphic Vampire is currently not compatible with theory reasoning");
-      //the code below is in preparation for 
-      //when theorey reasoning is updated to deal with polymorphism
+    case T_RATIONAL_TYPE: 
+    case T_BOOL_TYPE:
+    case T_DEFAULT_TYPE: {
       resetToks();
       switch (tok.tag) {
         case T_INTEGER_TYPE:
@@ -2916,6 +2915,12 @@ void TPTP::term()
         case T_RATIONAL_TYPE:
           _termLists.push(Term::rationalSort());
           break;
+        case T_BOOL_TYPE:
+          _termLists.push(Term::boolSort());
+          break;
+        case T_DEFAULT_TYPE:
+          _termLists.push(Term::defaultSort());
+          break;             
         default:
           ASSERTION_VIOLATION;
       }
@@ -3076,6 +3081,13 @@ void TPTP::formulaInfix()
     return;
   }
 
+  if(env.signature->functionExists(name, arity)){
+    //with polymorphism, we can have function symbols that are used as predicates
+    _termLists.push(createFunctionApplication(name, arity));
+    _states.push(END_TERM_AS_FORMULA);
+    return;
+  }
+
   _formulas.push(createPredicateApplication(name, arity));
 } // formulaInfix
 
@@ -3224,14 +3236,14 @@ Formula* TPTP::createPredicateApplication(vstring name, unsigned arity)
     TermList ts = _termLists.pop();
     TermList tsSort = sortOf(ts);
     if((unsigned)i < type->typeArgsArity()){
-      if(tsSort != Term::superSort()){
+      if(tsSort != Term::superSort()){      
         USER_ERROR("The sort " + tsSort.toString() + " of type argument " + ts.toString() + " "
                    "is not $ttype as madated by TFF1");
       }
     } else {
       static RobSubstitution subst;
       subst.reset();
-      if(!subst.match(sort, 0, tsSort, 1)){
+      if(!subst.match(sort, 0, tsSort, 1)){     
         USER_ERROR("The sort " + tsSort.toString() + " of term argument " + ts.toString() + " "
                    "is not an instance of sort " + sort.toString());
       }
@@ -3284,7 +3296,7 @@ TermList TPTP::createFunctionApplication(vstring name, unsigned arity)
     } else {
       static RobSubstitution subst;
       subst.reset();
-      if(!subst.match(sort, 0, ssSort, 1)){
+      if(!subst.match(sort, 0, ssSort, 1)){       
        //cout << "the type of " + name + " is " + type->toString() << endl; 
         USER_ERROR("The sort " + ssSort.toString() + " of term argument " + ss.toString() + " "
                    "is not an instance of sort " + sort.toString());
@@ -5186,13 +5198,13 @@ const char* TPTP::toString(State s)
 #ifdef DEBUG_SHOW_STATE
 void TPTP::printStacks() {
 
-  /*Stack<State>::Iterator stit(_states);
+  Stack<State>::Iterator stit(_states);
   cout << "States:";
   if   (!stit.hasNext()) cout << " <empty>";
   while (stit.hasNext()) cout << " " << toString(stit.next());
   cout << endl;
 
-  Stack<Type*>::Iterator tyit(_types);
+  /*Stack<Type*>::Iterator tyit(_types);
   cout << "Types:";
   if   (!tyit.hasNext()) cout << " <empty>";
   while (tyit.hasNext()) cout << " " << tyit.next()->tag();
@@ -5202,7 +5214,7 @@ void TPTP::printStacks() {
   cout << "Connectives:";
   if   (!cit.hasNext()) cout << " <empty>";
   while (cit.hasNext()) cout << " " << cit.next();
-  cout << endl; */
+  cout << endl; 
 
   Stack<vstring>::Iterator sit(_strings);
   cout << "Strings:";
@@ -5210,7 +5222,7 @@ void TPTP::printStacks() {
   while (sit.hasNext()) cout << " " << sit.next();
   cout << endl;
 
-  /*Stack<int>::Iterator iit(_ints);
+  Stack<int>::Iterator iit(_ints);
   cout << "Ints:";
   if   (!iit.hasNext()) cout << " <empty>";
   while (iit.hasNext()) cout << " " << iit.next();


### PR DESCRIPTION
Fixing parser bug whereby Vampire wasn't parsing `$i` and `$o` when these appeared as type arguments.