### PR TITLE
simplify CI script

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,9 +3,6 @@ on:
   workflow_dispatch:
   pull_request:
     types: [opened, reopened, synchronize]
-  schedule:
-    # build at least daily at UTC 00:00 to keep the Z3 build cache warm
-    - cron: '0 0 * * *'
 
 jobs:
   build:
@@ -19,26 +16,17 @@ jobs:
       run: checks/headers
     - name: Create Z3 Build Directory
       run: mkdir z3/build
-    - name: Cache Z3 Build
-      uses: actions/cache@v2
-      with:
-        path: ${{runner.workspace}}/vampire/z3/build
-        key: ${{runner.os}}-z3-${{hashFiles('.git/modules/z3/HEAD')}}
     - name: Configure Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
-      run: test -f libz3.so || cmake .. -DCMAKE_BUILD_TYPE=Debug
-      env:
-        CXX: clang++
+      run: cmake ..
     - name: Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
-      run: test -f libz3.so || make -j8
+      run: make -j8
     - name: Create Build Directory
       run: mkdir build
     - name: Configure Build
       working-directory: ${{runner.workspace}}/vampire/build
-      run: cmake .. -DCMAKE_BUILD_TYPE=Debug
-      env:
-        CXX: clang++
+      run: cmake ..
     - name: Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: make -j8

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,8 @@ jobs:
     - name: Configure Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug
+      env:
+        CXX: clang++
     - name: Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: make -j8
@@ -27,6 +29,8 @@ jobs:
     - name: Configure Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug
+      env:
+        CXX: clang++
     - name: Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: make -j8

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       run: mkdir z3/build
     - name: Configure Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
-      run: cmake ..
+      run: cmake .. -DCMAKE_BUILD_TYPE=Debug
     - name: Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: make -j8
@@ -26,7 +26,7 @@ jobs:
       run: mkdir build
     - name: Configure Build
       working-directory: ${{runner.workspace}}/vampire/build
-      run: cmake ..
+      run: cmake .. -DCMAKE_BUILD_TYPE=Debug
     - name: Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: make -j8


### PR DESCRIPTION
Simplify CI script to not cache Z3 as discussed. Also stop nightly builds since we no longer need to keep the cache warm.