### PR TITLE
Fixing schedule and slightly increasing stretch factor

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -231,7 +231,10 @@ void PortfolioMode::getExtraSchedules(Property& prop, Schedule& old, Schedule& e
    extra_opts.push("sp=frequency");
    extra_opts.push("avsq=on");
    extra_opts.push("plsq=on");
-   extra_opts.push("bsd=on:fsd=on");
+   if(!env.statistics->higherOrder){
+     //these options are not currently HOL compatible
+     extra_opts.push("bsd=on:fsd=on");
+   }
 
    // If contains integers, rationals and reals
    if(prop.props() & (Property::PR_HAS_INTEGERS | Property::PR_HAS_RATS | Property::PR_HAS_REALS)){

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -152,12 +152,12 @@ void Options::init()
          "struct_induction"});
     _schedule.description = "Schedule to be run by the portfolio mode. casc and smtcomp usually point to the most recent schedule in that category. Note that some old schedules may contain option values that are no longer supported - see ignore_missing.";
     _lookup.insert(&_schedule);
-    _schedule.reliesOnHard(Or(_mode.is(equal(Mode::CASC)),_mode.is(equal(Mode::CASC_SAT)),_mode.is(equal(Mode::SMTCOMP)),_mode.is(equal(Mode::PORTFOLIO))));
+    _schedule.reliesOnHard(Or(_mode.is(equal(Mode::CASC_HOL)),_mode.is(equal(Mode::CASC)),_mode.is(equal(Mode::CASC_SAT)),_mode.is(equal(Mode::SMTCOMP)),_mode.is(equal(Mode::PORTFOLIO))));
 
     _multicore = UnsignedOptionValue("cores","",1);
     _multicore.description = "When running in portfolio modes (including casc or smtcomp modes) specify the number of cores, set to 0 to use maximum";
     _lookup.insert(&_multicore);
-    _multicore.reliesOnHard(Or(_mode.is(equal(Mode::CASC)),_mode.is(equal(Mode::CASC_SAT)),_mode.is(equal(Mode::SMTCOMP)),_mode.is(equal(Mode::PORTFOLIO))));
+    _multicore.reliesOnHard(Or(_mode.is(equal(Mode::CASC)),_mode.is(equal(Mode::CASC_HOL)),_mode.is(equal(Mode::CASC_SAT)),_mode.is(equal(Mode::SMTCOMP)),_mode.is(equal(Mode::PORTFOLIO))));
 
     _ltbLearning = ChoiceOptionValue<LTBLearning>("ltb_learning","ltbl",LTBLearning::OFF,{"on","off","biased"});
     _ltbLearning.description = "Perform learning in LTB mode";

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -847,7 +847,7 @@ int main(int argc, char* argv[])
       env.options->setMemoryLimit(128000);
 
       unsigned int nthreads = std::thread::hardware_concurrency();
-      float slowness = 1.00 + (0.03 * nthreads);
+      float slowness = 1.00 + (0.04 * nthreads);
  
       if (CASC::PortfolioMode::perform(slowness)) {
         vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;


### PR DESCRIPTION
Options `bsd` and `fsd` are currently not compatible with HOL. This pull request ensures that they are not added to extra schedules when running on HOL problems.

This pull request also achieves the following:

1. Slightly increases the timing stretch factor when running with multiple cores (for HOL)
2. Fixes an issue where hard constraints on `mode` and `schedule` where preventing us from running with option `--mode casc_hol`