### PR TITLE
remove 'failing' build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/vprover/vampire/CI/master)
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/vprover/vampire)
 
 # Vampire


### PR DESCRIPTION
We don't do scheduled builds any more since #235 - hooray for no unnecessary compute! However this breaks the nice shiny 'build' badge we had in the README. Ho hum.