### PR TITLE
disable C++11 thread-safe statics, unused

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,13 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+# configure compilers
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
+  add_compile_options(-Wall)
+  # we don't use multithreading in (mainline!) Vampire
+  add_compile_options(-fno-threadsafe-statics)
+endif()
+
 # compile command database
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 

--- a/HACKING.md
+++ b/HACKING.md
@@ -36,6 +36,7 @@ In a pinch, `git grep PAT` works OK too.
 * Some amount of unused/dead code. If it looks like nonsense, doesn't compile, or isn't reachable, it might well just not be used any more. Pull requests appreciated.
 * A (possibly slightly outdated) explanation for the message [Attempted to use global new operator, thus bypassing Allocator!](https://github.com/vprover/vampire/wiki/Attempted-to-use-global-new-operator,-thus-bypassing-Allocator!)
 * for historians: [Yes, we had (and still have) a wiki on our github page](https://github.com/vprover/vampire/wiki) - maybe miscellaneous things can go here, I don't think it's completely historic just yet! - Michael
+* Vampire assumes that it runs in a single-threaded (but not necessarily single-process) context. Some constructs take advantage of this. In particular we disable C++11 thread-safe statics.
 * TODO more tips
 
 ## Building with CMake

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ endif
 ################################################################
 
 CXX = g++
-CXXFLAGS = $(XFLAGS) -Wall -std=c++14  $(INCLUDES) # -Wno-unknown-warning-option for clang
+CXXFLAGS = $(XFLAGS) -Wall -fno-threadsafe-statics -std=c++14  $(INCLUDES) # -Wno-unknown-warning-option for clang
 
 CC = gcc 
 CCFLAGS = -Wall -O3 -DNDBLSCR -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLPICOSAT 


### PR DESCRIPTION
C++11 mandates that concurrent initialisation of local `static` variables is thread-safe. Vampire generally assumes that we work in a single-threaded context (don't I know it...), but thread-safe initialisation adds [some overhead](https://godbolt.org/z/vx9fd541K) regardless of whether we use it or not. Disable this via compiler flag.

No measurable performance improvement, but every little helps. Binary size is down 30KB on my machine.

Should in principle be safe since the behaviour is identical in a single-threaded context. Scary global change to code generation, however...