### PR TITLE
Use of `virtual`, `override` and `final` keywords.

### DIFF
--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -42,15 +42,15 @@ class PortfolioMode;
 class PortfolioProcessPriorityPolicy : public ProcessPriorityPolicy
 {
 public:
-  float staticPriority(vstring sliceCode) override;
-  float dynamicPriority(pid_t pid) override;
+  float staticPriority(vstring sliceCode) final;
+  float dynamicPriority(pid_t pid) final;
 };
 
 class PortfolioSliceExecutor : public SliceExecutor
 {
 public:
   PortfolioSliceExecutor(PortfolioMode *mode);
-  void runSlice(vstring sliceCode, int remainingTime) override;
+  void runSlice(vstring sliceCode, int remainingTime) final;
 
 private:
   PortfolioMode *_mode;

--- a/DP/ShortConflictMetaDP.hpp
+++ b/DP/ShortConflictMetaDP.hpp
@@ -43,20 +43,20 @@ public:
   ShortConflictMetaDP(DecisionProcedure* inner, SAT2FO& sat2fo, SATSolver& solver)
   : _inner(inner), _sat2fo(sat2fo), _solver(solver) {}
 
-  void addLiterals(LiteralIterator lits, bool onlyEqualites) override {
+  void addLiterals(LiteralIterator lits, bool onlyEqualites) final {
     CALL("ShortConflictMetaDP::addLiterals");
     _inner->addLiterals(lits, onlyEqualites);
   }
 
-  void reset() override {
+  void reset() final {
     CALL("ShortConflictMetaDP::reset");
     _inner->reset();
     _unsatCores.reset();
   }
 
-  Status getStatus(bool getMultipleCores) override;
+  Status getStatus(bool getMultipleCores) final;
 
-  void getModel(LiteralStack& model) override {
+  void getModel(LiteralStack& model) final {
     _inner->getModel(model);
   }
 
@@ -67,8 +67,8 @@ public:
    *
    * Can be called only after getStatus before any next call to addLiterals.
    */
-  unsigned getUnsatCoreCount() override { return _unsatCores.size(); }
-  void getUnsatCore(LiteralStack& res, unsigned coreIndex) override;
+  unsigned getUnsatCoreCount() final { return _unsatCores.size(); }
+  void getUnsatCore(LiteralStack& res, unsigned coreIndex) final;
 
 
 private:

--- a/DP/ShortConflictMetaDP.hpp
+++ b/DP/ShortConflictMetaDP.hpp
@@ -43,18 +43,18 @@ public:
   ShortConflictMetaDP(DecisionProcedure* inner, SAT2FO& sat2fo, SATSolver& solver)
   : _inner(inner), _sat2fo(sat2fo), _solver(solver) {}
 
-  virtual void addLiterals(LiteralIterator lits, bool onlyEqualites) override {
+  void addLiterals(LiteralIterator lits, bool onlyEqualites) override {
     CALL("ShortConflictMetaDP::addLiterals");
     _inner->addLiterals(lits, onlyEqualites);
   }
 
-  virtual void reset() override {
+  void reset() override {
     CALL("ShortConflictMetaDP::reset");
     _inner->reset();
     _unsatCores.reset();
   }
 
-  virtual Status getStatus(bool getMultipleCores) override;
+  Status getStatus(bool getMultipleCores) override;
 
   void getModel(LiteralStack& model) override {
     _inner->getModel(model);
@@ -67,8 +67,8 @@ public:
    *
    * Can be called only after getStatus before any next call to addLiterals.
    */
-  virtual unsigned getUnsatCoreCount() override { return _unsatCores.size(); }
-  virtual void getUnsatCore(LiteralStack& res, unsigned coreIndex) override;
+  unsigned getUnsatCoreCount() override { return _unsatCores.size(); }
+  void getUnsatCore(LiteralStack& res, unsigned coreIndex) override;
 
 
 private:

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -53,15 +53,15 @@ public:
 
   SimpleCongruenceClosure(Ordering* ord);
 
-  virtual void addLiterals(LiteralIterator lits, bool onlyEqualites) override;
+  void addLiterals(LiteralIterator lits, bool onlyEqualites) override;
 
-  virtual Status getStatus(bool retrieveMultipleCores) override;
-  virtual unsigned getUnsatCoreCount() override { return _unsatEqs.size(); }
-  virtual void getUnsatCore(LiteralStack& res, unsigned coreIndex) override;
+  Status getStatus(bool retrieveMultipleCores) override;
+  unsigned getUnsatCoreCount() override { return _unsatEqs.size(); }
+  void getUnsatCore(LiteralStack& res, unsigned coreIndex) override;
 
   void getModel(LiteralStack& model) override;
   
-  virtual void reset() override;
+  void reset() override;
 
   /**
    * New, more fine-grained way of insertion. The terms may contain variables which are treated as constants.

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -53,15 +53,15 @@ public:
 
   SimpleCongruenceClosure(Ordering* ord);
 
-  void addLiterals(LiteralIterator lits, bool onlyEqualites) override;
+  void addLiterals(LiteralIterator lits, bool onlyEqualites) final;
 
-  Status getStatus(bool retrieveMultipleCores) override;
-  unsigned getUnsatCoreCount() override { return _unsatEqs.size(); }
-  void getUnsatCore(LiteralStack& res, unsigned coreIndex) override;
+  Status getStatus(bool retrieveMultipleCores) final;
+  unsigned getUnsatCoreCount() final { return _unsatEqs.size(); }
+  void getUnsatCore(LiteralStack& res, unsigned coreIndex) final;
 
-  void getModel(LiteralStack& model) override;
+  void getModel(LiteralStack& model) final;
   
-  void reset() override;
+  void reset() final;
 
   /**
    * New, more fine-grained way of insertion. The terms may contain variables which are treated as constants.

--- a/Debug/RuntimeStatistics.hpp
+++ b/Debug/RuntimeStatistics.hpp
@@ -116,7 +116,7 @@ class RSCounter
 public:
   RSCounter(const char* name) : RSObject(name), _counter(0) {}
 
-  void print(ostream& out) { out << name() << ": " << _counter << endl; }
+  void print(ostream& out) final { out << name() << ": " << _counter << endl; }
   void inc() { _counter++; }
   void inc(size_t num) { _counter+=num; }
 private:
@@ -129,21 +129,21 @@ class RSMultiCounter
 public:
   RSMultiCounter(const char* name) : RSObject(name) {}
 
-  void print(ostream& out);
+  void print(ostream& out) final;
   void inc(size_t index) { _counters[index]++; }
 private:
   ZIArray<size_t> _counters;
 };
 
-class RSMultiStatistic
+class RSMultiStatistic final
 : public RSObject
 {
   typedef List<int> ValList;
 public:
   RSMultiStatistic(const char* name) : RSObject(name) {}
-  ~RSMultiStatistic();
+  ~RSMultiStatistic() final;
 
-  void print(ostream& out);
+  void print(ostream& out) final;
   void addRecord(size_t index, int value) { ValList::push(value, _values[index]); }
 private:
   ZIArray<ValList* > _values;

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -61,14 +61,14 @@ public:
   USE_ALLOCATOR(FiniteModelBuilder);    
   
   FiniteModelBuilder(Problem& prb, const Options& opt);
-  ~FiniteModelBuilder();
+  ~FiniteModelBuilder() override;
 
 protected:
   // Sets up everything
-  virtual void init();
+  void init() override;
 
   // Runs the saturation loop
-  virtual MainLoopResult runImpl();
+  MainLoopResult runImpl() override;
 
 private:
 

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -55,20 +55,20 @@ using namespace SAT;
 
   };
 
-class FiniteModelBuilder : public MainLoop {
+class FiniteModelBuilder final : public MainLoop {
 public:
   CLASS_NAME(FiniteModedlBuilder);
   USE_ALLOCATOR(FiniteModelBuilder);    
   
   FiniteModelBuilder(Problem& prb, const Options& opt);
-  ~FiniteModelBuilder() override;
+  ~FiniteModelBuilder() final;
 
 protected:
   // Sets up everything
-  void init() override;
+  void init() final;
 
   // Runs the saturation loop
-  MainLoopResult runImpl() override;
+  MainLoopResult runImpl() final;
 
 private:
 
@@ -291,15 +291,15 @@ private:
 
     HackyDSAE() : _maxWeightSoFar(0) {}
 
-    bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>& dsc, Stack<std::pair<unsigned,unsigned>>& sdsc) override {
+    bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>& dsc, Stack<std::pair<unsigned,unsigned>>& sdsc) final {
       _distinct_sort_constraints = &dsc;
       _strict_distinct_sort_constraints = &sdsc;
       return true;
     }
 
-    bool isFmbComplete(unsigned noDomains) override { return noDomains <= 1; }
-    void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) override;
-    bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) override;
+    bool isFmbComplete(unsigned noDomains) final { return noDomains <= 1; }
+    void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) final;
+    bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) final;
   };
 
 #if VZ3
@@ -318,10 +318,10 @@ private:
 
     SmtBasedDSAE() : _smtSolver(_context) {}
 
-    bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>&, Stack<std::pair<unsigned,unsigned>>&) override;
-    void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) override;
-    bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) override;
-    bool isFmbComplete(unsigned) override { return true; }
+    bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>&, Stack<std::pair<unsigned,unsigned>>&) final;
+    void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) final;
+    bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) final;
+    bool isFmbComplete(unsigned) final { return true; }
   };
 #endif
 

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -299,7 +299,7 @@ SortFunctionTransformer(Literal* lit,
                         DArray<bool> isM,
                         DArray<unsigned> sf) : _lit(lit), _isM(isM), _sf(sf) {}
 
-TermList transformSubterm(TermList trm) override{
+TermList transformSubterm(TermList trm) final{
   CALL("SortFunctionTransformer::transformSubterm");
 
   // cout << "transformSubterm " << trm.toString() << endl;

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -299,7 +299,7 @@ SortFunctionTransformer(Literal* lit,
                         DArray<bool> isM,
                         DArray<unsigned> sf) : _lit(lit), _isM(isM), _sf(sf) {}
 
-TermList transformSubterm(TermList trm){
+TermList transformSubterm(TermList trm) override{
   CALL("SortFunctionTransformer::transformSubterm");
 
   // cout << "transformSubterm " << trm.toString() << endl;

--- a/HACKING.md
+++ b/HACKING.md
@@ -34,6 +34,7 @@ In a pinch, `git grep PAT` works OK too.
   No donkeys here.
 * Heavy use of "iterator" classes which can do slightly odd things. These are in the process of being re-organised somewhat by Joe.
 * Some amount of unused/dead code. If it looks like nonsense, doesn't compile, or isn't reachable, it might well just not be used any more. Pull requests appreciated.
+* We use the `final` keyword in various places where a virtual function is not _currently_ overridden by a subclass. This allows for some compiler optimisations, but it is not set in stone: if you need to override a `final` function, change it to `override` and carry on.
 * A (possibly slightly outdated) explanation for the message [Attempted to use global new operator, thus bypassing Allocator!](https://github.com/vprover/vampire/wiki/Attempted-to-use-global-new-operator,-thus-bypassing-Allocator!)
 * for historians: [Yes, we had (and still have) a wiki on our github page](https://github.com/vprover/vampire/wiki) - maybe miscellaneous things can go here, I don't think it's completely historic just yet! - Michael
 * TODO more tips

--- a/Indexing/AcyclicityIndex.hpp
+++ b/Indexing/AcyclicityIndex.hpp
@@ -52,7 +52,7 @@ struct CycleQueryResult {
 
 typedef Lib::VirtualIterator<CycleQueryResult*> CycleQueryResultsIterator;
 
-class AcyclicityIndex
+class AcyclicityIndex final
 : public Index
 {
 public:
@@ -61,7 +61,7 @@ public:
     _tis(tis)
   {}
 
-  ~AcyclicityIndex() override {}
+  ~AcyclicityIndex() final {}
   
   void insert(Kernel::Literal *lit, Kernel::Clause *c);
   void remove(Kernel::Literal *lit, Kernel::Clause *c);
@@ -71,7 +71,7 @@ public:
   CLASS_NAME(AcyclicityIndex);
   USE_ALLOCATOR(AcyclicityIndex);
 protected:
-  void handleClause(Kernel::Clause* c, bool adding) override;
+  void handleClause(Kernel::Clause* c, bool adding) final;
 private:
   bool matchesPattern(Kernel::Literal *lit, Kernel::TermList *&fs, Kernel::TermList *&t, TermList *sort);
   Lib::List<TermList>* getSubterms(Kernel::Term *t);

--- a/Indexing/AcyclicityIndex.hpp
+++ b/Indexing/AcyclicityIndex.hpp
@@ -61,7 +61,7 @@ public:
     _tis(tis)
   {}
 
-  ~AcyclicityIndex() {}
+  ~AcyclicityIndex() override {}
   
   void insert(Kernel::Literal *lit, Kernel::Clause *c);
   void remove(Kernel::Literal *lit, Kernel::Clause *c);
@@ -71,7 +71,7 @@ public:
   CLASS_NAME(AcyclicityIndex);
   USE_ALLOCATOR(AcyclicityIndex);
 protected:
-  void handleClause(Kernel::Clause* c, bool adding);
+  void handleClause(Kernel::Clause* c, bool adding) override;
 private:
   bool matchesPattern(Kernel::Literal *lit, Kernel::TermList *&fs, Kernel::TermList *&t, TermList *sort);
   Lib::List<TermList>* getSubterms(Kernel::Term *t);

--- a/Indexing/ClauseVariantIndex.hpp
+++ b/Indexing/ClauseVariantIndex.hpp
@@ -50,18 +50,18 @@ protected:
 };
 
 
-class SubstitutionTreeClauseVariantIndex : public ClauseVariantIndex
+class SubstitutionTreeClauseVariantIndex final : public ClauseVariantIndex
 {
 public:
   CLASS_NAME(SubstitutionTreeClauseVariantIndex);
   USE_ALLOCATOR(SubstitutionTreeClauseVariantIndex);
 
   SubstitutionTreeClauseVariantIndex() : _emptyClauses(0) {}
-  ~SubstitutionTreeClauseVariantIndex() override;
+  ~SubstitutionTreeClauseVariantIndex() final;
 
-  void insert(Clause* cl) override;
+  void insert(Clause* cl) final;
 
-  ClauseIterator retrieveVariants(Literal* const * lits, unsigned length) override;
+  ClauseIterator retrieveVariants(Literal* const * lits, unsigned length) final;
 
 private:
   class SLQueryResultToClauseFn;
@@ -75,17 +75,17 @@ private:
   ClauseList* _emptyClauses;
 };
 
-class HashingClauseVariantIndex : public ClauseVariantIndex
+class HashingClauseVariantIndex final : public ClauseVariantIndex
 {
 public:
   CLASS_NAME(HashingClauseVariantIndex);
   USE_ALLOCATOR(HashingClauseVariantIndex);
 
-  ~HashingClauseVariantIndex() override;
+  ~HashingClauseVariantIndex() final;
 
-  void insert(Clause* cl) override;
+  void insert(Clause* cl) final;
 
-  ClauseIterator retrieveVariants(Literal* const * lits, unsigned length) override;
+  ClauseIterator retrieveVariants(Literal* const * lits, unsigned length) final;
 
 private:
   struct VariableIgnoringComparator;

--- a/Indexing/ClauseVariantIndex.hpp
+++ b/Indexing/ClauseVariantIndex.hpp
@@ -57,9 +57,9 @@ public:
   USE_ALLOCATOR(SubstitutionTreeClauseVariantIndex);
 
   SubstitutionTreeClauseVariantIndex() : _emptyClauses(0) {}
-  virtual ~SubstitutionTreeClauseVariantIndex() override;
+  ~SubstitutionTreeClauseVariantIndex() override;
 
-  virtual void insert(Clause* cl) override;
+  void insert(Clause* cl) override;
 
   ClauseIterator retrieveVariants(Literal* const * lits, unsigned length) override;
 
@@ -81,9 +81,9 @@ public:
   CLASS_NAME(HashingClauseVariantIndex);
   USE_ALLOCATOR(HashingClauseVariantIndex);
 
-  virtual ~HashingClauseVariantIndex() override;
+  ~HashingClauseVariantIndex() override;
 
-  virtual void insert(Clause* cl) override;
+  void insert(Clause* cl) override;
 
   ClauseIterator retrieveVariants(Literal* const * lits, unsigned length) override;
 

--- a/Indexing/CodeTreeInterfaces.cpp
+++ b/Indexing/CodeTreeInterfaces.cpp
@@ -41,7 +41,7 @@ public:
   : _bindings(bindings), _resultNormalizer(resultNormalizer),
   _applicator(0)
   {}
-  ~CodeTreeSubstitution()
+  ~CodeTreeSubstitution() override
   {
     if(_applicator) {
       delete _applicator;
@@ -51,19 +51,19 @@ public:
   CLASS_NAME(CodeTreeSubstitution);
   USE_ALLOCATOR(CodeTreeSubstitution);
 
-  TermList applyToBoundResult(TermList t)
+  TermList applyToBoundResult(TermList t) override
   {
     CALL("CodeTreeSubstitution::applyToBoundResult(TermList)");
     return SubstHelper::apply(t, *getApplicator());
   }
 
-  Literal* applyToBoundResult(Literal* lit)
+  Literal* applyToBoundResult(Literal* lit) override
   {
     CALL("CodeTreeSubstitution::applyToBoundResult(Literal*)");
     return SubstHelper::apply(lit, *getApplicator());
   }
 
-  bool isIdentityOnQueryWhenResultBound() {return true;}
+  bool isIdentityOnQueryWhenResultBound() override {return true;}
 private:
   struct Applicator
   {
@@ -121,7 +121,7 @@ public:
     }
   }
 
-  ~ResultIterator()
+  ~ResultIterator() override
   {
     _matcher->deinit();
     Recycler::release(_matcher);
@@ -134,7 +134,7 @@ public:
   CLASS_NAME(CodeTreeTIS::ResultIterator);
   USE_ALLOCATOR(ResultIterator);
 
-  bool hasNext()
+  bool hasNext() override
   {
     CALL("CodeTreeTIS::ResultIterator::hasNext");
 
@@ -152,7 +152,7 @@ public:
     return _found;
   }
 
-  TermQueryResult next()
+  TermQueryResult next() override
   {
     CALL("CodeTreeTIS::ResultIterator::next");
     ASS(_found);
@@ -401,13 +401,13 @@ public:
     Recycler::get(cm);
     cm->init(tree, query, sres);
   }
-  ~ClauseSResIterator()
+  ~ClauseSResIterator() override
   {
     cm->deinit();
     Recycler::release(cm);
   }
   
-  bool hasNext()
+  bool hasNext() override
   {
     CALL("CodeTreeSubsumptionIndex::ClauseSResIterator::hasNext");
     if(ready) {
@@ -419,7 +419,7 @@ public:
     return result;
   }
   
-  ClauseSResQueryResult next()
+  ClauseSResQueryResult next() override
   {
     CALL("CodeTreeSubsumptionIndex::ClauseSResIterator::next");
     ASS(result);

--- a/Indexing/CodeTreeInterfaces.cpp
+++ b/Indexing/CodeTreeInterfaces.cpp
@@ -33,7 +33,7 @@ namespace Indexing
 using namespace Lib;
 using namespace Kernel;
 
-class CodeTreeSubstitution
+class CodeTreeSubstitution final
 : public ResultSubstitution
 {
 public:
@@ -41,7 +41,7 @@ public:
   : _bindings(bindings), _resultNormalizer(resultNormalizer),
   _applicator(0)
   {}
-  ~CodeTreeSubstitution() override
+  ~CodeTreeSubstitution() final
   {
     if(_applicator) {
       delete _applicator;
@@ -51,19 +51,19 @@ public:
   CLASS_NAME(CodeTreeSubstitution);
   USE_ALLOCATOR(CodeTreeSubstitution);
 
-  TermList applyToBoundResult(TermList t) override
+  TermList applyToBoundResult(TermList t) final
   {
     CALL("CodeTreeSubstitution::applyToBoundResult(TermList)");
     return SubstHelper::apply(t, *getApplicator());
   }
 
-  Literal* applyToBoundResult(Literal* lit) override
+  Literal* applyToBoundResult(Literal* lit) final
   {
     CALL("CodeTreeSubstitution::applyToBoundResult(Literal*)");
     return SubstHelper::apply(lit, *getApplicator());
   }
 
-  bool isIdentityOnQueryWhenResultBound() override {return true;}
+  bool isIdentityOnQueryWhenResultBound() final {return true;}
 private:
   struct Applicator
   {
@@ -104,7 +104,7 @@ private:
 ///////////////////////////////////////
 
 
-class CodeTreeTIS::ResultIterator
+class CodeTreeTIS::ResultIterator final
 : public IteratorCore<TermQueryResult>
 {
 public:
@@ -121,7 +121,7 @@ public:
     }
   }
 
-  ~ResultIterator() override
+  ~ResultIterator() final
   {
     _matcher->deinit();
     Recycler::release(_matcher);
@@ -134,7 +134,7 @@ public:
   CLASS_NAME(CodeTreeTIS::ResultIterator);
   USE_ALLOCATOR(ResultIterator);
 
-  bool hasNext() override
+  bool hasNext() final
   {
     CALL("CodeTreeTIS::ResultIterator::hasNext");
 
@@ -152,7 +152,7 @@ public:
     return _found;
   }
 
-  TermQueryResult next() override
+  TermQueryResult next() final
   {
     CALL("CodeTreeTIS::ResultIterator::next");
     ASS(_found);
@@ -391,7 +391,7 @@ bool CodeTreeTIS::generalizationExists(TermList t)
 
 /////////////////   CodeTreeSubsumptionIndex   //////////////////////
 
-class CodeTreeSubsumptionIndex::ClauseSResIterator
+class CodeTreeSubsumptionIndex::ClauseSResIterator final
 : public IteratorCore<ClauseSResQueryResult>
 {
 public:
@@ -401,13 +401,13 @@ public:
     Recycler::get(cm);
     cm->init(tree, query, sres);
   }
-  ~ClauseSResIterator() override
+  ~ClauseSResIterator() final
   {
     cm->deinit();
     Recycler::release(cm);
   }
   
-  bool hasNext() override
+  bool hasNext() final
   {
     CALL("CodeTreeSubsumptionIndex::ClauseSResIterator::hasNext");
     if(ready) {
@@ -419,7 +419,7 @@ public:
     return result;
   }
   
-  ClauseSResQueryResult next() override
+  ClauseSResQueryResult next() final
   {
     CALL("CodeTreeSubsumptionIndex::ClauseSResIterator::next");
     ASS(result);

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -43,11 +43,11 @@ public:
   CLASS_NAME(CodeTreeTIS);
   USE_ALLOCATOR(CodeTreeTIS);
 
-  void insert(TermList t, Literal* lit, Clause* cls) override;
-  void remove(TermList t, Literal* lit, Clause* cls) override;
+  void insert(TermList t, Literal* lit, Clause* cls) final;
+  void remove(TermList t, Literal* lit, Clause* cls) final;
 
-  TermQueryResultIterator getGeneralizations(TermList t, bool retrieveSubstitutions = true) override;
-  bool generalizationExists(TermList t) override;
+  TermQueryResultIterator getGeneralizations(TermList t, bool retrieveSubstitutions = true) final;
+  bool generalizationExists(TermList t) final;
 
 #if VDEBUG
   virtual void markTagged(){ NOT_IMPLEMENTED; } 
@@ -82,10 +82,10 @@ public:
   CLASS_NAME(CodeTreeSubsumptionIndex);
   USE_ALLOCATOR(CodeTreeSubsumptionIndex);
 
-  ClauseSResResultIterator getSubsumingOrSResolvingClauses(Clause* c, bool subsumptionResolution) override;
+  ClauseSResResultIterator getSubsumingOrSResolvingClauses(Clause* c, bool subsumptionResolution) final;
 protected:
   //overrides Index::handleClause
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   class ClauseSResIterator;
 

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -43,11 +43,11 @@ public:
   CLASS_NAME(CodeTreeTIS);
   USE_ALLOCATOR(CodeTreeTIS);
 
-  void insert(TermList t, Literal* lit, Clause* cls);
-  void remove(TermList t, Literal* lit, Clause* cls);
+  void insert(TermList t, Literal* lit, Clause* cls) override;
+  void remove(TermList t, Literal* lit, Clause* cls) override;
 
-  TermQueryResultIterator getGeneralizations(TermList t, bool retrieveSubstitutions = true);
-  bool generalizationExists(TermList t);
+  TermQueryResultIterator getGeneralizations(TermList t, bool retrieveSubstitutions = true) override;
+  bool generalizationExists(TermList t) override;
 
 #if VDEBUG
   virtual void markTagged(){ NOT_IMPLEMENTED; } 
@@ -82,10 +82,10 @@ public:
   CLASS_NAME(CodeTreeSubsumptionIndex);
   USE_ALLOCATOR(CodeTreeSubsumptionIndex);
 
-  ClauseSResResultIterator getSubsumingOrSResolvingClauses(Clause* c, bool subsumptionResolution);
+  ClauseSResResultIterator getSubsumingOrSResolvingClauses(Clause* c, bool subsumptionResolution) override;
 protected:
   //overrides Index::handleClause
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   class ClauseSResIterator;
 

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -50,7 +50,7 @@ public:
   bool generalizationExists(TermList t) final;
 
 #if VDEBUG
-  virtual void markTagged(){ NOT_IMPLEMENTED; } 
+  void markTagged() final { NOT_IMPLEMENTED; } 
 #endif
 
 private:

--- a/Indexing/GroundingIndex.hpp
+++ b/Indexing/GroundingIndex.hpp
@@ -39,7 +39,7 @@ public:
   GlobalSubsumptionGrounder& getGrounder() { return *_grounder; }
 
 protected:
-  virtual void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 
 private:
   ScopedPtr<SATSolverWithAssumptions> _solver;

--- a/Indexing/GroundingIndex.hpp
+++ b/Indexing/GroundingIndex.hpp
@@ -39,7 +39,7 @@ public:
   GlobalSubsumptionGrounder& getGrounder() { return *_grounder; }
 
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 
 private:
   ScopedPtr<SATSolverWithAssumptions> _solver;

--- a/Indexing/LiteralIndex.hpp
+++ b/Indexing/LiteralIndex.hpp
@@ -67,7 +67,7 @@ public:
   GeneratingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 class SimplifyingLiteralIndex
@@ -80,7 +80,7 @@ public:
   SimplifyingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 class FwSubsSimplifyingLiteralIndex
@@ -95,7 +95,7 @@ public:
   { }
 
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 class FSDLiteralIndex
@@ -110,7 +110,7 @@ public:
   { }
 
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 class UnitClauseLiteralIndex
@@ -123,7 +123,7 @@ public:
   UnitClauseLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 class NonUnitClauseLiteralIndex
@@ -136,12 +136,12 @@ public:
   NonUnitClauseLiteralIndex(LiteralIndexingStructure* is, bool selectedOnly=false)
   : LiteralIndex(is), _selectedOnly(selectedOnly) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   bool _selectedOnly;
 };
 
-class RewriteRuleIndex
+class RewriteRuleIndex final
 : public LiteralIndex
 {
 public:
@@ -149,13 +149,13 @@ public:
   USE_ALLOCATOR(RewriteRuleIndex);
 
   RewriteRuleIndex(LiteralIndexingStructure* is, Ordering& ordering);
-  ~RewriteRuleIndex() override;
+  ~RewriteRuleIndex() final;
 
   Clause* getCounterpart(Clause* c) {
     return _counterparts.get(c);
   }
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
   Literal* getGreater(Clause* c);
 
 private:
@@ -175,7 +175,7 @@ public:
 
   DismatchingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
   void addLiteral(Literal* c);
 };
 
@@ -190,7 +190,7 @@ public:
   : LiteralIndex(is) {}
 
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 };

--- a/Indexing/LiteralIndex.hpp
+++ b/Indexing/LiteralIndex.hpp
@@ -30,7 +30,7 @@ public:
   CLASS_NAME(LiteralIndex);
   USE_ALLOCATOR(LiteralIndex);
 
-  virtual ~LiteralIndex();
+  ~LiteralIndex() override;
 
   SLQueryResultIterator getAll();
 
@@ -67,7 +67,7 @@ public:
   GeneratingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 class SimplifyingLiteralIndex
@@ -80,7 +80,7 @@ public:
   SimplifyingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 class FwSubsSimplifyingLiteralIndex
@@ -123,7 +123,7 @@ public:
   UnitClauseLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 class NonUnitClauseLiteralIndex
@@ -136,7 +136,7 @@ public:
   NonUnitClauseLiteralIndex(LiteralIndexingStructure* is, bool selectedOnly=false)
   : LiteralIndex(is), _selectedOnly(selectedOnly) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   bool _selectedOnly;
 };
@@ -149,13 +149,13 @@ public:
   USE_ALLOCATOR(RewriteRuleIndex);
 
   RewriteRuleIndex(LiteralIndexingStructure* is, Ordering& ordering);
-  ~RewriteRuleIndex();
+  ~RewriteRuleIndex() override;
 
   Clause* getCounterpart(Clause* c) {
     return _counterparts.get(c);
   }
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
   Literal* getGreater(Clause* c);
 
 private:
@@ -175,7 +175,7 @@ public:
 
   DismatchingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
   void addLiteral(Literal* c);
 };
 
@@ -190,7 +190,7 @@ public:
   : LiteralIndex(is) {}
 
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 };

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -30,26 +30,26 @@ public:
 
   LiteralSubstitutionTree(bool useC=false);
 
-  void insert(Literal* lit, Clause* cls) override;
-  void remove(Literal* lit, Clause* cls) override;
+  void insert(Literal* lit, Clause* cls) final;
+  void remove(Literal* lit, Clause* cls) final;
   void handleLiteral(Literal* lit, Clause* cls, bool insert);
 
-  SLQueryResultIterator getAll() override;
+  SLQueryResultIterator getAll() final;
 
   SLQueryResultIterator getUnifications(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions) override;
+	  bool complementary, bool retrieveSubstitutions) final;
 
   SLQueryResultIterator getUnificationsWithConstraints(Literal* lit,
-          bool complementary, bool retrieveSubstitutions) override;
+          bool complementary, bool retrieveSubstitutions) final;
 
   SLQueryResultIterator getGeneralizations(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions) override;
+	  bool complementary, bool retrieveSubstitutions) final;
 
   SLQueryResultIterator getInstances(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions) override;
+	  bool complementary, bool retrieveSubstitutions) final;
 
   SLQueryResultIterator getVariants(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions) override;
+	  bool complementary, bool retrieveSubstitutions) final;
 
 #if VDEBUG
   virtual void markTagged(){ SubstitutionTree::markTagged();}

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -52,8 +52,8 @@ public:
 	  bool complementary, bool retrieveSubstitutions) final;
 
 #if VDEBUG
-  virtual void markTagged(){ SubstitutionTree::markTagged();}
-  vstring toString() {return SubstitutionTree::toString();}
+  void markTagged() final { SubstitutionTree::markTagged();}
+  vstring toString() final {return SubstitutionTree::toString();}
 #endif
 
 private:

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -30,26 +30,26 @@ public:
 
   LiteralSubstitutionTree(bool useC=false);
 
-  void insert(Literal* lit, Clause* cls);
-  void remove(Literal* lit, Clause* cls);
+  void insert(Literal* lit, Clause* cls) override;
+  void remove(Literal* lit, Clause* cls) override;
   void handleLiteral(Literal* lit, Clause* cls, bool insert);
 
-  SLQueryResultIterator getAll();
+  SLQueryResultIterator getAll() override;
 
   SLQueryResultIterator getUnifications(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions);
+	  bool complementary, bool retrieveSubstitutions) override;
 
   SLQueryResultIterator getUnificationsWithConstraints(Literal* lit,
-          bool complementary, bool retrieveSubstitutions);
+          bool complementary, bool retrieveSubstitutions) override;
 
   SLQueryResultIterator getGeneralizations(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions);
+	  bool complementary, bool retrieveSubstitutions) override;
 
   SLQueryResultIterator getInstances(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions);
+	  bool complementary, bool retrieveSubstitutions) override;
 
   SLQueryResultIterator getVariants(Literal* lit,
-	  bool complementary, bool retrieveSubstitutions);
+	  bool complementary, bool retrieveSubstitutions) override;
 
 #if VDEBUG
   virtual void markTagged(){ SubstitutionTree::markTagged();}

--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -31,27 +31,27 @@ public:
   RSProxy(RobSubstitution* subst, int queryBank, int resultBank)
   : _subst(subst), _queryBank(queryBank), _resultBank(resultBank) {}
 
-  TermList applyToQuery(TermList t)
+  TermList applyToQuery(TermList t) override
   { return _subst->apply(t,_queryBank); }
-  Literal* applyToQuery(Literal* l)
+  Literal* applyToQuery(Literal* l) override
   { return _subst->apply(l,_queryBank); }
 
-  TermList applyToResult(TermList t)
+  TermList applyToResult(TermList t) override
   { return _subst->apply(t,_resultBank); }
-  Literal* applyToResult(Literal* l)
+  Literal* applyToResult(Literal* l) override
   { return _subst->apply(l,_resultBank); }
 
-  TermList applyTo(TermList t,unsigned index)
+  TermList applyTo(TermList t,unsigned index) override
   { return _subst->apply(t,index); }
-  Literal* applyTo(Literal* l,unsigned index)
+  Literal* applyTo(Literal* l,unsigned index) override
   { return _subst->apply(l,index); }
 
-  virtual size_t getQueryApplicationWeight(TermList t) { return _subst->getApplicationResultWeight(t, _queryBank); }
-  virtual size_t getQueryApplicationWeight(Literal* l) { return _subst->getApplicationResultWeight(l, _queryBank); }
-  virtual size_t getResultApplicationWeight(TermList t) { return _subst->getApplicationResultWeight(t, _resultBank); }
-  virtual size_t getResultApplicationWeight(Literal* l) { return _subst->getApplicationResultWeight(l, _resultBank); }
+  size_t getQueryApplicationWeight(TermList t) override { return _subst->getApplicationResultWeight(t, _queryBank); }
+  size_t getQueryApplicationWeight(Literal* l) override { return _subst->getApplicationResultWeight(l, _queryBank); }
+  size_t getResultApplicationWeight(TermList t) override { return _subst->getApplicationResultWeight(t, _resultBank); }
+  size_t getResultApplicationWeight(Literal* l) override { return _subst->getApplicationResultWeight(l, _resultBank); }
 
-  RobSubstitution* tryGetRobSubstitution() { return _subst; }
+  RobSubstitution* tryGetRobSubstitution() override { return _subst; }
 
 #if VDEBUG
   vstring toStringDeref(bool deref){ return _subst->toString(deref); }

--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -31,27 +31,27 @@ public:
   RSProxy(RobSubstitution* subst, int queryBank, int resultBank)
   : _subst(subst), _queryBank(queryBank), _resultBank(resultBank) {}
 
-  TermList applyToQuery(TermList t) override
+  TermList applyToQuery(TermList t) final
   { return _subst->apply(t,_queryBank); }
-  Literal* applyToQuery(Literal* l) override
+  Literal* applyToQuery(Literal* l) final
   { return _subst->apply(l,_queryBank); }
 
-  TermList applyToResult(TermList t) override
+  TermList applyToResult(TermList t) final
   { return _subst->apply(t,_resultBank); }
-  Literal* applyToResult(Literal* l) override
+  Literal* applyToResult(Literal* l) final
   { return _subst->apply(l,_resultBank); }
 
-  TermList applyTo(TermList t,unsigned index) override
+  TermList applyTo(TermList t,unsigned index) final
   { return _subst->apply(t,index); }
-  Literal* applyTo(Literal* l,unsigned index) override
+  Literal* applyTo(Literal* l,unsigned index) final
   { return _subst->apply(l,index); }
 
-  size_t getQueryApplicationWeight(TermList t) override { return _subst->getApplicationResultWeight(t, _queryBank); }
-  size_t getQueryApplicationWeight(Literal* l) override { return _subst->getApplicationResultWeight(l, _queryBank); }
-  size_t getResultApplicationWeight(TermList t) override { return _subst->getApplicationResultWeight(t, _resultBank); }
-  size_t getResultApplicationWeight(Literal* l) override { return _subst->getApplicationResultWeight(l, _resultBank); }
+  size_t getQueryApplicationWeight(TermList t) final { return _subst->getApplicationResultWeight(t, _queryBank); }
+  size_t getQueryApplicationWeight(Literal* l) final { return _subst->getApplicationResultWeight(l, _queryBank); }
+  size_t getResultApplicationWeight(TermList t) final { return _subst->getApplicationResultWeight(t, _resultBank); }
+  size_t getResultApplicationWeight(Literal* l) final { return _subst->getApplicationResultWeight(l, _resultBank); }
 
-  RobSubstitution* tryGetRobSubstitution() override { return _subst; }
+  RobSubstitution* tryGetRobSubstitution() final { return _subst; }
 
 #if VDEBUG
   vstring toStringDeref(bool deref){ return _subst->toString(deref); }

--- a/Indexing/ResultSubstitution.hpp
+++ b/Indexing/ResultSubstitution.hpp
@@ -155,13 +155,13 @@ public:
   
   static ResultSubstitutionSP instance();
 
-  TermList applyToQuery(TermList t) override { return t; }
-  Literal* applyToQuery(Literal* l) override { return l; }
-  TermList applyToResult(TermList t) override { return t; }
-  Literal* applyToResult(Literal* l) override { return l; }
-  TermList applyTo(TermList t, unsigned index) override { return t; }
-  Literal* applyTo(Literal* l,unsigned index) override { return l; }
-  bool isIdentityOnQueryWhenResultBound() override {return true;}
+  TermList applyToQuery(TermList t) final { return t; }
+  Literal* applyToQuery(Literal* l) final { return l; }
+  TermList applyToResult(TermList t) final { return t; }
+  Literal* applyToResult(Literal* l) final { return l; }
+  TermList applyTo(TermList t, unsigned index) final { return t; }
+  Literal* applyTo(Literal* l,unsigned index) final { return l; }
+  bool isIdentityOnQueryWhenResultBound() final {return true;}
 #if VDEBUG
   virtual vstring toString(){ return "identity"; }
 #endif
@@ -174,17 +174,17 @@ public:
   CLASS_NAME(DisjunctQueryAndResultVariablesSubstitution);
   USE_ALLOCATOR(DisjunctQueryAndResultVariablesSubstitution);
   
-  TermList applyToQuery(TermList t) override;
-  Literal* applyToQuery(Literal* l) override;
-  TermList applyToResult(TermList t) override;
-  Literal* applyToResult(Literal* l) override;
-  TermList applyTo(TermList t, unsigned index) override { NOT_IMPLEMENTED; }
-  Literal* applyTo(Literal* l,unsigned index) override { NOT_IMPLEMENTED; }
+  TermList applyToQuery(TermList t) final;
+  Literal* applyToQuery(Literal* l) final;
+  TermList applyToResult(TermList t) final;
+  Literal* applyToResult(Literal* l) final;
+  TermList applyTo(TermList t, unsigned index) final { NOT_IMPLEMENTED; }
+  Literal* applyTo(Literal* l,unsigned index) final { NOT_IMPLEMENTED; }
 
   /**
    * we can return true because nothing is bound to the result
    */
-  bool isIdentityOnQueryWhenResultBound() override {return true;}
+  bool isIdentityOnQueryWhenResultBound() final {return true;}
 #if VDEBUG
   virtual vstring toString(){ return "DisjunctQueryAndResultVariablesSubstitution"; }
 #endif

--- a/Indexing/ResultSubstitution.hpp
+++ b/Indexing/ResultSubstitution.hpp
@@ -163,7 +163,7 @@ public:
   Literal* applyTo(Literal* l,unsigned index) final { return l; }
   bool isIdentityOnQueryWhenResultBound() final {return true;}
 #if VDEBUG
-  virtual vstring toString(){ return "identity"; }
+  vstring toString() final { return "identity"; }
 #endif
 };
 
@@ -186,7 +186,7 @@ public:
    */
   bool isIdentityOnQueryWhenResultBound() final {return true;}
 #if VDEBUG
-  virtual vstring toString(){ return "DisjunctQueryAndResultVariablesSubstitution"; }
+  vstring toString() final { return "DisjunctQueryAndResultVariablesSubstitution"; }
 #endif
 private:
   struct Applicator;

--- a/Indexing/ResultSubstitution.hpp
+++ b/Indexing/ResultSubstitution.hpp
@@ -155,13 +155,13 @@ public:
   
   static ResultSubstitutionSP instance();
 
-  TermList applyToQuery(TermList t) { return t; }
-  Literal* applyToQuery(Literal* l) { return l; }
-  TermList applyToResult(TermList t) { return t; }
-  Literal* applyToResult(Literal* l) { return l; }
-  TermList applyTo(TermList t, unsigned index) { return t; }
-  Literal* applyTo(Literal* l,unsigned index) { return l; }
-  bool isIdentityOnQueryWhenResultBound() {return true;}
+  TermList applyToQuery(TermList t) override { return t; }
+  Literal* applyToQuery(Literal* l) override { return l; }
+  TermList applyToResult(TermList t) override { return t; }
+  Literal* applyToResult(Literal* l) override { return l; }
+  TermList applyTo(TermList t, unsigned index) override { return t; }
+  Literal* applyTo(Literal* l,unsigned index) override { return l; }
+  bool isIdentityOnQueryWhenResultBound() override {return true;}
 #if VDEBUG
   virtual vstring toString(){ return "identity"; }
 #endif
@@ -174,17 +174,17 @@ public:
   CLASS_NAME(DisjunctQueryAndResultVariablesSubstitution);
   USE_ALLOCATOR(DisjunctQueryAndResultVariablesSubstitution);
   
-  TermList applyToQuery(TermList t);
-  Literal* applyToQuery(Literal* l);
-  TermList applyToResult(TermList t);
-  Literal* applyToResult(Literal* l);
-  TermList applyTo(TermList t, unsigned index) { NOT_IMPLEMENTED; }
-  Literal* applyTo(Literal* l,unsigned index) { NOT_IMPLEMENTED; }
+  TermList applyToQuery(TermList t) override;
+  Literal* applyToQuery(Literal* l) override;
+  TermList applyToResult(TermList t) override;
+  Literal* applyToResult(Literal* l) override;
+  TermList applyTo(TermList t, unsigned index) override { NOT_IMPLEMENTED; }
+  Literal* applyTo(Literal* l,unsigned index) override { NOT_IMPLEMENTED; }
 
   /**
    * we can return true because nothing is bound to the result
    */
-  bool isIdentityOnQueryWhenResultBound() {return true;}
+  bool isIdentityOnQueryWhenResultBound() override {return true;}
 #if VDEBUG
   virtual vstring toString(){ return "DisjunctQueryAndResultVariablesSubstitution"; }
 #endif

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -506,7 +506,7 @@ public:
     void remove(TermList t) final;
 
 #if VDEBUG
-    virtual void assertValid() const
+    void assertValid() const final
     {
       ASS_ALLOC_TYPE(this,"SubstitutionTree::UArrIntermediateNode");
     }
@@ -560,7 +560,7 @@ public:
     bool isEmpty() const final { return _nodes.isEmpty(); }
     int size() const final { return _nodes.size(); }
 #if VDEBUG
-    virtual void assertValid() const
+    void assertValid() const final
     {
       ASS_ALLOC_TYPE(this,"SubstitutionTree::SListIntermediateNode");
     }

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -329,7 +329,7 @@ public:
     IntermediateNode(TermList ts, unsigned childVar) : Node(ts), childVar(childVar),_childBySortHelper(0) {}
 
     inline
-    bool isLeaf() const override { return false; };
+    bool isLeaf() const final { return false; };
 
     virtual NodeIterator allChildren() = 0;
     virtual NodeIterator variableChildren() = 0;
@@ -361,7 +361,7 @@ public:
 
     void destroyChildren();
 
-    void makeEmpty() override
+    void makeEmpty() final
     {
       Node::makeEmpty();
       removeAllChildren();
@@ -384,7 +384,7 @@ public:
     const unsigned childVar;
     ChildBySortHelper* _childBySortHelper;
 
-    void print(unsigned depth=0) override{
+    void print(unsigned depth=0) final{
        auto children = allChildren();
        printDepth(depth);
        cout << "I [" << childVar << "] with " << term.toString() << endl;
@@ -428,13 +428,13 @@ public:
     Leaf(TermList ts) : Node(ts) {}
 
     inline
-    bool isLeaf() const override { return true; };
+    bool isLeaf() const final { return true; };
     virtual LDIterator allChildren() = 0;
     virtual void insert(LeafData ld) = 0;
     virtual void remove(LeafData ld) = 0;
     void loadChildren(LDIterator children);
 
-    void print(unsigned depth=0) override{
+    void print(unsigned depth=0) final{
        auto children = allChildren();
        while(children.hasNext()){
          printDepth(depth);
@@ -485,25 +485,25 @@ public:
       }
     }
 
-    void removeAllChildren() override
+    void removeAllChildren() final
     {
       _size=0;
       _nodes[0]=0;
     }
 
-    NodeAlgorithm algorithm() const override { return UNSORTED_LIST; }
-    bool isEmpty() const override { return !_size; }
-    int size() const override { return _size; }
-    NodeIterator allChildren() override
+    NodeAlgorithm algorithm() const final { return UNSORTED_LIST; }
+    bool isEmpty() const final { return !_size; }
+    int size() const final { return _size; }
+    NodeIterator allChildren() final
     { return pvi( PointerPtrIterator<Node*>(&_nodes[0],&_nodes[_size]) ); }
 
-    NodeIterator variableChildren() override
+    NodeIterator variableChildren() final
     {
       return pvi( getFilteredIterator(PointerPtrIterator<Node*>(&_nodes[0],&_nodes[_size]),
   	    IsPtrToVarNodeFn()) );
     }
-    Node** childByTop(TermList t, bool canCreate) override;
-    void remove(TermList t) override;
+    Node** childByTop(TermList t, bool canCreate) final;
+    void remove(TermList t) final;
 
 #if VDEBUG
     virtual void assertValid() const
@@ -545,7 +545,7 @@ public:
       }
     }
 
-    void removeAllChildren() override
+    void removeAllChildren() final
     {
       while(!_nodes.isEmpty()) {
         _nodes.pop();
@@ -555,10 +555,10 @@ public:
     static IntermediateNode* assimilate(IntermediateNode* orig);
 
     inline
-    NodeAlgorithm algorithm() const override { return SKIP_LIST; }
+    NodeAlgorithm algorithm() const final { return SKIP_LIST; }
     inline
-    bool isEmpty() const override { return _nodes.isEmpty(); }
-    int size() const override { return _nodes.size(); }
+    bool isEmpty() const final { return _nodes.isEmpty(); }
+    int size() const final { return _nodes.size(); }
 #if VDEBUG
     virtual void assertValid() const
     {
@@ -566,18 +566,18 @@ public:
     }
 #endif
     inline
-    NodeIterator allChildren() override
+    NodeIterator allChildren() final
     {
       return pvi( NodeSkipList::PtrIterator(_nodes) );
     }
     inline
-    NodeIterator variableChildren() override
+    NodeIterator variableChildren() final
     {
       return pvi( getWhileLimitedIterator(
   		    NodeSkipList::PtrIterator(_nodes),
   		    IsPtrToVarNodeFn()) );
     }
-    Node** childByTop(TermList t, bool canCreate) override
+    Node** childByTop(TermList t, bool canCreate) final
     {
       CALL("SubstitutionTree::SListIntermediateNode::childByTop");
 
@@ -594,7 +594,7 @@ public:
       return res;
     }
     inline
-    void remove(TermList t) override
+    void remove(TermList t) final
     {
       _nodes.remove(t);
       if(_childBySortHelper){
@@ -709,8 +709,8 @@ public:
     LeafIterator(SubstitutionTree* st)
     : _nextRootPtr(st->_nodes.begin()), _afterLastRootPtr(st->_nodes.end()),
     _nodeIterators(8) {}
-    bool hasNext() override;
-    Leaf* next() override
+    bool hasNext() final;
+    Leaf* next() final
     {
       ASS(_curr->isLeaf());
       return static_cast<Leaf*>(_curr);
@@ -730,7 +730,7 @@ public:
   /**
    * Iterator, that yields generalizations of given term/literal.
    */
-  class FastGeneralizationsIterator
+  class FastGeneralizationsIterator final
   : public IteratorCore<QueryResult>
   {
   public:
@@ -738,10 +738,10 @@ public:
             bool retrieveSubstitution, bool reversed,bool withoutTop,bool useC, 
             FuncSubtermMap* fstm = 0);
 
-    ~FastGeneralizationsIterator() override;
+    ~FastGeneralizationsIterator() final;
 
-    QueryResult next() override;
-    bool hasNext() override;
+    QueryResult next() final;
+    bool hasNext() final;
   protected:
     void createInitialBindings(Term* t);
     void createReversedInitialBindings(Term* t);
@@ -777,17 +777,17 @@ public:
   /**
    * Iterator, that yields generalizations of given term/literal.
    */
-  class FastInstancesIterator
+  class FastInstancesIterator final
   : public IteratorCore<QueryResult>
   {
   public:
     FastInstancesIterator(SubstitutionTree* parent, Node* root, Term* query,
 	    bool retrieveSubstitution, bool reversed, bool withoutTop, bool useC, 
       FuncSubtermMap* fstm = 0);
-    ~FastInstancesIterator() override;
+    ~FastInstancesIterator() final;
 
-    bool hasNext() override;
-    QueryResult next() override;
+    bool hasNext() final;
+    QueryResult next() final;
   protected:
     void createInitialBindings(Term* t);
     void createReversedInitialBindings(Term* t);
@@ -821,7 +821,7 @@ public:
       UWAMismatchHandler(c), _constraints(c), _bd(bd) {}
     //virtual bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2);
   private:
-    bool introduceConstraint(TermList t1,unsigned index1, TermList t2,unsigned index2) override;
+    bool introduceConstraint(TermList t1,unsigned index1, TermList t2,unsigned index2) final;
     Stack<UnificationConstraint>& _constraints;
     BacktrackData& _bd;
   };
@@ -831,23 +831,23 @@ public:
   public:
     STHOMismatchHandler(Stack<UnificationConstraint>& c, BacktrackData& bd) : 
       HOMismatchHandler(c), _constraints(c), _bd(bd) {}
-    bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2) override;
+    bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2) final;
   private:
     Stack<UnificationConstraint>& _constraints;
     BacktrackData& _bd;
   };  
 
-  class UnificationsIterator
+  class UnificationsIterator final
   : public IteratorCore<QueryResult>
   {
   public:
     UnificationsIterator(SubstitutionTree* parent, Node* root, Term* query, 
       bool retrieveSubstitution, bool reversed, bool withoutTop, bool useC, 
       FuncSubtermMap* funcSubtermMap = 0);
-    ~UnificationsIterator() override;
+    ~UnificationsIterator() final;
 
-    bool hasNext() override;
-    QueryResult next() override;
+    bool hasNext() final;
+    QueryResult next() final;
     bool tag;
   protected:
     virtual bool associate(TermList query, TermList node, BacktrackData& bd);

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -329,7 +329,7 @@ public:
     IntermediateNode(TermList ts, unsigned childVar) : Node(ts), childVar(childVar),_childBySortHelper(0) {}
 
     inline
-    bool isLeaf() const { return false; };
+    bool isLeaf() const override { return false; };
 
     virtual NodeIterator allChildren() = 0;
     virtual NodeIterator variableChildren() = 0;
@@ -361,7 +361,7 @@ public:
 
     void destroyChildren();
 
-    void makeEmpty()
+    void makeEmpty() override
     {
       Node::makeEmpty();
       removeAllChildren();
@@ -384,7 +384,7 @@ public:
     const unsigned childVar;
     ChildBySortHelper* _childBySortHelper;
 
-    virtual void print(unsigned depth=0){
+    void print(unsigned depth=0) override{
        auto children = allChildren();
        printDepth(depth);
        cout << "I [" << childVar << "] with " << term.toString() << endl;
@@ -428,13 +428,13 @@ public:
     Leaf(TermList ts) : Node(ts) {}
 
     inline
-    bool isLeaf() const { return true; };
+    bool isLeaf() const override { return true; };
     virtual LDIterator allChildren() = 0;
     virtual void insert(LeafData ld) = 0;
     virtual void remove(LeafData ld) = 0;
     void loadChildren(LDIterator children);
 
-    virtual void print(unsigned depth=0){
+    void print(unsigned depth=0) override{
        auto children = allChildren();
        while(children.hasNext()){
          printDepth(depth);
@@ -478,32 +478,32 @@ public:
       _nodes[0]=0;
     }
 
-    ~UArrIntermediateNode()
+    ~UArrIntermediateNode() override
     {
       if(!isEmpty()) {
 	destroyChildren();
       }
     }
 
-    void removeAllChildren()
+    void removeAllChildren() override
     {
       _size=0;
       _nodes[0]=0;
     }
 
-    NodeAlgorithm algorithm() const { return UNSORTED_LIST; }
-    bool isEmpty() const { return !_size; }
-    int size() const { return _size; }
-    NodeIterator allChildren()
+    NodeAlgorithm algorithm() const override { return UNSORTED_LIST; }
+    bool isEmpty() const override { return !_size; }
+    int size() const override { return _size; }
+    NodeIterator allChildren() override
     { return pvi( PointerPtrIterator<Node*>(&_nodes[0],&_nodes[_size]) ); }
 
-    NodeIterator variableChildren()
+    NodeIterator variableChildren() override
     {
       return pvi( getFilteredIterator(PointerPtrIterator<Node*>(&_nodes[0],&_nodes[_size]),
   	    IsPtrToVarNodeFn()) );
     }
-    virtual Node** childByTop(TermList t, bool canCreate);
-    void remove(TermList t);
+    Node** childByTop(TermList t, bool canCreate) override;
+    void remove(TermList t) override;
 
 #if VDEBUG
     virtual void assertValid() const
@@ -538,14 +538,14 @@ public:
     SListIntermediateNode(unsigned childVar) : IntermediateNode(childVar) {}
     SListIntermediateNode(TermList ts, unsigned childVar) : IntermediateNode(ts, childVar) {}
 
-    ~SListIntermediateNode()
+    ~SListIntermediateNode() override
     {
       if(!isEmpty()) {
 	destroyChildren();
       }
     }
 
-    void removeAllChildren()
+    void removeAllChildren() override
     {
       while(!_nodes.isEmpty()) {
         _nodes.pop();
@@ -555,10 +555,10 @@ public:
     static IntermediateNode* assimilate(IntermediateNode* orig);
 
     inline
-    NodeAlgorithm algorithm() const { return SKIP_LIST; }
+    NodeAlgorithm algorithm() const override { return SKIP_LIST; }
     inline
-    bool isEmpty() const { return _nodes.isEmpty(); }
-    int size() const { return _nodes.size(); }
+    bool isEmpty() const override { return _nodes.isEmpty(); }
+    int size() const override { return _nodes.size(); }
 #if VDEBUG
     virtual void assertValid() const
     {
@@ -566,18 +566,18 @@ public:
     }
 #endif
     inline
-    NodeIterator allChildren()
+    NodeIterator allChildren() override
     {
       return pvi( NodeSkipList::PtrIterator(_nodes) );
     }
     inline
-    NodeIterator variableChildren()
+    NodeIterator variableChildren() override
     {
       return pvi( getWhileLimitedIterator(
   		    NodeSkipList::PtrIterator(_nodes),
   		    IsPtrToVarNodeFn()) );
     }
-    virtual Node** childByTop(TermList t, bool canCreate)
+    Node** childByTop(TermList t, bool canCreate) override
     {
       CALL("SubstitutionTree::SListIntermediateNode::childByTop");
 
@@ -594,7 +594,7 @@ public:
       return res;
     }
     inline
-    void remove(TermList t)
+    void remove(TermList t) override
     {
       _nodes.remove(t);
       if(_childBySortHelper){
@@ -709,8 +709,8 @@ public:
     LeafIterator(SubstitutionTree* st)
     : _nextRootPtr(st->_nodes.begin()), _afterLastRootPtr(st->_nodes.end()),
     _nodeIterators(8) {}
-    bool hasNext();
-    Leaf* next()
+    bool hasNext() override;
+    Leaf* next() override
     {
       ASS(_curr->isLeaf());
       return static_cast<Leaf*>(_curr);
@@ -738,10 +738,10 @@ public:
             bool retrieveSubstitution, bool reversed,bool withoutTop,bool useC, 
             FuncSubtermMap* fstm = 0);
 
-    ~FastGeneralizationsIterator();
+    ~FastGeneralizationsIterator() override;
 
-    QueryResult next();
-    bool hasNext();
+    QueryResult next() override;
+    bool hasNext() override;
   protected:
     void createInitialBindings(Term* t);
     void createReversedInitialBindings(Term* t);
@@ -784,10 +784,10 @@ public:
     FastInstancesIterator(SubstitutionTree* parent, Node* root, Term* query,
 	    bool retrieveSubstitution, bool reversed, bool withoutTop, bool useC, 
       FuncSubtermMap* fstm = 0);
-    ~FastInstancesIterator();
+    ~FastInstancesIterator() override;
 
-    bool hasNext();
-    QueryResult next();
+    bool hasNext() override;
+    QueryResult next() override;
   protected:
     void createInitialBindings(Term* t);
     void createReversedInitialBindings(Term* t);
@@ -821,7 +821,7 @@ public:
       UWAMismatchHandler(c), _constraints(c), _bd(bd) {}
     //virtual bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2);
   private:
-    virtual bool introduceConstraint(TermList t1,unsigned index1, TermList t2,unsigned index2);
+    bool introduceConstraint(TermList t1,unsigned index1, TermList t2,unsigned index2) override;
     Stack<UnificationConstraint>& _constraints;
     BacktrackData& _bd;
   };
@@ -831,7 +831,7 @@ public:
   public:
     STHOMismatchHandler(Stack<UnificationConstraint>& c, BacktrackData& bd) : 
       HOMismatchHandler(c), _constraints(c), _bd(bd) {}
-    virtual bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2);
+    bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2) override;
   private:
     Stack<UnificationConstraint>& _constraints;
     BacktrackData& _bd;
@@ -844,10 +844,10 @@ public:
     UnificationsIterator(SubstitutionTree* parent, Node* root, Term* query, 
       bool retrieveSubstitution, bool reversed, bool withoutTop, bool useC, 
       FuncSubtermMap* funcSubtermMap = 0);
-    ~UnificationsIterator();
+    ~UnificationsIterator() override;
 
-    bool hasNext();
-    QueryResult next();
+    bool hasNext() override;
+    QueryResult next() override;
     bool tag;
   protected:
     virtual bool associate(TermList query, TermList node, BacktrackData& bd);

--- a/Indexing/SubstitutionTree_FastGen.cpp
+++ b/Indexing/SubstitutionTree_FastGen.cpp
@@ -173,7 +173,7 @@ private:
   BindingMap _cache;
 };
 
-class SubstitutionTree::GenMatcher::Substitution
+class SubstitutionTree::GenMatcher::Substitution final
 : public ResultSubstitution
 {
 public:
@@ -184,27 +184,27 @@ public:
   : _parent(parent), _resultNormalizer(resultNormalizer),
   _applicator(0)
   {}
-  ~Substitution() override
+  ~Substitution() final
   {
     if(_applicator) {
       delete _applicator;
     }
   }
 
-  TermList applyToBoundResult(TermList t) override
+  TermList applyToBoundResult(TermList t) final
   { return SubstHelper::apply(t, *getApplicator()); }
 
-  Literal* applyToBoundResult(Literal* lit) override
+  Literal* applyToBoundResult(Literal* lit) final
   { return SubstHelper::apply(lit, *getApplicator()); }
 
-  bool matchSorts(TermList base, TermList instance) override
+  bool matchSorts(TermList base, TermList instance) final
   { return _parent->matchNextAux(instance, base, false); }
 
-  bool isIdentityOnQueryWhenResultBound() override
+  bool isIdentityOnQueryWhenResultBound() final
   { return true; }
 
 #if VDEBUG
-  vstring toString() override
+  vstring toString() final
   { return _resultNormalizer->toString(); }
 #endif
 

--- a/Indexing/SubstitutionTree_FastGen.cpp
+++ b/Indexing/SubstitutionTree_FastGen.cpp
@@ -184,7 +184,7 @@ public:
   : _parent(parent), _resultNormalizer(resultNormalizer),
   _applicator(0)
   {}
-  ~Substitution()
+  ~Substitution() override
   {
     if(_applicator) {
       delete _applicator;
@@ -204,7 +204,7 @@ public:
   { return true; }
 
 #if VDEBUG
-  virtual vstring toString() override
+  vstring toString() override
   { return _resultNormalizer->toString(); }
 #endif
 

--- a/Indexing/SubstitutionTree_FastInst.cpp
+++ b/Indexing/SubstitutionTree_FastInst.cpp
@@ -231,7 +231,7 @@ public:
   Substitution(InstMatcher* parent, Renaming* resultDenormalizer)
   : _parent(parent), _resultDenormalizer(resultDenormalizer)
   {}
-  ~Substitution()
+  ~Substitution() override
   {
   }
 

--- a/Indexing/SubstitutionTree_FastInst.cpp
+++ b/Indexing/SubstitutionTree_FastInst.cpp
@@ -221,7 +221,7 @@ std::ostream& operator<< (ostream& out, SubstitutionTree::InstMatcher::TermSpec 
 }
 
 
-class SubstitutionTree::InstMatcher::Substitution
+class SubstitutionTree::InstMatcher::Substitution final
 : public ResultSubstitution
 {
 public:
@@ -231,18 +231,18 @@ public:
   Substitution(InstMatcher* parent, Renaming* resultDenormalizer)
   : _parent(parent), _resultDenormalizer(resultDenormalizer)
   {}
-  ~Substitution() override
+  ~Substitution() final
   {
   }
 
-  bool matchSorts(TermList base, TermList instance) override
+  bool matchSorts(TermList base, TermList instance) final
   {
     CALL("SubstitutionTree::InstMatcher::Substitution::matchSorts");
 
     return _parent->matchNextAux(base, instance, false);
   }
 
-  TermList applyToBoundQuery(TermList t) override
+  TermList applyToBoundQuery(TermList t) final
   {
     CALL("SubstitutionTree::InstMatcher::Substitution::applyToBoundQuery");
 
@@ -258,7 +258,7 @@ public:
     return _resultDenormalizer->apply(normalized);
   }
   
-  bool isIdentityOnResultWhenQueryBound() override
+  bool isIdentityOnResultWhenQueryBound() final
   { return true; }
 private:
   InstMatcher* _parent;

--- a/Indexing/SubstitutionTree_Nodes.cpp
+++ b/Indexing/SubstitutionTree_Nodes.cpp
@@ -37,31 +37,31 @@ public:
   UListLeaf() : _children(0), _size(0) {}
   inline
   UListLeaf(TermList ts) : Leaf(ts), _children(0), _size(0) {}
-  ~UListLeaf()
+  ~UListLeaf() override
   {
     LDList::destroy(_children);
   }
 
   inline
-  NodeAlgorithm algorithm() const { return UNSORTED_LIST; }
+  NodeAlgorithm algorithm() const override { return UNSORTED_LIST; }
   inline
-  bool isEmpty() const { return !_children; }
+  bool isEmpty() const override { return !_children; }
   inline
-  int size() const { return _size; }
+  int size() const override { return _size; }
   inline
-  LDIterator allChildren()
+  LDIterator allChildren() override
   {
     return pvi( LDList::RefIterator(_children) );
   }
   inline
-  void insert(LeafData ld)
+  void insert(LeafData ld) override
   {
     CALL("SubstitutionTree::UListLeaf::insert");
     LDList::push(ld, _children);
     _size++;
   }
   inline
-  void remove(LeafData ld)
+  void remove(LeafData ld) override
   {
     CALL("SubstitutionTree::UListLeaf::remove");
     _children = LDList::remove(ld, _children);
@@ -87,23 +87,23 @@ public:
   static SListLeaf* assimilate(Leaf* orig);
 
   inline
-  NodeAlgorithm algorithm() const { return SKIP_LIST; }
+  NodeAlgorithm algorithm() const override { return SKIP_LIST; }
   inline
-  bool isEmpty() const { return _children.isEmpty(); }
+  bool isEmpty() const override { return _children.isEmpty(); }
 #if VDEBUG
   inline
-  int size() const { return _children.size(); }
+  int size() const override { return _children.size(); }
 #endif
   inline
-  LDIterator allChildren()
+  LDIterator allChildren() override
   {
     return pvi( LDSkipList::RefIterator(_children) );
   }
-  void insert(LeafData ld) {
+  void insert(LeafData ld) override {
     CALL("SubstitutionTree::SListLeaf::insert");
     _children.insert(ld);
   }
-  void remove(LeafData ld) {
+  void remove(LeafData ld) override {
     CALL("SubstitutionTree::SListLeaf::remove");
     _children.remove(ld);
   }

--- a/Indexing/SubstitutionTree_Nodes.cpp
+++ b/Indexing/SubstitutionTree_Nodes.cpp
@@ -29,7 +29,7 @@
 namespace Indexing
 {
 
-class SubstitutionTree::UListLeaf
+class SubstitutionTree::UListLeaf final
 : public Leaf
 {
 public:
@@ -37,31 +37,31 @@ public:
   UListLeaf() : _children(0), _size(0) {}
   inline
   UListLeaf(TermList ts) : Leaf(ts), _children(0), _size(0) {}
-  ~UListLeaf() override
+  ~UListLeaf() final
   {
     LDList::destroy(_children);
   }
 
   inline
-  NodeAlgorithm algorithm() const override { return UNSORTED_LIST; }
+  NodeAlgorithm algorithm() const final { return UNSORTED_LIST; }
   inline
-  bool isEmpty() const override { return !_children; }
+  bool isEmpty() const final { return !_children; }
   inline
-  int size() const override { return _size; }
+  int size() const final { return _size; }
   inline
-  LDIterator allChildren() override
+  LDIterator allChildren() final
   {
     return pvi( LDList::RefIterator(_children) );
   }
   inline
-  void insert(LeafData ld) override
+  void insert(LeafData ld) final
   {
     CALL("SubstitutionTree::UListLeaf::insert");
     LDList::push(ld, _children);
     _size++;
   }
   inline
-  void remove(LeafData ld) override
+  void remove(LeafData ld) final
   {
     CALL("SubstitutionTree::UListLeaf::remove");
     _children = LDList::remove(ld, _children);
@@ -87,23 +87,23 @@ public:
   static SListLeaf* assimilate(Leaf* orig);
 
   inline
-  NodeAlgorithm algorithm() const override { return SKIP_LIST; }
+  NodeAlgorithm algorithm() const final { return SKIP_LIST; }
   inline
-  bool isEmpty() const override { return _children.isEmpty(); }
+  bool isEmpty() const final { return _children.isEmpty(); }
 #if VDEBUG
   inline
-  int size() const override { return _children.size(); }
+  int size() const final { return _children.size(); }
 #endif
   inline
-  LDIterator allChildren() override
+  LDIterator allChildren() final
   {
     return pvi( LDSkipList::RefIterator(_children) );
   }
-  void insert(LeafData ld) override {
+  void insert(LeafData ld) final {
     CALL("SubstitutionTree::SListLeaf::insert");
     _children.insert(ld);
   }
-  void remove(LeafData ld) override {
+  void remove(LeafData ld) final {
     CALL("SubstitutionTree::SListLeaf::remove");
     _children.remove(ld);
   }

--- a/Indexing/TermIndex.hpp
+++ b/Indexing/TermIndex.hpp
@@ -59,7 +59,7 @@ public:
   SuperpositionSubtermIndex(TermIndexingStructure* is, Ordering& ord)
   : TermIndex(is), _ord(ord) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   Ordering& _ord;
 };
@@ -74,7 +74,7 @@ public:
   SuperpositionLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord), _opt(opt) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   Ordering& _ord;
   const Options& _opt;
@@ -106,7 +106,7 @@ public:
   DemodulationSubtermIndexImpl(TermIndexingStructure* is)
   : DemodulationSubtermIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 /**
@@ -122,7 +122,7 @@ public:
   DemodulationLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord), _opt(opt) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   Ordering& _ord;
   const Options& _opt;
@@ -142,7 +142,7 @@ public:
   : TermIndex(is) {}
 
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 /////////////////////////////////////////////////////
@@ -174,7 +174,7 @@ public:
   SubVarSupSubtermIndex(TermIndexingStructure* is, Ordering& ord)
   : TermIndex(is), _ord(ord) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   Ordering& _ord;
 };
@@ -189,7 +189,7 @@ public:
   SubVarSupLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord) {};
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   Ordering& _ord;
 };
@@ -236,7 +236,7 @@ public:
   {}
 protected:
   void insertInstantiation(TermList sort, TermList instantiation);
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 private:
   Set<TermList> _insertedInstantiations;
 };
@@ -252,7 +252,7 @@ public:
   {}
   void insertFormula(TermList formula, TermList name, Literal* lit, Clause* cls);
 protected:
-  void handleClause(Clause* c, bool adding) override;
+  void handleClause(Clause* c, bool adding) final;
 };
 
 };

--- a/Indexing/TermIndex.hpp
+++ b/Indexing/TermIndex.hpp
@@ -30,7 +30,7 @@ public:
   CLASS_NAME(TermIndex);
   USE_ALLOCATOR(TermIndex);
 
-  virtual ~TermIndex();
+  ~TermIndex() override;
 
   TermQueryResultIterator getUnifications(TermList t,
 	  bool retrieveSubstitutions = true);
@@ -59,7 +59,7 @@ public:
   SuperpositionSubtermIndex(TermIndexingStructure* is, Ordering& ord)
   : TermIndex(is), _ord(ord) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   Ordering& _ord;
 };
@@ -74,7 +74,7 @@ public:
   SuperpositionLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord), _opt(opt) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   Ordering& _ord;
   const Options& _opt;
@@ -92,7 +92,7 @@ public:
   : TermIndex(is) {};
 protected:
   // it's the implementation of this below in DemodulationSubtermIndexImpl, which makes this work
-  void handleClause(Clause* c, bool adding) = 0;
+  void handleClause(Clause* c, bool adding) override = 0;
 };
 
 template <bool combinatorySupSupport>
@@ -106,7 +106,7 @@ public:
   DemodulationSubtermIndexImpl(TermIndexingStructure* is)
   : DemodulationSubtermIndex(is) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 /**
@@ -122,7 +122,7 @@ public:
   DemodulationLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord), _opt(opt) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   Ordering& _ord;
   const Options& _opt;
@@ -142,7 +142,7 @@ public:
   : TermIndex(is) {}
 
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 /////////////////////////////////////////////////////
@@ -174,7 +174,7 @@ public:
   SubVarSupSubtermIndex(TermIndexingStructure* is, Ordering& ord)
   : TermIndex(is), _ord(ord) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   Ordering& _ord;
 };
@@ -189,7 +189,7 @@ public:
   SubVarSupLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord) {};
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   Ordering& _ord;
 };
@@ -236,7 +236,7 @@ public:
   {}
 protected:
   void insertInstantiation(TermList sort, TermList instantiation);
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 private:
   Set<TermList> _insertedInstantiations;
 };
@@ -252,7 +252,7 @@ public:
   {}
   void insertFormula(TermList formula, TermList name, Literal* lit, Clause* cls);
 protected:
-  void handleClause(Clause* c, bool adding);
+  void handleClause(Clause* c, bool adding) override;
 };
 
 };

--- a/Indexing/TermSubstitutionTree.hpp
+++ b/Indexing/TermSubstitutionTree.hpp
@@ -54,31 +54,31 @@ public:
    */
   TermSubstitutionTree(bool useC=false, bool replaceFunctionalSubterms = false, bool extra = false);
 
-  void insert(TermList t, Literal* lit, Clause* cls);
-  void remove(TermList t, Literal* lit, Clause* cls);
-  void insert(TermList t, TermList trm);
-  void insert(TermList t, TermList trm, Literal* lit, Clause* cls);
+  void insert(TermList t, Literal* lit, Clause* cls) override;
+  void remove(TermList t, Literal* lit, Clause* cls) override;
+  void insert(TermList t, TermList trm) override;
+  void insert(TermList t, TermList trm, Literal* lit, Clause* cls) override;
 
-  bool generalizationExists(TermList t);
+  bool generalizationExists(TermList t) override;
 
 
   TermQueryResultIterator getUnifications(TermList t,
-	  bool retrieveSubstitutions);
+	  bool retrieveSubstitutions) override;
 
   TermQueryResultIterator getUnificationsWithConstraints(TermList t,
-    bool retrieveSubstitutions);
+    bool retrieveSubstitutions) override;
 
   /*
    * A higher order concern (though it may be useful in other situations)
    */
   TermQueryResultIterator getUnificationsUsingSorts(TermList t, TermList sort,
-    bool retrieveSubstitutions);
+    bool retrieveSubstitutions) override;
 
   TermQueryResultIterator getGeneralizations(TermList t,
-	  bool retrieveSubstitutions);
+	  bool retrieveSubstitutions) override;
 
   TermQueryResultIterator getInstances(TermList t,
-	  bool retrieveSubstitutions);
+	  bool retrieveSubstitutions) override;
 
 #if VDEBUG
   virtual void markTagged(){ SubstitutionTree::markTagged();}

--- a/Indexing/TermSubstitutionTree.hpp
+++ b/Indexing/TermSubstitutionTree.hpp
@@ -81,7 +81,7 @@ public:
 	  bool retrieveSubstitutions) final;
 
 #if VDEBUG
-  virtual void markTagged(){ SubstitutionTree::markTagged();}
+  void markTagged() final { SubstitutionTree::markTagged();}
 #endif
 
 private:

--- a/Indexing/TermSubstitutionTree.hpp
+++ b/Indexing/TermSubstitutionTree.hpp
@@ -54,31 +54,31 @@ public:
    */
   TermSubstitutionTree(bool useC=false, bool replaceFunctionalSubterms = false, bool extra = false);
 
-  void insert(TermList t, Literal* lit, Clause* cls) override;
-  void remove(TermList t, Literal* lit, Clause* cls) override;
-  void insert(TermList t, TermList trm) override;
-  void insert(TermList t, TermList trm, Literal* lit, Clause* cls) override;
+  void insert(TermList t, Literal* lit, Clause* cls) final;
+  void remove(TermList t, Literal* lit, Clause* cls) final;
+  void insert(TermList t, TermList trm) final;
+  void insert(TermList t, TermList trm, Literal* lit, Clause* cls) final;
 
-  bool generalizationExists(TermList t) override;
+  bool generalizationExists(TermList t) final;
 
 
   TermQueryResultIterator getUnifications(TermList t,
-	  bool retrieveSubstitutions) override;
+	  bool retrieveSubstitutions) final;
 
   TermQueryResultIterator getUnificationsWithConstraints(TermList t,
-    bool retrieveSubstitutions) override;
+    bool retrieveSubstitutions) final;
 
   /*
    * A higher order concern (though it may be useful in other situations)
    */
   TermQueryResultIterator getUnificationsUsingSorts(TermList t, TermList sort,
-    bool retrieveSubstitutions) override;
+    bool retrieveSubstitutions) final;
 
   TermQueryResultIterator getGeneralizations(TermList t,
-	  bool retrieveSubstitutions) override;
+	  bool retrieveSubstitutions) final;
 
   TermQueryResultIterator getInstances(TermList t,
-	  bool retrieveSubstitutions) override;
+	  bool retrieveSubstitutions) final;
 
 #if VDEBUG
   virtual void markTagged(){ SubstitutionTree::markTagged();}

--- a/Indexing/TypeSubstitutionTree.hpp
+++ b/Indexing/TypeSubstitutionTree.hpp
@@ -39,12 +39,12 @@ public:
   void insert(TermList sort, LeafData ld);
   void remove(TermList sort, LeafData ld);
   void handleTerm(TermList t, LeafData ld, bool insert);
-  void insert(TermList t, Literal* lit, Clause* cls) override{ NOT_IMPLEMENTED; }
-  void remove(TermList t, Literal* lit, Clause* cls) override{ NOT_IMPLEMENTED; }
+  void insert(TermList t, Literal* lit, Clause* cls) final{ NOT_IMPLEMENTED; }
+  void remove(TermList t, Literal* lit, Clause* cls) final{ NOT_IMPLEMENTED; }
 
 
   TermQueryResultIterator getUnifications(TermList sort,
-	  bool retrieveSubstitutions) override{ NOT_IMPLEMENTED; }
+	  bool retrieveSubstitutions) final{ NOT_IMPLEMENTED; }
 
   TermQueryResultIterator getUnifications(TermList sort, TermList trm, 
     bool retrieveSubstitutions);

--- a/Indexing/TypeSubstitutionTree.hpp
+++ b/Indexing/TypeSubstitutionTree.hpp
@@ -50,7 +50,7 @@ public:
     bool retrieveSubstitutions);
 
 #if VDEBUG
-  virtual void markTagged(){ SubstitutionTree::markTagged();}
+  void markTagged() final { SubstitutionTree::markTagged();}
 #endif
   
 private:

--- a/Indexing/TypeSubstitutionTree.hpp
+++ b/Indexing/TypeSubstitutionTree.hpp
@@ -39,12 +39,12 @@ public:
   void insert(TermList sort, LeafData ld);
   void remove(TermList sort, LeafData ld);
   void handleTerm(TermList t, LeafData ld, bool insert);
-  void insert(TermList t, Literal* lit, Clause* cls){ NOT_IMPLEMENTED; }
-  void remove(TermList t, Literal* lit, Clause* cls){ NOT_IMPLEMENTED; }
+  void insert(TermList t, Literal* lit, Clause* cls) override{ NOT_IMPLEMENTED; }
+  void remove(TermList t, Literal* lit, Clause* cls) override{ NOT_IMPLEMENTED; }
 
 
   TermQueryResultIterator getUnifications(TermList sort,
-	  bool retrieveSubstitutions){ NOT_IMPLEMENTED; }
+	  bool retrieveSubstitutions) override{ NOT_IMPLEMENTED; }
 
   TermQueryResultIterator getUnifications(TermList sort, TermList trm, 
     bool retrieveSubstitutions);

--- a/Inferences/ArgCong.hpp
+++ b/Inferences/ArgCong.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(ArgCong);
   USE_ALLOCATOR(ArgCong);
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 private:
   struct ResultFn;
   struct IsPositiveEqualityFn;

--- a/Inferences/ArgCong.hpp
+++ b/Inferences/ArgCong.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(ArgCong);
   USE_ALLOCATOR(ArgCong);
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 private:
   struct ResultFn;
   struct IsPositiveEqualityFn;

--- a/Inferences/ArithmeticSubtermGeneralization.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization.hpp
@@ -19,55 +19,55 @@
 
 namespace Inferences {
 
-class NumeralMultiplicationGeneralization
+class NumeralMultiplicationGeneralization final
 : public SimplifyingGeneratingInference1
 {
 public:
   CLASS_NAME(NumeralMultiplicationGeneralization);
   USE_ALLOCATOR(NumeralMultiplicationGeneralization);
 
-  ~NumeralMultiplicationGeneralization() override;
+  ~NumeralMultiplicationGeneralization() final;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) final;
 };
 
 
-class VariableMultiplicationGeneralization
+class VariableMultiplicationGeneralization final
 : public SimplifyingGeneratingInference1
 {
 public:
   CLASS_NAME(VariableMultiplicationGeneralization);
   USE_ALLOCATOR(VariableMultiplicationGeneralization);
 
-  ~VariableMultiplicationGeneralization() override;
+  ~VariableMultiplicationGeneralization() final;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) final;
 };
 
 
-class VariablePowerGeneralization
+class VariablePowerGeneralization final
 : public SimplifyingGeneratingInference1
 {
 public:
   CLASS_NAME(VariablePowerGeneralization);
   USE_ALLOCATOR(VariablePowerGeneralization);
 
-  ~VariablePowerGeneralization() override;
+  ~VariablePowerGeneralization() final;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) final;
 };
 
 
-class AdditionGeneralization
+class AdditionGeneralization final
 : public SimplifyingGeneratingInference1
 {
 public:
   CLASS_NAME(AdditionGeneralization);
   USE_ALLOCATOR(AdditionGeneralization);
 
-  ~AdditionGeneralization() override;
+  ~AdditionGeneralization() final;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) final;
 };
 
 Stack<SimplifyingGeneratingInference1*> allArithmeticSubtermGeneralizations();

--- a/Inferences/ArithmeticSubtermGeneralization.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization.hpp
@@ -26,9 +26,9 @@ public:
   CLASS_NAME(NumeralMultiplicationGeneralization);
   USE_ALLOCATOR(NumeralMultiplicationGeneralization);
 
-  virtual ~NumeralMultiplicationGeneralization();
+  ~NumeralMultiplicationGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 
@@ -39,9 +39,9 @@ public:
   CLASS_NAME(VariableMultiplicationGeneralization);
   USE_ALLOCATOR(VariableMultiplicationGeneralization);
 
-  virtual ~VariableMultiplicationGeneralization();
+  ~VariableMultiplicationGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 
@@ -52,9 +52,9 @@ public:
   CLASS_NAME(VariablePowerGeneralization);
   USE_ALLOCATOR(VariablePowerGeneralization);
 
-  virtual ~VariablePowerGeneralization();
+  ~VariablePowerGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 
@@ -65,9 +65,9 @@ public:
   CLASS_NAME(AdditionGeneralization);
   USE_ALLOCATOR(AdditionGeneralization);
 
-  virtual ~AdditionGeneralization();
+  ~AdditionGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 Stack<SimplifyingGeneratingInference1*> allArithmeticSubtermGeneralizations();

--- a/Inferences/BackwardDemodulation.hpp
+++ b/Inferences/BackwardDemodulation.hpp
@@ -33,10 +33,10 @@ public:
   CLASS_NAME(BackwardDemodulation);
   USE_ALLOCATOR(BackwardDemodulation);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
+  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) final;
 private:
   struct RemovedIsNonzeroFn;
   struct RewritableClausesFn;

--- a/Inferences/BackwardDemodulation.hpp
+++ b/Inferences/BackwardDemodulation.hpp
@@ -33,10 +33,10 @@ public:
   CLASS_NAME(BackwardDemodulation);
   USE_ALLOCATOR(BackwardDemodulation);
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications);
+  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
 private:
   struct RemovedIsNonzeroFn;
   struct RewritableClausesFn;

--- a/Inferences/BackwardSubsumptionDemodulation.hpp
+++ b/Inferences/BackwardSubsumptionDemodulation.hpp
@@ -54,10 +54,10 @@ class BackwardSubsumptionDemodulation
 
     BackwardSubsumptionDemodulation();
 
-    void attach(SaturationAlgorithm* salg) override;
-    void detach() override;
+    void attach(SaturationAlgorithm* salg) final;
+    void detach() final;
 
-    void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
+    void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) final;
 
   private:
     RequestedIndex<SimplifyingLiteralIndex> _index;

--- a/Inferences/BackwardSubsumptionResolution.hpp
+++ b/Inferences/BackwardSubsumptionResolution.hpp
@@ -31,10 +31,10 @@ public:
 
   BackwardSubsumptionResolution(bool byUnitsOnly) : _byUnitsOnly(byUnitsOnly) {}
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
+  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) final;
 private:
   struct ClauseExtractorFn;
   struct ClauseToBwSimplRecordFn;

--- a/Inferences/BackwardSubsumptionResolution.hpp
+++ b/Inferences/BackwardSubsumptionResolution.hpp
@@ -31,10 +31,10 @@ public:
 
   BackwardSubsumptionResolution(bool byUnitsOnly) : _byUnitsOnly(byUnitsOnly) {}
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications);
+  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
 private:
   struct ClauseExtractorFn;
   struct ClauseToBwSimplRecordFn;

--- a/Inferences/BinaryResolution.hpp
+++ b/Inferences/BinaryResolution.hpp
@@ -41,11 +41,11 @@ public:
     _unificationWithAbstraction(false)
   {  }
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
   static Clause* generateClause(Clause* queryCl, Literal* queryLit, SLQueryResult res, const Options& opts, PassiveClauseContainer* passive=0, Ordering* ord=0, LiteralSelector* ls = 0);
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
 private:
   struct UnificationsFn;

--- a/Inferences/BinaryResolution.hpp
+++ b/Inferences/BinaryResolution.hpp
@@ -41,11 +41,11 @@ public:
     _unificationWithAbstraction(false)
   {  }
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
   static Clause* generateClause(Clause* queryCl, Literal* queryLit, SLQueryResult res, const Options& opts, PassiveClauseContainer* passive=0, Ordering* ord=0, LiteralSelector* ls = 0);
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
 private:
   struct UnificationsFn;

--- a/Inferences/BoolEqToDiseq.hpp
+++ b/Inferences/BoolEqToDiseq.hpp
@@ -27,7 +27,7 @@ class BoolEqToDiseq : public GeneratingInferenceEngine
     CLASS_NAME(BoolEqToDiseq);
     USE_ALLOCATOR(BoolEqToDiseq);
 
-    ClauseIterator generateClauses(Clause* premise);
+    ClauseIterator generateClauses(Clause* premise) override;
 
 };
 

--- a/Inferences/BoolEqToDiseq.hpp
+++ b/Inferences/BoolEqToDiseq.hpp
@@ -27,7 +27,7 @@ class BoolEqToDiseq : public GeneratingInferenceEngine
     CLASS_NAME(BoolEqToDiseq);
     USE_ALLOCATOR(BoolEqToDiseq);
 
-    ClauseIterator generateClauses(Clause* premise) override;
+    ClauseIterator generateClauses(Clause* premise) final;
 
 };
 

--- a/Inferences/BoolSimp.hpp
+++ b/Inferences/BoolSimp.hpp
@@ -26,7 +26,7 @@ class BoolSimp : public ImmediateSimplificationEngine
   public:
     CLASS_NAME(BoolSimp);
     USE_ALLOCATOR(BoolSimp);
-    Clause* simplify(Clause* premise) override;
+    Clause* simplify(Clause* premise) final;
 
   private:
     TermList boolSimplify(TermList term); 

--- a/Inferences/BoolSimp.hpp
+++ b/Inferences/BoolSimp.hpp
@@ -26,7 +26,7 @@ class BoolSimp : public ImmediateSimplificationEngine
   public:
     CLASS_NAME(BoolSimp);
     USE_ALLOCATOR(BoolSimp);
-    Clause* simplify(Clause* premise);
+    Clause* simplify(Clause* premise) override;
 
   private:
     TermList boolSimplify(TermList term); 

--- a/Inferences/CNFOnTheFly.hpp
+++ b/Inferences/CNFOnTheFly.hpp
@@ -38,7 +38,7 @@ public:
   CLASS_NAME(IFFXORRewriterISE);
   USE_ALLOCATOR(IFFXORRewriterISE);
 
-  Clause* simplify(Clause* c) override;
+  Clause* simplify(Clause* c) final;
 };
 
 class EagerClausificationISE
@@ -49,8 +49,8 @@ public:
   CLASS_NAME(EagerClausificationISE);
   USE_ALLOCATOR(EagerClausificationISE);
 
-  ClauseIterator simplifyMany(Clause* c) override;
-  Clause* simplify(Clause* c) override{ NOT_IMPLEMENTED; }
+  ClauseIterator simplifyMany(Clause* c) final;
+  Clause* simplify(Clause* c) final{ NOT_IMPLEMENTED; }
 
 };
 
@@ -65,10 +65,10 @@ public:
     _formulaIndex = 0;
   }
 
-  ClauseIterator perform(Clause* c) override;
+  ClauseIterator perform(Clause* c) final;
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
 private:
   SkolemisingFormulaIndex* _formulaIndex;
@@ -86,10 +86,10 @@ public:
     _formulaIndex = 0;
   }
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  ClauseIterator generateClauses(Clause* c) override;
+  ClauseIterator generateClauses(Clause* c) final;
 
 private:
   SkolemisingFormulaIndex* _formulaIndex;

--- a/Inferences/CNFOnTheFly.hpp
+++ b/Inferences/CNFOnTheFly.hpp
@@ -38,7 +38,7 @@ public:
   CLASS_NAME(IFFXORRewriterISE);
   USE_ALLOCATOR(IFFXORRewriterISE);
 
-  Clause* simplify(Clause* c);
+  Clause* simplify(Clause* c) override;
 };
 
 class EagerClausificationISE
@@ -49,8 +49,8 @@ public:
   CLASS_NAME(EagerClausificationISE);
   USE_ALLOCATOR(EagerClausificationISE);
 
-  ClauseIterator simplifyMany(Clause* c);
-  Clause* simplify(Clause* c){ NOT_IMPLEMENTED; }
+  ClauseIterator simplifyMany(Clause* c) override;
+  Clause* simplify(Clause* c) override{ NOT_IMPLEMENTED; }
 
 };
 

--- a/Inferences/CTFwSubsAndRes.hpp
+++ b/Inferences/CTFwSubsAndRes.hpp
@@ -35,9 +35,9 @@ public:
   CTFwSubsAndRes(bool subsumptionResolution)
   : _subsumptionResolution(subsumptionResolution) {}
   
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 private:
   Clause* buildSResClause(Clause* cl, unsigned resolvedIndex, Clause* premise);
 

--- a/Inferences/Cancellation.hpp
+++ b/Inferences/Cancellation.hpp
@@ -24,7 +24,7 @@ public:
   USE_ALLOCATOR(Cancellation);
 
   Cancellation(Ordering& ordering);
-  virtual ~Cancellation();
+  ~Cancellation() override;
 
   Result simplifyLiteral(Literal*) override;
 };

--- a/Inferences/Cancellation.hpp
+++ b/Inferences/Cancellation.hpp
@@ -16,7 +16,7 @@
 namespace Inferences {
 
 
-class Cancellation
+class Cancellation final
 : public SimplifyingGeneratingLiteralSimplification
 {
 public:
@@ -24,9 +24,9 @@ public:
   USE_ALLOCATOR(Cancellation);
 
   Cancellation(Ordering& ordering);
-  ~Cancellation() override;
+  ~Cancellation() final;
 
-  Result simplifyLiteral(Literal*) override;
+  Result simplifyLiteral(Literal*) final;
 };
 
 

--- a/Inferences/Cases.hpp
+++ b/Inferences/Cases.hpp
@@ -27,7 +27,7 @@ class Cases : public GeneratingInferenceEngine {
     USE_ALLOCATOR(Cases);
     
     Clause* performParamodulation(Clause* cl, Literal* lit, TermList t);
-    ClauseIterator generateClauses(Clause* premise) override;
+    ClauseIterator generateClauses(Clause* premise) final;
     struct RewriteableSubtermsFn;
     struct ResultFn;
 };

--- a/Inferences/Cases.hpp
+++ b/Inferences/Cases.hpp
@@ -27,7 +27,7 @@ class Cases : public GeneratingInferenceEngine {
     USE_ALLOCATOR(Cases);
     
     Clause* performParamodulation(Clause* cl, Literal* lit, TermList t);
-    ClauseIterator generateClauses(Clause* premise);
+    ClauseIterator generateClauses(Clause* premise) override;
     struct RewriteableSubtermsFn;
     struct ResultFn;
 };

--- a/Inferences/CasesSimp.hpp
+++ b/Inferences/CasesSimp.hpp
@@ -26,8 +26,8 @@ class CasesSimp : public ImmediateSimplificationEngine {
     CLASS_NAME(CasesSimp);
     USE_ALLOCATOR(CasesSimp);
 
-    ClauseIterator simplifyMany(Clause* premise) override;
-    Clause* simplify(Clause* premise) override{ NOT_IMPLEMENTED; }
+    ClauseIterator simplifyMany(Clause* premise) final;
+    Clause* simplify(Clause* premise) final{ NOT_IMPLEMENTED; }
 
     ClauseIterator performSimplification(Clause* cl, Literal* lit, TermList t);
     ClauseIterator generateClauses(Clause* premise);

--- a/Inferences/CasesSimp.hpp
+++ b/Inferences/CasesSimp.hpp
@@ -26,8 +26,8 @@ class CasesSimp : public ImmediateSimplificationEngine {
     CLASS_NAME(CasesSimp);
     USE_ALLOCATOR(CasesSimp);
 
-    ClauseIterator simplifyMany(Clause* premise);
-    Clause* simplify(Clause* premise){ NOT_IMPLEMENTED; }
+    ClauseIterator simplifyMany(Clause* premise) override;
+    Clause* simplify(Clause* premise) override{ NOT_IMPLEMENTED; }
 
     ClauseIterator performSimplification(Clause* cl, Literal* lit, TermList t);
     ClauseIterator generateClauses(Clause* premise);

--- a/Inferences/Choice.hpp
+++ b/Inferences/Choice.hpp
@@ -27,7 +27,7 @@ class Choice : public GeneratingInferenceEngine
     CLASS_NAME(Choice);
     USE_ALLOCATOR(Choice);
 
-    ClauseIterator generateClauses(Clause* premise) override;
+    ClauseIterator generateClauses(Clause* premise) final;
 
   private:
     struct SubtermsFn;

--- a/Inferences/Choice.hpp
+++ b/Inferences/Choice.hpp
@@ -27,7 +27,7 @@ class Choice : public GeneratingInferenceEngine
     CLASS_NAME(Choice);
     USE_ALLOCATOR(Choice);
 
-    ClauseIterator generateClauses(Clause* premise);
+    ClauseIterator generateClauses(Clause* premise) override;
 
   private:
     struct SubtermsFn;

--- a/Inferences/CombinatorDemodISE.hpp
+++ b/Inferences/CombinatorDemodISE.hpp
@@ -29,7 +29,7 @@ public:
   USE_ALLOCATOR(CombinatorDemodISE);
 
   CombinatorDemodISE(){}
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 private:
    TermList reduce(TermList t, unsigned& length);
    bool headNormalForm(TermList& t);

--- a/Inferences/CombinatorDemodISE.hpp
+++ b/Inferences/CombinatorDemodISE.hpp
@@ -29,7 +29,7 @@ public:
   USE_ALLOCATOR(CombinatorDemodISE);
 
   CombinatorDemodISE(){}
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 private:
    TermList reduce(TermList t, unsigned& length);
    bool headNormalForm(TermList& t);

--- a/Inferences/CombinatorNormalisationISE.hpp
+++ b/Inferences/CombinatorNormalisationISE.hpp
@@ -44,7 +44,7 @@ public:
   USE_ALLOCATOR(CombinatorNormalisationISE);
 
   CombinatorNormalisationISE(){}
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 private:
    TermList normalise(TermList t);
    bool replaceWithSmallerCombinator(TermList& t);

--- a/Inferences/CombinatorNormalisationISE.hpp
+++ b/Inferences/CombinatorNormalisationISE.hpp
@@ -44,7 +44,7 @@ public:
   USE_ALLOCATOR(CombinatorNormalisationISE);
 
   CombinatorNormalisationISE(){}
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 private:
    TermList normalise(TermList t);
    bool replaceWithSmallerCombinator(TermList& t);

--- a/Inferences/Condensation.hpp
+++ b/Inferences/Condensation.hpp
@@ -37,7 +37,7 @@ public:
   CLASS_NAME(Condensation);
   USE_ALLOCATOR(Condensation);
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 };
 
 };

--- a/Inferences/Condensation.hpp
+++ b/Inferences/Condensation.hpp
@@ -37,7 +37,7 @@ public:
   CLASS_NAME(Condensation);
   USE_ALLOCATOR(Condensation);
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 };
 
 };

--- a/Inferences/DistinctEqualitySimplifier.hpp
+++ b/Inferences/DistinctEqualitySimplifier.hpp
@@ -27,7 +27,7 @@ public:
   CLASS_NAME(DistinctEqualitySimplifier);
   USE_ALLOCATOR(DistinctEqualitySimplifier);
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
   static bool mustBeDistinct(TermList t1, TermList t2);
   static bool mustBeDistinct(TermList t1, TermList t2, unsigned& grp);
 private:

--- a/Inferences/DistinctEqualitySimplifier.hpp
+++ b/Inferences/DistinctEqualitySimplifier.hpp
@@ -27,7 +27,7 @@ public:
   CLASS_NAME(DistinctEqualitySimplifier);
   USE_ALLOCATOR(DistinctEqualitySimplifier);
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
   static bool mustBeDistinct(TermList t1, TermList t2);
   static bool mustBeDistinct(TermList t1, TermList t2, unsigned& grp);
 private:

--- a/Inferences/ElimLeibniz.hpp
+++ b/Inferences/ElimLeibniz.hpp
@@ -28,7 +28,7 @@ class ElimLeibniz : public GeneratingInferenceEngine
     CLASS_NAME(ElimLeibniz);
     USE_ALLOCATOR(ElimLeibniz);
 
-    ClauseIterator generateClauses(Clause* premise);
+    ClauseIterator generateClauses(Clause* premise) override;
 
   private:
 

--- a/Inferences/ElimLeibniz.hpp
+++ b/Inferences/ElimLeibniz.hpp
@@ -28,7 +28,7 @@ class ElimLeibniz : public GeneratingInferenceEngine
     CLASS_NAME(ElimLeibniz);
     USE_ALLOCATOR(ElimLeibniz);
 
-    ClauseIterator generateClauses(Clause* premise) override;
+    ClauseIterator generateClauses(Clause* premise) final;
 
   private:
 

--- a/Inferences/EqualityFactoring.hpp
+++ b/Inferences/EqualityFactoring.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(EqualityFactoring);
   USE_ALLOCATOR(EqualityFactoring);
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 private:
   struct IsPositiveEqualityFn;
   struct IsDifferentPositiveEqualityFn;

--- a/Inferences/EqualityFactoring.hpp
+++ b/Inferences/EqualityFactoring.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(EqualityFactoring);
   USE_ALLOCATOR(EqualityFactoring);
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 private:
   struct IsPositiveEqualityFn;
   struct IsDifferentPositiveEqualityFn;

--- a/Inferences/EqualityResolution.hpp
+++ b/Inferences/EqualityResolution.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(EqualityResolution);
   USE_ALLOCATOR(EqualityResolution);
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
   static Clause* tryResolveEquality(Clause* cl, Literal* toResolve);
 private:
   struct ResultFn;

--- a/Inferences/EqualityResolution.hpp
+++ b/Inferences/EqualityResolution.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(EqualityResolution);
   USE_ALLOCATOR(EqualityResolution);
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
   static Clause* tryResolveEquality(Clause* cl, Literal* toResolve);
 private:
   struct ResultFn;

--- a/Inferences/EquationalTautologyRemoval.hpp
+++ b/Inferences/EquationalTautologyRemoval.hpp
@@ -31,7 +31,7 @@ public:
 
   EquationalTautologyRemoval() : _cc(nullptr) {}
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 private:
   DP::SimpleCongruenceClosure _cc;
 };

--- a/Inferences/ExtensionalityResolution.hpp
+++ b/Inferences/ExtensionalityResolution.hpp
@@ -45,7 +45,7 @@ public:
 
   ExtensionalityResolution() {}
   
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
   static Clause* performExtensionalityResolution(
     Clause* extCl, Literal* extLit,

--- a/Inferences/ExtensionalityResolution.hpp
+++ b/Inferences/ExtensionalityResolution.hpp
@@ -45,7 +45,7 @@ public:
 
   ExtensionalityResolution() {}
   
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
   static Clause* performExtensionalityResolution(
     Clause* extCl, Literal* extLit,

--- a/Inferences/FOOLParamodulation.hpp
+++ b/Inferences/FOOLParamodulation.hpp
@@ -25,7 +25,7 @@ class FOOLParamodulation : public GeneratingInferenceEngine {
   public:
     CLASS_NAME(FOOLParamodulation);
     USE_ALLOCATOR(FOOLParamodulation);
-    ClauseIterator generateClauses(Clause* premise) override;
+    ClauseIterator generateClauses(Clause* premise) final;
 };
 
 }

--- a/Inferences/FOOLParamodulation.hpp
+++ b/Inferences/FOOLParamodulation.hpp
@@ -25,7 +25,7 @@ class FOOLParamodulation : public GeneratingInferenceEngine {
   public:
     CLASS_NAME(FOOLParamodulation);
     USE_ALLOCATOR(FOOLParamodulation);
-    ClauseIterator generateClauses(Clause* premise);
+    ClauseIterator generateClauses(Clause* premise) override;
 };
 
 }

--- a/Inferences/Factoring.hpp
+++ b/Inferences/Factoring.hpp
@@ -33,7 +33,7 @@ public:
   CLASS_NAME(Factoring);
   USE_ALLOCATOR(Factoring);
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 private:
   class UnificationsOnPositiveFn;
   class ResultsFn;

--- a/Inferences/Factoring.hpp
+++ b/Inferences/Factoring.hpp
@@ -33,7 +33,7 @@ public:
   CLASS_NAME(Factoring);
   USE_ALLOCATOR(Factoring);
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 private:
   class UnificationsOnPositiveFn;
   class ResultsFn;

--- a/Inferences/FastCondensation.hpp
+++ b/Inferences/FastCondensation.hpp
@@ -46,7 +46,7 @@ public:
   CLASS_NAME(FastCondensation);
   USE_ALLOCATOR(FastCondensation);
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 private:
   struct CondensationBinder;
 };

--- a/Inferences/FastCondensation.hpp
+++ b/Inferences/FastCondensation.hpp
@@ -46,7 +46,7 @@ public:
   CLASS_NAME(FastCondensation);
   USE_ALLOCATOR(FastCondensation);
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 private:
   struct CondensationBinder;
 };

--- a/Inferences/ForwardDemodulation.hpp
+++ b/Inferences/ForwardDemodulation.hpp
@@ -35,8 +35,8 @@ public:
   CLASS_NAME(ForwardDemodulation);
   USE_ALLOCATOR(ForwardDemodulation);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override = 0;
 protected:
   bool _preorderedOnly;
@@ -51,7 +51,7 @@ public:
   CLASS_NAME(ForwardDemodulationImpl);
   USE_ALLOCATOR(ForwardDemodulationImpl);
 
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 private:
 };
 

--- a/Inferences/ForwardLiteralRewriting.hpp
+++ b/Inferences/ForwardLiteralRewriting.hpp
@@ -34,9 +34,9 @@ public:
   CLASS_NAME(ForwardLiteralRewriting);
   USE_ALLOCATOR(ForwardLiteralRewriting);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 private:
   RewriteRuleIndex* _index;
 };

--- a/Inferences/ForwardSubsumptionAndResolution.hpp
+++ b/Inferences/ForwardSubsumptionAndResolution.hpp
@@ -36,9 +36,9 @@ public:
   ForwardSubsumptionAndResolution(bool subsumptionResolution=true)
   : _subsumptionResolution(subsumptionResolution) {}
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 
   static Clause* generateSubsumptionResolutionClause(Clause* cl, Literal* lit, Clause* baseClause);
 private:

--- a/Inferences/ForwardSubsumptionDemodulation.hpp
+++ b/Inferences/ForwardSubsumptionDemodulation.hpp
@@ -55,9 +55,9 @@ class ForwardSubsumptionDemodulation
       : _doSubsumption(doSubsumption)
     { }
 
-    void attach(SaturationAlgorithm* salg) override;
-    void detach() override;
-    bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+    void attach(SaturationAlgorithm* salg) final;
+    void detach() final;
+    bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 
   private:
     RequestedIndex<LiteralIndex> _unitIndex;

--- a/Inferences/GaussianVariableElimination.hpp
+++ b/Inferences/GaussianVariableElimination.hpp
@@ -21,7 +21,7 @@ public:
   CLASS_NAME(GaussianVariableElimination);
   USE_ALLOCATOR(GaussianVariableElimination);
 
-  SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) override;
+  SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) final;
 private:
   SimplifyingGeneratingInference1::Result rewrite(Clause &cl, TermList find, TermList replace,
                   unsigned skipLiteral, bool doOrderingCheck) const;

--- a/Inferences/GlobalSubsumption.hpp
+++ b/Inferences/GlobalSubsumption.hpp
@@ -48,9 +48,9 @@ public:
    */
   GlobalSubsumption(const Options& opts, GroundingIndex* idx) : GlobalSubsumption(opts) { _index = idx; }
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
   
   Clause* perform(Clause* cl, Stack<Unit*>& prems);
  

--- a/Inferences/HyperSuperposition.hpp
+++ b/Inferences/HyperSuperposition.hpp
@@ -36,12 +36,12 @@ public:
 
   HyperSuperposition() : _index(0) {}
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
   ClauseIterator generateClauses(Clause* premise);
 
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 private:
   typedef pair<TermList,TermList> TermPair;
   /** The int here is a variable bank index of the term's variables */

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -43,7 +43,7 @@ class TermReplacement : public TermTransformer {
 
 public:
   TermReplacement(Term* o, TermList r) : _o(o), _r(r) {} 
-  virtual TermList transformSubterm(TermList trm);
+  TermList transformSubterm(TermList trm) override;
 private:
   Term* _o;
   TermList _r;
@@ -65,7 +65,7 @@ public:
   List<pair<Literal*, InferenceRule>>* getListOfTransformedLiterals(InferenceRule rule);
 
 protected:
-  virtual TermList transformSubterm(TermList trm);
+  TermList transformSubterm(TermList trm) override;
 
 private:
   // _iteration serves as a map of occurrences to replace
@@ -89,10 +89,10 @@ public:
 
   Induction() {}
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
 private:
   // The following pointers can be null if int induction is off.

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -43,7 +43,7 @@ class TermReplacement : public TermTransformer {
 
 public:
   TermReplacement(Term* o, TermList r) : _o(o), _r(r) {} 
-  TermList transformSubterm(TermList trm) override;
+  TermList transformSubterm(TermList trm) final;
 private:
   Term* _o;
   TermList _r;
@@ -65,7 +65,7 @@ public:
   List<pair<Literal*, InferenceRule>>* getListOfTransformedLiterals(InferenceRule rule);
 
 protected:
-  TermList transformSubterm(TermList trm) override;
+  TermList transformSubterm(TermList trm) final;
 
 private:
   // _iteration serves as a map of occurrences to replace
@@ -89,10 +89,10 @@ public:
 
   Induction() {}
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
 private:
   // The following pointers can be null if int induction is off.

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -124,7 +124,7 @@ class GeneratingInferenceEngine
 public:
   virtual ClauseIterator generateClauses(Clause* premise) = 0;
 
-  ClauseGenerationResult generateSimplify(Clause* premise) override
+  ClauseGenerationResult generateSimplify(Clause* premise) final
   { return { .clauses = generateClauses(premise), 
              .premiseRedundant = false, }; }
 };
@@ -177,7 +177,7 @@ public:
 
   };
 
-  ClauseGenerationResult generateSimplify(Clause* cl) override;
+  ClauseGenerationResult generateSimplify(Clause* cl) final;
 
   /** 
    * Turns this SimplifyingGeneratingInference1 into and ImmediateSimplificationEngine. 
@@ -201,7 +201,7 @@ protected:
    */
   virtual Result simplify(Clause* cl, bool doOrderingCheck) = 0;
 private:
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 };
 
 /**
@@ -232,7 +232,7 @@ public:
 protected:
   SimplifyingGeneratingLiteralSimplification(InferenceRule rule, Ordering& ordering);
   virtual Result simplifyLiteral(Literal* l) = 0;
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) final;
 
 private:
   Ordering* _ordering;
@@ -304,7 +304,7 @@ public:
   CLASS_NAME(DummyGIE);
   USE_ALLOCATOR(DummyGIE);
 
-  ClauseIterator generateClauses(Clause* premise) override
+  ClauseIterator generateClauses(Clause* premise) final
   {
     return ClauseIterator::getEmpty();
   }
@@ -340,7 +340,7 @@ public:
 };
 */
 
-class CompositeISE
+class CompositeISE final
 : public ImmediateSimplificationEngine
 {
 public:
@@ -348,13 +348,13 @@ public:
   USE_ALLOCATOR(CompositeISE);
 
   CompositeISE() : _inners(0), _innersMany(0) {}
-  ~CompositeISE() override;
+  ~CompositeISE() final;
   void addFront(ImmediateSimplificationEngine* fse);
   void addFrontMany(ImmediateSimplificationEngine* fse);
-  Clause* simplify(Clause* cl) override;
-  ClauseIterator simplifyMany(Clause* cl) override;
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  Clause* simplify(Clause* cl) final;
+  ClauseIterator simplifyMany(Clause* cl) final;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 private:
   typedef List<ImmediateSimplificationEngine*> ISList;
   ISList* _inners;
@@ -376,7 +376,7 @@ private:
 //  FSList* _inners;
 //};
 
-class CompositeGIE
+class CompositeGIE final
 : public GeneratingInferenceEngine
 {
 public:
@@ -384,18 +384,18 @@ public:
   USE_ALLOCATOR(CompositeGIE);
 
   CompositeGIE() : _inners(0) {}
-  ~CompositeGIE() override;
+  ~CompositeGIE() final;
   void addFront(GeneratingInferenceEngine* fse);
-  ClauseIterator generateClauses(Clause* premise) override;
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  ClauseIterator generateClauses(Clause* premise) final;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 private:
   typedef List<GeneratingInferenceEngine*> GIList;
   GIList* _inners;
 };
 
 
-class CompositeSGI
+class CompositeSGI final
 : public SimplifyingGeneratingInference
 {
 public:
@@ -403,12 +403,12 @@ public:
   USE_ALLOCATOR(CompositeSGI);
 
   CompositeSGI() : _simplifiers(), _generators() {}
-  ~CompositeSGI() override;
+  ~CompositeSGI() final;
   void push(SimplifyingGeneratingInference*);
   void push(GeneratingInferenceEngine*);
-  ClauseGenerationResult generateSimplify(Clause* premise) override;
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  ClauseGenerationResult generateSimplify(Clause* premise) final;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 private:
   Stack<SimplifyingGeneratingInference*> _simplifiers;
   Stack<GeneratingInferenceEngine*> _generators;
@@ -422,7 +422,7 @@ public:
   CLASS_NAME(ChoiceDefinitionISE);
   USE_ALLOCATOR(ChoiceDefinitionISE);
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 
   bool isPositive(Literal* lit);
  
@@ -437,7 +437,7 @@ public:
   CLASS_NAME(DuplicateLiteralRemovalISE);
   USE_ALLOCATOR(DuplicateLiteralRemovalISE);
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 };
 
 class TautologyDeletionISE2
@@ -447,14 +447,14 @@ public:
   CLASS_NAME(TautologyDeletionISE2);
   USE_ALLOCATOR(TautologyDeletionISE2);
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 };
 
 class TrivialInequalitiesRemovalISE
 : public ImmediateSimplificationEngine
 {
 public:
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 };
 
 };

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -188,8 +188,8 @@ public:
    */
   ImmediateSimplificationEngine& asISE();
 
-  virtual void attach(SaturationAlgorithm* salg) override { SimplifyingGeneratingInference::attach(salg); }
-  virtual void detach() override { SimplifyingGeneratingInference::detach(); }
+  void attach(SaturationAlgorithm* salg) override { SimplifyingGeneratingInference::attach(salg); }
+  void detach() override { SimplifyingGeneratingInference::detach(); }
   
 protected:
 
@@ -304,7 +304,7 @@ public:
   CLASS_NAME(DummyGIE);
   USE_ALLOCATOR(DummyGIE);
 
-  ClauseIterator generateClauses(Clause* premise)
+  ClauseIterator generateClauses(Clause* premise) override
   {
     return ClauseIterator::getEmpty();
   }
@@ -348,13 +348,13 @@ public:
   USE_ALLOCATOR(CompositeISE);
 
   CompositeISE() : _inners(0), _innersMany(0) {}
-  virtual ~CompositeISE();
+  ~CompositeISE() override;
   void addFront(ImmediateSimplificationEngine* fse);
   void addFrontMany(ImmediateSimplificationEngine* fse);
-  Clause* simplify(Clause* cl);
-  ClauseIterator simplifyMany(Clause* cl);
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  Clause* simplify(Clause* cl) override;
+  ClauseIterator simplifyMany(Clause* cl) override;
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 private:
   typedef List<ImmediateSimplificationEngine*> ISList;
   ISList* _inners;
@@ -384,7 +384,7 @@ public:
   USE_ALLOCATOR(CompositeGIE);
 
   CompositeGIE() : _inners(0) {}
-  virtual ~CompositeGIE();
+  ~CompositeGIE() override;
   void addFront(GeneratingInferenceEngine* fse);
   ClauseIterator generateClauses(Clause* premise) override;
   void attach(SaturationAlgorithm* salg) override;
@@ -403,7 +403,7 @@ public:
   USE_ALLOCATOR(CompositeSGI);
 
   CompositeSGI() : _simplifiers(), _generators() {}
-  virtual ~CompositeSGI();
+  ~CompositeSGI() override;
   void push(SimplifyingGeneratingInference*);
   void push(GeneratingInferenceEngine*);
   ClauseGenerationResult generateSimplify(Clause* premise) override;
@@ -422,7 +422,7 @@ public:
   CLASS_NAME(ChoiceDefinitionISE);
   USE_ALLOCATOR(ChoiceDefinitionISE);
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 
   bool isPositive(Literal* lit);
  
@@ -437,7 +437,7 @@ public:
   CLASS_NAME(DuplicateLiteralRemovalISE);
   USE_ALLOCATOR(DuplicateLiteralRemovalISE);
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 };
 
 class TautologyDeletionISE2
@@ -447,14 +447,14 @@ public:
   CLASS_NAME(TautologyDeletionISE2);
   USE_ALLOCATOR(TautologyDeletionISE2);
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 };
 
 class TrivialInequalitiesRemovalISE
 : public ImmediateSimplificationEngine
 {
 public:
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 };
 
 };

--- a/Inferences/Injectivity.hpp
+++ b/Inferences/Injectivity.hpp
@@ -25,7 +25,7 @@ class Injectivity : public GeneratingInferenceEngine {
   public:
     CLASS_NAME(Injectivity);
     USE_ALLOCATOR(Injectivity);
-    ClauseIterator generateClauses(Clause* premise) override;
+    ClauseIterator generateClauses(Clause* premise) final;
 
   private:
   	TermList createNewLhs(TermList oldhead, TermStack& termArgs, unsigned index);

--- a/Inferences/Injectivity.hpp
+++ b/Inferences/Injectivity.hpp
@@ -25,7 +25,7 @@ class Injectivity : public GeneratingInferenceEngine {
   public:
     CLASS_NAME(Injectivity);
     USE_ALLOCATOR(Injectivity);
-    ClauseIterator generateClauses(Clause* premise);
+    ClauseIterator generateClauses(Clause* premise) override;
 
   private:
   	TermList createNewLhs(TermList oldhead, TermStack& termArgs, unsigned index);

--- a/Inferences/InnerRewriting.hpp
+++ b/Inferences/InnerRewriting.hpp
@@ -33,7 +33,7 @@ public:
   CLASS_NAME(InnerRewriting);
   USE_ALLOCATOR(InnerRewriting);
   
-  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
+  bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) final;
 };
 
 };

--- a/Inferences/Instantiation.hpp
+++ b/Inferences/Instantiation.hpp
@@ -40,7 +40,7 @@ public:
 
   //void init();
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
   void registerClause(Clause* cl);
 

--- a/Inferences/Instantiation.hpp
+++ b/Inferences/Instantiation.hpp
@@ -40,7 +40,7 @@ public:
 
   //void init();
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
   void registerClause(Clause* cl);
 

--- a/Inferences/InterpretedEvaluation.hpp
+++ b/Inferences/InterpretedEvaluation.hpp
@@ -27,7 +27,7 @@
 
 namespace Inferences {
 
-class InterpretedEvaluation
+class InterpretedEvaluation final
 : public ImmediateSimplificationEngine
 {
 public:
@@ -35,9 +35,9 @@ public:
   USE_ALLOCATOR(InterpretedEvaluation);
 
   InterpretedEvaluation(bool doNormalize, Ordering& ordering);
-  ~InterpretedEvaluation() override;
+  ~InterpretedEvaluation() final;
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 private:
   bool simplifyLiteral(Literal* lit, bool& constant, Literal*& res, bool& constantTrue,Stack<Literal*>& sideConditions);
 

--- a/Inferences/InterpretedEvaluation.hpp
+++ b/Inferences/InterpretedEvaluation.hpp
@@ -35,9 +35,9 @@ public:
   USE_ALLOCATOR(InterpretedEvaluation);
 
   InterpretedEvaluation(bool doNormalize, Ordering& ordering);
-  virtual ~InterpretedEvaluation();
+  ~InterpretedEvaluation() override;
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 private:
   bool simplifyLiteral(Literal* lit, bool& constant, Literal*& res, bool& constantTrue,Stack<Literal*>& sideConditions);
 

--- a/Inferences/LfpRule.hpp
+++ b/Inferences/LfpRule.hpp
@@ -26,9 +26,9 @@ public:
  
   LfpRule(Rule rule);
   LfpRule();
-  SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) override;
-  void attach(SaturationAlgorithm* alg) override { SimplifyingGeneratingInference1::attach(alg); _inner.attach(alg); }
-  void detach() override { SimplifyingGeneratingInference1::detach(); _inner.detach(); }
+  SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) final;
+  void attach(SaturationAlgorithm* alg) final { SimplifyingGeneratingInference1::attach(alg); _inner.attach(alg); }
+  void detach() final { SimplifyingGeneratingInference1::detach(); _inner.detach(); }
 };
 
 

--- a/Inferences/Narrow.hpp
+++ b/Inferences/Narrow.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(Narrow);
   USE_ALLOCATOR(Narrow);
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
 private:
   NarrowingIndex* _index;

--- a/Inferences/Narrow.hpp
+++ b/Inferences/Narrow.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(Narrow);
   USE_ALLOCATOR(Narrow);
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
 private:
   NarrowingIndex* _index;

--- a/Inferences/NegativeExt.hpp
+++ b/Inferences/NegativeExt.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(NegativeExt);
   USE_ALLOCATOR(NegativeExt);
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 private:
   struct ResultFn;
   struct IsNegativeEqualityFn;

--- a/Inferences/NegativeExt.hpp
+++ b/Inferences/NegativeExt.hpp
@@ -34,7 +34,7 @@ public:
   CLASS_NAME(NegativeExt);
   USE_ALLOCATOR(NegativeExt);
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 private:
   struct ResultFn;
   struct IsNegativeEqualityFn;

--- a/Inferences/PolynomialEvaluation.hpp
+++ b/Inferences/PolynomialEvaluation.hpp
@@ -26,7 +26,7 @@ namespace Inferences
 {
 
 using SortId = TermList;
-class PolynomialEvaluation
+class PolynomialEvaluation final
 : public SimplifyingGeneratingLiteralSimplification
 {
 public:
@@ -34,11 +34,11 @@ public:
   USE_ALLOCATOR(PolynomialEvaluation);
 
   PolynomialEvaluation(Ordering& ordering);
-  ~PolynomialEvaluation() override;
+  ~PolynomialEvaluation() final;
 
 private:
 
-  Result simplifyLiteral(Literal*) override;
+  Result simplifyLiteral(Literal*) final;
 
   Option<PolyNf> evaluate(TermList in, SortId sortNumber) const;
   Option<PolyNf> evaluate(Term* in) const;

--- a/Inferences/PolynomialEvaluation.hpp
+++ b/Inferences/PolynomialEvaluation.hpp
@@ -34,7 +34,7 @@ public:
   USE_ALLOCATOR(PolynomialEvaluation);
 
   PolynomialEvaluation(Ordering& ordering);
-  virtual ~PolynomialEvaluation();
+  ~PolynomialEvaluation() override;
 
 private:
 

--- a/Inferences/PrimitiveInstantiation.hpp
+++ b/Inferences/PrimitiveInstantiation.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(PrimitiveInstantiation);
   USE_ALLOCATOR(PrimitiveInstantiation);
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
   
 private:
   PrimitiveInstantiationIndex* _index;  

--- a/Inferences/PrimitiveInstantiation.hpp
+++ b/Inferences/PrimitiveInstantiation.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(PrimitiveInstantiation);
   USE_ALLOCATOR(PrimitiveInstantiation);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
   
 private:
   PrimitiveInstantiationIndex* _index;  

--- a/Inferences/PushUnaryMinus.hpp
+++ b/Inferences/PushUnaryMinus.hpp
@@ -23,16 +23,16 @@
 
 namespace Inferences {
 
-class PushUnaryMinus
+class PushUnaryMinus final
 : public ImmediateSimplificationEngine
 {
 public:
   CLASS_NAME(PushUnaryMinus);
   USE_ALLOCATOR(PushUnaryMinus);
 
-  ~PushUnaryMinus() override;
+  ~PushUnaryMinus() final;
 
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 };
 
 };

--- a/Inferences/PushUnaryMinus.hpp
+++ b/Inferences/PushUnaryMinus.hpp
@@ -30,9 +30,9 @@ public:
   CLASS_NAME(PushUnaryMinus);
   USE_ALLOCATOR(PushUnaryMinus);
 
-  virtual ~PushUnaryMinus();
+  ~PushUnaryMinus() override;
 
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 };
 
 };

--- a/Inferences/RenamingOnTheFly.hpp
+++ b/Inferences/RenamingOnTheFly.hpp
@@ -36,8 +36,8 @@ public:
 
   ClauseIterator perform(Clause* c);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
   //todo make an option
 private:

--- a/Inferences/SLQueryBackwardSubsumption.hpp
+++ b/Inferences/SLQueryBackwardSubsumption.hpp
@@ -40,10 +40,10 @@ public:
    */
   SLQueryBackwardSubsumption(SimplifyingLiteralIndex* index, bool byUnitsOnly=false) : _byUnitsOnly(byUnitsOnly), _index(index) {}
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications);
+  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
 private:
   struct ClauseExtractorFn;
   struct ClauseToBwSimplRecordFn;

--- a/Inferences/SLQueryBackwardSubsumption.hpp
+++ b/Inferences/SLQueryBackwardSubsumption.hpp
@@ -40,10 +40,10 @@ public:
    */
   SLQueryBackwardSubsumption(SimplifyingLiteralIndex* index, bool byUnitsOnly=false) : _byUnitsOnly(byUnitsOnly), _index(index) {}
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) override;
+  void perform(Clause* premise, BwSimplificationRecordIterator& simplifications) final;
 private:
   struct ClauseExtractorFn;
   struct ClauseToBwSimplRecordFn;

--- a/Inferences/SubVarSup.hpp
+++ b/Inferences/SubVarSup.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(SubVarSup);
   USE_ALLOCATOR(SubVarSup);
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
 
 private:

--- a/Inferences/SubVarSup.hpp
+++ b/Inferences/SubVarSup.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(SubVarSup);
   USE_ALLOCATOR(SubVarSup);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
 
 private:

--- a/Inferences/Superposition.hpp
+++ b/Inferences/Superposition.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(Superposition);
   USE_ALLOCATOR(Superposition);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
 
 private:

--- a/Inferences/Superposition.hpp
+++ b/Inferences/Superposition.hpp
@@ -34,10 +34,10 @@ public:
   CLASS_NAME(Superposition);
   USE_ALLOCATOR(Superposition);
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
 
 private:

--- a/Inferences/TautologyDeletionISE.hpp
+++ b/Inferences/TautologyDeletionISE.hpp
@@ -29,7 +29,7 @@ public:
   USE_ALLOCATOR(TautologyDeletionISE);
 
   TautologyDeletionISE(bool deleteEqTautologies=true) : _deleteEqTautologies(deleteEqTautologies) {}
-  Clause* simplify(Clause* cl);
+  Clause* simplify(Clause* cl) override;
 private:
   int compare(Literal* l1,Literal* l2);
   void sort(Literal** lits,int to);

--- a/Inferences/TautologyDeletionISE.hpp
+++ b/Inferences/TautologyDeletionISE.hpp
@@ -29,7 +29,7 @@ public:
   USE_ALLOCATOR(TautologyDeletionISE);
 
   TautologyDeletionISE(bool deleteEqTautologies=true) : _deleteEqTautologies(deleteEqTautologies) {}
-  Clause* simplify(Clause* cl) override;
+  Clause* simplify(Clause* cl) final;
 private:
   int compare(Literal* l1,Literal* l2);
   void sort(Literal** lits,int to);

--- a/Inferences/TermAlgebraReasoning.hpp
+++ b/Inferences/TermAlgebraReasoning.hpp
@@ -53,7 +53,7 @@ public:
   CLASS_NAME(DistinctnessISE);
   USE_ALLOCATOR(DistinctnessISE);
   
-  Kernel::Clause* simplify(Kernel::Clause* c) override;
+  Kernel::Clause* simplify(Kernel::Clause* c) final;
 };
 
 /*
@@ -73,7 +73,7 @@ public:
   CLASS_NAME(InjectivityGIE);
   USE_ALLOCATOR(InjectivityGIE);
   
-  Kernel::ClauseIterator generateClauses(Kernel::Clause* c) override;
+  Kernel::ClauseIterator generateClauses(Kernel::Clause* c) final;
 
 private:
   struct SubtermIterator;
@@ -96,7 +96,7 @@ public:
   CLASS_NAME(InjectivityISE);
   USE_ALLOCATOR(InjectivityISE);
   
-  Kernel::Clause* simplify(Kernel::Clause* c) override;
+  Kernel::Clause* simplify(Kernel::Clause* c) final;
 };
 
 class NegativeInjectivityISE
@@ -106,7 +106,7 @@ public:
   CLASS_NAME(NegativeInjectivityISE);
   USE_ALLOCATOR(NegativeInjectivityISE);
 
-  Kernel::Clause* simplify(Kernel::Clause* c) override;
+  Kernel::Clause* simplify(Kernel::Clause* c) final;
 
 private:
   bool litCondition(Clause* c, unsigned i);
@@ -118,9 +118,9 @@ public:
   CLASS_NAME(AcyclicityGIE);
   USE_ALLOCATOR(AcyclicityGIE);
 
-  void attach(Saturation::SaturationAlgorithm* salg) override;
-  void detach() override;
-  Kernel::ClauseIterator generateClauses(Kernel::Clause *c) override;
+  void attach(Saturation::SaturationAlgorithm* salg) final;
+  void detach() final;
+  Kernel::ClauseIterator generateClauses(Kernel::Clause *c) final;
 private:
   struct AcyclicityGenIterator;
   struct AcyclicityGenFn;
@@ -134,7 +134,7 @@ public:
   CLASS_NAME(AcyclicityGIE1);
   USE_ALLOCATOR(AcyclicityGIE1);
   
-  Kernel::ClauseIterator generateClauses(Kernel::Clause* c) override;
+  Kernel::ClauseIterator generateClauses(Kernel::Clause* c) final;
 
 private:
   struct SubtermDisequalityFn;

--- a/Inferences/TermAlgebraReasoning.hpp
+++ b/Inferences/TermAlgebraReasoning.hpp
@@ -53,7 +53,7 @@ public:
   CLASS_NAME(DistinctnessISE);
   USE_ALLOCATOR(DistinctnessISE);
   
-  Kernel::Clause* simplify(Kernel::Clause* c);
+  Kernel::Clause* simplify(Kernel::Clause* c) override;
 };
 
 /*
@@ -73,7 +73,7 @@ public:
   CLASS_NAME(InjectivityGIE);
   USE_ALLOCATOR(InjectivityGIE);
   
-  Kernel::ClauseIterator generateClauses(Kernel::Clause* c);
+  Kernel::ClauseIterator generateClauses(Kernel::Clause* c) override;
 
 private:
   struct SubtermIterator;
@@ -96,7 +96,7 @@ public:
   CLASS_NAME(InjectivityISE);
   USE_ALLOCATOR(InjectivityISE);
   
-  Kernel::Clause* simplify(Kernel::Clause* c);
+  Kernel::Clause* simplify(Kernel::Clause* c) override;
 };
 
 class NegativeInjectivityISE
@@ -106,7 +106,7 @@ public:
   CLASS_NAME(NegativeInjectivityISE);
   USE_ALLOCATOR(NegativeInjectivityISE);
 
-  Kernel::Clause* simplify(Kernel::Clause* c);
+  Kernel::Clause* simplify(Kernel::Clause* c) override;
 
 private:
   bool litCondition(Clause* c, unsigned i);
@@ -118,9 +118,9 @@ public:
   CLASS_NAME(AcyclicityGIE);
   USE_ALLOCATOR(AcyclicityGIE);
 
-  void attach(Saturation::SaturationAlgorithm* salg);
-  void detach();
-  Kernel::ClauseIterator generateClauses(Kernel::Clause *c);
+  void attach(Saturation::SaturationAlgorithm* salg) override;
+  void detach() override;
+  Kernel::ClauseIterator generateClauses(Kernel::Clause *c) override;
 private:
   struct AcyclicityGenIterator;
   struct AcyclicityGenFn;
@@ -134,7 +134,7 @@ public:
   CLASS_NAME(AcyclicityGIE1);
   USE_ALLOCATOR(AcyclicityGIE1);
   
-  Kernel::ClauseIterator generateClauses(Kernel::Clause* c);
+  Kernel::ClauseIterator generateClauses(Kernel::Clause* c) override;
 
 private:
   struct SubtermDisequalityFn;

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -55,9 +55,9 @@ public:
   TheoryInstAndSimp(Options& opts);
   TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, vstring const& exportSmtlib);
 
-  void attach(SaturationAlgorithm* salg);
+  void attach(SaturationAlgorithm* salg) override;
 
-  ClauseGenerationResult generateSimplify(Clause* premise);
+  ClauseGenerationResult generateSimplify(Clause* premise) override;
 
 private:
   struct SkolemizedLiterals {

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -55,9 +55,9 @@ public:
   TheoryInstAndSimp(Options& opts);
   TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, vstring const& exportSmtlib);
 
-  void attach(SaturationAlgorithm* salg) override;
+  void attach(SaturationAlgorithm* salg) final;
 
-  ClauseGenerationResult generateSimplify(Clause* premise) override;
+  ClauseGenerationResult generateSimplify(Clause* premise) final;
 
 private:
   struct SkolemizedLiterals {

--- a/Inferences/URResolution.hpp
+++ b/Inferences/URResolution.hpp
@@ -37,10 +37,10 @@ public:
   URResolution(bool selectedOnly, UnitClauseLiteralIndex* unitIndex,
       NonUnitClauseLiteralIndex* nonUnitIndex);
 
-  void attach(SaturationAlgorithm* salg) override;
-  void detach() override;
+  void attach(SaturationAlgorithm* salg) final;
+  void detach() final;
 
-  ClauseIterator generateClauses(Clause* premise) override;
+  ClauseIterator generateClauses(Clause* premise) final;
 
 private:
   struct Item;

--- a/Inferences/URResolution.hpp
+++ b/Inferences/URResolution.hpp
@@ -37,10 +37,10 @@ public:
   URResolution(bool selectedOnly, UnitClauseLiteralIndex* unitIndex,
       NonUnitClauseLiteralIndex* nonUnitIndex);
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
 
 private:
   struct Item;

--- a/InstGen/IGAlgorithm.hpp
+++ b/InstGen/IGAlgorithm.hpp
@@ -62,7 +62,7 @@ using namespace Shell;
 // This is why it uses the monomorphic version of EqualityProxy
 // to transform equations
 
-class IGAlgorithm : public MainLoop {
+class IGAlgorithm final : public MainLoop {
 public:
   CLASS_NAME(IGAlgorithm);
   USE_ALLOCATOR(IGAlgorithm);  
@@ -70,15 +70,15 @@ public:
   typedef Statistics::TerminationReason TerminationReason;
 
   IGAlgorithm(Problem& prb, const Options& opt);
-  ~IGAlgorithm() override;
+  ~IGAlgorithm() final;
 
   GroundingIndex& getGroundingIndex() { return *_groundingIndex.ptr(); }
 
   ClauseIterator getActive();
 
 protected:
-  void init() override;
-  MainLoopResult runImpl() override;
+  void init() final;
+  MainLoopResult runImpl() final;
 private:
 
   bool addClause(Clause* cl);

--- a/InstGen/IGAlgorithm.hpp
+++ b/InstGen/IGAlgorithm.hpp
@@ -70,15 +70,15 @@ public:
   typedef Statistics::TerminationReason TerminationReason;
 
   IGAlgorithm(Problem& prb, const Options& opt);
-  ~IGAlgorithm();
+  ~IGAlgorithm() override;
 
   GroundingIndex& getGroundingIndex() { return *_groundingIndex.ptr(); }
 
   ClauseIterator getActive();
 
 protected:
-  virtual void init();
-  virtual MainLoopResult runImpl();
+  void init() override;
+  MainLoopResult runImpl() override;
 private:
 
   bool addClause(Clause* cl);

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -64,9 +64,9 @@ class BestLiteralSelector
     _comp.attachSelector(this);
   }
 
-  bool isBGComplete() const override { return false; }
+  bool isBGComplete() const final { return false; }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override
+  void doSelection(Clause* c, unsigned eligible) final
   {
     CALL("BestLiteralSelector::doSelection");
 
@@ -130,9 +130,9 @@ public:
     _comp.attachSelector(this);
   }
 
-  bool isBGComplete() const override { return true; }
+  bool isBGComplete() const final { return true; }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override
+  void doSelection(Clause* c, unsigned eligible) final
   {
     CALL("CompleteBestLiteralSelector::doSelection");
     ASS_G(eligible, 1); //trivial cases should be taken care of by the base LiteralSelector

--- a/Kernel/ELiteralSelector.hpp
+++ b/Kernel/ELiteralSelector.hpp
@@ -51,9 +51,9 @@ public:
   ELiteralSelector(const Ordering& ordering, const Options& options, Values value) :
     LiteralSelector(ordering, options), _value(value) {}
 
-  bool isBGComplete() const override { return true; }
+  bool isBGComplete() const final { return true; }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override;
+  void doSelection(Clause* c, unsigned eligible) final;
 
 private:
   LiteralList* getMaximalsInOrder(Clause* c, unsigned eligible);

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -448,7 +448,7 @@ struct ScanAndApplyLiteralTransformer::LitFormulaTransformer : public FormulaTra
   LitFormulaTransformer(ScanAndApplyLiteralTransformer& parent, UnitStack& premAcc)
       : _parent(parent), _premAcc(premAcc) {}
 
-  virtual Formula* applyLiteral(Formula* f) {
+  Formula* applyLiteral(Formula* f) override {
     Literal* l = f->literal();
     Literal* l1 = _parent.apply(l, _premAcc);
     if(l1!=l) {

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -448,7 +448,7 @@ struct ScanAndApplyLiteralTransformer::LitFormulaTransformer : public FormulaTra
   LitFormulaTransformer(ScanAndApplyLiteralTransformer& parent, UnitStack& premAcc)
       : _parent(parent), _premAcc(premAcc) {}
 
-  Formula* applyLiteral(Formula* f) override {
+  Formula* applyLiteral(Formula* f) final {
     Literal* l = f->literal();
     Literal* l1 = _parent.apply(l, _premAcc);
     if(l1!=l) {

--- a/Kernel/FormulaTransformer.hpp
+++ b/Kernel/FormulaTransformer.hpp
@@ -86,7 +86,7 @@ class TermTransformingFormulaTransformer : public FormulaTransformer
 public:
   TermTransformingFormulaTransformer(TermTransformer& termTransformer) : _termTransformer(termTransformer) {}
 protected:
-  virtual Formula* applyLiteral(Formula* f);
+  Formula* applyLiteral(Formula* f) override;
 
   TermTransformer& _termTransformer;
 };
@@ -97,24 +97,24 @@ class TermTransformerTransformTransformedFormulaTransformer : public FormulaTran
     TermTransformerTransformTransformedFormulaTransformer(TermTransformerTransformTransformed& termTransformer)
       : _termTransformer(termTransformer) {}
   protected:
-    virtual Formula* applyLiteral(Formula* f);
+    Formula* applyLiteral(Formula* f) override;
 
     TermTransformerTransformTransformed& _termTransformer;
 };
 
 class PolarityAwareFormulaTransformer : protected FormulaTransformer {
 public:
-  ~PolarityAwareFormulaTransformer();
+  ~PolarityAwareFormulaTransformer() override;
 
   virtual Formula* transformWithPolarity(Formula* f, int polarity=1);
 protected:
   PolarityAwareFormulaTransformer();
 
-  virtual Formula* applyNot(Formula* f);
+  Formula* applyNot(Formula* f) override;
 
-  virtual Formula* applyImp(Formula* f);
+  Formula* applyImp(Formula* f) override;
 
-  virtual Formula* applyBinary(Formula* f);
+  Formula* applyBinary(Formula* f) override;
 
   int polarity() const { return _polarity; }
 
@@ -146,7 +146,7 @@ public:
 
   virtual Formula* transform(Formula* f) = 0;
 
-  virtual FormulaUnit* transform(FormulaUnit* unit);
+  FormulaUnit* transform(FormulaUnit* unit) override;
 
 private:
   InferenceRule _rule;
@@ -161,7 +161,7 @@ public:
 
   using LocalFormulaUnitTransformer::transform;
 
-  virtual Formula* transform(Formula* f)
+  Formula* transform(Formula* f) override
   {
     CALL("FTFormulaUnitTransformer::transform(Formula*)");
     return _formulaTransformer.transform(f);
@@ -210,8 +210,8 @@ protected:
    */
   virtual Literal* apply(Literal* l, UnitStack& premAcc) = 0;
 
-  virtual bool apply(FormulaUnit* unit, Unit*& res);
-  virtual bool apply(Clause* cl, Unit*& res);
+  bool apply(FormulaUnit* unit, Unit*& res) override;
+  bool apply(Clause* cl, Unit*& res) override;
 
 private:
   struct LitFormulaTransformer;

--- a/Kernel/FormulaTransformer.hpp
+++ b/Kernel/FormulaTransformer.hpp
@@ -86,7 +86,7 @@ class TermTransformingFormulaTransformer : public FormulaTransformer
 public:
   TermTransformingFormulaTransformer(TermTransformer& termTransformer) : _termTransformer(termTransformer) {}
 protected:
-  Formula* applyLiteral(Formula* f) override;
+  Formula* applyLiteral(Formula* f) final;
 
   TermTransformer& _termTransformer;
 };
@@ -97,24 +97,24 @@ class TermTransformerTransformTransformedFormulaTransformer : public FormulaTran
     TermTransformerTransformTransformedFormulaTransformer(TermTransformerTransformTransformed& termTransformer)
       : _termTransformer(termTransformer) {}
   protected:
-    Formula* applyLiteral(Formula* f) override;
+    Formula* applyLiteral(Formula* f) final;
 
     TermTransformerTransformTransformed& _termTransformer;
 };
 
-class PolarityAwareFormulaTransformer : protected FormulaTransformer {
+class PolarityAwareFormulaTransformer final : protected FormulaTransformer {
 public:
-  ~PolarityAwareFormulaTransformer() override;
+  ~PolarityAwareFormulaTransformer() final;
 
   virtual Formula* transformWithPolarity(Formula* f, int polarity=1);
 protected:
   PolarityAwareFormulaTransformer();
 
-  Formula* applyNot(Formula* f) override;
+  Formula* applyNot(Formula* f) final;
 
-  Formula* applyImp(Formula* f) override;
+  Formula* applyImp(Formula* f) final;
 
-  Formula* applyBinary(Formula* f) override;
+  Formula* applyBinary(Formula* f) final;
 
   int polarity() const { return _polarity; }
 
@@ -146,7 +146,7 @@ public:
 
   virtual Formula* transform(Formula* f) = 0;
 
-  FormulaUnit* transform(FormulaUnit* unit) override;
+  FormulaUnit* transform(FormulaUnit* unit) final;
 
 private:
   InferenceRule _rule;
@@ -161,7 +161,7 @@ public:
 
   using LocalFormulaUnitTransformer::transform;
 
-  Formula* transform(Formula* f) override
+  Formula* transform(Formula* f) final
   {
     CALL("FTFormulaUnitTransformer::transform(Formula*)");
     return _formulaTransformer.transform(f);
@@ -210,8 +210,8 @@ protected:
    */
   virtual Literal* apply(Literal* l, UnitStack& premAcc) = 0;
 
-  bool apply(FormulaUnit* unit, Unit*& res) override;
-  bool apply(Clause* cl, Unit*& res) override;
+  bool apply(FormulaUnit* unit, Unit*& res) final;
+  bool apply(Clause* cl, Unit*& res) final;
 
 private:
   struct LitFormulaTransformer;

--- a/Kernel/Grounder.hpp
+++ b/Kernel/Grounder.hpp
@@ -76,7 +76,7 @@ public:
   GlobalSubsumptionGrounder(SATSolver* satSolver, bool doNormalization=true) 
           : Grounder(satSolver), _doNormalization(doNormalization) {}
 protected:
-  virtual void normalize(unsigned cnt, Literal** lits);
+  void normalize(unsigned cnt, Literal** lits) override;
 };
 
 class IGGrounder : public Grounder {
@@ -88,7 +88,7 @@ public:
 private:
   TermList _tgtTerm;
 protected:
-  virtual void normalize(unsigned cnt, Literal** lits);
+  void normalize(unsigned cnt, Literal** lits) override;
 private:
   class CollapsingApplicator;
   Literal* collapseVars(Literal* lit);

--- a/Kernel/Grounder.hpp
+++ b/Kernel/Grounder.hpp
@@ -76,7 +76,7 @@ public:
   GlobalSubsumptionGrounder(SATSolver* satSolver, bool doNormalization=true) 
           : Grounder(satSolver), _doNormalization(doNormalization) {}
 protected:
-  void normalize(unsigned cnt, Literal** lits) override;
+  void normalize(unsigned cnt, Literal** lits) final;
 };
 
 class IGGrounder : public Grounder {
@@ -88,7 +88,7 @@ public:
 private:
   TermList _tgtTerm;
 protected:
-  void normalize(unsigned cnt, Literal** lits) override;
+  void normalize(unsigned cnt, Literal** lits) final;
 private:
   class CollapsingApplicator;
   Literal* collapseVars(Literal* lit);

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -496,7 +496,7 @@ struct InferenceStore::ProofPropertyPrinter
     last_one = false;
   }
 
-  void print()
+  void print() override
   {
     ProofPrinter::print();
     for(unsigned i=0;i<11;i++){ out << buckets[i] << " ";}
@@ -507,7 +507,7 @@ struct InferenceStore::ProofPropertyPrinter
 
 protected:
 
-  void printStep(Unit* us)
+  void printStep(Unit* us) override
   {
     static unsigned lastP = Unit::getLastParsingNumber();
     static float chunk = lastP / 10.0;
@@ -582,7 +582,7 @@ struct InferenceStore::TPTPProofPrinter
     delayPrinting = false;
   }
 
-  void print()
+  void print() override
   {
     //outputSymbolDeclarations also deals with sorts for now
     //UIHelper::outputSortDeclarations(env.out());
@@ -741,7 +741,7 @@ protected:
     return getNewSymbols(origin, SymbolStack::ConstIterator(syms));
   }
 
-  void printStep(Unit* us)
+  void printStep(Unit* us) override
   {
     CALL("InferenceStore::TPTPProofPrinter::printStep");
 
@@ -952,7 +952,7 @@ struct InferenceStore::ProofCheckPrinter
   : ProofPrinter(out, is) {}
 
 protected:
-  void printStep(Unit* cs)
+  void printStep(Unit* cs) override
   {
     CALL("InferenceStore::ProofCheckPrinter::printStep");
     InferenceRule rule;
@@ -984,7 +984,7 @@ protected:
   }
 
 
-  bool hideProofStep(InferenceRule rule)
+  bool hideProofStep(InferenceRule rule) override
   {
     switch(rule) {
     case InferenceRule::INPUT:
@@ -1017,7 +1017,7 @@ protected:
     }
   }
 
-  void print()
+  void print() override
   {
     ProofPrinter::print();
     out << "%#\n";

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -496,7 +496,7 @@ struct InferenceStore::ProofPropertyPrinter
     last_one = false;
   }
 
-  void print() override
+  void print() final
   {
     ProofPrinter::print();
     for(unsigned i=0;i<11;i++){ out << buckets[i] << " ";}
@@ -507,7 +507,7 @@ struct InferenceStore::ProofPropertyPrinter
 
 protected:
 
-  void printStep(Unit* us) override
+  void printStep(Unit* us) final
   {
     static unsigned lastP = Unit::getLastParsingNumber();
     static float chunk = lastP / 10.0;
@@ -582,7 +582,7 @@ struct InferenceStore::TPTPProofPrinter
     delayPrinting = false;
   }
 
-  void print() override
+  void print() final
   {
     //outputSymbolDeclarations also deals with sorts for now
     //UIHelper::outputSortDeclarations(env.out());
@@ -741,7 +741,7 @@ protected:
     return getNewSymbols(origin, SymbolStack::ConstIterator(syms));
   }
 
-  void printStep(Unit* us) override
+  void printStep(Unit* us) final
   {
     CALL("InferenceStore::TPTPProofPrinter::printStep");
 
@@ -952,7 +952,7 @@ struct InferenceStore::ProofCheckPrinter
   : ProofPrinter(out, is) {}
 
 protected:
-  void printStep(Unit* cs) override
+  void printStep(Unit* cs) final
   {
     CALL("InferenceStore::ProofCheckPrinter::printStep");
     InferenceRule rule;
@@ -984,7 +984,7 @@ protected:
   }
 
 
-  bool hideProofStep(InferenceRule rule) override
+  bool hideProofStep(InferenceRule rule) final
   {
     switch(rule) {
     case InferenceRule::INPUT:
@@ -1017,7 +1017,7 @@ protected:
     }
   }
 
-  void print() override
+  void print() final
   {
     ProofPrinter::print();
     out << "%#\n";

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -139,9 +139,9 @@ CLASS_NAME(InterpretedLiteralEvaluator::ACFunEvaluator<AbelianGroup>);
   ACFunEvaluator() : _fun(env.signature->getInterpretingSymbol(AbelianGroup::interpreation)) { }
   const unsigned _fun; 
 
-  bool canEvaluateFunc(unsigned func) override { return func == _fun; }
+  bool canEvaluateFunc(unsigned func) final { return func == _fun; }
 
-  bool tryEvaluateFunc(Term* trm, TermList& res) override {
+  bool tryEvaluateFunc(Term* trm, TermList& res) final {
     CALL( "ACFunEvaluator::tryEvaluateFunc()" );
     ASS_EQ(trm->functor(), _fun);
     ASS_EQ(trm->arity(),2);
@@ -270,7 +270,7 @@ class IntLess {
 class InterpretedLiteralEvaluator::EqualityEvaluator
   : public Evaluator
 {
-  bool canEvaluatePred(unsigned pred) override {
+  bool canEvaluatePred(unsigned pred) final {
     return Signature::isEqualityPredicate(pred);
   }
 
@@ -293,7 +293,7 @@ class InterpretedLiteralEvaluator::EqualityEvaluator
   }
 
   /** is to be called when interpreted functions were already evaluated */
-  PredEvalResult tryEvaluatePred(Literal* lit_) override
+  PredEvalResult tryEvaluatePred(Literal* lit_) final
   {
     auto& lit = *lit_;
     ASS(lit.isEquality());
@@ -321,7 +321,7 @@ class InterpretedLiteralEvaluator::ConversionEvaluator
   : public Evaluator
 {
 public:
-  bool canEvaluateFunc(unsigned func) override
+  bool canEvaluateFunc(unsigned func) final
   {
     CALL("InterpretedLiteralEvaluator::ConversionEvaluator::canEvaluateFunc");
 
@@ -331,7 +331,7 @@ public:
     return theory->isConversionOperation(theory->interpretFunction(func));
   }
 
-  bool tryEvaluateFunc(Term* trm, TermList& res) override
+  bool tryEvaluateFunc(Term* trm, TermList& res) final
   {
     CALL("InterpretedLiteralEvaluator::ConversionEvaluator::tryEvaluateFunc");
     ASS(theory->isInterpretedFunction(trm));
@@ -454,7 +454,7 @@ public:
     return opSort==T::getSort();
   }
 
-  bool tryEvaluateFunc(Term* trm, TermList& res) override
+  bool tryEvaluateFunc(Term* trm, TermList& res) final
   {
     CALL("InterpretedLiteralEvaluator::tryEvaluateFunc");
     ASS(theory->isInterpretedFunction(trm));
@@ -553,7 +553,7 @@ public:
     }
   }
 
-  PredEvalResult tryEvaluatePred(Literal* lit) override
+  PredEvalResult tryEvaluatePred(Literal* lit) final
   {
     CALL("InterpretedLiteralEvaluator::tryEvaluatePred");
     ASS(theory->isInterpretedPredicate(lit->functor()));
@@ -591,7 +591,7 @@ public:
 
   }
 
-  bool canEvaluateFunc(unsigned func) override
+  bool canEvaluateFunc(unsigned func) final
   {
     CALL("InterpretedLiteralEvaluator::TypedEvaluator::canEvaluateFunc");
 
@@ -602,7 +602,7 @@ public:
     return canEvaluate(interp);
   }
 
-  bool canEvaluatePred(unsigned pred) override
+  bool canEvaluatePred(unsigned pred) final
   {
     CALL("InterpretedLiteralEvaluator::TypedEvaluator::canEvaluatePred");
 
@@ -692,12 +692,12 @@ class InterpretedLiteralEvaluator::IntEvaluator : public TypedEvaluator<IntegerC
 {
 protected:
 
-  bool isDivision(Interpretation interp) const override {
+  bool isDivision(Interpretation interp) const final {
     return interp==Theory::INT_QUOTIENT_E || interp==Theory::INT_QUOTIENT_T || 
            interp==Theory::INT_QUOTIENT_F; 
   }
 
-  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) override
+  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) final
   {
     CALL("InterpretedLiteralEvaluator::IntEvaluator::tryEvaluateUnaryFunc");
 
@@ -728,7 +728,7 @@ protected:
   }
 
   bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
-      const Value& arg2, Value& res) override
+      const Value& arg2, Value& res) final
   {
     CALL("InterpretedLiteralEvaluator::IntEvaluator::tryEvaluateBinaryFunc");
 
@@ -767,7 +767,7 @@ protected:
   }
 
   bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
-      const Value& arg2, bool& res) override
+      const Value& arg2, bool& res) final
   {
     CALL("InterpretedLiteralEvaluator::IntEvaluator::tryEvaluateBinaryPred");
 
@@ -799,12 +799,12 @@ protected:
 class InterpretedLiteralEvaluator::RatEvaluator : public TypedEvaluator<RationalConstantType>
 {
 protected:
-  bool isDivision(Interpretation interp) const override {
+  bool isDivision(Interpretation interp) const final {
     return interp==Theory::RAT_QUOTIENT || interp==Theory::RAT_QUOTIENT_E || 
            interp==Theory::RAT_QUOTIENT_T || interp==Theory::RAT_QUOTIENT_F;
   }
 
-  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) override
+  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) final
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateUnaryFunc");
 
@@ -827,7 +827,7 @@ protected:
   }
 
   bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
-      const Value& arg2, Value& res) override
+      const Value& arg2, Value& res) final
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateBinaryFunc");
 
@@ -851,7 +851,7 @@ protected:
   }
 
   bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
-      const Value& arg2, bool& res) override
+      const Value& arg2, bool& res) final
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateBinaryPred");
 
@@ -874,7 +874,7 @@ protected:
   }
 
   bool tryEvaluateUnaryPred(Interpretation op, const Value& arg1,
-      bool& res) override
+      bool& res) final
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateBinaryPred");
 
@@ -896,12 +896,12 @@ protected:
 class InterpretedLiteralEvaluator::RealEvaluator : public TypedEvaluator<RealConstantType>
 {
 protected:
-  bool isDivision(Interpretation interp) const override {
+  bool isDivision(Interpretation interp) const final {
     return interp==Theory::REAL_QUOTIENT || interp==Theory::REAL_QUOTIENT_E ||
            interp==Theory::REAL_QUOTIENT_T || interp==Theory::REAL_QUOTIENT_F;
   }
 
-  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) override
+  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) final
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateUnaryFunc");
 
@@ -924,7 +924,7 @@ protected:
   }
 
   bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
-      const Value& arg2, Value& res) override
+      const Value& arg2, Value& res) final
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateBinaryFunc");
 
@@ -948,7 +948,7 @@ protected:
   }
 
   bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
-      const Value& arg2, bool& res) override
+      const Value& arg2, bool& res) final
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateBinaryPred");
 
@@ -971,7 +971,7 @@ protected:
   }
 
   bool tryEvaluateUnaryPred(Interpretation op, const Value& arg1,
-      bool& res) override
+      bool& res) final
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateBinaryPred");
 

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -139,9 +139,9 @@ CLASS_NAME(InterpretedLiteralEvaluator::ACFunEvaluator<AbelianGroup>);
   ACFunEvaluator() : _fun(env.signature->getInterpretingSymbol(AbelianGroup::interpreation)) { }
   const unsigned _fun; 
 
-  virtual bool canEvaluateFunc(unsigned func) { return func == _fun; }
+  bool canEvaluateFunc(unsigned func) override { return func == _fun; }
 
-  virtual bool tryEvaluateFunc(Term* trm, TermList& res) { 
+  bool tryEvaluateFunc(Term* trm, TermList& res) override {
     CALL( "ACFunEvaluator::tryEvaluateFunc()" );
     ASS_EQ(trm->functor(), _fun);
     ASS_EQ(trm->arity(),2);
@@ -331,7 +331,7 @@ public:
     return theory->isConversionOperation(theory->interpretFunction(func));
   }
 
-  virtual bool tryEvaluateFunc(Term* trm, TermList& res) override
+  bool tryEvaluateFunc(Term* trm, TermList& res) override
   {
     CALL("InterpretedLiteralEvaluator::ConversionEvaluator::tryEvaluateFunc");
     ASS(theory->isInterpretedFunction(trm));
@@ -454,7 +454,7 @@ public:
     return opSort==T::getSort();
   }
 
-  virtual bool tryEvaluateFunc(Term* trm, TermList& res) override
+  bool tryEvaluateFunc(Term* trm, TermList& res) override
   {
     CALL("InterpretedLiteralEvaluator::tryEvaluateFunc");
     ASS(theory->isInterpretedFunction(trm));
@@ -553,7 +553,7 @@ public:
     }
   }
 
-  virtual PredEvalResult tryEvaluatePred(Literal* lit) override
+  PredEvalResult tryEvaluatePred(Literal* lit) override
   {
     CALL("InterpretedLiteralEvaluator::tryEvaluatePred");
     ASS(theory->isInterpretedPredicate(lit->functor()));
@@ -692,12 +692,12 @@ class InterpretedLiteralEvaluator::IntEvaluator : public TypedEvaluator<IntegerC
 {
 protected:
 
-  virtual bool isDivision(Interpretation interp) const { 
+  bool isDivision(Interpretation interp) const override {
     return interp==Theory::INT_QUOTIENT_E || interp==Theory::INT_QUOTIENT_T || 
            interp==Theory::INT_QUOTIENT_F; 
   }
 
-  virtual bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res)
+  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) override
   {
     CALL("InterpretedLiteralEvaluator::IntEvaluator::tryEvaluateUnaryFunc");
 
@@ -727,8 +727,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
-      const Value& arg2, Value& res)
+  bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
+      const Value& arg2, Value& res) override
   {
     CALL("InterpretedLiteralEvaluator::IntEvaluator::tryEvaluateBinaryFunc");
 
@@ -766,8 +766,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
-      const Value& arg2, bool& res)
+  bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
+      const Value& arg2, bool& res) override
   {
     CALL("InterpretedLiteralEvaluator::IntEvaluator::tryEvaluateBinaryPred");
 
@@ -799,12 +799,12 @@ protected:
 class InterpretedLiteralEvaluator::RatEvaluator : public TypedEvaluator<RationalConstantType>
 {
 protected:
-  virtual bool isDivision(Interpretation interp) const { 
+  bool isDivision(Interpretation interp) const override {
     return interp==Theory::RAT_QUOTIENT || interp==Theory::RAT_QUOTIENT_E || 
            interp==Theory::RAT_QUOTIENT_T || interp==Theory::RAT_QUOTIENT_F;
   }
 
-  virtual bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res)
+  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) override
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateUnaryFunc");
 
@@ -826,8 +826,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
-      const Value& arg2, Value& res)
+  bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
+      const Value& arg2, Value& res) override
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateBinaryFunc");
 
@@ -850,8 +850,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
-      const Value& arg2, bool& res)
+  bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
+      const Value& arg2, bool& res) override
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateBinaryPred");
 
@@ -873,8 +873,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateUnaryPred(Interpretation op, const Value& arg1,
-      bool& res)
+  bool tryEvaluateUnaryPred(Interpretation op, const Value& arg1,
+      bool& res) override
   {
     CALL("InterpretedLiteralEvaluator::RatEvaluator::tryEvaluateBinaryPred");
 
@@ -896,12 +896,12 @@ protected:
 class InterpretedLiteralEvaluator::RealEvaluator : public TypedEvaluator<RealConstantType>
 {
 protected:
-  virtual bool isDivision(Interpretation interp) const { 
+  bool isDivision(Interpretation interp) const override {
     return interp==Theory::REAL_QUOTIENT || interp==Theory::REAL_QUOTIENT_E ||
            interp==Theory::REAL_QUOTIENT_T || interp==Theory::REAL_QUOTIENT_F;
   }
 
-  virtual bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res)
+  bool tryEvaluateUnaryFunc(Interpretation op, const Value& arg, Value& res) override
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateUnaryFunc");
 
@@ -923,8 +923,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
-      const Value& arg2, Value& res)
+  bool tryEvaluateBinaryFunc(Interpretation op, const Value& arg1,
+      const Value& arg2, Value& res) override
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateBinaryFunc");
 
@@ -947,8 +947,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
-      const Value& arg2, bool& res)
+  bool tryEvaluateBinaryPred(Interpretation op, const Value& arg1,
+      const Value& arg2, bool& res) override
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateBinaryPred");
 
@@ -970,8 +970,8 @@ protected:
     }
   }
 
-  virtual bool tryEvaluateUnaryPred(Interpretation op, const Value& arg1,
-      bool& res)
+  bool tryEvaluateUnaryPred(Interpretation op, const Value& arg1,
+      bool& res) override
   {
     CALL("InterpretedLiteralEvaluator::RealEvaluator::tryEvaluateBinaryPred");
 

--- a/Kernel/InterpretedLiteralEvaluator.hpp
+++ b/Kernel/InterpretedLiteralEvaluator.hpp
@@ -27,7 +27,7 @@
 
 namespace Kernel {
 
-class InterpretedLiteralEvaluator
+class InterpretedLiteralEvaluator final
   :  private TermTransformerTransformTransformed 
 {
 public:
@@ -35,7 +35,7 @@ public:
   USE_ALLOCATOR(InterpretedLiteralEvaluator);
   
   InterpretedLiteralEvaluator(bool doNormalize = true);
-  ~InterpretedLiteralEvaluator() override;
+  ~InterpretedLiteralEvaluator() final;
 
   bool evaluate(Literal* lit, bool& isConstant, Literal*& resLit, bool& resConst,Stack<Literal*>& sideConditions);
   TermList evaluate(TermList);
@@ -52,7 +52,7 @@ protected:
   class RealEvaluator;
 
   typedef Stack<Evaluator*> EvalStack;
-  TermList transformSubterm(TermList trm) override;
+  TermList transformSubterm(TermList trm) final;
   Evaluator* getFuncEvaluator(unsigned func);
   Evaluator* getPredEvaluator(unsigned pred);
   EvalStack _evals;

--- a/Kernel/InterpretedLiteralEvaluator.hpp
+++ b/Kernel/InterpretedLiteralEvaluator.hpp
@@ -35,7 +35,7 @@ public:
   USE_ALLOCATOR(InterpretedLiteralEvaluator);
   
   InterpretedLiteralEvaluator(bool doNormalize = true);
-  ~InterpretedLiteralEvaluator();
+  ~InterpretedLiteralEvaluator() override;
 
   bool evaluate(Literal* lit, bool& isConstant, Literal*& resLit, bool& resConst,Stack<Literal*>& sideConditions);
   TermList evaluate(TermList);
@@ -52,7 +52,7 @@ protected:
   class RealEvaluator;
 
   typedef Stack<Evaluator*> EvalStack;
-  virtual TermList transformSubterm(TermList trm);
+  TermList transformSubterm(TermList trm) override;
   Evaluator* getFuncEvaluator(unsigned func);
   Evaluator* getPredEvaluator(unsigned pred);
   EvalStack _evals;

--- a/Kernel/KBO.hpp
+++ b/Kernel/KBO.hpp
@@ -150,7 +150,7 @@ public:
 
   static KBO testKBO();
 
-  virtual ~KBO();
+  ~KBO() override;
   void showConcrete(ostream&) const override;
   template<class HandleError>
   void checkAdmissibility(HandleError handle) const;

--- a/Kernel/KBO.hpp
+++ b/Kernel/KBO.hpp
@@ -124,7 +124,7 @@ private:
  * Class for instances of the Knuth-Bendix orderings
  * @since 30/04/2008 flight Brussels-Tel Aviv
  */
-class KBO
+class KBO final
 : public PrecedenceOrdering
 {
 public:
@@ -150,15 +150,15 @@ public:
 
   static KBO testKBO();
 
-  ~KBO() override;
-  void showConcrete(ostream&) const override;
+  ~KBO() final;
+  void showConcrete(ostream&) const final;
   template<class HandleError>
   void checkAdmissibility(HandleError handle) const;
 
   using PrecedenceOrdering::compare;
-  Result compare(TermList tl1, TermList tl2) const override;
+  Result compare(TermList tl1, TermList tl2) const final;
 protected:
-  Result comparePredicates(Literal* l1, Literal* l2) const override;
+  Result comparePredicates(Literal* l1, Literal* l2) const final;
 
 
   class State;

--- a/Kernel/KBOForEPR.hpp
+++ b/Kernel/KBOForEPR.hpp
@@ -37,10 +37,10 @@ public:
   KBOForEPR(Problem& prb, const Options& opt);
 
   using PrecedenceOrdering::compare;
-  Result compare(TermList tl1, TermList tl2) const override;
-  void showConcrete(ostream&) const override;
+  Result compare(TermList tl1, TermList tl2) const final;
+  void showConcrete(ostream&) const final;
 protected:
-  Result comparePredicates(Literal* l1, Literal* l2) const override;
+  Result comparePredicates(Literal* l1, Literal* l2) const final;
 };
 
 }

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -39,7 +39,7 @@ public:
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}
-  virtual ~LPO() {}
+  ~LPO() override {}
 
   using PrecedenceOrdering::compare;
   Result compare(TermList tl1, TermList tl2) const override;

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -29,7 +29,7 @@ using namespace Lib;
 /**
  * Class for instances of the lexicographic path orderings
  */
-class LPO
+class LPO final
 : public PrecedenceOrdering
 {
 public:
@@ -39,13 +39,13 @@ public:
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}
-  ~LPO() override {}
+  ~LPO() final {}
 
   using PrecedenceOrdering::compare;
-  Result compare(TermList tl1, TermList tl2) const override;
-  void showConcrete(ostream&) const override;
+  Result compare(TermList tl1, TermList tl2) const final;
+  void showConcrete(ostream&) const final;
 protected:
-  Result comparePredicates(Literal* l1, Literal* l2) const override;
+  Result comparePredicates(Literal* l1, Literal* l2) const final;
 
   Result cLMA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
   Result cMA(Term* t, TermList* tl, unsigned arity) const;

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -58,7 +58,7 @@ public:
     return (res1==EQUAL)?_c2.compare(l1,l2):res1;
   }
 
-  void attachSelector(LiteralSelector* selector) override
+  void attachSelector(LiteralSelector* selector) final
   {
     CALL("LiteralComparators::Composite::attachSelector");
 
@@ -80,7 +80,7 @@ public:
     return _c.compare(l2,l1);
   }
 
-  void attachSelector(LiteralSelector* selector) override
+  void attachSelector(LiteralSelector* selector) final
   {
     CALL("LiteralComparators::Inverse::attachSelector");
 

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -58,7 +58,7 @@ public:
     return (res1==EQUAL)?_c2.compare(l1,l2):res1;
   }
 
-  virtual void attachSelector(LiteralSelector* selector)
+  void attachSelector(LiteralSelector* selector) override
   {
     CALL("LiteralComparators::Composite::attachSelector");
 
@@ -80,7 +80,7 @@ public:
     return _c.compare(l2,l1);
   }
 
-  virtual void attachSelector(LiteralSelector* selector)
+  void attachSelector(LiteralSelector* selector) override
   {
     CALL("LiteralComparators::Inverse::attachSelector");
 

--- a/Kernel/LiteralSelector.hpp
+++ b/Kernel/LiteralSelector.hpp
@@ -124,12 +124,12 @@ public:
   TotalLiteralSelector(const Ordering& ordering, const Options& options)
   : LiteralSelector(ordering, options) {}
 
-  bool isBGComplete() const override {
+  bool isBGComplete() const final {
     // this is on purpose; we don't want any extra checks with total selection
     return false;
   }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override;
+  void doSelection(Clause* c, unsigned eligible) final;
 };
 
 

--- a/Kernel/LookaheadLiteralSelector.hpp
+++ b/Kernel/LookaheadLiteralSelector.hpp
@@ -36,9 +36,9 @@ public:
     _startupSelector = (_delay==0) ? 0 : LiteralSelector::getSelector(ordering, options, completeSelection ? 10 : 1010);
   }
 
-  bool isBGComplete() const override { return _completeSelection; }
+  bool isBGComplete() const final { return _completeSelection; }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override;
+  void doSelection(Clause* c, unsigned eligible) final;
 private:
   Literal* pickTheBest(Literal** lits, unsigned cnt);
   void removeVariants(LiteralStack& lits);

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -451,14 +451,14 @@ public:
     ASS(_base->commutative());
     ASS_EQ(_base->arity(), 2);
   }
-  ~CommutativeMatchIterator()
+  ~CommutativeMatchIterator() override
   {
     if(_state!=FINISHED && _state!=FIRST) {
   backtrack();
     }
     ASS(_bdata.isEmpty());
   }
-  bool hasNext()
+  bool hasNext() override
   {
     CALL("Matcher::CommutativeMatchIterator::hasNext");
 
@@ -501,7 +501,7 @@ public:
     ASS(_state!=FINISHED || _bdata.isEmpty());
     return _state!=FINISHED;
   }
-  Matcher* next()
+  Matcher* next() override
   {
     _used=true;
     return _matcher;

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -440,7 +440,7 @@ Literal* OCMatchIterator::apply(Literal* lit)
 
 //////////////// Matcher ////////////////////
 
-class Matcher::CommutativeMatchIterator
+class Matcher::CommutativeMatchIterator final
 : public IteratorCore<Matcher*>
 {
 public:
@@ -451,14 +451,14 @@ public:
     ASS(_base->commutative());
     ASS_EQ(_base->arity(), 2);
   }
-  ~CommutativeMatchIterator() override
+  ~CommutativeMatchIterator() final
   {
     if(_state!=FINISHED && _state!=FIRST) {
   backtrack();
     }
     ASS(_bdata.isEmpty());
   }
-  bool hasNext() override
+  bool hasNext() final
   {
     CALL("Matcher::CommutativeMatchIterator::hasNext");
 
@@ -501,7 +501,7 @@ public:
     ASS(_state!=FINISHED || _bdata.isEmpty());
     return _state!=FINISHED;
   }
-  Matcher* next() override
+  Matcher* next() final
   {
     _used=true;
     return _matcher;

--- a/Kernel/Matcher.hpp
+++ b/Kernel/Matcher.hpp
@@ -269,7 +269,7 @@ private:
     public:
       BindingBacktrackObject(MapBinder* bnd, unsigned var)
       :_map(&bnd->_map), _var(var) {}
-      void backtrack()
+      void backtrack() override
       { ALWAYS(_map->remove(_var)); }
 
       CLASS_NAME(Matcher::MapBinder::BindingBacktrackObject);

--- a/Kernel/Matcher.hpp
+++ b/Kernel/Matcher.hpp
@@ -269,7 +269,7 @@ private:
     public:
       BindingBacktrackObject(MapBinder* bnd, unsigned var)
       :_map(&bnd->_map), _var(var) {}
-      void backtrack() override
+      void backtrack() final
       { ALWAYS(_map->remove(_var)); }
 
       CLASS_NAME(Matcher::MapBinder::BindingBacktrackObject);

--- a/Kernel/MaximalLiteralSelector.hpp
+++ b/Kernel/MaximalLiteralSelector.hpp
@@ -39,9 +39,9 @@ public:
 
   MaximalLiteralSelector(const Ordering& ordering, const Options& options) : LiteralSelector(ordering, options) {}
 
-  bool isBGComplete() const override { return true; }
+  bool isBGComplete() const final { return true; }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override;
+  void doSelection(Clause* c, unsigned eligible) final;
 };
 
 };

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -33,7 +33,7 @@ class UWAMismatchHandler : public MismatchHandler
 {
 public:
   UWAMismatchHandler(Stack<UnificationConstraint>& c) : constraints(c) /*, specialVar(0)*/ {}
-  bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2) override;
+  bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2) final;
 
   CLASS_NAME(UWAMismatchHandler);
   USE_ALLOCATOR(UWAMismatchHandler);

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -33,7 +33,7 @@ class UWAMismatchHandler : public MismatchHandler
 {
 public:
   UWAMismatchHandler(Stack<UnificationConstraint>& c) : constraints(c) /*, specialVar(0)*/ {}
-  virtual bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2);
+  bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2) override;
 
   CLASS_NAME(UWAMismatchHandler);
   USE_ALLOCATOR(UWAMismatchHandler);
@@ -51,7 +51,7 @@ class HOMismatchHandler : public MismatchHandler
 public:
   HOMismatchHandler(UnificationConstraintStack& c) : constraints(c) {}
   
-  virtual bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2);
+  bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2) override;
 
   CLASS_NAME(HOMismatchHandler);
   USE_ALLOCATOR(HOMismatchHandler);

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -156,9 +156,9 @@ class PrecedenceOrdering
 : public Ordering
 {
 public:
-  Result compare(Literal* l1, Literal* l2) const override;
-  Comparison compareFunctors(unsigned fun1, unsigned fun2) const override;
-  void show(ostream&) const override;
+  Result compare(Literal* l1, Literal* l2) const final;
+  Comparison compareFunctors(unsigned fun1, unsigned fun2) const final;
+  void show(ostream&) const final;
   virtual void showConcrete(ostream&) const = 0;
 
 protected:

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -972,7 +972,7 @@ private:
  * [1] associate means either match or unify
  */
 template<class Fn>
-class RobSubstitution::AssocIterator: public IteratorCore<RobSubstitution*> {
+class RobSubstitution::AssocIterator final: public IteratorCore<RobSubstitution*> {
 public:
   AssocIterator(RobSubstitution* subst, Literal* l1, int l1Index, Literal* l2,
       int l2Index) :
@@ -982,7 +982,7 @@ public:
     ASS(_l1->commutative());
     ASS_EQ(_l1->arity(), 2);
   }
-  ~AssocIterator() override {
+  ~AssocIterator() final {
     CALL("RobSubstitution::AssocIterator::~AssocIterator");
     if (_state != FINISHED && _state != FIRST) {
       backtrack(_bdataMain);
@@ -991,7 +991,7 @@ public:
     ASS(_bdataMain.isEmpty());
     ASS(_bdataEqAssoc.isEmpty());
   }
-  bool hasNext() override {
+  bool hasNext() final {
     CALL("RobSubstitution::AssocIterator::hasNext");
 
     if (_state == FINISHED) {
@@ -1051,7 +1051,7 @@ public:
     return _state != FINISHED;
   }
 
-  RobSubstitution* next() override {
+  RobSubstitution* next() final {
     _used = true;
     return _subst;
   }

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -982,7 +982,7 @@ public:
     ASS(_l1->commutative());
     ASS_EQ(_l1->arity(), 2);
   }
-  ~AssocIterator() {
+  ~AssocIterator() override {
     CALL("RobSubstitution::AssocIterator::~AssocIterator");
     if (_state != FINISHED && _state != FIRST) {
       backtrack(_bdataMain);
@@ -991,7 +991,7 @@ public:
     ASS(_bdataMain.isEmpty());
     ASS(_bdataEqAssoc.isEmpty());
   }
-  bool hasNext() {
+  bool hasNext() override {
     CALL("RobSubstitution::AssocIterator::hasNext");
 
     if (_state == FINISHED) {
@@ -1051,7 +1051,7 @@ public:
     return _state != FINISHED;
   }
 
-  RobSubstitution* next() {
+  RobSubstitution* next() override {
     _used = true;
     return _subst;
   }

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -302,7 +302,7 @@ private:
       }
     }
 #if VDEBUG
-    vstring toString() const
+    vstring toString() const final
     {
       return "(ROB backtrack object for "+ _var.toString() +")";
     }

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -293,7 +293,7 @@ private:
 	_term.term.makeEmpty();
       }
     }
-    void backtrack()
+    void backtrack() override
     {
       if(_term.term.isEmpty()) {
 	_subst->_bank.remove(_var);

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -293,7 +293,7 @@ private:
 	_term.term.makeEmpty();
       }
     }
-    void backtrack() override
+    void backtrack() final
     {
       if(_term.term.isEmpty()) {
 	_subst->_bank.remove(_var);

--- a/Kernel/SKIKBO.hpp
+++ b/Kernel/SKIKBO.hpp
@@ -35,7 +35,7 @@ using namespace Lib;
  * Class for instances of the Knuth-Bendix orderings
  * @since 30/04/2008 flight Brussels-Tel Aviv
  */
-class SKIKBO
+class SKIKBO final
 : public PrecedenceOrdering
 {
 public:
@@ -43,19 +43,19 @@ public:
   USE_ALLOCATOR(SKIKBO);
 
   SKIKBO(Problem& prb, const Options& opt, bool basic_hol = false);
-  ~SKIKBO() override;
+  ~SKIKBO() final;
 
   typedef SmartPtr<ApplicativeArgsIt> ArgsIt_ptr;
 
   using PrecedenceOrdering::compare;
-  Result compare(TermList tl1, TermList tl2) const override;
+  Result compare(TermList tl1, TermList tl2) const final;
   static unsigned maximumReductionLength(Term* t);
   static TermList reduce(TermStack& args, TermList& head);
 
 protected:
   typedef DHMap<unsigned, DArray<DArray<unsigned>*>*> VarOccMap;
 
-  //Result comparePredicates(Literal* l1, Literal* l2) const override;
+  //Result comparePredicates(Literal* l1, Literal* l2) const final;
 
   enum VarCondRes {
     INCOMP,
@@ -66,12 +66,12 @@ protected:
  
   class State;
 
-  Result comparePredicates(Literal* l1, Literal* l2) const override
+  Result comparePredicates(Literal* l1, Literal* l2) const final
   {
     return Ordering::INCOMPARABLE;
   }
 
-  void showConcrete(ostream&) const override
+  void showConcrete(ostream&) const final
   { NOT_IMPLEMENTED; }
 
   //VarCondRes compareVariables(VarOccMap&, VarOccMap&, VarCondRes) const;

--- a/Kernel/SKIKBO.hpp
+++ b/Kernel/SKIKBO.hpp
@@ -43,7 +43,7 @@ public:
   USE_ALLOCATOR(SKIKBO);
 
   SKIKBO(Problem& prb, const Options& opt, bool basic_hol = false);
-  virtual ~SKIKBO();
+  ~SKIKBO() override;
 
   typedef SmartPtr<ApplicativeArgsIt> ArgsIt_ptr;
 

--- a/Kernel/SpassLiteralSelector.hpp
+++ b/Kernel/SpassLiteralSelector.hpp
@@ -44,9 +44,9 @@ public:
   SpassLiteralSelector(const Ordering& ordering, const Options& options, Values value) :
     LiteralSelector(ordering, options), _value(value) {}
 
-  bool isBGComplete() const override { return true; }
+  bool isBGComplete() const final { return true; }
 protected:
-  void doSelection(Clause* c, unsigned eligible) override;
+  void doSelection(Clause* c, unsigned eligible) final;
 
 private:
   LiteralList* getMaximalsInOrder(Clause* c, unsigned eligible);

--- a/Kernel/SubformulaIterator.hpp
+++ b/Kernel/SubformulaIterator.hpp
@@ -33,10 +33,10 @@ class SubformulaIterator
 public:
   SubformulaIterator (Formula*);
   SubformulaIterator (FormulaList*);
-  ~SubformulaIterator ();
+  ~SubformulaIterator () override;
 
-  bool hasNext ();
-  Formula* next ();
+  bool hasNext () override;
+  Formula* next () override;
   Formula* next (int& polarity);
 private:
   class Element;

--- a/Kernel/SubformulaIterator.hpp
+++ b/Kernel/SubformulaIterator.hpp
@@ -27,16 +27,16 @@ namespace Kernel {
 /**
  * Implements an iterator over subformulas of a formula or formula list.
  */
-class SubformulaIterator
+class SubformulaIterator final
 : public IteratorCore<Formula*>
 {
 public:
   SubformulaIterator (Formula*);
   SubformulaIterator (FormulaList*);
-  ~SubformulaIterator () override;
+  ~SubformulaIterator () final;
 
-  bool hasNext () override;
-  Formula* next () override;
+  bool hasNext () final;
+  Formula* next () final;
   Formula* next (int& polarity);
 private:
   class Element;

--- a/Kernel/TermIterators.hpp
+++ b/Kernel/TermIterators.hpp
@@ -103,10 +103,10 @@ public:
   }
 
 
-  bool hasNext() override;
+  bool hasNext() final;
   /** Return the next variable
    * @warning hasNext() must have been called before */
-  TermList next() override
+  TermList next() final
   {
     ASS(!_used);
     ASS(_stack.top()->isVar());
@@ -173,10 +173,10 @@ public:
     }
   }
 
-  bool hasNext() override;
+  bool hasNext() final;
   /** Return the next variable
    * @warning hasNext() must have been called before */
-  pair<TermList, TermList> next() override
+  pair<TermList, TermList> next() final
   {
     ASS(!_used);
     _used=true;
@@ -209,10 +209,10 @@ public:
     Recycler::release(_stack);
   }
 
-  bool hasNext() override;
+  bool hasNext() final;
   /** Return next subterm
    * @warning hasNext() must have been called before */
-  TermList next() override
+  TermList next() final
   {
     ASS(!_used && !_stack->isEmpty());
     _used=true;
@@ -270,12 +270,12 @@ public:
     _argNum = _stack.size();
   }
 
-  bool hasNext() override{
+  bool hasNext() final{
     return !_stack.isEmpty();
   }
   /** Return next arg of _head
    * @warning hasNext() must have been called before */
-  TermList next() override
+  TermList next() final
   {
     ASS(!_stack.isEmpty());
     return _stack.pop();
@@ -327,9 +327,9 @@ public:
     }
   }
 
-  bool hasNext() override;
+  bool hasNext() final;
 
-  Term* next() override
+  Term* next() final
   {
     ASS(_next);
     Term* res = _next;
@@ -359,9 +359,9 @@ public:
     }  
   }
   
-  bool hasNext() override;
+  bool hasNext() final;
 
-  TermList next() override
+  TermList next() final
   {
     ASS(!_next.isEmpty());
     TermList res = _next;
@@ -403,8 +403,8 @@ public: //includeSelf for compatibility
     _sorts.push(SortHelper::getResultSort(t));
   }
 
-  bool hasNext() override;
-  TermList next() override{
+  bool hasNext() final;
+  TermList next() final{
     ASS(!_next.isEmpty());
     ASS(_next.isVar());
     TermList res = _next;
@@ -437,8 +437,8 @@ public:
     _stack.push(TermList(t)); 
   }
   
-  bool hasNext() override;
-  TermList next() override
+  bool hasNext() final;
+  TermList next() final
   {
     ASS(!_next.isEmpty());
     TermList res = _next;
@@ -473,8 +473,8 @@ public:
     }
   }
 
-  bool hasNext() override{ return !_stack.isEmpty(); }
-  TermList next() override;
+  bool hasNext() final{ return !_stack.isEmpty(); }
+  TermList next() final;
   void right();
 
 private:
@@ -502,8 +502,8 @@ public:
     //TODO
   }
 
-  bool hasNext() override;
-  TermList next() override{
+  bool hasNext() final;
+  TermList next() final{
     ASS(!_used);
     _used = true;
     return _next;
@@ -536,8 +536,8 @@ public:
     _stack.push(term);
   }
 
-  bool hasNext() override;
-  TermList next() override{
+  bool hasNext() final;
+  TermList next() final{
     ASS(!_used);
     _used = true;
     return _next;
@@ -596,10 +596,10 @@ public:
     pushNext(term->args());
   }
 
-  bool hasNext() override;
+  bool hasNext() final;
   /** Return next subterm
    * @warning hasNext() must have been called before */
-  TermList next() override
+  TermList next() final
   {
     ASS(!_used && !_stack.isEmpty());
     _used=true;
@@ -654,8 +654,8 @@ public:
   // NonVariableIterator(TermList ts);
 
   /** true if there exists at least one subterm */
-  bool hasNext() override { return !_stack.isEmpty(); }
-  TermList next() override;
+  bool hasNext() final { return !_stack.isEmpty(); }
+  TermList next() final;
   void right();
 private:
   /** available non-variable subterms */
@@ -697,8 +697,8 @@ public:
   // NonVariableIterator(TermList ts);
 
   /** true if there exists at least one subterm */
-  bool hasNext() override { return !_stack.isEmpty(); }
-  TermList next() override;
+  bool hasNext() final { return !_stack.isEmpty(); }
+  TermList next() final;
   void right();
 private:
   /** available non-variable subterms */
@@ -792,11 +792,11 @@ public:
     }
   }
 
-  bool hasNext() override;
+  bool hasNext() final;
 
   /** Return next subterm
    * @warning hasNext() must have been called before */
-  pair<TermList, TermList> next() override
+  pair<TermList, TermList> next() final
   {
     pair<TermList, TermList> res(_arg1,_arg2);
     _arg1.makeEmpty();
@@ -823,8 +823,8 @@ class TermFunIterator
 public:
   TermFunIterator (const Term*);
 
-  bool hasNext() override;
-  unsigned next() override;
+  bool hasNext() final;
+  unsigned next() final;
 private:
   /** True if the next symbol is found */
   bool _hasNext;
@@ -847,8 +847,8 @@ public:
   TermVarIterator (const Term*);
   TermVarIterator (const TermList*);
 
-  bool hasNext () override;
-  unsigned next () override;
+  bool hasNext () final;
+  unsigned next () final;
 private:
   /** True if the next variable is found */
   // bool _hasNext; // MS: unused

--- a/Kernel/TermIterators.hpp
+++ b/Kernel/TermIterators.hpp
@@ -103,10 +103,10 @@ public:
   }
 
 
-  bool hasNext();
+  bool hasNext() override;
   /** Return the next variable
    * @warning hasNext() must have been called before */
-  TermList next()
+  TermList next() override
   {
     ASS(!_used);
     ASS(_stack.top()->isVar());
@@ -173,10 +173,10 @@ public:
     }
   }
 
-  bool hasNext();
+  bool hasNext() override;
   /** Return the next variable
    * @warning hasNext() must have been called before */
-  pair<TermList, TermList> next()
+  pair<TermList, TermList> next() override
   {
     ASS(!_used);
     _used=true;
@@ -204,15 +204,15 @@ public:
 
     pushNext(term->args());
   }
-  ~SubtermIterator()
+  ~SubtermIterator() override
   {
     Recycler::release(_stack);
   }
 
-  bool hasNext();
+  bool hasNext() override;
   /** Return next subterm
    * @warning hasNext() must have been called before */
-  TermList next()
+  TermList next() override
   {
     ASS(!_used && !_stack->isEmpty());
     _used=true;
@@ -270,12 +270,12 @@ public:
     _argNum = _stack.size();
   }
 
-  bool hasNext(){
+  bool hasNext() override{
     return !_stack.isEmpty();
   }
   /** Return next arg of _head
    * @warning hasNext() must have been called before */
-  TermList next()
+  TermList next() override
   {
     ASS(!_stack.isEmpty());
     return _stack.pop();
@@ -327,9 +327,9 @@ public:
     }
   }
 
-  bool hasNext();
+  bool hasNext() override;
 
-  Term* next()
+  Term* next() override
   {
     ASS(_next);
     Term* res = _next;
@@ -359,9 +359,9 @@ public:
     }  
   }
   
-  bool hasNext();
+  bool hasNext() override;
 
-  TermList next()
+  TermList next() override
   {
     ASS(!_next.isEmpty());
     TermList res = _next;
@@ -403,8 +403,8 @@ public: //includeSelf for compatibility
     _sorts.push(SortHelper::getResultSort(t));
   }
 
-  bool hasNext();
-  TermList next(){
+  bool hasNext() override;
+  TermList next() override{
     ASS(!_next.isEmpty());
     ASS(_next.isVar());
     TermList res = _next;
@@ -437,8 +437,8 @@ public:
     _stack.push(TermList(t)); 
   }
   
-  bool hasNext();
-  TermList next()
+  bool hasNext() override;
+  TermList next() override
   {
     ASS(!_next.isEmpty());
     TermList res = _next;
@@ -473,8 +473,8 @@ public:
     }
   }
 
-  bool hasNext(){ return !_stack.isEmpty(); }
-  TermList next();
+  bool hasNext() override{ return !_stack.isEmpty(); }
+  TermList next() override;
   void right();
 
 private:
@@ -502,8 +502,8 @@ public:
     //TODO
   }
 
-  bool hasNext();
-  TermList next(){
+  bool hasNext() override;
+  TermList next() override{
     ASS(!_used);
     _used = true;
     return _next;
@@ -536,8 +536,8 @@ public:
     _stack.push(term);
   }
 
-  bool hasNext();
-  TermList next(){
+  bool hasNext() override;
+  TermList next() override{
     ASS(!_used);
     _used = true;
     return _next;
@@ -596,10 +596,10 @@ public:
     pushNext(term->args());
   }
 
-  bool hasNext();
+  bool hasNext() override;
   /** Return next subterm
    * @warning hasNext() must have been called before */
-  TermList next()
+  TermList next() override
   {
     ASS(!_used && !_stack.isEmpty());
     _used=true;
@@ -654,8 +654,8 @@ public:
   // NonVariableIterator(TermList ts);
 
   /** true if there exists at least one subterm */
-  bool hasNext() { return !_stack.isEmpty(); }
-  TermList next();
+  bool hasNext() override { return !_stack.isEmpty(); }
+  TermList next() override;
   void right();
 private:
   /** available non-variable subterms */
@@ -697,8 +697,8 @@ public:
   // NonVariableIterator(TermList ts);
 
   /** true if there exists at least one subterm */
-  bool hasNext() { return !_stack.isEmpty(); }
-  TermList next();
+  bool hasNext() override { return !_stack.isEmpty(); }
+  TermList next() override;
   void right();
 private:
   /** available non-variable subterms */
@@ -792,11 +792,11 @@ public:
     }
   }
 
-  bool hasNext();
+  bool hasNext() override;
 
   /** Return next subterm
    * @warning hasNext() must have been called before */
-  pair<TermList, TermList> next()
+  pair<TermList, TermList> next() override
   {
     pair<TermList, TermList> res(_arg1,_arg2);
     _arg1.makeEmpty();
@@ -823,8 +823,8 @@ class TermFunIterator
 public:
   TermFunIterator (const Term*);
 
-  bool hasNext();
-  unsigned next();
+  bool hasNext() override;
+  unsigned next() override;
 private:
   /** True if the next symbol is found */
   bool _hasNext;
@@ -847,8 +847,8 @@ public:
   TermVarIterator (const Term*);
   TermVarIterator (const TermList*);
 
-  bool hasNext ();
-  unsigned next ();
+  bool hasNext () override;
+  unsigned next () override;
 private:
   /** True if the next variable is found */
   // bool _hasNext; // MS: unused

--- a/Lib/Array.hpp
+++ b/Lib/Array.hpp
@@ -252,7 +252,7 @@ public:
   }
 
 
-  void fillInterval(size_t start,size_t end) override
+  void fillInterval(size_t start,size_t end) final
   {
     for(size_t i=start; i<end; i++) {
       Array<T>::_array[i]=static_cast<T>(0);

--- a/Lib/Array.hpp
+++ b/Lib/Array.hpp
@@ -252,7 +252,7 @@ public:
   }
 
 
-  void fillInterval(size_t start,size_t end)
+  void fillInterval(size_t start,size_t end) override
   {
     for(size_t i=start; i<end; i++) {
       Array<T>::_array[i]=static_cast<T>(0);

--- a/Lib/Backtrackable.hpp
+++ b/Lib/Backtrackable.hpp
@@ -210,7 +210,7 @@ private:
   public:
     SetValueBacktrackObject(T* addr, T previousVal)
     : addr(addr), previousVal(previousVal) {}
-    void backtrack()
+    void backtrack() override
     {
       *addr=previousVal;
     }

--- a/Lib/Backtrackable.hpp
+++ b/Lib/Backtrackable.hpp
@@ -210,7 +210,7 @@ private:
   public:
     SetValueBacktrackObject(T* addr, T previousVal)
     : addr(addr), previousVal(previousVal) {}
-    void backtrack() override
+    void backtrack() final
     {
       *addr=previousVal;
     }

--- a/Lib/BinaryHeap.hpp
+++ b/Lib/BinaryHeap.hpp
@@ -234,7 +234,7 @@ private:
   public:
     BHPopBacktrackObject(BinaryHeap* bh, T v, unsigned lastBubbleIndex)
     :_bh(bh), _val(v), _lastBubbleIndex(lastBubbleIndex) {}
-    void backtrack() override
+    void backtrack() final
     {
       _bh->backtrackPop(_val,_lastBubbleIndex);
     }
@@ -252,7 +252,7 @@ private:
   public:
     BHInsertBacktrackObject(BinaryHeap* bh, unsigned lastBubbleIndex)
     :_bh(bh), _lastBubbleIndex(lastBubbleIndex) {}
-    void backtrack() override
+    void backtrack() final
     {
       _bh->backtrackInsert(_lastBubbleIndex);
     }

--- a/Lib/BinaryHeap.hpp
+++ b/Lib/BinaryHeap.hpp
@@ -234,7 +234,7 @@ private:
   public:
     BHPopBacktrackObject(BinaryHeap* bh, T v, unsigned lastBubbleIndex)
     :_bh(bh), _val(v), _lastBubbleIndex(lastBubbleIndex) {}
-    void backtrack()
+    void backtrack() override
     {
       _bh->backtrackPop(_val,_lastBubbleIndex);
     }
@@ -252,7 +252,7 @@ private:
   public:
     BHInsertBacktrackObject(BinaryHeap* bh, unsigned lastBubbleIndex)
     :_bh(bh), _lastBubbleIndex(lastBubbleIndex) {}
-    void backtrack()
+    void backtrack() override
     {
       _bh->backtrackInsert(_lastBubbleIndex);
     }

--- a/Lib/DHMap.hpp
+++ b/Lib/DHMap.hpp
@@ -766,13 +766,13 @@ private:
     /** Create a new iterator */
     inline DomainIteratorCore(const DHMap& map) : _base(map) {}
     /** True if there exists next element */
-    inline bool hasNext() override { return _base.hasNext(); }
+    inline bool hasNext() final { return _base.hasNext(); }
 
     /**
      * Return the next key
      * @warning hasNext() must have been called before
      */
-    inline Key next() override { return _base.next()->_key; }
+    inline Key next() final { return _base.next()->_key; }
   private:
     IteratorBase _base;
   }; // class DHMap::DomainIteratorCore
@@ -783,13 +783,13 @@ private:
         /** Create a new iterator */
         inline RangeIteratorCore(const DHMap& map) : _base(map) {}
         /** True if there exists next element */
-        inline bool hasNext() override { return _base.hasNext(); }
+        inline bool hasNext() final { return _base.hasNext(); }
         
         /**
          * Return the next key
          * @warning hasNext() must have been called before
          */
-        inline Val next() override { return _base.next()->_val; }
+        inline Val next() final { return _base.next()->_val; }
     private:
         IteratorBase _base;
     }; // class DHMap::RangeIteratorCore
@@ -813,13 +813,13 @@ private:
     /** Create a new iterator */
     inline ItemIteratorCore(const DHMap& map) : _base(map) {}
     /** True if there exists next element */
-    inline bool hasNext() override { return _base.hasNext(); }
+    inline bool hasNext() final { return _base.hasNext(); }
 
     /**
      * Return the next key
      * @warning hasNext() must have been called before
      */
-    inline Item next() override
+    inline Item next() final
     {
       Entry* e=_base.next();
       return Item(e->_key, e->_val);

--- a/Lib/DHMap.hpp
+++ b/Lib/DHMap.hpp
@@ -766,13 +766,13 @@ private:
     /** Create a new iterator */
     inline DomainIteratorCore(const DHMap& map) : _base(map) {}
     /** True if there exists next element */
-    inline bool hasNext() { return _base.hasNext(); }
+    inline bool hasNext() override { return _base.hasNext(); }
 
     /**
      * Return the next key
      * @warning hasNext() must have been called before
      */
-    inline Key next() { return _base.next()->_key; }
+    inline Key next() override { return _base.next()->_key; }
   private:
     IteratorBase _base;
   }; // class DHMap::DomainIteratorCore
@@ -783,13 +783,13 @@ private:
         /** Create a new iterator */
         inline RangeIteratorCore(const DHMap& map) : _base(map) {}
         /** True if there exists next element */
-        inline bool hasNext() { return _base.hasNext(); }
+        inline bool hasNext() override { return _base.hasNext(); }
         
         /**
          * Return the next key
          * @warning hasNext() must have been called before
          */
-        inline Val next() { return _base.next()->_val; }
+        inline Val next() override { return _base.next()->_val; }
     private:
         IteratorBase _base;
     }; // class DHMap::RangeIteratorCore
@@ -813,13 +813,13 @@ private:
     /** Create a new iterator */
     inline ItemIteratorCore(const DHMap& map) : _base(map) {}
     /** True if there exists next element */
-    inline bool hasNext() { return _base.hasNext(); }
+    inline bool hasNext() override { return _base.hasNext(); }
 
     /**
      * Return the next key
      * @warning hasNext() must have been called before
      */
-    inline Item next()
+    inline Item next() override
     {
       Entry* e=_base.next();
       return Item(e->_key, e->_val);

--- a/Lib/Event.hpp
+++ b/Lib/Event.hpp
@@ -107,7 +107,7 @@ protected:
   {
     Cls* pObj;
     void(Cls::*pMethod)();
-    void fire()
+    void fire() override
     {
       (pObj->*pMethod)();
     }
@@ -159,7 +159,7 @@ protected:
     Cls* pObj;
     void(Cls::*pMethod)(T);
 
-    void fire(T t)
+    void fire(T t) override
     {
       (pObj->*pMethod)(t);
     }

--- a/Lib/Event.hpp
+++ b/Lib/Event.hpp
@@ -107,7 +107,7 @@ protected:
   {
     Cls* pObj;
     void(Cls::*pMethod)();
-    void fire() override
+    void fire() final
     {
       (pObj->*pMethod)();
     }
@@ -159,7 +159,7 @@ protected:
     Cls* pObj;
     void(Cls::*pMethod)(T);
 
-    void fire(T t) override
+    void fire(T t) final
     {
       (pObj->*pMethod)(t);
     }

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -126,7 +126,7 @@ class UserErrorException
   UserErrorException (const vstring msg)
     : Exception(msg)
   {}
-  void cry (ostream&) const override;
+  void cry (ostream&) const final;
 }; // UserErrorException
 
 /**
@@ -196,7 +196,7 @@ class InvalidOperationException
    InvalidOperationException (const vstring msg)
     : Exception(msg)
   {}
-  void cry (ostream&) const override;
+  void cry (ostream&) const final;
 }; // InvalidOperationException
 
 /**
@@ -207,7 +207,7 @@ class SystemFailException
 {
 public:
   SystemFailException (const vstring msg, int err);
-  void cry (ostream&) const override;
+  void cry (ostream&) const final;
 
   int err;
 }; // InvalidOperationException
@@ -222,7 +222,7 @@ class NotImplementedException
    NotImplementedException (const char* file,int line)
     : Exception(""), file(file), line(line)
   {}
-   void cry (ostream&) const override;
+   void cry (ostream&) const final;
  private:
    const char* file;
    int line;

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -126,7 +126,7 @@ class UserErrorException
   UserErrorException (const vstring msg)
     : Exception(msg)
   {}
-  void cry (ostream&) const;
+  void cry (ostream&) const override;
 }; // UserErrorException
 
 /**
@@ -196,7 +196,7 @@ class InvalidOperationException
    InvalidOperationException (const vstring msg)
     : Exception(msg)
   {}
-  void cry (ostream&) const;
+  void cry (ostream&) const override;
 }; // InvalidOperationException
 
 /**
@@ -207,7 +207,7 @@ class SystemFailException
 {
 public:
   SystemFailException (const vstring msg, int err);
-  void cry (ostream&) const;
+  void cry (ostream&) const override;
 
   int err;
 }; // InvalidOperationException
@@ -222,7 +222,7 @@ class NotImplementedException
    NotImplementedException (const char* file,int line)
     : Exception(""), file(file), line(line)
   {}
-   void cry (ostream&) const;
+   void cry (ostream&) const override;
  private:
    const char* file;
    int line;

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -917,7 +917,7 @@ FlatMapIter<Inner,Functor> getMapAndFlattenIterator(Inner it, Functor f)
  * @see VirtualIterator
  */
 template<class Inner>
-class PersistentIterator
+class PersistentIterator final
 : public IteratorCore<ELEMENT_TYPE(Inner)>
 {
 public:
@@ -931,15 +931,15 @@ public:
       ptr=&(*ptr)->tailReference();
     }
   }
-  ~PersistentIterator() override
+  ~PersistentIterator() final
   {
     if(_items) {
       List<T>::destroy(_items);
     }
   }
-  inline bool hasNext() override { return _items; };
+  inline bool hasNext() final { return _items; };
   inline
-  T next() override
+  T next() final
   {
     return List<T>::pop(_items);
   };
@@ -977,7 +977,7 @@ VirtualIterator<ELEMENT_TYPE(Inner)> getPersistentIterator(Inner it)
  * @see VirtualIterator
  */
 template<class Inner>
-class UniquePersistentIterator
+class UniquePersistentIterator final
 : public IteratorCore<ELEMENT_TYPE(Inner)>
 {
 public:
@@ -990,20 +990,20 @@ public:
   {
     _items=getUniqueItemList(inn, _size);
   }
-  ~UniquePersistentIterator() override
+  ~UniquePersistentIterator() final
   {
     if(_items) {
       ItemList::destroy(_items);
     }
   }
-  inline bool hasNext() override { return _items; };
-  inline T next() override
+  inline bool hasNext() final { return _items; };
+  inline T next() final
   {
     return ItemList::pop(_items);
   };
 
-  inline bool knowsSize() const override { return true; }
-  inline size_t size() const override { return _size; }
+  inline bool knowsSize() const final { return true; }
+  inline size_t size() const final { return _size; }
 private:
   typedef DHSet<T> ItemSet;
 
@@ -1340,13 +1340,13 @@ public:
   explicit TimeCountedIterator(Inner inn, TimeCounterUnit tcu)
   : _inn(inn), _tcu(tcu) {}
 
-  inline bool hasNext() override
+  inline bool hasNext() final
   {
     TimeCounter tc(_tcu);
     return _inn.hasNext();
   };
   inline
-  T next() override
+  T next() final
   {
     TimeCounter tc(_tcu);
     return _inn.next();

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -931,15 +931,15 @@ public:
       ptr=&(*ptr)->tailReference();
     }
   }
-  ~PersistentIterator()
+  ~PersistentIterator() override
   {
     if(_items) {
       List<T>::destroy(_items);
     }
   }
-  inline bool hasNext() { return _items; };
+  inline bool hasNext() override { return _items; };
   inline
-  T next()
+  T next() override
   {
     return List<T>::pop(_items);
   };
@@ -990,20 +990,20 @@ public:
   {
     _items=getUniqueItemList(inn, _size);
   }
-  ~UniquePersistentIterator()
+  ~UniquePersistentIterator() override
   {
     if(_items) {
       ItemList::destroy(_items);
     }
   }
-  inline bool hasNext() { return _items; };
-  inline T next()
+  inline bool hasNext() override { return _items; };
+  inline T next() override
   {
     return ItemList::pop(_items);
   };
 
-  inline bool knowsSize() const { return true; }
-  inline size_t size() const { return _size; }
+  inline bool knowsSize() const override { return true; }
+  inline size_t size() const override { return _size; }
 private:
   typedef DHSet<T> ItemSet;
 
@@ -1340,13 +1340,13 @@ public:
   explicit TimeCountedIterator(Inner inn, TimeCounterUnit tcu)
   : _inn(inn), _tcu(tcu) {}
 
-  inline bool hasNext()
+  inline bool hasNext() override
   {
     TimeCounter tc(_tcu);
     return _inn.hasNext();
   };
   inline
-  T next()
+  T next() override
   {
     TimeCounter tc(_tcu);
     return _inn.next();

--- a/Lib/SkipList.hpp
+++ b/Lib/SkipList.hpp
@@ -580,7 +580,7 @@ private:
       REMOVE, INSERT
     };
     SingleValBacktrackObject(SkipList* sl, Action a, Value v): sl(sl), a(a), v(v) {}
-    void backtrack() override
+    void backtrack() final
     {
       switch(a) {
       case REMOVE:

--- a/Lib/SkipList.hpp
+++ b/Lib/SkipList.hpp
@@ -580,7 +580,7 @@ private:
       REMOVE, INSERT
     };
     SingleValBacktrackObject(SkipList* sl, Action a, Value v): sl(sl), a(a), v(v) {}
-    void backtrack()
+    void backtrack() override
     {
       switch(a) {
       case REMOVE:

--- a/Lib/Stack.hpp
+++ b/Lib/Stack.hpp
@@ -817,7 +817,7 @@ protected:
     USE_ALLOCATOR(Stack::PushBacktrackObject);
     
     PushBacktrackObject(Stack* st) : st(st) {}
-    void backtrack() override { st->pop(); }
+    void backtrack() final { st->pop(); }
   };
 public:
 

--- a/Lib/Stack.hpp
+++ b/Lib/Stack.hpp
@@ -817,7 +817,7 @@ protected:
     USE_ALLOCATOR(Stack::PushBacktrackObject);
     
     PushBacktrackObject(Stack* st) : st(st) {}
-    void backtrack() { st->pop(); }
+    void backtrack() override { st->pop(); }
   };
 public:
 

--- a/Lib/VirtualIterator.hpp
+++ b/Lib/VirtualIterator.hpp
@@ -107,10 +107,10 @@ public:
   USE_ALLOCATOR(EmptyIterator);
 
   EmptyIterator() {}
-  bool hasNext() { return false; };
-  T next() { INVALID_OPERATION("next() called on EmptyIterator object"); };
-  bool knowsSize() const { return true; }
-  size_t size() const { return 0; }
+  bool hasNext() override { return false; };
+  T next() override { INVALID_OPERATION("next() called on EmptyIterator object"); };
+  bool knowsSize() const override { return true; }
+  size_t size() const override { return 0; }
 };
 
 /**
@@ -315,8 +315,8 @@ public:
   USE_ALLOCATOR(ProxyIterator);
   
   explicit ProxyIterator(Inner inn) :_inn(inn) {}
-  bool hasNext() { return _inn.hasNext(); };
-  T next() { return _inn.next(); };
+  bool hasNext() override { return _inn.hasNext(); };
+  T next() override { return _inn.next(); };
 private:
   Inner _inn;
 };

--- a/Lib/VirtualIterator.hpp
+++ b/Lib/VirtualIterator.hpp
@@ -107,10 +107,10 @@ public:
   USE_ALLOCATOR(EmptyIterator);
 
   EmptyIterator() {}
-  bool hasNext() override { return false; };
-  T next() override { INVALID_OPERATION("next() called on EmptyIterator object"); };
-  bool knowsSize() const override { return true; }
-  size_t size() const override { return 0; }
+  bool hasNext() final { return false; };
+  T next() final { INVALID_OPERATION("next() called on EmptyIterator object"); };
+  bool knowsSize() const final { return true; }
+  size_t size() const final { return 0; }
 };
 
 /**
@@ -315,8 +315,8 @@ public:
   USE_ALLOCATOR(ProxyIterator);
   
   explicit ProxyIterator(Inner inn) :_inn(inn) {}
-  bool hasNext() override { return _inn.hasNext(); };
-  T next() override { return _inn.next(); };
+  bool hasNext() final { return _inn.hasNext(); };
+  T next() final { return _inn.next(); };
 private:
   Inner _inn;
 };

--- a/Lib/fdstream.hpp
+++ b/Lib/fdstream.hpp
@@ -46,7 +46,7 @@ public:
   basic_fdbuf( int fd ) : _fd( fd ), _preRead(-1)
   { }
 
-  ~basic_fdbuf()
+  ~basic_fdbuf() override
   {
   }
 
@@ -56,7 +56,7 @@ protected:
 //  /**
 //   * Get the CURRENT character without advancing the file pointer
 //   */
-  virtual int_type underflow()
+  int_type underflow() override
   {
     if(_preRead!=-1) {
       return _preRead;
@@ -68,7 +68,7 @@ protected:
     return ch;
   }
 
-  virtual streamsize xsgetn ( char_type * s0, streamsize n0 )
+  streamsize xsgetn ( char_type * s0, streamsize n0 ) override
   {
     char_type * s=s0;
     streamsize n=n0;
@@ -92,7 +92,7 @@ protected:
   /**
    * Get the CURRENT character AND advance the file pointer
    */
-  virtual int_type uflow()
+  int_type uflow() override
   {
     if(_preRead!=-1) {
       int_type res=_preRead;
@@ -111,13 +111,13 @@ protected:
     return (res==sizeof(char_type)) ? ch : traits_type::eof();
   }
 
-  virtual int_type sync()
+  int_type sync() override
   {
     _preRead=-1; //we throw away the preread char
     return 0;
   }
 
-  virtual streamsize xsputn (const char_type * s, streamsize n)
+  streamsize xsputn (const char_type * s, streamsize n) override
   {
     ssize_t res=write(_fd, s, n*sizeof(char_type));
     if(res<0) {
@@ -126,7 +126,7 @@ protected:
     return res/sizeof(char_type);
   }
 
-  virtual int_type overflow( int_type c = traits_type::eof() )
+  int_type overflow( int_type c = traits_type::eof() ) override
   {
     char_type ch=c;
     ssize_t res=write(_fd, &ch, sizeof(char_type));
@@ -156,7 +156,7 @@ struct basic_fdstream: public std::basic_iostream <CharType, CharTraits>
     base_type( new sbuf_type( fd ) )
   { }
 
-  ~basic_fdstream()
+  ~basic_fdstream() override
   { delete static_cast<sbuf_type*>(this->rdbuf()); }
 
   typename traits_type::int_type getPreReadChar() const

--- a/Lib/fdstream.hpp
+++ b/Lib/fdstream.hpp
@@ -32,7 +32,7 @@ template <
   typename CharType,
   typename CharTraits = std::char_traits <CharType>
   >
-class basic_fdbuf: public std::basic_streambuf <CharType, CharTraits>
+class basic_fdbuf final : public std::basic_streambuf <CharType, CharTraits>
 {
 public:
   typedef CharType                                char_type;
@@ -46,7 +46,7 @@ public:
   basic_fdbuf( int fd ) : _fd( fd ), _preRead(-1)
   { }
 
-  ~basic_fdbuf() override
+  ~basic_fdbuf() final
   {
   }
 
@@ -56,7 +56,7 @@ protected:
 //  /**
 //   * Get the CURRENT character without advancing the file pointer
 //   */
-  int_type underflow() override
+  int_type underflow() final
   {
     if(_preRead!=-1) {
       return _preRead;
@@ -68,7 +68,7 @@ protected:
     return ch;
   }
 
-  streamsize xsgetn ( char_type * s0, streamsize n0 ) override
+  streamsize xsgetn ( char_type * s0, streamsize n0 ) final
   {
     char_type * s=s0;
     streamsize n=n0;
@@ -92,7 +92,7 @@ protected:
   /**
    * Get the CURRENT character AND advance the file pointer
    */
-  int_type uflow() override
+  int_type uflow() final
   {
     if(_preRead!=-1) {
       int_type res=_preRead;
@@ -111,13 +111,13 @@ protected:
     return (res==sizeof(char_type)) ? ch : traits_type::eof();
   }
 
-  int_type sync() override
+  int_type sync() final
   {
     _preRead=-1; //we throw away the preread char
     return 0;
   }
 
-  streamsize xsputn (const char_type * s, streamsize n) override
+  streamsize xsputn (const char_type * s, streamsize n) final
   {
     ssize_t res=write(_fd, s, n*sizeof(char_type));
     if(res<0) {
@@ -126,7 +126,7 @@ protected:
     return res/sizeof(char_type);
   }
 
-  int_type overflow( int_type c = traits_type::eof() ) override
+  int_type overflow( int_type c = traits_type::eof() ) final
   {
     char_type ch=c;
     ssize_t res=write(_fd, &ch, sizeof(char_type));
@@ -143,7 +143,7 @@ template <
 typename CharType,
 typename CharTraits = std::char_traits <CharType>
 >
-struct basic_fdstream: public std::basic_iostream <CharType, CharTraits>
+struct basic_fdstream final: public std::basic_iostream <CharType, CharTraits>
 {
   typedef CharType                                      char_type;
   typedef CharTraits                                    traits_type;
@@ -156,7 +156,7 @@ struct basic_fdstream: public std::basic_iostream <CharType, CharTraits>
     base_type( new sbuf_type( fd ) )
   { }
 
-  ~basic_fdstream() override
+  ~basic_fdstream() final
   { delete static_cast<sbuf_type*>(this->rdbuf()); }
 
   typename traits_type::int_type getPreReadChar() const

--- a/Minisat/simp/SimpSolver.h
+++ b/Minisat/simp/SimpSolver.h
@@ -40,7 +40,7 @@ class SimpSolver : public Solver {
     // Constructor/Destructor:
     //
     SimpSolver();
-    ~SimpSolver();
+    ~SimpSolver() override;
 
     // Problem specification:
     //
@@ -77,7 +77,7 @@ class SimpSolver : public Solver {
 
     // Memory managment:
     //
-    virtual void garbageCollect();
+    void garbageCollect() override;
 
     // Mode of operation:
     //

--- a/Minisat/simp/SimpSolver.h
+++ b/Minisat/simp/SimpSolver.h
@@ -35,12 +35,12 @@ namespace Minisat {
 //=================================================================================================
 
 
-class SimpSolver : public Solver {
+class SimpSolver final : public Solver {
  public:
     // Constructor/Destructor:
     //
     SimpSolver();
-    ~SimpSolver() override;
+    ~SimpSolver() final;
 
     // Problem specification:
     //
@@ -77,7 +77,7 @@ class SimpSolver : public Solver {
 
     // Memory managment:
     //
-    void garbageCollect() override;
+    void garbageCollect() final;
 
     // Mode of operation:
     //

--- a/Minisat/utils/Options.h
+++ b/Minisat/utils/Options.h
@@ -139,7 +139,7 @@ class DoubleOption : public Option
     operator      double&  (void)       { return value; }
     DoubleOption& operator=(double x)   { value = x; return *this; }
 
-    virtual bool parse(const char* str){
+    bool parse(const char* str) override{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -163,7 +163,7 @@ class DoubleOption : public Option
         return true;
     }
 
-    virtual void help (bool verbose = false){
+    void help (bool verbose = false) override{
         fprintf(stderr, "  -%-12s = %-8s %c%4.2g .. %4.2g%c (default: %g)\n", 
                 name, type_name, 
                 range.begin_inclusive ? '[' : '(', 
@@ -197,7 +197,7 @@ class IntOption : public Option
     operator   int32_t&  (void)       { return value; }
     IntOption& operator= (int32_t x)  { value = x; return *this; }
 
-    virtual bool parse(const char* str){
+    bool parse(const char* str) override{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -220,7 +220,7 @@ class IntOption : public Option
         return true;
     }
 
-    virtual void help (bool verbose = false){
+    void help (bool verbose = false) override{
         fprintf(stderr, "  -%-12s = %-8s [", name, type_name);
         if (range.begin == INT32_MIN)
             fprintf(stderr, "imin");
@@ -259,7 +259,7 @@ class Int64Option : public Option
     operator     int64_t&  (void)       { return value; }
     Int64Option& operator= (int64_t x)  { value = x; return *this; }
 
-    virtual bool parse(const char* str){
+    bool parse(const char* str) override{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -282,7 +282,7 @@ class Int64Option : public Option
         return true;
     }
 
-    virtual void help (bool verbose = false){
+    void help (bool verbose = false) override{
         fprintf(stderr, "  -%-12s = %-8s [", name, type_name);
         if (range.begin == INT64_MIN)
             fprintf(stderr, "imin");
@@ -319,7 +319,7 @@ class StringOption : public Option
     operator      const char*& (void)           { return value; }
     StringOption& operator=    (const char* x)  { value = x; return *this; }
 
-    virtual bool parse(const char* str){
+    bool parse(const char* str) override{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -329,7 +329,7 @@ class StringOption : public Option
         return true;
     }
 
-    virtual void help (bool verbose = false){
+    void help (bool verbose = false) override{
         fprintf(stderr, "  -%-10s = %8s\n", name, type_name);
         if (verbose){
             fprintf(stderr, "\n        %s\n", description);
@@ -355,7 +355,7 @@ class BoolOption : public Option
     operator    bool&    (void)       { return value; }
     BoolOption& operator=(bool b)     { value = b; return *this; }
 
-    virtual bool parse(const char* str){
+    bool parse(const char* str) override{
         const char* span = str; 
         
         if (match(span, "-")){
@@ -369,7 +369,7 @@ class BoolOption : public Option
         return false;
     }
 
-    virtual void help (bool verbose = false){
+    void help (bool verbose = false) override{
 
         fprintf(stderr, "  -%s, -no-%s", name, name);
 

--- a/Minisat/utils/Options.h
+++ b/Minisat/utils/Options.h
@@ -139,7 +139,7 @@ class DoubleOption : public Option
     operator      double&  (void)       { return value; }
     DoubleOption& operator=(double x)   { value = x; return *this; }
 
-    bool parse(const char* str) override{
+    bool parse(const char* str) final{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -163,7 +163,7 @@ class DoubleOption : public Option
         return true;
     }
 
-    void help (bool verbose = false) override{
+    void help (bool verbose = false) final{
         fprintf(stderr, "  -%-12s = %-8s %c%4.2g .. %4.2g%c (default: %g)\n", 
                 name, type_name, 
                 range.begin_inclusive ? '[' : '(', 
@@ -197,7 +197,7 @@ class IntOption : public Option
     operator   int32_t&  (void)       { return value; }
     IntOption& operator= (int32_t x)  { value = x; return *this; }
 
-    bool parse(const char* str) override{
+    bool parse(const char* str) final{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -220,7 +220,7 @@ class IntOption : public Option
         return true;
     }
 
-    void help (bool verbose = false) override{
+    void help (bool verbose = false) final{
         fprintf(stderr, "  -%-12s = %-8s [", name, type_name);
         if (range.begin == INT32_MIN)
             fprintf(stderr, "imin");
@@ -259,7 +259,7 @@ class Int64Option : public Option
     operator     int64_t&  (void)       { return value; }
     Int64Option& operator= (int64_t x)  { value = x; return *this; }
 
-    bool parse(const char* str) override{
+    bool parse(const char* str) final{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -282,7 +282,7 @@ class Int64Option : public Option
         return true;
     }
 
-    void help (bool verbose = false) override{
+    void help (bool verbose = false) final{
         fprintf(stderr, "  -%-12s = %-8s [", name, type_name);
         if (range.begin == INT64_MIN)
             fprintf(stderr, "imin");
@@ -319,7 +319,7 @@ class StringOption : public Option
     operator      const char*& (void)           { return value; }
     StringOption& operator=    (const char* x)  { value = x; return *this; }
 
-    bool parse(const char* str) override{
+    bool parse(const char* str) final{
         const char* span = str; 
 
         if (!match(span, "-") || !match(span, name) || !match(span, "="))
@@ -329,7 +329,7 @@ class StringOption : public Option
         return true;
     }
 
-    void help (bool verbose = false) override{
+    void help (bool verbose = false) final{
         fprintf(stderr, "  -%-10s = %8s\n", name, type_name);
         if (verbose){
             fprintf(stderr, "\n        %s\n", description);
@@ -355,7 +355,7 @@ class BoolOption : public Option
     operator    bool&    (void)       { return value; }
     BoolOption& operator=(bool b)     { value = b; return *this; }
 
-    bool parse(const char* str) override{
+    bool parse(const char* str) final{
         const char* span = str; 
         
         if (match(span, "-")){
@@ -369,7 +369,7 @@ class BoolOption : public Option
         return false;
     }
 
-    void help (bool verbose = false) override{
+    void help (bool verbose = false) final{
 
         fprintf(stderr, "  -%s, -no-%s", name, name);
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -308,8 +308,8 @@ public:
     ParseErrorException(vstring message,unsigned ln) : _message(message), _ln(ln) {}
     ParseErrorException(vstring message,Token& tok,unsigned ln);
     ParseErrorException(vstring message,int position,unsigned ln);
-    void cry(ostream&) const;
-    ~ParseErrorException() {}
+    void cry(ostream&) const override;
+    ~ParseErrorException() override {}
   protected:
     vstring _message;
     unsigned _ln;
@@ -853,13 +853,13 @@ public:
   struct FileSourceRecord : SourceRecord {
     const vstring fileName;
     const vstring nameInFile;
-    bool isFile(){ return true; } 
+    bool isFile() override{ return true; } 
     FileSourceRecord(vstring fN, vstring nF) : fileName(fN), nameInFile(nF) {}
   };
   struct InferenceSourceRecord : SourceRecord{
     const vstring name;
     Stack<vstring> premises; 
-    bool isFile(){ return false; } 
+    bool isFile() override{ return false; } 
     InferenceSourceRecord(vstring n) : name(n) {}
   };
   

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -301,15 +301,15 @@ public:
   /**
    * Implements lexer and parser exceptions.
    */
-  class ParseErrorException 
+  class ParseErrorException final
     : public ::Exception
   {
   public:
     ParseErrorException(vstring message,unsigned ln) : _message(message), _ln(ln) {}
     ParseErrorException(vstring message,Token& tok,unsigned ln);
     ParseErrorException(vstring message,int position,unsigned ln);
-    void cry(ostream&) const override;
-    ~ParseErrorException() override {}
+    void cry(ostream&) const final;
+    ~ParseErrorException() final {}
   protected:
     vstring _message;
     unsigned _ln;
@@ -853,13 +853,13 @@ public:
   struct FileSourceRecord : SourceRecord {
     const vstring fileName;
     const vstring nameInFile;
-    bool isFile() override{ return true; } 
+    bool isFile() final{ return true; } 
     FileSourceRecord(vstring fN, vstring nF) : fileName(fN), nameInFile(nF) {}
   };
   struct InferenceSourceRecord : SourceRecord{
     const vstring name;
     Stack<vstring> premises; 
-    bool isFile() override{ return false; } 
+    bool isFile() final{ return false; } 
     InferenceSourceRecord(vstring n) : name(n) {}
   };
   

--- a/SAT/BufferedSolver.hpp
+++ b/SAT/BufferedSolver.hpp
@@ -40,11 +40,11 @@ public:
 
   BufferedSolver(SATSolver* inner);
 
-  virtual SATClause* getRefutation() override { return _inner->getRefutation(); }
-  virtual SATClauseList* getRefutationPremiseList() override {
+  SATClause* getRefutation() override { return _inner->getRefutation(); }
+  SATClauseList* getRefutationPremiseList() override {
     return _inner->getRefutationPremiseList();
   }
-  virtual void randomizeForNextAssignment(unsigned maxVar) override {
+  void randomizeForNextAssignment(unsigned maxVar) override {
     _inner->randomizeForNextAssignment(maxVar);
 
     // This is not ideal, but we can't wait till solve, because
@@ -53,28 +53,28 @@ public:
     _lastStatus = _inner->solve();
   }
 
-  virtual void addClause(SATClause* cl) override;
-  virtual Status solve(unsigned conflictCountLimit) override;
-  virtual VarAssignment getAssignment(unsigned var) override;
+  void addClause(SATClause* cl) override;
+  Status solve(unsigned conflictCountLimit) override;
+  VarAssignment getAssignment(unsigned var) override;
 
-  virtual bool isZeroImplied(unsigned var) override {
+  bool isZeroImplied(unsigned var) override {
     CALL("BufferedSolver::isZeroImplied");
     ASS_G(var,0); ASS_LE(var,_varCnt);
     // alternatively, we could directly refer to _inner, it must handle variables up to _varCnt as well
     return (var > _varCntInnerOld) ? false : _inner->isZeroImplied(var);
   }
-  virtual void collectZeroImplied(SATLiteralStack& acc) override { _inner->collectZeroImplied(acc); }
-  virtual SATClause* getZeroImpliedCertificate(unsigned var) override { return _inner->getZeroImpliedCertificate(var); }
+  void collectZeroImplied(SATLiteralStack& acc) override { _inner->collectZeroImplied(acc); }
+  SATClause* getZeroImpliedCertificate(unsigned var) override { return _inner->getZeroImpliedCertificate(var); }
 
-  virtual void ensureVarCount(unsigned newVarCnt) override { _inner->ensureVarCount(newVarCnt); _varCnt=max(_varCnt,newVarCnt); }
-  virtual unsigned newVar() override { 
+  void ensureVarCount(unsigned newVarCnt) override { _inner->ensureVarCount(newVarCnt); _varCnt=max(_varCnt,newVarCnt); }
+  unsigned newVar() override { 
     CALL("BufferedSolver::newVar");
     
     ALWAYS(_inner->newVar() == ++_varCnt);
     return _varCnt;
   }
   
-  virtual void suggestPolarity(unsigned var,unsigned pol) override { _inner->suggestPolarity(var,pol); }
+  void suggestPolarity(unsigned var,unsigned pol) override { _inner->suggestPolarity(var,pol); }
 
 private:
 

--- a/SAT/BufferedSolver.hpp
+++ b/SAT/BufferedSolver.hpp
@@ -40,11 +40,11 @@ public:
 
   BufferedSolver(SATSolver* inner);
 
-  SATClause* getRefutation() override { return _inner->getRefutation(); }
-  SATClauseList* getRefutationPremiseList() override {
+  SATClause* getRefutation() final { return _inner->getRefutation(); }
+  SATClauseList* getRefutationPremiseList() final {
     return _inner->getRefutationPremiseList();
   }
-  void randomizeForNextAssignment(unsigned maxVar) override {
+  void randomizeForNextAssignment(unsigned maxVar) final {
     _inner->randomizeForNextAssignment(maxVar);
 
     // This is not ideal, but we can't wait till solve, because
@@ -53,28 +53,28 @@ public:
     _lastStatus = _inner->solve();
   }
 
-  void addClause(SATClause* cl) override;
-  Status solve(unsigned conflictCountLimit) override;
-  VarAssignment getAssignment(unsigned var) override;
+  void addClause(SATClause* cl) final;
+  Status solve(unsigned conflictCountLimit) final;
+  VarAssignment getAssignment(unsigned var) final;
 
-  bool isZeroImplied(unsigned var) override {
+  bool isZeroImplied(unsigned var) final {
     CALL("BufferedSolver::isZeroImplied");
     ASS_G(var,0); ASS_LE(var,_varCnt);
     // alternatively, we could directly refer to _inner, it must handle variables up to _varCnt as well
     return (var > _varCntInnerOld) ? false : _inner->isZeroImplied(var);
   }
-  void collectZeroImplied(SATLiteralStack& acc) override { _inner->collectZeroImplied(acc); }
-  SATClause* getZeroImpliedCertificate(unsigned var) override { return _inner->getZeroImpliedCertificate(var); }
+  void collectZeroImplied(SATLiteralStack& acc) final { _inner->collectZeroImplied(acc); }
+  SATClause* getZeroImpliedCertificate(unsigned var) final { return _inner->getZeroImpliedCertificate(var); }
 
-  void ensureVarCount(unsigned newVarCnt) override { _inner->ensureVarCount(newVarCnt); _varCnt=max(_varCnt,newVarCnt); }
-  unsigned newVar() override { 
+  void ensureVarCount(unsigned newVarCnt) final { _inner->ensureVarCount(newVarCnt); _varCnt=max(_varCnt,newVarCnt); }
+  unsigned newVar() final { 
     CALL("BufferedSolver::newVar");
     
     ALWAYS(_inner->newVar() == ++_varCnt);
     return _varCnt;
   }
   
-  void suggestPolarity(unsigned var,unsigned pol) override { _inner->suggestPolarity(var,pol); }
+  void suggestPolarity(unsigned var,unsigned pol) final { _inner->suggestPolarity(var,pol); }
 
 private:
 

--- a/SAT/FallbackSolverWrapper.hpp
+++ b/SAT/FallbackSolverWrapper.hpp
@@ -42,28 +42,28 @@ public:
 
   FallbackSolverWrapper(SATSolver* inner,SATSolver* fallback);
 
-  virtual SATClause* getRefutation() override { 
+  SATClause* getRefutation() override { 
     if(_usingFallback){
       return _fallback->getRefutation();
     }
     return _inner->getRefutation(); 
   }
-  virtual SATClauseList* getRefutationPremiseList() override {
+  SATClauseList* getRefutationPremiseList() override {
     if(_usingFallback){
       return _fallback->getRefutationPremiseList();
     }
     return _inner->getRefutationPremiseList();
   }
-  virtual void randomizeForNextAssignment(unsigned maxVar) override {
+  void randomizeForNextAssignment(unsigned maxVar) override {
     _fallback->randomizeForNextAssignment(maxVar);
     _inner->randomizeForNextAssignment(maxVar);
   }
 
-  virtual void addClause(SATClause* cl) override;
-  virtual Status solve(unsigned conflictCountLimit) override;
-  virtual VarAssignment getAssignment(unsigned var) override;
+  void addClause(SATClause* cl) override;
+  Status solve(unsigned conflictCountLimit) override;
+  VarAssignment getAssignment(unsigned var) override;
 
-  virtual bool isZeroImplied(unsigned var) override {
+  bool isZeroImplied(unsigned var) override {
     CALL("FallbackSolverWrapper::isZeroImplied");
     ASS_G(var,0); ASS_LE(var,_varCnt);
 
@@ -74,7 +74,7 @@ public:
     // alternatively, we could directly refer to _inner, it must handle variables up to _varCnt as well
     return  _inner->isZeroImplied(var);
   }
-  virtual void collectZeroImplied(SATLiteralStack& acc) override { 
+  void collectZeroImplied(SATLiteralStack& acc) override { 
     if(_usingFallback){
       _fallback->collectZeroImplied(acc);
       return;
@@ -82,21 +82,21 @@ public:
     _inner->collectZeroImplied(acc); 
   }
 
-  virtual SATClause* getZeroImpliedCertificate(unsigned var) override { 
+  SATClause* getZeroImpliedCertificate(unsigned var) override { 
     if(_usingFallback){
       return _fallback->getZeroImpliedCertificate(var);
     }
     return _inner->getZeroImpliedCertificate(var); 
   }
 
-  virtual void ensureVarCount(unsigned newVarCnt) override { 
+  void ensureVarCount(unsigned newVarCnt) override { 
     _inner->ensureVarCount(newVarCnt); 
     _fallback->ensureVarCount(newVarCnt); 
     _varCnt=max(_varCnt,newVarCnt); 
   }
 
 
-  virtual unsigned newVar() override { 
+  unsigned newVar() override { 
     CALL("FallbackSolverWrapper::newVar");
     
     ALWAYS(_inner->newVar() == ++_varCnt);
@@ -104,7 +104,7 @@ public:
     return _varCnt;
   }
   
-  virtual void suggestPolarity(unsigned var,unsigned pol) override { 
+  void suggestPolarity(unsigned var,unsigned pol) override { 
     _inner->suggestPolarity(var,pol); 
     _fallback->suggestPolarity(var,pol); 
   }

--- a/SAT/FallbackSolverWrapper.hpp
+++ b/SAT/FallbackSolverWrapper.hpp
@@ -42,28 +42,28 @@ public:
 
   FallbackSolverWrapper(SATSolver* inner,SATSolver* fallback);
 
-  SATClause* getRefutation() override { 
+  SATClause* getRefutation() final { 
     if(_usingFallback){
       return _fallback->getRefutation();
     }
     return _inner->getRefutation(); 
   }
-  SATClauseList* getRefutationPremiseList() override {
+  SATClauseList* getRefutationPremiseList() final {
     if(_usingFallback){
       return _fallback->getRefutationPremiseList();
     }
     return _inner->getRefutationPremiseList();
   }
-  void randomizeForNextAssignment(unsigned maxVar) override {
+  void randomizeForNextAssignment(unsigned maxVar) final {
     _fallback->randomizeForNextAssignment(maxVar);
     _inner->randomizeForNextAssignment(maxVar);
   }
 
-  void addClause(SATClause* cl) override;
-  Status solve(unsigned conflictCountLimit) override;
-  VarAssignment getAssignment(unsigned var) override;
+  void addClause(SATClause* cl) final;
+  Status solve(unsigned conflictCountLimit) final;
+  VarAssignment getAssignment(unsigned var) final;
 
-  bool isZeroImplied(unsigned var) override {
+  bool isZeroImplied(unsigned var) final {
     CALL("FallbackSolverWrapper::isZeroImplied");
     ASS_G(var,0); ASS_LE(var,_varCnt);
 
@@ -74,7 +74,7 @@ public:
     // alternatively, we could directly refer to _inner, it must handle variables up to _varCnt as well
     return  _inner->isZeroImplied(var);
   }
-  void collectZeroImplied(SATLiteralStack& acc) override { 
+  void collectZeroImplied(SATLiteralStack& acc) final { 
     if(_usingFallback){
       _fallback->collectZeroImplied(acc);
       return;
@@ -82,21 +82,21 @@ public:
     _inner->collectZeroImplied(acc); 
   }
 
-  SATClause* getZeroImpliedCertificate(unsigned var) override { 
+  SATClause* getZeroImpliedCertificate(unsigned var) final { 
     if(_usingFallback){
       return _fallback->getZeroImpliedCertificate(var);
     }
     return _inner->getZeroImpliedCertificate(var); 
   }
 
-  void ensureVarCount(unsigned newVarCnt) override { 
+  void ensureVarCount(unsigned newVarCnt) final { 
     _inner->ensureVarCount(newVarCnt); 
     _fallback->ensureVarCount(newVarCnt); 
     _varCnt=max(_varCnt,newVarCnt); 
   }
 
 
-  unsigned newVar() override { 
+  unsigned newVar() final { 
     CALL("FallbackSolverWrapper::newVar");
     
     ALWAYS(_inner->newVar() == ++_varCnt);
@@ -104,7 +104,7 @@ public:
     return _varCnt;
   }
   
-  void suggestPolarity(unsigned var,unsigned pol) override { 
+  void suggestPolarity(unsigned var,unsigned pol) final { 
     _inner->suggestPolarity(var,pol); 
     _fallback->suggestPolarity(var,pol); 
   }

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -41,26 +41,26 @@ public:
 
   MinimizingSolver(SATSolver* inner);
 
-  virtual SATClause* getRefutation() override { return _inner->getRefutation(); }
-  virtual SATClauseList* getRefutationPremiseList() override {
+  SATClause* getRefutation() override { return _inner->getRefutation(); }
+  SATClauseList* getRefutationPremiseList() override {
     return _inner->getRefutationPremiseList();
   }
-  virtual void randomizeForNextAssignment(unsigned maxVar) override {
+  void randomizeForNextAssignment(unsigned maxVar) override {
     _inner->randomizeForNextAssignment(maxVar); _assignmentValid = false;
   }
 
-  virtual void addClause(SATClause* cl) override;
-  virtual void addClauseIgnoredInPartialModel(SATClause* cl) override;
-  virtual Status solve(unsigned conflictCountLimit) override;
+  void addClause(SATClause* cl) override;
+  void addClauseIgnoredInPartialModel(SATClause* cl) override;
+  Status solve(unsigned conflictCountLimit) override;
   
-  virtual VarAssignment getAssignment(unsigned var) override;
-  virtual bool isZeroImplied(unsigned var) override;
-  virtual void collectZeroImplied(SATLiteralStack& acc) override { _inner->collectZeroImplied(acc); }
-  virtual SATClause* getZeroImpliedCertificate(unsigned var) override { return _inner->getZeroImpliedCertificate(var); }
+  VarAssignment getAssignment(unsigned var) override;
+  bool isZeroImplied(unsigned var) override;
+  void collectZeroImplied(SATLiteralStack& acc) override { _inner->collectZeroImplied(acc); }
+  SATClause* getZeroImpliedCertificate(unsigned var) override { return _inner->getZeroImpliedCertificate(var); }
 
-  virtual void ensureVarCount(unsigned newVarCnt) override;
+  void ensureVarCount(unsigned newVarCnt) override;
 
-  virtual unsigned newVar() override {
+  unsigned newVar() override {
     CALL("MinimizingSolver::newVar");
     DEBUG_CODE(unsigned oldVC = _varCnt);
     ensureVarCount(_varCnt+1);
@@ -68,7 +68,7 @@ public:
     return _varCnt;
   }
 
-  virtual void suggestPolarity(unsigned var, unsigned pol) override { _inner->suggestPolarity(var,pol); }
+  void suggestPolarity(unsigned var, unsigned pol) override { _inner->suggestPolarity(var,pol); }
 
 private:
   bool admitsDontcare(unsigned var) { 

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -41,26 +41,26 @@ public:
 
   MinimizingSolver(SATSolver* inner);
 
-  SATClause* getRefutation() override { return _inner->getRefutation(); }
-  SATClauseList* getRefutationPremiseList() override {
+  SATClause* getRefutation() final { return _inner->getRefutation(); }
+  SATClauseList* getRefutationPremiseList() final {
     return _inner->getRefutationPremiseList();
   }
-  void randomizeForNextAssignment(unsigned maxVar) override {
+  void randomizeForNextAssignment(unsigned maxVar) final {
     _inner->randomizeForNextAssignment(maxVar); _assignmentValid = false;
   }
 
-  void addClause(SATClause* cl) override;
-  void addClauseIgnoredInPartialModel(SATClause* cl) override;
-  Status solve(unsigned conflictCountLimit) override;
+  void addClause(SATClause* cl) final;
+  void addClauseIgnoredInPartialModel(SATClause* cl) final;
+  Status solve(unsigned conflictCountLimit) final;
   
-  VarAssignment getAssignment(unsigned var) override;
-  bool isZeroImplied(unsigned var) override;
-  void collectZeroImplied(SATLiteralStack& acc) override { _inner->collectZeroImplied(acc); }
-  SATClause* getZeroImpliedCertificate(unsigned var) override { return _inner->getZeroImpliedCertificate(var); }
+  VarAssignment getAssignment(unsigned var) final;
+  bool isZeroImplied(unsigned var) final;
+  void collectZeroImplied(SATLiteralStack& acc) final { _inner->collectZeroImplied(acc); }
+  SATClause* getZeroImpliedCertificate(unsigned var) final { return _inner->getZeroImpliedCertificate(var); }
 
-  void ensureVarCount(unsigned newVarCnt) override;
+  void ensureVarCount(unsigned newVarCnt) final;
 
-  unsigned newVar() override {
+  unsigned newVar() final {
     CALL("MinimizingSolver::newVar");
     DEBUG_CODE(unsigned oldVC = _varCnt);
     ensureVarCount(_varCnt+1);
@@ -68,7 +68,7 @@ public:
     return _varCnt;
   }
 
-  void suggestPolarity(unsigned var, unsigned pol) override { _inner->suggestPolarity(var,pol); }
+  void suggestPolarity(unsigned var, unsigned pol) final { _inner->suggestPolarity(var,pol); }
 
 private:
   bool admitsDontcare(unsigned var) { 

--- a/SAT/MinisatInterfacing.hpp
+++ b/SAT/MinisatInterfacing.hpp
@@ -35,30 +35,30 @@ public:
    *
    * A requirement is that in a clause, each variable occurs at most once.
    */
-  void addClause(SATClause* cl) override;
+  void addClause(SATClause* cl) final;
   
   /**
    * Opportunity to perform in-processing of the clause database.
    *
    * (Minisat deletes unconditionally satisfied clauses.)
    */
-  void simplify() override {
+  void simplify() final {
     CALL("MinisatInterfacing::simplify");
     _solver.simplify();
   }
 
-  Status solve(unsigned conflictCountLimit) override;
+  Status solve(unsigned conflictCountLimit) final;
   
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
-  VarAssignment getAssignment(unsigned var) override;
+  VarAssignment getAssignment(unsigned var) final;
 
   /**
    * If status is @c SATISFIABLE, return 0 if the assignment of @c var is
    * implied only by unit propagation (i.e. does not depend on any decisions)
    */
-  bool isZeroImplied(unsigned var) override;
+  bool isZeroImplied(unsigned var) final;
   /**
    * Collect zero-implied literals.
    *
@@ -66,7 +66,7 @@ public:
    *
    * @see isZeroImplied()
    */
-  void collectZeroImplied(SATLiteralStack& acc) override;
+  void collectZeroImplied(SATLiteralStack& acc) final;
   /**
    * Return a valid clause that contains the zero-implied literal
    * and possibly the assumptions that implied it. Return 0 if @c var
@@ -74,13 +74,13 @@ public:
    * If called on a proof producing solver, the clause will have
    * a proper proof history.
    */
-  SATClause* getZeroImpliedCertificate(unsigned var) override;
+  SATClause* getZeroImpliedCertificate(unsigned var) final;
 
-  void ensureVarCount(unsigned newVarCnt) override;
+  void ensureVarCount(unsigned newVarCnt) final;
   
-  unsigned newVar() override;
+  unsigned newVar() final;
   
-  void suggestPolarity(unsigned var, unsigned pol) override {
+  void suggestPolarity(unsigned var, unsigned pol) final {
     // 0 -> true which means negated, e.g. false in the model
     bool mpol = pol ? false : true; 
     _solver.suggestPolarity(vampireVar2Minisat(var),mpol);
@@ -89,18 +89,18 @@ public:
   /**
    * Add an assumption into the solver.
    */
-  void addAssumption(SATLiteral lit) override;
+  void addAssumption(SATLiteral lit) final;
   
-  void retractAllAssumptions() override {
+  void retractAllAssumptions() final {
     _assumptions.clear();
     _status = UNKNOWN;
   };
   
-  bool hasAssumptions() const override {
+  bool hasAssumptions() const final {
     return (_assumptions.size() > 0);
   };
 
-  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool) override;
+  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool) final;
 
   /**
    * Use minisat and solving under assumptions to minimize the given set of premises (= unsat core extraction).

--- a/SAT/MinisatInterfacing.hpp
+++ b/SAT/MinisatInterfacing.hpp
@@ -35,30 +35,30 @@ public:
    *
    * A requirement is that in a clause, each variable occurs at most once.
    */
-  virtual void addClause(SATClause* cl) override;
+  void addClause(SATClause* cl) override;
   
   /**
    * Opportunity to perform in-processing of the clause database.
    *
    * (Minisat deletes unconditionally satisfied clauses.)
    */
-  virtual void simplify() override {
+  void simplify() override {
     CALL("MinisatInterfacing::simplify");
     _solver.simplify();
   }
 
-  virtual Status solve(unsigned conflictCountLimit) override;
+  Status solve(unsigned conflictCountLimit) override;
   
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
-  virtual VarAssignment getAssignment(unsigned var) override;
+  VarAssignment getAssignment(unsigned var) override;
 
   /**
    * If status is @c SATISFIABLE, return 0 if the assignment of @c var is
    * implied only by unit propagation (i.e. does not depend on any decisions)
    */
-  virtual bool isZeroImplied(unsigned var) override;
+  bool isZeroImplied(unsigned var) override;
   /**
    * Collect zero-implied literals.
    *
@@ -66,7 +66,7 @@ public:
    *
    * @see isZeroImplied()
    */
-  virtual void collectZeroImplied(SATLiteralStack& acc) override;
+  void collectZeroImplied(SATLiteralStack& acc) override;
   /**
    * Return a valid clause that contains the zero-implied literal
    * and possibly the assumptions that implied it. Return 0 if @c var
@@ -74,13 +74,13 @@ public:
    * If called on a proof producing solver, the clause will have
    * a proper proof history.
    */
-  virtual SATClause* getZeroImpliedCertificate(unsigned var) override;
+  SATClause* getZeroImpliedCertificate(unsigned var) override;
 
-  virtual void ensureVarCount(unsigned newVarCnt) override;
+  void ensureVarCount(unsigned newVarCnt) override;
   
-  virtual unsigned newVar() override;
+  unsigned newVar() override;
   
-  virtual void suggestPolarity(unsigned var, unsigned pol) override {
+  void suggestPolarity(unsigned var, unsigned pol) override {
     // 0 -> true which means negated, e.g. false in the model
     bool mpol = pol ? false : true; 
     _solver.suggestPolarity(vampireVar2Minisat(var),mpol);
@@ -89,14 +89,14 @@ public:
   /**
    * Add an assumption into the solver.
    */
-  virtual void addAssumption(SATLiteral lit) override;
+  void addAssumption(SATLiteral lit) override;
   
-  virtual void retractAllAssumptions() override {
+  void retractAllAssumptions() override {
     _assumptions.clear();
     _status = UNKNOWN;
   };
   
-  virtual bool hasAssumptions() const override {
+  bool hasAssumptions() const override {
     return (_assumptions.size() > 0);
   };
 

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -42,30 +42,30 @@ public:
    *
    * A requirement is that in a clause, each variable occurs at most once.
    */
-  void addClause(SATClause* cl) override;
+  void addClause(SATClause* cl) final;
   
   /**
    * Opportunity to perform in-processing of the clause database.
    *
    * (Minisat deletes unconditionally satisfied clauses.)
    */
-  void simplify() override {
+  void simplify() final {
     CALL("MinisatInterfacingNewSimp::simplify");
     _solver.simplify();
   }
 
-  Status solve(unsigned conflictCountLimit) override;
+  Status solve(unsigned conflictCountLimit) final;
   
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
-  VarAssignment getAssignment(unsigned var) override;
+  VarAssignment getAssignment(unsigned var) final;
 
   /**
    * If status is @c SATISFIABLE, return 0 if the assignment of @c var is
    * implied only by unit propagation (i.e. does not depend on any decisions)
    */
-  bool isZeroImplied(unsigned var) override;
+  bool isZeroImplied(unsigned var) final;
   /**
    * Collect zero-implied literals.
    *
@@ -73,7 +73,7 @@ public:
    *
    * @see isZeroImplied()
    */
-  void collectZeroImplied(SATLiteralStack& acc) override;
+  void collectZeroImplied(SATLiteralStack& acc) final;
   /**
    * Return a valid clause that contains the zero-implied literal
    * and possibly the assumptions that implied it. Return 0 if @c var
@@ -81,13 +81,13 @@ public:
    * If called on a proof producing solver, the clause will have
    * a proper proof history.
    */
-  SATClause* getZeroImpliedCertificate(unsigned var) override;
+  SATClause* getZeroImpliedCertificate(unsigned var) final;
 
-  void ensureVarCount(unsigned newVarCnt) override;
+  void ensureVarCount(unsigned newVarCnt) final;
   
-  unsigned newVar() override;
+  unsigned newVar() final;
   
-  void suggestPolarity(unsigned var, unsigned pol) override {
+  void suggestPolarity(unsigned var, unsigned pol) final {
     // 0 -> true which means negated, e.g. false in the model
     bool mpol = pol ? false : true; 
     _solver.suggestPolarity(vampireVar2Minisat(var),mpol);
@@ -96,20 +96,20 @@ public:
   /**
    * Add an assumption into the solver.
    */
-  void addAssumption(SATLiteral lit) override;
+  void addAssumption(SATLiteral lit) final;
   
-  void retractAllAssumptions() override {
+  void retractAllAssumptions() final {
     _assumptions.clear();
     _status = UNKNOWN;
   };
   
-  bool hasAssumptions() const override {
+  bool hasAssumptions() const final {
     return (_assumptions.size() > 0);
   };
 
-  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool) override;
+  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool) final;
 
-  SATClause* getRefutation() override { ASSERTION_VIOLATION; }
+  SATClause* getRefutation() final { ASSERTION_VIOLATION; }
 
   static void reportMinisatOutOfMemory();
 

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -42,30 +42,30 @@ public:
    *
    * A requirement is that in a clause, each variable occurs at most once.
    */
-  virtual void addClause(SATClause* cl) override;
+  void addClause(SATClause* cl) override;
   
   /**
    * Opportunity to perform in-processing of the clause database.
    *
    * (Minisat deletes unconditionally satisfied clauses.)
    */
-  virtual void simplify() override {
+  void simplify() override {
     CALL("MinisatInterfacingNewSimp::simplify");
     _solver.simplify();
   }
 
-  virtual Status solve(unsigned conflictCountLimit) override;
+  Status solve(unsigned conflictCountLimit) override;
   
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
-  virtual VarAssignment getAssignment(unsigned var) override;
+  VarAssignment getAssignment(unsigned var) override;
 
   /**
    * If status is @c SATISFIABLE, return 0 if the assignment of @c var is
    * implied only by unit propagation (i.e. does not depend on any decisions)
    */
-  virtual bool isZeroImplied(unsigned var) override;
+  bool isZeroImplied(unsigned var) override;
   /**
    * Collect zero-implied literals.
    *
@@ -73,7 +73,7 @@ public:
    *
    * @see isZeroImplied()
    */
-  virtual void collectZeroImplied(SATLiteralStack& acc) override;
+  void collectZeroImplied(SATLiteralStack& acc) override;
   /**
    * Return a valid clause that contains the zero-implied literal
    * and possibly the assumptions that implied it. Return 0 if @c var
@@ -81,13 +81,13 @@ public:
    * If called on a proof producing solver, the clause will have
    * a proper proof history.
    */
-  virtual SATClause* getZeroImpliedCertificate(unsigned var) override;
+  SATClause* getZeroImpliedCertificate(unsigned var) override;
 
-  virtual void ensureVarCount(unsigned newVarCnt) override;
+  void ensureVarCount(unsigned newVarCnt) override;
   
-  virtual unsigned newVar() override;
+  unsigned newVar() override;
   
-  virtual void suggestPolarity(unsigned var, unsigned pol) override {
+  void suggestPolarity(unsigned var, unsigned pol) override {
     // 0 -> true which means negated, e.g. false in the model
     bool mpol = pol ? false : true; 
     _solver.suggestPolarity(vampireVar2Minisat(var),mpol);
@@ -96,20 +96,20 @@ public:
   /**
    * Add an assumption into the solver.
    */
-  virtual void addAssumption(SATLiteral lit) override;
+  void addAssumption(SATLiteral lit) override;
   
-  virtual void retractAllAssumptions() override {
+  void retractAllAssumptions() override {
     _assumptions.clear();
     _status = UNKNOWN;
   };
   
-  virtual bool hasAssumptions() const override {
+  bool hasAssumptions() const override {
     return (_assumptions.size() > 0);
   };
 
   Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool) override;
 
-  virtual SATClause* getRefutation() override { ASSERTION_VIOLATION; }
+  SATClause* getRefutation() override { ASSERTION_VIOLATION; }
 
   static void reportMinisatOutOfMemory();
 

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -80,7 +80,7 @@ public:
   static SATInference* copy(const SATInference* inf);
 };
 
-class PropInference : public SATInference
+class PropInference final : public SATInference
 {
 public:
   CLASS_NAME(PropInference);
@@ -97,19 +97,19 @@ public:
     SATClauseList::push(prem2, _premises);
   }
 
-  ~PropInference() override
+  ~PropInference() final
   {
     SATClauseList::destroy(_premises);
   }
 
-  InfType getType() const override { return PROP_INF; }
+  InfType getType() const final { return PROP_INF; }
   SATClauseList* getPremises() const { return const_cast<SATClauseList*>(_premises); }
   void setPremises(SATClauseList* prems) { _premises = prems; }
 private:
   SATClauseList* _premises;
 };
 
-class FOConversionInference : public SATInference
+class FOConversionInference final : public SATInference
 {
 public:
   CLASS_NAME(FOConversionInference);
@@ -117,9 +117,9 @@ public:
 
   FOConversionInference(Unit* origin);
   FOConversionInference(Clause* cl);
-  ~FOConversionInference() override;
+  ~FOConversionInference() final;
 
-  InfType getType() const override { return FO_CONVERSION; }
+  InfType getType() const final { return FO_CONVERSION; }
   Unit* getOrigin() const { return _origin; }
 private:
   Unit* _origin;
@@ -131,7 +131,7 @@ public:
   CLASS_NAME(AssumptionInference);
   USE_ALLOCATOR(AssumptionInference);
 
-  InfType getType() const override { return ASSUMPTION; }
+  InfType getType() const final { return ASSUMPTION; }
 };
 
 /**

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -97,12 +97,12 @@ public:
     SATClauseList::push(prem2, _premises);
   }
 
-  ~PropInference()
+  ~PropInference() override
   {
     SATClauseList::destroy(_premises);
   }
 
-  virtual InfType getType() const { return PROP_INF; }
+  InfType getType() const override { return PROP_INF; }
   SATClauseList* getPremises() const { return const_cast<SATClauseList*>(_premises); }
   void setPremises(SATClauseList* prems) { _premises = prems; }
 private:
@@ -117,9 +117,9 @@ public:
 
   FOConversionInference(Unit* origin);
   FOConversionInference(Clause* cl);
-  ~FOConversionInference();
+  ~FOConversionInference() override;
 
-  virtual InfType getType() const { return FO_CONVERSION; }
+  InfType getType() const override { return FO_CONVERSION; }
   Unit* getOrigin() const { return _origin; }
 private:
   Unit* _origin;
@@ -131,7 +131,7 @@ public:
   CLASS_NAME(AssumptionInference);
   USE_ALLOCATOR(AssumptionInference);
 
-  virtual InfType getType() const { return ASSUMPTION; }
+  InfType getType() const override { return ASSUMPTION; }
 };
 
 /**

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -367,21 +367,21 @@ public:
       _refutation->setInference(_refutationInference);    
     }
   
-  virtual ~PrimitiveProofRecordingSATSolver() {
+  ~PrimitiveProofRecordingSATSolver() override {
     CALL("PrimitiveProofRecordingSATSolver::~PrimitiveProofRecordingSATSolver");
 
     // cannot clear the list - some inferences may be keeping its suffices till proof printing phase ...
     // _addedClauses->destroy(); // we clear the list but not its content
   }
 
-  virtual void addClause(SATClause* cl) override 
+  void addClause(SATClause* cl) override 
   {
     CALL("PrimitiveProofRecordingSATSolver::addClause");
     
     SATClauseList::push(cl,_addedClauses);
   }
   
-  virtual SATClause* getRefutation() override
+  SATClause* getRefutation() override
   {
     CALL("PrimitiveProofRecordingSATSolver::getRefutation");
 
@@ -410,7 +410,7 @@ public:
     return _refutation; 
   }
   
-  virtual SATClauseList* getRefutationPremiseList() override {
+  SATClauseList* getRefutationPremiseList() override {
     return _addedClauses;
   }
 

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -374,7 +374,7 @@ public:
     // _addedClauses->destroy(); // we clear the list but not its content
   }
 
-  void addClause(SATClause* cl) override 
+  void addClause(SATClause* cl) override
   {
     CALL("PrimitiveProofRecordingSATSolver::addClause");
     

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -64,20 +64,20 @@ public:
 
   static char const* z3_full_version();
 
-  void addClause(SATClause* cl) override;
+  void addClause(SATClause* cl) final;
 
   Status solve();
-  Status solve(unsigned conflictCountLimit) override { return solve(); };
+  Status solve(unsigned conflictCountLimit) final { return solve(); };
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
-  VarAssignment getAssignment(unsigned var) override;
+  VarAssignment getAssignment(unsigned var) final;
 
   /**
    * If status is @c SATISFIABLE, return 0 if the assignment of @c var is
    * implied only by unit propagation (i.e. does not depend on any decisions)
    */
-  bool isZeroImplied(unsigned var) override;
+  bool isZeroImplied(unsigned var) final;
   /**
    * Collect zero-implied literals.
    *
@@ -85,7 +85,7 @@ public:
    *
    * @see isZeroImplied()
    */
-  void collectZeroImplied(SATLiteralStack& acc) override;
+  void collectZeroImplied(SATLiteralStack& acc) final;
   /**
    * Return a valid clause that contains the zero-implied literal
    * and possibly the assumptions that implied it. Return 0 if @c var
@@ -93,9 +93,9 @@ public:
    * If called on a proof producing solver, the clause will have
    * a proper proof history.
    */
-  SATClause* getZeroImpliedCertificate(unsigned var) override;
+  SATClause* getZeroImpliedCertificate(unsigned var) final;
 
-  void ensureVarCount(unsigned newVarCnt) override {
+  void ensureVarCount(unsigned newVarCnt) final {
     CALL("Z3Interfacing::ensureVarCnt");
 
     while (_varCnt < newVarCnt) {
@@ -104,18 +104,18 @@ public:
   }
 
 
-  unsigned newVar() override;
+  unsigned newVar() final;
 
   // Currently not implemented for Z3
-  virtual void suggestPolarity(unsigned var, unsigned pol) override {}
+  virtual void suggestPolarity(unsigned var, unsigned pol) final {}
 
-  virtual void addAssumption(SATLiteral lit) override;
-  virtual void retractAllAssumptions() override;
-  virtual bool hasAssumptions() const override { return !_assumptions.isEmpty(); }
+  virtual void addAssumption(SATLiteral lit) final;
+  virtual void retractAllAssumptions() final;
+  virtual bool hasAssumptions() const final { return !_assumptions.isEmpty(); }
 
-  virtual Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool onlyProperSubusets) override;
+  virtual Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit, bool onlyProperSubusets) final;
 
-  SATClause* getRefutation() override;
+  SATClause* getRefutation() final;
 
   template<class F>
   auto scoped(F f)  -> decltype(f())

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -67,17 +67,17 @@ public:
   void addClause(SATClause* cl) override;
 
   Status solve();
-  virtual Status solve(unsigned conflictCountLimit) override { return solve(); };
+  Status solve(unsigned conflictCountLimit) override { return solve(); };
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
-  virtual VarAssignment getAssignment(unsigned var) override;
+  VarAssignment getAssignment(unsigned var) override;
 
   /**
    * If status is @c SATISFIABLE, return 0 if the assignment of @c var is
    * implied only by unit propagation (i.e. does not depend on any decisions)
    */
-  virtual bool isZeroImplied(unsigned var) override;
+  bool isZeroImplied(unsigned var) override;
   /**
    * Collect zero-implied literals.
    *
@@ -85,7 +85,7 @@ public:
    *
    * @see isZeroImplied()
    */
-  virtual void collectZeroImplied(SATLiteralStack& acc) override;
+  void collectZeroImplied(SATLiteralStack& acc) override;
   /**
    * Return a valid clause that contains the zero-implied literal
    * and possibly the assumptions that implied it. Return 0 if @c var
@@ -93,7 +93,7 @@ public:
    * If called on a proof producing solver, the clause will have
    * a proper proof history.
    */
-  virtual SATClause* getZeroImpliedCertificate(unsigned var) override;
+  SATClause* getZeroImpliedCertificate(unsigned var) override;
 
   void ensureVarCount(unsigned newVarCnt) override {
     CALL("Z3Interfacing::ensureVarCnt");

--- a/SAT/Z3MainLoop.hpp
+++ b/SAT/Z3MainLoop.hpp
@@ -35,18 +35,18 @@ using namespace Kernel;
 using namespace Shell;
 using namespace Lib;
 
-class Z3MainLoop : public MainLoop 
+class Z3MainLoop final : public MainLoop 
 {
 public:
   CLASS_NAME(Z3MainLoop);
   USE_ALLOCATOR(Z3MainLoop);  
   
   Z3MainLoop(Problem& prb, const Options& opt);
-  ~Z3MainLoop() override{};
+  ~Z3MainLoop() final{};
 
 protected:
-  void init() override;
-  MainLoopResult runImpl() override;
+  void init() final;
+  MainLoopResult runImpl() final;
 //private:
 
 };

--- a/SAT/Z3MainLoop.hpp
+++ b/SAT/Z3MainLoop.hpp
@@ -42,11 +42,11 @@ public:
   USE_ALLOCATOR(Z3MainLoop);  
   
   Z3MainLoop(Problem& prb, const Options& opt);
-  ~Z3MainLoop(){};
+  ~Z3MainLoop() override{};
 
 protected:
-  virtual void init();
-  virtual MainLoopResult runImpl();
+  void init() override;
+  MainLoopResult runImpl() override;
 //private:
 
 };

--- a/Saturation/AWPassiveClauseContainer.hpp
+++ b/Saturation/AWPassiveClauseContainer.hpp
@@ -36,7 +36,7 @@ public:
   AgeQueue(const Options& opt) : _opt(opt) {}
 protected:
 
-  virtual bool lessThan(Clause*,Clause*);
+  bool lessThan(Clause*,Clause*) override;
 
   friend class AWPassiveClauseContainer;
 
@@ -50,7 +50,7 @@ class WeightQueue
 public:
   WeightQueue(const Options& opt) : _opt(opt) {}
 protected:
-  virtual bool lessThan(Clause*,Clause*);
+  bool lessThan(Clause*,Clause*) override;
 
   friend class AWPassiveClauseContainer;
 private:
@@ -69,7 +69,7 @@ public:
   USE_ALLOCATOR(AWPassiveClauseContainer);
 
   AWPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name);
-  ~AWPassiveClauseContainer();
+  ~AWPassiveClauseContainer() override;
   void add(Clause* cl) override;
 
   void remove(Clause* cl) override;
@@ -159,7 +159,7 @@ class AWClauseContainer: public ClauseContainer
 public:
   AWClauseContainer(const Shell::Options& opt);
 
-  void add(Clause* cl);
+  void add(Clause* cl) override;
   bool remove(Clause* cl);
 
   /**

--- a/Saturation/AWPassiveClauseContainer.hpp
+++ b/Saturation/AWPassiveClauseContainer.hpp
@@ -36,7 +36,7 @@ public:
   AgeQueue(const Options& opt) : _opt(opt) {}
 protected:
 
-  bool lessThan(Clause*,Clause*) override;
+  bool lessThan(Clause*,Clause*) final;
 
   friend class AWPassiveClauseContainer;
 
@@ -50,7 +50,7 @@ class WeightQueue
 public:
   WeightQueue(const Options& opt) : _opt(opt) {}
 protected:
-  bool lessThan(Clause*,Clause*) override;
+  bool lessThan(Clause*,Clause*) final;
 
   friend class AWPassiveClauseContainer;
 private:
@@ -61,7 +61,7 @@ private:
  * Defines the class Passive of passive clauses
  * @since 31/12/2007 Manchester
  */
-class AWPassiveClauseContainer
+class AWPassiveClauseContainer final
 : public PassiveClauseContainer
 {
 public:
@@ -69,19 +69,19 @@ public:
   USE_ALLOCATOR(AWPassiveClauseContainer);
 
   AWPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name);
-  ~AWPassiveClauseContainer() override;
-  void add(Clause* cl) override;
+  ~AWPassiveClauseContainer() final;
+  void add(Clause* cl) final;
 
-  void remove(Clause* cl) override;
+  void remove(Clause* cl) final;
 
   bool byWeight(int balance);
 
-  Clause* popSelected() override;
+  Clause* popSelected() final;
   /** True if there are no passive clauses */
-  bool isEmpty() const override
+  bool isEmpty() const final
   { return _ageQueue.isEmpty() && _weightQueue.isEmpty(); }
 
-  unsigned sizeEstimate() const override { return _size; }
+  unsigned sizeEstimate() const final { return _size; }
 
   static Comparison compareWeight(Clause* cl1, Clause* cl2, const Shell::Options& opt);
 
@@ -104,16 +104,16 @@ private:
    * LRS specific methods and fields for computation of Limits
    */
 public:
-  void simulationInit() override;
-  bool simulationHasNext() override;
-  void simulationPopSelected() override;
+  void simulationInit() final;
+  bool simulationHasNext() final;
+  void simulationPopSelected() final;
 
   // returns whether at least one of the limits was tightened
-  bool setLimitsToMax() override;
+  bool setLimitsToMax() final;
   // returns whether at least one of the limits was tightened
-  bool setLimitsFromSimulation() override;
+  bool setLimitsFromSimulation() final;
 
-  void onLimitsUpdated() override;
+  void onLimitsUpdated() final;
 private:
   bool setLimits(unsigned newAgeSelectionMaxAge, unsigned newAgeSelectionMaxWeight, unsigned newWeightSelectionMaxWeight, unsigned newWeightSelectionMaxAge);
 
@@ -132,21 +132,21 @@ private:
    * LRS specific methods and fields for usage of limits
    */
 public:
-  bool ageLimited() const override;
-  bool weightLimited() const override;
+  bool ageLimited() const final;
+  bool weightLimited() const final;
 
-  bool fulfilsAgeLimit(Clause* c) const override;
+  bool fulfilsAgeLimit(Clause* c) const final;
   // note: w here denotes the weight as returned by weight().
   // age is to be recovered from inference
   // this method internally takes care of computing the corresponding weightForClauseSelection.
-  bool fulfilsAgeLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const override;
-  bool fulfilsWeightLimit(Clause* cl) const override;
+  bool fulfilsAgeLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const final;
+  bool fulfilsWeightLimit(Clause* cl) const final;
   // note: w here denotes the weight as returned by weight().
   // age is to be recovered from inference
   // this method internally takes care of computing the corresponding weightForClauseSelection.
-  bool fulfilsWeightLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const override;
+  bool fulfilsWeightLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const final;
 
-  bool childrenPotentiallyFulfilLimits(Clause* cl, unsigned upperBoundNumSelLits) const override;
+  bool childrenPotentiallyFulfilLimits(Clause* cl, unsigned upperBoundNumSelLits) const final;
   
 }; // class AWPassiveClauseContainer
 
@@ -159,7 +159,7 @@ class AWClauseContainer: public ClauseContainer
 public:
   AWClauseContainer(const Shell::Options& opt);
 
-  void add(Clause* cl) override;
+  void add(Clause* cl) final;
   bool remove(Clause* cl);
 
   /**

--- a/Saturation/ClauseContainer.hpp
+++ b/Saturation/ClauseContainer.hpp
@@ -104,7 +104,7 @@ public:
   CLASS_NAME(UnprocessedClauseContainer);
   USE_ALLOCATOR(UnprocessedClauseContainer);
 
-  virtual ~UnprocessedClauseContainer();
+  ~UnprocessedClauseContainer() override;
   UnprocessedClauseContainer() : _data(64) {}
   void add(Clause* c) override;
   Clause* pop();
@@ -124,14 +124,14 @@ public:
   USE_ALLOCATOR(PassiveClauseContainer);
 
   PassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name = "") : _isOutermost(isOutermost), _opt(opt), _name(name) {}
-  virtual ~PassiveClauseContainer(){};
+  ~PassiveClauseContainer() override{};
 
   LimitsChangeEvent changedEvent;
 
   virtual bool isEmpty() const = 0;
   virtual Clause* popSelected() = 0;
 
-  virtual unsigned sizeEstimate() const = 0;
+  unsigned sizeEstimate() const override = 0;
 
   /*
    * LRS specific methods for computation of Limits
@@ -147,7 +147,7 @@ public:
   // returns whether at least one of the limits was tightened
   virtual bool setLimitsFromSimulation() = 0;
 
-  virtual void onLimitsUpdated() = 0;
+  void onLimitsUpdated() override = 0;
 
   /*
    * LRS specific methods and fields for usage of limits

--- a/Saturation/ClauseContainer.hpp
+++ b/Saturation/ClauseContainer.hpp
@@ -90,23 +90,23 @@ public:
   CLASS_NAME(PlainClauseContainer);
   USE_ALLOCATOR(PlainClauseContainer);
 
-  void add(Clause* c) override
+  void add(Clause* c) final
   {
     addedEvent.fire(c);
   }
 };
 
 
-class UnprocessedClauseContainer
+class UnprocessedClauseContainer final
 : public ClauseContainer
 {
 public:
   CLASS_NAME(UnprocessedClauseContainer);
   USE_ALLOCATOR(UnprocessedClauseContainer);
 
-  ~UnprocessedClauseContainer() override;
+  ~UnprocessedClauseContainer() final;
   UnprocessedClauseContainer() : _data(64) {}
-  void add(Clause* c) override;
+  void add(Clause* c) final;
   Clause* pop();
   bool isEmpty() const
   { return _data.isEmpty(); }
@@ -124,7 +124,7 @@ public:
   USE_ALLOCATOR(PassiveClauseContainer);
 
   PassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name = "") : _isOutermost(isOutermost), _opt(opt), _name(name) {}
-  ~PassiveClauseContainer() override{};
+  ~PassiveClauseContainer() override {};
 
   LimitsChangeEvent changedEvent;
 
@@ -186,13 +186,13 @@ public:
 
   ActiveClauseContainer(const Shell::Options& opt) : _size(0)/*, _opt(opt)*/ {}
 
-  void add(Clause* c) override;
-  void remove(Clause* c) override;
+  void add(Clause* c) final;
+  void remove(Clause* c) final;
 
-  unsigned sizeEstimate() const override { return _size; }
+  unsigned sizeEstimate() const final { return _size; }
 
 protected:
-  void onLimitsUpdated() override;
+  void onLimitsUpdated() final;
 private:
   unsigned _size;
   // const Shell::Options& _opt;

--- a/Saturation/Discount.hpp
+++ b/Saturation/Discount.hpp
@@ -34,12 +34,12 @@ public:
   Discount(Problem& prb, const Options& opt)
     : SaturationAlgorithm(prb, opt) {}
 
-  ClauseContainer* getSimplifyingClauseContainer();
+  ClauseContainer* getSimplifyingClauseContainer() override;
 
 protected:
 
   //overrides SaturationAlgorithm::handleClauseBeforeActivation
-  bool handleClauseBeforeActivation(Clause* cl);
+  bool handleClauseBeforeActivation(Clause* cl) override;
 
 };
 

--- a/Saturation/Discount.hpp
+++ b/Saturation/Discount.hpp
@@ -34,12 +34,12 @@ public:
   Discount(Problem& prb, const Options& opt)
     : SaturationAlgorithm(prb, opt) {}
 
-  ClauseContainer* getSimplifyingClauseContainer() override;
+  ClauseContainer* getSimplifyingClauseContainer() final;
 
 protected:
 
   //overrides SaturationAlgorithm::handleClauseBeforeActivation
-  bool handleClauseBeforeActivation(Clause* cl) override;
+  bool handleClauseBeforeActivation(Clause* cl) final;
 
 };
 

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -40,10 +40,10 @@ public:
 protected:
 
   //overrides SaturationAlgorithm::isComplete
-  bool isComplete() override;
+  bool isComplete() final;
 
   //overrides SaturationAlgorithm::onUnprocessedSelected
-  void onUnprocessedSelected(Clause* c) override;
+  void onUnprocessedSelected(Clause* c) final;
 
   bool shouldUpdateLimits();
 

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -40,10 +40,10 @@ public:
 protected:
 
   //overrides SaturationAlgorithm::isComplete
-  bool isComplete();
+  bool isComplete() override;
 
   //overrides SaturationAlgorithm::onUnprocessedSelected
-  void onUnprocessedSelected(Clause* c);
+  void onUnprocessedSelected(Clause* c) override;
 
   bool shouldUpdateLimits();
 

--- a/Saturation/ManCSPassiveClauseContainer.cpp
+++ b/Saturation/ManCSPassiveClauseContainer.cpp
@@ -31,8 +31,8 @@ public:
   USE_ALLOCATOR(VectorIteratorWrapper);
   
   explicit VectorIteratorWrapper(const std::vector<Clause*>& v) : curr(v.begin()), end(v.end()) {}
-  bool hasNext() { return curr != end; };
-  Clause* next() { auto cl = *curr; curr = std::next(curr); return cl;};
+  bool hasNext() override { return curr != end; };
+  Clause* next() override { auto cl = *curr; curr = std::next(curr); return cl;};
 
 private:
   std::vector<Clause*>::const_iterator curr;

--- a/Saturation/ManCSPassiveClauseContainer.cpp
+++ b/Saturation/ManCSPassiveClauseContainer.cpp
@@ -31,8 +31,8 @@ public:
   USE_ALLOCATOR(VectorIteratorWrapper);
   
   explicit VectorIteratorWrapper(const std::vector<Clause*>& v) : curr(v.begin()), end(v.end()) {}
-  bool hasNext() override { return curr != end; };
-  Clause* next() override { auto cl = *curr; curr = std::next(curr); return cl;};
+  bool hasNext() final { return curr != end; };
+  Clause* next() final { auto cl = *curr; curr = std::next(curr); return cl;};
 
 private:
   std::vector<Clause*>::const_iterator curr;

--- a/Saturation/ManCSPassiveClauseContainer.hpp
+++ b/Saturation/ManCSPassiveClauseContainer.hpp
@@ -35,7 +35,7 @@ public:
   USE_ALLOCATOR(ManCSPassiveClauseContainer);
 
   ManCSPassiveClauseContainer(bool isOutermost, const Shell::Options& opt) : PassiveClauseContainer(isOutermost, opt) {}
-  virtual ~ManCSPassiveClauseContainer(){}
+  ~ManCSPassiveClauseContainer() override{}
   
   unsigned sizeEstimate() const override;
   bool isEmpty() const override;

--- a/Saturation/ManCSPassiveClauseContainer.hpp
+++ b/Saturation/ManCSPassiveClauseContainer.hpp
@@ -28,20 +28,20 @@ using namespace Kernel;
  * Subclass of PassiveClauseContainer for manual selection of clauses
  * asks in each iteration the user to pick the id of the clause which should be activated next
  */
-class ManCSPassiveClauseContainer : public PassiveClauseContainer
+class ManCSPassiveClauseContainer final : public PassiveClauseContainer
 {
 public:
   CLASS_NAME(ManCSPassiveClauseContainer);
   USE_ALLOCATOR(ManCSPassiveClauseContainer);
 
   ManCSPassiveClauseContainer(bool isOutermost, const Shell::Options& opt) : PassiveClauseContainer(isOutermost, opt) {}
-  ~ManCSPassiveClauseContainer() override{}
+  ~ManCSPassiveClauseContainer() final{}
   
-  unsigned sizeEstimate() const override;
-  bool isEmpty() const override;
-  void add(Clause* cl) override;
-  void remove(Clause* cl) override;
-  Clause* popSelected() override;
+  unsigned sizeEstimate() const final;
+  bool isEmpty() const final;
+  void add(Clause* cl) final;
+  void remove(Clause* cl) final;
+  Clause* popSelected() final;
   
 private:
   std::vector<Clause*> clauses;
@@ -50,34 +50,34 @@ private:
    * LRS specific methods for computation of Limits
    */
 public:
-  void simulationInit() override {}
-  bool simulationHasNext() override { return false; }
-  void simulationPopSelected() override {}
+  void simulationInit() final {}
+  bool simulationHasNext() final { return false; }
+  void simulationPopSelected() final {}
 
   // returns whether at least one of the limits was tightened
-  bool setLimitsToMax() override { return false; }
+  bool setLimitsToMax() final { return false; }
   // returns whether at least one of the limits was tightened
-  bool setLimitsFromSimulation() override { return false; }
+  bool setLimitsFromSimulation() final { return false; }
 
-  void onLimitsUpdated() override {}
+  void onLimitsUpdated() final {}
 
   /*
    * LRS specific methods and fields for usage of limits
    */
-  bool ageLimited() const override { return false; }
-  bool weightLimited() const override { return false; }
+  bool ageLimited() const final { return false; }
+  bool weightLimited() const final { return false; }
 
-  bool fulfilsAgeLimit(Clause* c) const override { return true; }
+  bool fulfilsAgeLimit(Clause* c) const final { return true; }
   // note: w here denotes the weight as returned by weight().
   // this method internally takes care of computing the corresponding weightForClauseSelection.
 
-  bool fulfilsAgeLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const override { return true; }
-  bool fulfilsWeightLimit(Clause* cl) const override { return true; }
+  bool fulfilsAgeLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const final { return true; }
+  bool fulfilsWeightLimit(Clause* cl) const final { return true; }
   // note: w here denotes the weight as returned by weight().
   // this method internally takes care of computing the corresponding weightForClauseSelection.
-  bool fulfilsWeightLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const override { return true; }
+  bool fulfilsWeightLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const final { return true; }
 
-  bool childrenPotentiallyFulfilLimits(Clause* cl, unsigned upperBoundNumSelLits) const override { return true; }
+  bool childrenPotentiallyFulfilLimits(Clause* cl, unsigned upperBoundNumSelLits) const final { return true; }
 };
 
 }

--- a/Saturation/Otter.hpp
+++ b/Saturation/Otter.hpp
@@ -33,24 +33,24 @@ public:
 
   Otter(Problem& prb, const Options& opt);
 
-  ClauseContainer* getSimplifyingClauseContainer() override;
+  ClauseContainer* getSimplifyingClauseContainer() final;
 
 protected:
 
-  void onSOSClauseAdded(Clause* cl) override;
+  void onSOSClauseAdded(Clause* cl) final;
 
-  void onActiveRemoved(Clause* cl) override;
+  void onActiveRemoved(Clause* cl) final;
 
-  void onPassiveAdded(Clause* cl) override;
+  void onPassiveAdded(Clause* cl) final;
 
-  void onPassiveRemoved(Clause* cl) override;
+  void onPassiveRemoved(Clause* cl) final;
 
-  void onClauseRetained(Clause* cl) override;
+  void onClauseRetained(Clause* cl) final;
 
 
 
   /** called before the selected clause is deleted from the searchspace */
-  void beforeSelectedRemoved(Clause* cl) override;
+  void beforeSelectedRemoved(Clause* cl) final;
 
   /**
    * Dummy container for simplification indexes to subscribe
@@ -63,7 +63,7 @@ protected:
      * This method is called by @b saturate() method when a clause
      * makes it from unprocessed to passive container.
      */
-    void add(Clause* c) override
+    void add(Clause* c) final
     { addedEvent.fire(c); }
 
     /**

--- a/Saturation/Otter.hpp
+++ b/Saturation/Otter.hpp
@@ -63,7 +63,7 @@ protected:
      * This method is called by @b saturate() method when a clause
      * makes it from unprocessed to passive container.
      */
-    void add(Clause* c)
+    void add(Clause* c) override
     { addedEvent.fire(c); }
 
     /**

--- a/Saturation/PredicateSplitPassiveClauseContainer.hpp
+++ b/Saturation/PredicateSplitPassiveClauseContainer.hpp
@@ -29,11 +29,11 @@ public:
   PredicateSplitPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues, Lib::vvector<float> cutoffs, Lib::vvector<int> ratios, bool layeredArrangement);
   ~PredicateSplitPassiveClauseContainer() override;
 
-  void add(Clause* cl) override;
-  void remove(Clause* cl) override;
-  Clause* popSelected() override;
-  bool isEmpty() const override; /** True if there are no passive clauses */
-  unsigned sizeEstimate() const override;
+  void add(Clause* cl) final;
+  void remove(Clause* cl) final;
+  Clause* popSelected() final;
+  bool isEmpty() const final; /** True if there are no passive clauses */
+  unsigned sizeEstimate() const final;
 
 private:
   Lib::vvector<std::unique_ptr<PassiveClauseContainer>> _queues;
@@ -51,16 +51,16 @@ private:
    * LRS specific methods for computation of Limits
    */
 public:
-  void simulationInit() override;
-  bool simulationHasNext() override;
-  void simulationPopSelected() override;
+  void simulationInit() final;
+  bool simulationHasNext() final;
+  void simulationPopSelected() final;
 
   // returns whether at least one of the limits was tightened
-  bool setLimitsToMax() override;
+  bool setLimitsToMax() final;
   // returns whether at least one of the limits was tightened
-  bool setLimitsFromSimulation() override;
+  bool setLimitsFromSimulation() final;
 
-  void onLimitsUpdated() override;
+  void onLimitsUpdated() final;
 
 private:
   Lib::vvector<unsigned> _simulationBalances;
@@ -69,20 +69,20 @@ private:
    * LRS specific methods and fields for usage of limits
    */
 public:
-  bool ageLimited() const override;
-  bool weightLimited() const override;
+  bool ageLimited() const final;
+  bool weightLimited() const final;
 
-  bool fulfilsAgeLimit(Clause* cl) const override;
+  bool fulfilsAgeLimit(Clause* cl) const final;
   // note: w here denotes the weight as returned by weight().
   // age is to be recovered from inference
   // this method internally takes care of computing the corresponding weightForClauseSelection.
-  bool fulfilsAgeLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const override;
-  bool fulfilsWeightLimit(Clause* cl) const override;
+  bool fulfilsAgeLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const final;
+  bool fulfilsWeightLimit(Clause* cl) const final;
   // note: w here denotes the weight as returned by weight().
   // age is to be recovered from inference
   // this method internally takes care of computing the corresponding weightForClauseSelection.
-  bool fulfilsWeightLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const override;
-  bool childrenPotentiallyFulfilLimits(Clause* cl, unsigned upperBoundNumSelLits) const override;
+  bool fulfilsWeightLimit(unsigned w, unsigned numPositiveLiterals, const Inference& inference) const final;
+  bool childrenPotentiallyFulfilLimits(Clause* cl, unsigned upperBoundNumSelLits) const final;
   
 }; // class PredicateSplitPassiveClauseContainer
 
@@ -92,8 +92,8 @@ public:
   TheoryMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, Lib::vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues);
 
 private:
-  float evaluateFeature(Clause* cl) const override;
-  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const override;
+  float evaluateFeature(Clause* cl) const final;
+  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const final;
 };
 
 class AvatarMultiSplitPassiveClauseContainer : public PredicateSplitPassiveClauseContainer
@@ -102,8 +102,8 @@ public:
   AvatarMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, Lib::vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues);
 
 private:
-  float evaluateFeature(Clause* cl) const override;
-  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const override;
+  float evaluateFeature(Clause* cl) const final;
+  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const final;
 };
 
 class SineLevelMultiSplitPassiveClauseContainer : public PredicateSplitPassiveClauseContainer
@@ -112,8 +112,8 @@ public:
   SineLevelMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, Lib::vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues);
 
 private:
-  float evaluateFeature(Clause* cl) const override;
-  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const override;
+  float evaluateFeature(Clause* cl) const final;
+  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const final;
 };
 
 class PositiveLiteralMultiSplitPassiveClauseContainer : public PredicateSplitPassiveClauseContainer
@@ -122,8 +122,8 @@ public:
   PositiveLiteralMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, Lib::vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues);
 
 private:
-  float evaluateFeature(Clause* cl) const override;
-  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const override;
+  float evaluateFeature(Clause* cl) const final;
+  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const final;
 };
 
 };

--- a/Saturation/PredicateSplitPassiveClauseContainer.hpp
+++ b/Saturation/PredicateSplitPassiveClauseContainer.hpp
@@ -27,7 +27,7 @@ public:
   USE_ALLOCATOR(PredicateSplitPassiveClauseContainer);
 
   PredicateSplitPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues, Lib::vvector<float> cutoffs, Lib::vvector<int> ratios, bool layeredArrangement);
-  virtual ~PredicateSplitPassiveClauseContainer();
+  ~PredicateSplitPassiveClauseContainer() override;
 
   void add(Clause* cl) override;
   void remove(Clause* cl) override;

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -56,7 +56,7 @@ public:
   static SaturationAlgorithm* createFromOptions(Problem& prb, const Options& opt, IndexManager* indexMgr=0);
 
   SaturationAlgorithm(Problem& prb, const Options& opt);
-  virtual ~SaturationAlgorithm();
+  ~SaturationAlgorithm() override;
 
 
   //the following two functions allow to run the saturation algorithm step by step.
@@ -123,8 +123,8 @@ public:
   Splitter* getSplitter() { return _splitter; }
 
 protected:
-  virtual void init();
-  virtual MainLoopResult runImpl();
+  void init() override;
+  MainLoopResult runImpl() override;
   void doUnprocessedLoop();
   virtual bool handleClauseBeforeActivation(Clause* c);
   void addInputSOSClause(Clause* cl);

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -123,8 +123,8 @@ public:
   Splitter* getSplitter() { return _splitter; }
 
 protected:
-  void init() override;
-  MainLoopResult runImpl() override;
+  void init() final;
+  MainLoopResult runImpl() final;
   void doUnprocessedLoop();
   virtual bool handleClauseBeforeActivation(Clause* c);
   void addInputSOSClause(Clause* cl);

--- a/Shell/AnswerExtractor.hpp
+++ b/Shell/AnswerExtractor.hpp
@@ -44,7 +44,7 @@ protected:
 
 class ConjunctionGoalAnswerExractor : public AnswerExtractor {
 public:
-  bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer) override;
+  bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer) final;
 
 private:
   class SubstBuilder;
@@ -56,7 +56,7 @@ class AnswerLiteralManager : public AnswerExtractor
 public:
   static AnswerLiteralManager* getInstance();
 
-  bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer) override;
+  bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer) final;
 
   void addAnswerLiterals(Problem& prb);
   bool addAnswerLiterals(UnitList*& units);

--- a/Shell/AnswerExtractor.hpp
+++ b/Shell/AnswerExtractor.hpp
@@ -44,7 +44,7 @@ protected:
 
 class ConjunctionGoalAnswerExractor : public AnswerExtractor {
 public:
-  virtual bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer);
+  bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer) override;
 
 private:
   class SubstBuilder;
@@ -56,7 +56,7 @@ class AnswerLiteralManager : public AnswerExtractor
 public:
   static AnswerLiteralManager* getInstance();
 
-  virtual bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer);
+  bool tryGetAnswer(Clause* refutation, Stack<TermList>& answer) override;
 
   void addAnswerLiterals(Problem& prb);
   bool addAnswerLiterals(UnitList*& units);

--- a/Shell/BlockedClauseElimination.cpp
+++ b/Shell/BlockedClauseElimination.cpp
@@ -206,7 +206,7 @@ public:
   VarMaxUpdatingNormalizer(const Lib::DHMap<TermList, TermList>& replacements, int& varMax)
     : _repls(replacements), _varMax(varMax) {}
 protected:
-  TermList transformSubterm(TermList trm) override {
+  TermList transformSubterm(TermList trm) final {
     TermList res;
     if (_repls.find(trm,res)) {
       return res;
@@ -229,7 +229,7 @@ public:
   RenanigApartNormalizer(const Lib::DHMap<TermList, TermList>& replacements, int varMax, Lib::DHMap<unsigned, unsigned>& varMap)
     : _repls(replacements), _varMax(varMax), _varMap(varMap) {}
 protected:
-  TermList transformSubterm(TermList trm) override {
+  TermList transformSubterm(TermList trm) final {
     TermList res;
     if (_repls.find(trm,res)) {
       return res;

--- a/Shell/CParser.hpp
+++ b/Shell/CParser.hpp
@@ -43,7 +43,7 @@ public:
   public:                                
     LexerException(const CParser&,unsigned pos,Lib::vstring message);
     void cry(ostream&) const override;
-    ~LexerException() {}
+    ~LexerException() override {}
   protected:
     Lib::vstring _message;
     unsigned _pos;
@@ -59,7 +59,7 @@ public:
   public:                                
     ParserException(const CParser&,unsigned pos,Lib::vstring message);
     void cry(ostream&) const override;
-    ~ParserException() {}
+    ~ParserException() override {}
   protected:
     Lib::vstring _message;
     unsigned _pos;

--- a/Shell/CParser.hpp
+++ b/Shell/CParser.hpp
@@ -37,13 +37,13 @@ public:
    * Implements lexer exceptions.
    * @since 14/01/2011 Manchester
    */
-  class LexerException 
+  class LexerException final
     : public Lib::Exception
   {
   public:                                
     LexerException(const CParser&,unsigned pos,Lib::vstring message);
-    void cry(ostream&) const override;
-    ~LexerException() override {}
+    void cry(ostream&) const final;
+    ~LexerException() final {}
   protected:
     Lib::vstring _message;
     unsigned _pos;
@@ -53,13 +53,13 @@ public:
    * Implements parser exceptions.
    * @since 17/01/2011 Manchester
    */
-  class ParserException 
+  class ParserException final
     : public Lib::Exception
   {
   public:                                
     ParserException(const CParser&,unsigned pos,Lib::vstring message);
-    void cry(ostream&) const override;
-    ~ParserException() override {}
+    void cry(ostream&) const final;
+    ~ParserException() final {}
   protected:
     Lib::vstring _message;
     unsigned _pos;

--- a/Shell/DistinctProcessor.hpp
+++ b/Shell/DistinctProcessor.hpp
@@ -37,10 +37,10 @@ public:
   static bool isDistinctPred(Literal* l);
 
 protected:
-  virtual bool apply(FormulaUnit* unit, Unit*& res);
-  virtual bool apply(Clause* cl, Unit*& res);
+  bool apply(FormulaUnit* unit, Unit*& res) override;
+  bool apply(Clause* cl, Unit*& res) override;
 
-  virtual void updateModifiedProblem(Problem& prb)
+  void updateModifiedProblem(Problem& prb) override
   {
     CALL("DistinctProcessor::updateModifiedProblem");
     prb.invalidateProperty();

--- a/Shell/DistinctProcessor.hpp
+++ b/Shell/DistinctProcessor.hpp
@@ -37,10 +37,10 @@ public:
   static bool isDistinctPred(Literal* l);
 
 protected:
-  bool apply(FormulaUnit* unit, Unit*& res) override;
-  bool apply(Clause* cl, Unit*& res) override;
+  bool apply(FormulaUnit* unit, Unit*& res) final;
+  bool apply(Clause* cl, Unit*& res) final;
 
-  void updateModifiedProblem(Problem& prb) override
+  void updateModifiedProblem(Problem& prb) final
   {
     CALL("DistinctProcessor::updateModifiedProblem");
     prb.invalidateProperty();

--- a/Shell/InterpolantMinimizerNew.hpp
+++ b/Shell/InterpolantMinimizerNew.hpp
@@ -37,7 +37,7 @@ namespace Shell
          * and ask solver for an optimal solution
          * we use z3 as solver
          */
-        virtual std::unordered_map<Kernel::Unit*, Kernel::Color> computeSplittingFunction(Kernel::Unit* refutation, UnitWeight weightFunction) override;
+        std::unordered_map<Kernel::Unit*, Kernel::Color> computeSplittingFunction(Kernel::Unit* refutation, UnitWeight weightFunction) override;
         
         /*
          * print statistics for a given local proof

--- a/Shell/InterpolantMinimizerNew.hpp
+++ b/Shell/InterpolantMinimizerNew.hpp
@@ -37,7 +37,7 @@ namespace Shell
          * and ask solver for an optimal solution
          * we use z3 as solver
          */
-        std::unordered_map<Kernel::Unit*, Kernel::Color> computeSplittingFunction(Kernel::Unit* refutation, UnitWeight weightFunction) override;
+        std::unordered_map<Kernel::Unit*, Kernel::Color> computeSplittingFunction(Kernel::Unit* refutation, UnitWeight weightFunction) final;
         
         /*
          * print statistics for a given local proof

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -61,7 +61,7 @@ public:
 
   }
 
-  virtual TermList translate(Term* trm)
+  TermList translate(Term* trm) override
   {
     CALL("InterpretedNormalizer::RoundingFunctionTranslator::translate");
     ASS_EQ(trm->functor(), _origFun);
@@ -101,7 +101,7 @@ public:
     _one = TermList(theory->representConstant(IntegerConstantType(1)));
   }
 
-  virtual TermList translate(Term* trm)
+  TermList translate(Term* trm) override
   {
     CALL("InterpretedNormalizer::SuccessorTranslator::translate");
     ASS_EQ(trm->functor(), _succFun);
@@ -138,7 +138,7 @@ public:
     _uMinusFun = env.signature->getInterpretingSymbol(uMinus);
   }
 
-  virtual TermList translate(Term* trm)
+  TermList translate(Term* trm) override
   {
     CALL("InterpretedNormalizer::BinaryMinusTranslator::translate");
     ASS_EQ(trm->functor(), _bMinusFun);
@@ -271,7 +271,7 @@ public:
 protected:
   using TermTransformer::transform;
 
-  virtual TermList transformSubterm(TermList trm)
+  TermList transformSubterm(TermList trm) override
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::transformSubterm");
 
@@ -407,7 +407,7 @@ protected:
    *
    * The rest of transformations is done by the @c FormulaTransformer ancestor.
    */
-  virtual Formula* applyLiteral(Formula* f)
+  Formula* applyLiteral(Formula* f) override
   {
     CALL("InterpretedNormalizer::NFormulaTransformer::applyLiteral");
 

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -61,7 +61,7 @@ public:
 
   }
 
-  TermList translate(Term* trm) override
+  TermList translate(Term* trm) final
   {
     CALL("InterpretedNormalizer::RoundingFunctionTranslator::translate");
     ASS_EQ(trm->functor(), _origFun);
@@ -101,7 +101,7 @@ public:
     _one = TermList(theory->representConstant(IntegerConstantType(1)));
   }
 
-  TermList translate(Term* trm) override
+  TermList translate(Term* trm) final
   {
     CALL("InterpretedNormalizer::SuccessorTranslator::translate");
     ASS_EQ(trm->functor(), _succFun);
@@ -138,7 +138,7 @@ public:
     _uMinusFun = env.signature->getInterpretingSymbol(uMinus);
   }
 
-  TermList translate(Term* trm) override
+  TermList translate(Term* trm) final
   {
     CALL("InterpretedNormalizer::BinaryMinusTranslator::translate");
     ASS_EQ(trm->functor(), _bMinusFun);
@@ -271,7 +271,7 @@ public:
 protected:
   using TermTransformer::transform;
 
-  TermList transformSubterm(TermList trm) override
+  TermList transformSubterm(TermList trm) final
   {
     CALL("InterpretedNormalizer::NLiteralTransformer::transformSubterm");
 
@@ -407,7 +407,7 @@ protected:
    *
    * The rest of transformations is done by the @c FormulaTransformer ancestor.
    */
-  Formula* applyLiteral(Formula* f) override
+  Formula* applyLiteral(Formula* f) final
   {
     CALL("InterpretedNormalizer::NFormulaTransformer::applyLiteral");
 

--- a/Shell/Lexer.hpp
+++ b/Shell/Lexer.hpp
@@ -41,8 +41,8 @@ class LexerException
 {
  public:                                
   LexerException(vstring message,const Lexer&);
-  void cry(ostream&) const;
-  ~LexerException() {}
+  void cry(ostream&) const override;
+  ~LexerException() override {}
  protected:
   vstring _message;
 }; // LexerException

--- a/Shell/Lexer.hpp
+++ b/Shell/Lexer.hpp
@@ -36,13 +36,13 @@ class Lexer;
  * Class LexerException. Implements lexer exceptions.
  * @since 14/07/2004 Turku
  */
-class LexerException 
+class LexerException final
   : public Exception
 {
  public:                                
   LexerException(vstring message,const Lexer&);
-  void cry(ostream&) const override;
-  ~LexerException() override {}
+  void cry(ostream&) const final;
+  ~LexerException() final {}
  protected:
   vstring _message;
 }; // LexerException

--- a/Shell/LispLexer.hpp
+++ b/Shell/LispLexer.hpp
@@ -28,13 +28,13 @@ namespace Shell {
  * Class LispLexer, implements a LispLexer.
  * @since 25/08/2009 Redmond
  */
-class LispLexer 
+class LispLexer final
   : public Lexer
 {
 public:
   LispLexer(istream& in);
-  void readToken (Token&) override;
-  ~LispLexer () override {}
+  void readToken (Token&) final;
+  ~LispLexer () final {}
 
 private:
   void skipWhiteSpacesAndComments();

--- a/Shell/LispLexer.hpp
+++ b/Shell/LispLexer.hpp
@@ -33,8 +33,8 @@ class LispLexer
 {
 public:
   LispLexer(istream& in);
-  void readToken (Token&);
-  ~LispLexer () {}
+  void readToken (Token&) override;
+  ~LispLexer () override {}
 
 private:
   void skipWhiteSpacesAndComments();

--- a/Shell/LispParser.hpp
+++ b/Shell/LispParser.hpp
@@ -97,8 +97,8 @@ public:
   {
   public:                                
     Exception (vstring message,const Token&);
-    void cry (ostream&) const;
-    ~Exception () {}
+    void cry (ostream&) const override;
+    ~Exception () override {}
   protected:
     vstring _message;
   }; // Exception

--- a/Shell/LispParser.hpp
+++ b/Shell/LispParser.hpp
@@ -92,13 +92,13 @@ public:
    * Class Exception. Implements parser exceptions.
    * @since 17/07/2004 Helsinki airport
    */
-  class Exception 
+  class Exception final
     : public Lib::Exception
   {
   public:                                
     Exception (vstring message,const Token&);
-    void cry (ostream&) const override;
-    ~Exception () override {}
+    void cry (ostream&) const final;
+    ~Exception () final {}
   protected:
     vstring _message;
   }; // Exception

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -961,7 +961,7 @@ private:
         T defaultValue;
         T actualValue;
         
-        bool isDefault() const override { return defaultValue==actualValue;}
+        bool isDefault() const final { return defaultValue==actualValue;}
 
         // Getting the string versions of values, useful for output
         virtual vstring getStringOfValue(T value) const{ ASSERTION_VIOLATION;}
@@ -994,7 +994,7 @@ private:
             _constraints.push(std::move(tc));
         }
         // This checks the constraints and may cause a UserError
-        bool checkConstraints() override;
+        bool checkConstraints() final;
         
         // Produces a separate constraint object based on this option
         /// Useful for IfThen constraints and reliesOn i.e. _splitting.is(equal(true))
@@ -1005,7 +1005,7 @@ private:
         bool hasProblemConstraints(){ 
           return !supress_problemconstraints && !_prob_constraints.isEmpty(); 
         }
-        bool checkProblemConstraints(Property* prop) override;
+        bool checkProblemConstraints(Property* prop) final;
         
         void output(ostream& out, bool linewrap) const override {
             CALL("Options::OptionValue::output");
@@ -1014,7 +1014,7 @@ private:
         }
        
         // This is where actual randomisation happens
-        bool randomize(Property* p) override;
+        bool randomize(Property* p) final;
  
     private:
         Lib::Stack<OptionValueConstraintUP<T>> _constraints;
@@ -1045,7 +1045,7 @@ private:
         OptionValue<T>(l,s,def), choices(c) {}
         ChoiceOptionValue(vstring l, vstring s,T d) : ChoiceOptionValue(l,s,d, T::optionChoiceValues()) {}
         
-        bool setValue(const vstring& value) override{
+        bool setValue(const vstring& value) final{
             // makes reasonable assumption about ordering of every enum
             int index = choices.find(value.c_str());
             if(index<0) return false;
@@ -1053,7 +1053,7 @@ private:
             return true;
         }
         
-        void output(ostream& out,bool linewrap) const override {
+        void output(ostream& out,bool linewrap) const final {
             AbstractOptionValue::output(out,linewrap);
             out << "\tdefault: " << choices[static_cast<unsigned>(this->defaultValue)];
             out << endl;
@@ -1080,7 +1080,7 @@ private:
             out << endl;
         }
         
-        vstring getStringOfValue(T value) const override {
+        vstring getStringOfValue(T value) const final {
             unsigned i = static_cast<unsigned>(value);
             return choices[i];
         }
@@ -1097,7 +1097,7 @@ private:
     struct BoolOptionValue : public OptionValue<bool> {
         BoolOptionValue(){}
         BoolOptionValue(vstring l,vstring s, bool d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value) override{
+        bool setValue(const vstring& value) final{
             if (! value.compare("on") || ! value.compare("true")) {
                 actualValue=true;
                 
@@ -1110,36 +1110,36 @@ private:
             return true;
         }
         
-        vstring getStringOfValue(bool value) const override { return (value ? "on" : "off"); }
+        vstring getStringOfValue(bool value) const final { return (value ? "on" : "off"); }
     };
 
     struct IntOptionValue : public OptionValue<int> {
         IntOptionValue(){}
         IntOptionValue(vstring l,vstring s, int d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value) override{
+        bool setValue(const vstring& value) final{
             return Int::stringToInt(value.c_str(),actualValue);
         }
-        vstring getStringOfValue(int value) const override{ return Lib::Int::toString(value); }
+        vstring getStringOfValue(int value) const final{ return Lib::Int::toString(value); }
     };
     
     struct UnsignedOptionValue : public OptionValue<unsigned> {
         UnsignedOptionValue(){}
         UnsignedOptionValue(vstring l,vstring s, unsigned d) : OptionValue(l,s,d){}
 
-        bool setValue(const vstring& value) override{
+        bool setValue(const vstring& value) final{
             return Int::stringToUnsignedInt(value.c_str(),actualValue);
         }
-        vstring getStringOfValue(unsigned value) const override{ return Lib::Int::toString(value); }
+        vstring getStringOfValue(unsigned value) const final{ return Lib::Int::toString(value); }
     };
     
     struct StringOptionValue : public OptionValue<vstring> {
         StringOptionValue(){}
         StringOptionValue(vstring l,vstring s, vstring d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value) override{
+        bool setValue(const vstring& value) final{
             actualValue = (value=="<empty>") ? "" : value;
             return true;
         }
-        vstring getStringOfValue(vstring value) const override{
+        vstring getStringOfValue(vstring value) const final{
             if(value.empty()) return "<empty>";
             return value;
         }
@@ -1148,19 +1148,19 @@ private:
     struct LongOptionValue : public OptionValue<long> {
         LongOptionValue(){}
         LongOptionValue(vstring l,vstring s, long d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value) override{
+        bool setValue(const vstring& value) final{
             return Int::stringToLong(value.c_str(),actualValue);
         }
-        vstring getStringOfValue(long value) const override{ return Lib::Int::toString(value); }
+        vstring getStringOfValue(long value) const final{ return Lib::Int::toString(value); }
     };
     
 struct FloatOptionValue : public OptionValue<float>{
 FloatOptionValue(){}
 FloatOptionValue(vstring l,vstring s, float d) : OptionValue(l,s,d){}
-bool setValue(const vstring& value) override{
+bool setValue(const vstring& value) final{
     return Int::stringToFloat(value.c_str(),actualValue);
 }
-vstring getStringOfValue(float value) const override{ return Lib::Int::toString(value); }
+vstring getStringOfValue(float value) const final{ return Lib::Int::toString(value); }
 };
 
 /**
@@ -1177,14 +1177,14 @@ RatioOptionValue(){}
 RatioOptionValue(vstring l, vstring s, int def, int other, char sp=':') :
 OptionValue(l,s,def), sep(sp), defaultOtherValue(other), otherValue(other) {};
 
-OptionValueConstraintUP<int> getNotDefault() override { return isNotDefaultRatio(); }
+OptionValueConstraintUP<int> getNotDefault() final { return isNotDefaultRatio(); }
 
 void addConstraintIfNotDefault(AbstractWrappedConstraintUP c){
     addConstraint(If(isNotDefaultRatio()).then(unwrap<int>(c)));
 }
 
 bool readRatio(const char* val,char seperator);
-bool setValue(const vstring& value) override {
+bool setValue(const vstring& value) final {
     return readRatio(value.c_str(),sep);
 }
 
@@ -1192,14 +1192,14 @@ char sep;
 int defaultOtherValue;
 int otherValue;
 
-void output(ostream& out,bool linewrap) const override {
+void output(ostream& out,bool linewrap) const final {
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault left: " << defaultValue << endl;
     out << "\tdefault right: " << defaultOtherValue << endl;
 }
 
-vstring getStringOfValue(int value) const override { ASSERTION_VIOLATION;}
-vstring getStringOfActual() const override {
+vstring getStringOfValue(int value) const final { ASSERTION_VIOLATION;}
+vstring getStringOfActual() const final {
     return Lib::Int::toString(actualValue)+sep+Lib::Int::toString(otherValue);
 }
 
@@ -1221,14 +1221,14 @@ NonGoalWeightOptionValue(){}
 NonGoalWeightOptionValue(vstring l, vstring s, float def) :
 OptionValue(l,s,def), numerator(1), denominator(1) {};
 
-bool setValue(const vstring& value) override;
+bool setValue(const vstring& value) final;
 
 // output does not output numerator and denominator as they
 // are produced from defaultValue
 int numerator;
 int denominator;
 
-vstring getStringOfValue(float value) const override{ return Lib::Int::toString(value); }
+vstring getStringOfValue(float value) const final{ return Lib::Int::toString(value); }
 };
 
 /**
@@ -1241,14 +1241,14 @@ SelectionOptionValue(){}
 SelectionOptionValue(vstring l,vstring s, int def):
 OptionValue(l,s,def){};
 
-bool setValue(const vstring& value) override;
+bool setValue(const vstring& value) final;
 
-void output(ostream& out,bool linewrap) const override {
+void output(ostream& out,bool linewrap) const final {
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault: " << defaultValue << endl;;
 }
 
-vstring getStringOfValue(int value) const override{ return Lib::Int::toString(value); }
+vstring getStringOfValue(int value) const final{ return Lib::Int::toString(value); }
 
 AbstractWrappedConstraintUP isLookAheadSelection(){
   return AbstractWrappedConstraintUP(new WrappedConstraint<int>(*this,OptionValueConstraintUP<int>(new isLookAheadSelectionConstraint())));
@@ -1264,13 +1264,13 @@ InputFileOptionValue(){}
 InputFileOptionValue(vstring l,vstring s, vstring def,Options* p):
 OptionValue(l,s,def), parent(p){};
 
-bool setValue(const vstring& value) override;
+bool setValue(const vstring& value) final;
 
-void output(ostream& out,bool linewrap) const override {
+void output(ostream& out,bool linewrap) const final {
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault: " << defaultValue << endl;;
 }
-vstring getStringOfValue(vstring value) const override{ return value; }
+vstring getStringOfValue(vstring value) const final{ return value; }
 private:
 Options* parent;
 
@@ -1284,11 +1284,11 @@ DecodeOptionValue(){ AbstractOptionValue::_should_copy=false;}
 DecodeOptionValue(vstring l,vstring s,Options* p):
 OptionValue(l,s,""), parent(p){ AbstractOptionValue::_should_copy=false;}
 
-bool setValue(const vstring& value) override{
+bool setValue(const vstring& value) final{
     parent->readFromEncodedOptions(value);
     return true;
 }
-vstring getStringOfValue(vstring value) const override{ return value; }
+vstring getStringOfValue(vstring value) const final{ return value; }
 
 private:
 Options* parent;
@@ -1304,14 +1304,14 @@ TimeLimitOptionValue(){}
 TimeLimitOptionValue(vstring l, vstring s, float def) :
 OptionValue(l,s,def) {};
 
-bool setValue(const vstring& value) override;
+bool setValue(const vstring& value) final;
 
-void output(ostream& out,bool linewrap) const override {
+void output(ostream& out,bool linewrap) const final {
     CALL("Options::TimeLimitOptionValue::output");
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault: " << defaultValue << "d" << endl;
 }
-vstring getStringOfValue(int value) const override{ return Lib::Int::toString(value)+"d"; }
+vstring getStringOfValue(int value) const final{ return Lib::Int::toString(value)+"d"; }
 };
 
 /**
@@ -1388,10 +1388,10 @@ bool _hard;
         
         WrappedConstraint(const OptionValue<T>& v, OptionValueConstraintUP<T> c) : value(v), con(std::move(c)) {}
         
-        bool check() override {
+        bool check() final {
             return con->check(value);
         }
-        vstring msg() override {
+        vstring msg() final {
             return con->msg(value);
         }
 
@@ -1403,10 +1403,10 @@ bool _hard;
         CLASS_NAME(WrappedConstraintOrWrapper);
         USE_ALLOCATOR(WrappedConstraintOrWrapper);
         WrappedConstraintOrWrapper(AbstractWrappedConstraintUP l, AbstractWrappedConstraintUP r) : left(std::move(l)),right(std::move(r)) {}
-        bool check() override {
+        bool check() final {
             return left->check() || right->check();
         }
-        vstring msg() override { return left->msg() + " or " + right->msg(); }
+        vstring msg() final { return left->msg() + " or " + right->msg(); }
 
         AbstractWrappedConstraintUP left;
         AbstractWrappedConstraintUP right;
@@ -1416,10 +1416,10 @@ bool _hard;
         CLASS_NAME(WrappedConstraintAndWrapper);
         USE_ALLOCATOR(WrappedConstraintAndWrapper);
         WrappedConstraintAndWrapper(AbstractWrappedConstraintUP l, AbstractWrappedConstraintUP r) : left(std::move(l)),right(std::move(r)) {}
-        bool check() override {
+        bool check() final {
             return left->check() && right->check();
         }
-        vstring msg() override { return left->msg() + " and " + right->msg(); }
+        vstring msg() final { return left->msg() + " and " + right->msg(); }
 
         AbstractWrappedConstraintUP left;
         AbstractWrappedConstraintUP right;
@@ -1430,10 +1430,10 @@ bool _hard;
         CLASS_NAME(OptionValueConstraintOrWrapper);
         USE_ALLOCATOR(OptionValueConstraintOrWrapper);
         OptionValueConstraintOrWrapper(OptionValueConstraintUP<T> l, OptionValueConstraintUP<T> r) : left(std::move(l)),right(std::move(r)) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return left->check(value) || right->check(value);
         }
-        vstring msg(const OptionValue<T>& value) override{ return left->msg(value) + " or " + right->msg(value); }
+        vstring msg(const OptionValue<T>& value) final{ return left->msg(value) + " or " + right->msg(value); }
 
         OptionValueConstraintUP<T> left;
         OptionValueConstraintUP<T> right;
@@ -1444,10 +1444,10 @@ bool _hard;
         CLASS_NAME(OptionValueConstraintAndWrapper);
         USE_ALLOCATOR(OptionValueConstraintAndWrapper);
         OptionValueConstraintAndWrapper(OptionValueConstraintUP<T> l, OptionValueConstraintUP<T> r) : left(std::move(l)),right(std::move(r)) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return left->check(value) && right->check(value);
         }
-        vstring msg(const OptionValue<T>& value) override{ return left->msg(value) + " and " + right->msg(value); }
+        vstring msg(const OptionValue<T>& value) final{ return left->msg(value) + " and " + right->msg(value); }
 
         OptionValueConstraintUP<T> left;
         OptionValueConstraintUP<T> right;
@@ -1460,8 +1460,8 @@ bool _hard;
         
         UnWrappedConstraint(AbstractWrappedConstraintUP c) : con(std::move(c)) {}
         
-        bool check(const OptionValue<T>&) override{ return con->check(); }
-        vstring msg(const OptionValue<T>&) override{ return con->msg(); }
+        bool check(const OptionValue<T>&) final{ return con->check(); }
+        vstring msg(const OptionValue<T>&) final{ return con->msg(); }
         
         AbstractWrappedConstraintUP con;
     };
@@ -1523,10 +1523,10 @@ bool _hard;
         CLASS_NAME(Equal);
         USE_ALLOCATOR(Equal);
         Equal(T gv) : _goodvalue(gv) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return value.actualValue == _goodvalue;
         }
-        vstring msg(const OptionValue<T>& value) override{
+        vstring msg(const OptionValue<T>& value) final{
             return value.longName+"("+value.getStringOfActual()+") is equal to " + value.getStringOfValue(_goodvalue);
         }
         T _goodvalue;
@@ -1541,10 +1541,10 @@ bool _hard;
         CLASS_NAME(NotEqual);
         USE_ALLOCATOR(NotEqual);
         NotEqual(T bv) : _badvalue(bv) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return value.actualValue != _badvalue;
         }
-        vstring msg(const OptionValue<T>& value) override{ return value.longName+"("+value.getStringOfActual()+") is not equal to " + value.getStringOfValue(_badvalue); }
+        vstring msg(const OptionValue<T>& value) final{ return value.longName+"("+value.getStringOfActual()+") is not equal to " + value.getStringOfValue(_badvalue); }
         T _badvalue;
     };
     template<typename T>
@@ -1559,10 +1559,10 @@ bool _hard;
         CLASS_NAME(LessThan);
         USE_ALLOCATOR(LessThan);
         LessThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
         }
-        vstring msg(const OptionValue<T>& value) override{
+        vstring msg(const OptionValue<T>& value) final{
             if(_orequal) return value.longName+"("+value.getStringOfActual()+") is less than or equal to " + value.getStringOfValue(_goodvalue);
             return value.longName+"("+value.getStringOfActual()+") is less than "+ value.getStringOfValue(_goodvalue);
         }
@@ -1586,11 +1586,11 @@ bool _hard;
         CLASS_NAME(GreaterThan);
         USE_ALLOCATOR(GreaterThan);
         GreaterThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return (value.actualValue > _goodvalue || (_orequal && value.actualValue==_goodvalue));
         }
         
-        vstring msg(const OptionValue<T>& value) override{
+        vstring msg(const OptionValue<T>& value) final{
             if(_orequal) return value.longName+"("+value.getStringOfActual()+") is greater than or equal to " + value.getStringOfValue(_goodvalue);
             return value.longName+"("+value.getStringOfActual()+") is greater than "+ value.getStringOfValue(_goodvalue);
         }
@@ -1614,11 +1614,11 @@ bool _hard;
         CLASS_NAME(SmallerThan);
         USE_ALLOCATOR(SmallerThan);
         SmallerThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
         }
 
-        vstring msg(const OptionValue<T>& value) override{
+        vstring msg(const OptionValue<T>& value) final{
             if(_orequal) return value.longName+"("+value.getStringOfActual()+") is smaller than or equal to " + value.getStringOfValue(_goodvalue);
             return value.longName+"("+value.getStringOfActual()+") is smaller than "+ value.getStringOfValue(_goodvalue);
         }
@@ -1650,12 +1650,12 @@ bool _hard;
         IfThenConstraint(OptionValueConstraintUP<T> ic, OptionValueConstraintUP<T> c) :
         if_con(std::move(ic)), then_con(std::move(c)) {}
         
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             ASS(then_con);
             return !if_con->check(value) || then_con->check(value);
         }
         
-        vstring msg(const OptionValue<T>& value) override{
+        vstring msg(const OptionValue<T>& value) final{
             return "if "+if_con->msg(value)+" then "+ then_con->msg(value);
         }
         
@@ -1696,20 +1696,20 @@ bool _hard;
     struct NotDefaultConstraint : public OptionValueConstraint<T> {
         NotDefaultConstraint() {}
         
-        bool check(const OptionValue<T>& value) override{
+        bool check(const OptionValue<T>& value) final{
             return value.defaultValue != value.actualValue;
         }
-        vstring msg(const OptionValue<T>& value) override { return value.longName+"("+value.getStringOfActual()+") is not default("+value.getStringOfValue(value.defaultValue)+")";}
+        vstring msg(const OptionValue<T>& value) final { return value.longName+"("+value.getStringOfActual()+") is not default("+value.getStringOfValue(value.defaultValue)+")";}
     };
     struct NotDefaultRatioConstraint : public OptionValueConstraint<int> {
         NotDefaultRatioConstraint() {}
         
-        bool check(const OptionValue<int>& value) override{
+        bool check(const OptionValue<int>& value) final{
             const RatioOptionValue& rvalue = static_cast<const RatioOptionValue&>(value);
             return (rvalue.defaultValue != rvalue.actualValue ||
                     rvalue.defaultOtherValue != rvalue.otherValue);
         }
-        vstring msg(const OptionValue<int>& value) override { return value.longName+"("+value.getStringOfActual()+") is not default";}
+        vstring msg(const OptionValue<int>& value) final { return value.longName+"("+value.getStringOfActual()+") is not default";}
         
     };
     
@@ -1727,10 +1727,10 @@ bool _hard;
         CLASS_NAME(isLookAheadSelectionConstraint);
         USE_ALLOCATOR(isLookAheadSelectionConstraint);
         isLookAheadSelectionConstraint() {}
-        bool check(const OptionValue<int>& value) override{
+        bool check(const OptionValue<int>& value) final{
             return value.actualValue == 11 || value.actualValue == 1011 || value.actualValue == -11 || value.actualValue == -1011;
         }
-        vstring msg(const OptionValue<int>& value) override{
+        vstring msg(const OptionValue<int>& value) final{
             return value.longName+"("+value.getStringOfActual()+") is not lookahead selection";
         }
     };
@@ -1760,12 +1760,12 @@ bool _hard;
       USE_ALLOCATOR(CategoryCondition);
 
       CategoryCondition(Property::Category c,bool h) : cat(c), has(h) {}
-      bool check(Property*p) override{
+      bool check(Property*p) final{
           CALL("Options::CategoryCondition::check");
           ASS(p);
           return has ? p->category()==cat : p->category()!=cat;
       }
-      vstring msg() override{
+      vstring msg() final{
         vstring m =" not useful for property ";
         if(has) m+="not";
         return m+" in category "+Property::categoryToString(cat);
@@ -1778,34 +1778,34 @@ bool _hard;
       CLASS_NAME(UsesEquality);
       USE_ALLOCATOR(UsesEquality);
 
-      bool check(Property*p) override{
+      bool check(Property*p) final{
         CALL("Options::UsesEquality::check");
         ASS(p)
         return (p->equalityAtoms() != 0);
       }
-      vstring msg() override{ return " only useful with equality"; }
+      vstring msg() final{ return " only useful with equality"; }
     };
 
     struct HasNonUnits : OptionProblemConstraint{
       CLASS_NAME(HasNonUnits);
       USE_ALLOCATOR(HasNonUnits);
 
-      bool check(Property*p) override{
+      bool check(Property*p) final{
         CALL("Options::HasNonUnits::check");
         return (p->clauses()-p->unitClauses())!=0;
       }
-      vstring msg() override{ return " only useful with non-unit clauses"; }
+      vstring msg() final{ return " only useful with non-unit clauses"; }
     };
 
     struct HasPredicates : OptionProblemConstraint{
       CLASS_NAME(HasPredicates);
       USE_ALLOCATOR(HasPredicates);
 
-      bool check(Property*p) override{
+      bool check(Property*p) final{
         CALL("Options::HasPredicates::check");
         return (p->category()==Property::PEQ || p->category()==Property::UEQ);
       }
-      vstring msg() override{ return " only useful with predicates"; }
+      vstring msg() final{ return " only useful with predicates"; }
     };
 
     struct AtomConstraint : OptionProblemConstraint{
@@ -1815,12 +1815,12 @@ bool _hard;
       AtomConstraint(int a,bool g) : atoms(a),greater(g) {}
       int atoms;
       bool greater;
-      bool check(Property*p) override{ 
+      bool check(Property*p) final{ 
         CALL("Options::AtomConstraint::check");
         return greater ? p->atoms()>atoms : p->atoms()<atoms;
       }
           
-      vstring msg() override{ 
+      vstring msg() final{ 
         vstring m = " not with ";
         if(greater){ m+="more";}else{m+="less";}
         return m+" than "+Lib::Int::toString(atoms)+" atoms";
@@ -1856,8 +1856,8 @@ bool _hard;
       USE_ALLOCATOR(OptionHasValue);
 
       OptionHasValue(vstring ov,vstring v) : option_value(ov),value(v) {}
-      bool check(Property*p) override;
-      vstring msg() override{ return option_value+" has value "+value; } 
+      bool check(Property*p) final;
+      vstring msg() final{ return option_value+" has value "+value; } 
       vstring option_value;
       vstring value; 
     };
@@ -1868,7 +1868,7 @@ bool _hard;
 
       ManyOptionProblemConstraints(bool a) : is_and(a) {}
 
-      bool check(Property*p) override{
+      bool check(Property*p) final{
         CALL("Options::ManyOptionProblemConstraints::check");
         bool res = is_and;
         Stack<OptionProblemConstraintUP>::Iterator it(cons);
@@ -1877,7 +1877,7 @@ bool _hard;
         return res;
       } 
 
-      vstring msg() override{
+      vstring msg() final{
         vstring res="";
         Stack<OptionProblemConstraintUP>::Iterator it(cons);
         if(it.hasNext()){ res=it.next()->msg();}

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -961,11 +961,11 @@ private:
         T defaultValue;
         T actualValue;
         
-        virtual bool isDefault() const { return defaultValue==actualValue;}
+        bool isDefault() const override { return defaultValue==actualValue;}
 
         // Getting the string versions of values, useful for output
         virtual vstring getStringOfValue(T value) const{ ASSERTION_VIOLATION;}
-        virtual vstring getStringOfActual() const { return getStringOfValue(actualValue); }
+        vstring getStringOfActual() const override { return getStringOfValue(actualValue); }
         
         // Adding and checking constraints
         // By default constraints are soft and reaction to them is controlled by the bad_option option
@@ -994,7 +994,7 @@ private:
             _constraints.push(std::move(tc));
         }
         // This checks the constraints and may cause a UserError
-        bool checkConstraints();
+        bool checkConstraints() override;
         
         // Produces a separate constraint object based on this option
         /// Useful for IfThen constraints and reliesOn i.e. _splitting.is(equal(true))
@@ -1005,16 +1005,16 @@ private:
         bool hasProblemConstraints(){ 
           return !supress_problemconstraints && !_prob_constraints.isEmpty(); 
         }
-        virtual bool checkProblemConstraints(Property* prop);
+        bool checkProblemConstraints(Property* prop) override;
         
-        virtual void output(ostream& out, bool linewrap) const {
+        void output(ostream& out, bool linewrap) const override {
             CALL("Options::OptionValue::output");
             AbstractOptionValue::output(out,linewrap);
             out << "\tdefault: " << getStringOfValue(defaultValue) << endl;
         }
        
         // This is where actual randomisation happens
-        bool randomize(Property* p);
+        bool randomize(Property* p) override;
  
     private:
         Lib::Stack<OptionValueConstraintUP<T>> _constraints;
@@ -1045,7 +1045,7 @@ private:
         OptionValue<T>(l,s,def), choices(c) {}
         ChoiceOptionValue(vstring l, vstring s,T d) : ChoiceOptionValue(l,s,d, T::optionChoiceValues()) {}
         
-        bool setValue(const vstring& value){
+        bool setValue(const vstring& value) override{
             // makes reasonable assumption about ordering of every enum
             int index = choices.find(value.c_str());
             if(index<0) return false;
@@ -1053,7 +1053,7 @@ private:
             return true;
         }
         
-        virtual void output(ostream& out,bool linewrap) const {
+        void output(ostream& out,bool linewrap) const override {
             AbstractOptionValue::output(out,linewrap);
             out << "\tdefault: " << choices[static_cast<unsigned>(this->defaultValue)];
             out << endl;
@@ -1080,7 +1080,7 @@ private:
             out << endl;
         }
         
-        vstring getStringOfValue(T value) const {
+        vstring getStringOfValue(T value) const override {
             unsigned i = static_cast<unsigned>(value);
             return choices[i];
         }
@@ -1097,7 +1097,7 @@ private:
     struct BoolOptionValue : public OptionValue<bool> {
         BoolOptionValue(){}
         BoolOptionValue(vstring l,vstring s, bool d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value){
+        bool setValue(const vstring& value) override{
             if (! value.compare("on") || ! value.compare("true")) {
                 actualValue=true;
                 
@@ -1110,36 +1110,36 @@ private:
             return true;
         }
         
-        vstring getStringOfValue(bool value) const { return (value ? "on" : "off"); }
+        vstring getStringOfValue(bool value) const override { return (value ? "on" : "off"); }
     };
 
     struct IntOptionValue : public OptionValue<int> {
         IntOptionValue(){}
         IntOptionValue(vstring l,vstring s, int d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value){
+        bool setValue(const vstring& value) override{
             return Int::stringToInt(value.c_str(),actualValue);
         }
-        vstring getStringOfValue(int value) const{ return Lib::Int::toString(value); }
+        vstring getStringOfValue(int value) const override{ return Lib::Int::toString(value); }
     };
     
     struct UnsignedOptionValue : public OptionValue<unsigned> {
         UnsignedOptionValue(){}
         UnsignedOptionValue(vstring l,vstring s, unsigned d) : OptionValue(l,s,d){}
 
-        bool setValue(const vstring& value){
+        bool setValue(const vstring& value) override{
             return Int::stringToUnsignedInt(value.c_str(),actualValue);
         }
-        vstring getStringOfValue(unsigned value) const{ return Lib::Int::toString(value); }
+        vstring getStringOfValue(unsigned value) const override{ return Lib::Int::toString(value); }
     };
     
     struct StringOptionValue : public OptionValue<vstring> {
         StringOptionValue(){}
         StringOptionValue(vstring l,vstring s, vstring d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value){
+        bool setValue(const vstring& value) override{
             actualValue = (value=="<empty>") ? "" : value;
             return true;
         }
-        vstring getStringOfValue(vstring value) const{
+        vstring getStringOfValue(vstring value) const override{
             if(value.empty()) return "<empty>";
             return value;
         }
@@ -1148,19 +1148,19 @@ private:
     struct LongOptionValue : public OptionValue<long> {
         LongOptionValue(){}
         LongOptionValue(vstring l,vstring s, long d) : OptionValue(l,s,d){}
-        bool setValue(const vstring& value){
+        bool setValue(const vstring& value) override{
             return Int::stringToLong(value.c_str(),actualValue);
         }
-        vstring getStringOfValue(long value) const{ return Lib::Int::toString(value); }
+        vstring getStringOfValue(long value) const override{ return Lib::Int::toString(value); }
     };
     
 struct FloatOptionValue : public OptionValue<float>{
 FloatOptionValue(){}
 FloatOptionValue(vstring l,vstring s, float d) : OptionValue(l,s,d){}
-bool setValue(const vstring& value){
+bool setValue(const vstring& value) override{
     return Int::stringToFloat(value.c_str(),actualValue);
 }
-vstring getStringOfValue(float value) const{ return Lib::Int::toString(value); }
+vstring getStringOfValue(float value) const override{ return Lib::Int::toString(value); }
 };
 
 /**
@@ -1177,7 +1177,7 @@ RatioOptionValue(){}
 RatioOptionValue(vstring l, vstring s, int def, int other, char sp=':') :
 OptionValue(l,s,def), sep(sp), defaultOtherValue(other), otherValue(other) {};
 
-virtual OptionValueConstraintUP<int> getNotDefault() override { return isNotDefaultRatio(); }
+OptionValueConstraintUP<int> getNotDefault() override { return isNotDefaultRatio(); }
 
 void addConstraintIfNotDefault(AbstractWrappedConstraintUP c){
     addConstraint(If(isNotDefaultRatio()).then(unwrap<int>(c)));
@@ -1192,14 +1192,14 @@ char sep;
 int defaultOtherValue;
 int otherValue;
 
-virtual void output(ostream& out,bool linewrap) const override {
+void output(ostream& out,bool linewrap) const override {
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault left: " << defaultValue << endl;
     out << "\tdefault right: " << defaultOtherValue << endl;
 }
 
-virtual vstring getStringOfValue(int value) const override { ASSERTION_VIOLATION;}
-virtual vstring getStringOfActual() const override {
+vstring getStringOfValue(int value) const override { ASSERTION_VIOLATION;}
+vstring getStringOfActual() const override {
     return Lib::Int::toString(actualValue)+sep+Lib::Int::toString(otherValue);
 }
 
@@ -1221,14 +1221,14 @@ NonGoalWeightOptionValue(){}
 NonGoalWeightOptionValue(vstring l, vstring s, float def) :
 OptionValue(l,s,def), numerator(1), denominator(1) {};
 
-bool setValue(const vstring& value);
+bool setValue(const vstring& value) override;
 
 // output does not output numerator and denominator as they
 // are produced from defaultValue
 int numerator;
 int denominator;
 
-virtual vstring getStringOfValue(float value) const{ return Lib::Int::toString(value); }
+vstring getStringOfValue(float value) const override{ return Lib::Int::toString(value); }
 };
 
 /**
@@ -1241,14 +1241,14 @@ SelectionOptionValue(){}
 SelectionOptionValue(vstring l,vstring s, int def):
 OptionValue(l,s,def){};
 
-bool setValue(const vstring& value);
+bool setValue(const vstring& value) override;
 
-virtual void output(ostream& out,bool linewrap) const {
+void output(ostream& out,bool linewrap) const override {
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault: " << defaultValue << endl;;
 }
 
-virtual vstring getStringOfValue(int value) const{ return Lib::Int::toString(value); }
+vstring getStringOfValue(int value) const override{ return Lib::Int::toString(value); }
 
 AbstractWrappedConstraintUP isLookAheadSelection(){
   return AbstractWrappedConstraintUP(new WrappedConstraint<int>(*this,OptionValueConstraintUP<int>(new isLookAheadSelectionConstraint())));
@@ -1264,13 +1264,13 @@ InputFileOptionValue(){}
 InputFileOptionValue(vstring l,vstring s, vstring def,Options* p):
 OptionValue(l,s,def), parent(p){};
 
-bool setValue(const vstring& value);
+bool setValue(const vstring& value) override;
 
-virtual void output(ostream& out,bool linewrap) const {
+void output(ostream& out,bool linewrap) const override {
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault: " << defaultValue << endl;;
 }
-virtual vstring getStringOfValue(vstring value) const{ return value; }
+vstring getStringOfValue(vstring value) const override{ return value; }
 private:
 Options* parent;
 
@@ -1284,11 +1284,11 @@ DecodeOptionValue(){ AbstractOptionValue::_should_copy=false;}
 DecodeOptionValue(vstring l,vstring s,Options* p):
 OptionValue(l,s,""), parent(p){ AbstractOptionValue::_should_copy=false;}
 
-bool setValue(const vstring& value){
+bool setValue(const vstring& value) override{
     parent->readFromEncodedOptions(value);
     return true;
 }
-virtual vstring getStringOfValue(vstring value) const{ return value; }
+vstring getStringOfValue(vstring value) const override{ return value; }
 
 private:
 Options* parent;
@@ -1304,14 +1304,14 @@ TimeLimitOptionValue(){}
 TimeLimitOptionValue(vstring l, vstring s, float def) :
 OptionValue(l,s,def) {};
 
-bool setValue(const vstring& value);
+bool setValue(const vstring& value) override;
 
-virtual void output(ostream& out,bool linewrap) const {
+void output(ostream& out,bool linewrap) const override {
     CALL("Options::TimeLimitOptionValue::output");
     AbstractOptionValue::output(out,linewrap);
     out << "\tdefault: " << defaultValue << "d" << endl;
 }
-virtual vstring getStringOfValue(int value) const{ return Lib::Int::toString(value)+"d"; }
+vstring getStringOfValue(int value) const override{ return Lib::Int::toString(value)+"d"; }
 };
 
 /**
@@ -1430,10 +1430,10 @@ bool _hard;
         CLASS_NAME(OptionValueConstraintOrWrapper);
         USE_ALLOCATOR(OptionValueConstraintOrWrapper);
         OptionValueConstraintOrWrapper(OptionValueConstraintUP<T> l, OptionValueConstraintUP<T> r) : left(std::move(l)),right(std::move(r)) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return left->check(value) || right->check(value);
         }
-        vstring msg(const OptionValue<T>& value){ return left->msg(value) + " or " + right->msg(value); }
+        vstring msg(const OptionValue<T>& value) override{ return left->msg(value) + " or " + right->msg(value); }
 
         OptionValueConstraintUP<T> left;
         OptionValueConstraintUP<T> right;
@@ -1444,10 +1444,10 @@ bool _hard;
         CLASS_NAME(OptionValueConstraintAndWrapper);
         USE_ALLOCATOR(OptionValueConstraintAndWrapper);
         OptionValueConstraintAndWrapper(OptionValueConstraintUP<T> l, OptionValueConstraintUP<T> r) : left(std::move(l)),right(std::move(r)) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return left->check(value) && right->check(value);
         }
-        vstring msg(const OptionValue<T>& value){ return left->msg(value) + " and " + right->msg(value); }
+        vstring msg(const OptionValue<T>& value) override{ return left->msg(value) + " and " + right->msg(value); }
 
         OptionValueConstraintUP<T> left;
         OptionValueConstraintUP<T> right;
@@ -1460,8 +1460,8 @@ bool _hard;
         
         UnWrappedConstraint(AbstractWrappedConstraintUP c) : con(std::move(c)) {}
         
-        bool check(const OptionValue<T>&){ return con->check(); }
-        vstring msg(const OptionValue<T>&){ return con->msg(); }
+        bool check(const OptionValue<T>&) override{ return con->check(); }
+        vstring msg(const OptionValue<T>&) override{ return con->msg(); }
         
         AbstractWrappedConstraintUP con;
     };
@@ -1523,10 +1523,10 @@ bool _hard;
         CLASS_NAME(Equal);
         USE_ALLOCATOR(Equal);
         Equal(T gv) : _goodvalue(gv) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return value.actualValue == _goodvalue;
         }
-        vstring msg(const OptionValue<T>& value){
+        vstring msg(const OptionValue<T>& value) override{
             return value.longName+"("+value.getStringOfActual()+") is equal to " + value.getStringOfValue(_goodvalue);
         }
         T _goodvalue;
@@ -1541,10 +1541,10 @@ bool _hard;
         CLASS_NAME(NotEqual);
         USE_ALLOCATOR(NotEqual);
         NotEqual(T bv) : _badvalue(bv) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return value.actualValue != _badvalue;
         }
-        vstring msg(const OptionValue<T>& value){ return value.longName+"("+value.getStringOfActual()+") is not equal to " + value.getStringOfValue(_badvalue); }
+        vstring msg(const OptionValue<T>& value) override{ return value.longName+"("+value.getStringOfActual()+") is not equal to " + value.getStringOfValue(_badvalue); }
         T _badvalue;
     };
     template<typename T>
@@ -1559,10 +1559,10 @@ bool _hard;
         CLASS_NAME(LessThan);
         USE_ALLOCATOR(LessThan);
         LessThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
         }
-        vstring msg(const OptionValue<T>& value){
+        vstring msg(const OptionValue<T>& value) override{
             if(_orequal) return value.longName+"("+value.getStringOfActual()+") is less than or equal to " + value.getStringOfValue(_goodvalue);
             return value.longName+"("+value.getStringOfActual()+") is less than "+ value.getStringOfValue(_goodvalue);
         }
@@ -1586,11 +1586,11 @@ bool _hard;
         CLASS_NAME(GreaterThan);
         USE_ALLOCATOR(GreaterThan);
         GreaterThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return (value.actualValue > _goodvalue || (_orequal && value.actualValue==_goodvalue));
         }
         
-        vstring msg(const OptionValue<T>& value){
+        vstring msg(const OptionValue<T>& value) override{
             if(_orequal) return value.longName+"("+value.getStringOfActual()+") is greater than or equal to " + value.getStringOfValue(_goodvalue);
             return value.longName+"("+value.getStringOfActual()+") is greater than "+ value.getStringOfValue(_goodvalue);
         }
@@ -1614,11 +1614,11 @@ bool _hard;
         CLASS_NAME(SmallerThan);
         USE_ALLOCATOR(SmallerThan);
         SmallerThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
         }
 
-        vstring msg(const OptionValue<T>& value){
+        vstring msg(const OptionValue<T>& value) override{
             if(_orequal) return value.longName+"("+value.getStringOfActual()+") is smaller than or equal to " + value.getStringOfValue(_goodvalue);
             return value.longName+"("+value.getStringOfActual()+") is smaller than "+ value.getStringOfValue(_goodvalue);
         }
@@ -1650,12 +1650,12 @@ bool _hard;
         IfThenConstraint(OptionValueConstraintUP<T> ic, OptionValueConstraintUP<T> c) :
         if_con(std::move(ic)), then_con(std::move(c)) {}
         
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             ASS(then_con);
             return !if_con->check(value) || then_con->check(value);
         }
         
-        vstring msg(const OptionValue<T>& value){
+        vstring msg(const OptionValue<T>& value) override{
             return "if "+if_con->msg(value)+" then "+ then_con->msg(value);
         }
         
@@ -1696,20 +1696,20 @@ bool _hard;
     struct NotDefaultConstraint : public OptionValueConstraint<T> {
         NotDefaultConstraint() {}
         
-        bool check(const OptionValue<T>& value){
+        bool check(const OptionValue<T>& value) override{
             return value.defaultValue != value.actualValue;
         }
-        vstring msg(const OptionValue<T>& value) { return value.longName+"("+value.getStringOfActual()+") is not default("+value.getStringOfValue(value.defaultValue)+")";}
+        vstring msg(const OptionValue<T>& value) override { return value.longName+"("+value.getStringOfActual()+") is not default("+value.getStringOfValue(value.defaultValue)+")";}
     };
     struct NotDefaultRatioConstraint : public OptionValueConstraint<int> {
         NotDefaultRatioConstraint() {}
         
-        bool check(const OptionValue<int>& value){
+        bool check(const OptionValue<int>& value) override{
             const RatioOptionValue& rvalue = static_cast<const RatioOptionValue&>(value);
             return (rvalue.defaultValue != rvalue.actualValue ||
                     rvalue.defaultOtherValue != rvalue.otherValue);
         }
-        vstring msg(const OptionValue<int>& value) { return value.longName+"("+value.getStringOfActual()+") is not default";}
+        vstring msg(const OptionValue<int>& value) override { return value.longName+"("+value.getStringOfActual()+") is not default";}
         
     };
     
@@ -1727,10 +1727,10 @@ bool _hard;
         CLASS_NAME(isLookAheadSelectionConstraint);
         USE_ALLOCATOR(isLookAheadSelectionConstraint);
         isLookAheadSelectionConstraint() {}
-        bool check(const OptionValue<int>& value){
+        bool check(const OptionValue<int>& value) override{
             return value.actualValue == 11 || value.actualValue == 1011 || value.actualValue == -11 || value.actualValue == -1011;
         }
-        vstring msg(const OptionValue<int>& value){
+        vstring msg(const OptionValue<int>& value) override{
             return value.longName+"("+value.getStringOfActual()+") is not lookahead selection";
         }
     };
@@ -1760,12 +1760,12 @@ bool _hard;
       USE_ALLOCATOR(CategoryCondition);
 
       CategoryCondition(Property::Category c,bool h) : cat(c), has(h) {}
-      bool check(Property*p){
+      bool check(Property*p) override{
           CALL("Options::CategoryCondition::check");
           ASS(p);
           return has ? p->category()==cat : p->category()!=cat;
       }
-      vstring msg(){
+      vstring msg() override{
         vstring m =" not useful for property ";
         if(has) m+="not";
         return m+" in category "+Property::categoryToString(cat);
@@ -1778,34 +1778,34 @@ bool _hard;
       CLASS_NAME(UsesEquality);
       USE_ALLOCATOR(UsesEquality);
 
-      bool check(Property*p){
+      bool check(Property*p) override{
         CALL("Options::UsesEquality::check");
         ASS(p)
         return (p->equalityAtoms() != 0);
       }
-      vstring msg(){ return " only useful with equality"; }
+      vstring msg() override{ return " only useful with equality"; }
     };
 
     struct HasNonUnits : OptionProblemConstraint{
       CLASS_NAME(HasNonUnits);
       USE_ALLOCATOR(HasNonUnits);
 
-      bool check(Property*p){
+      bool check(Property*p) override{
         CALL("Options::HasNonUnits::check");
         return (p->clauses()-p->unitClauses())!=0;
       }
-      vstring msg(){ return " only useful with non-unit clauses"; }
+      vstring msg() override{ return " only useful with non-unit clauses"; }
     };
 
     struct HasPredicates : OptionProblemConstraint{
       CLASS_NAME(HasPredicates);
       USE_ALLOCATOR(HasPredicates);
 
-      bool check(Property*p){
+      bool check(Property*p) override{
         CALL("Options::HasPredicates::check");
         return (p->category()==Property::PEQ || p->category()==Property::UEQ);
       }
-      vstring msg(){ return " only useful with predicates"; }
+      vstring msg() override{ return " only useful with predicates"; }
     };
 
     struct AtomConstraint : OptionProblemConstraint{
@@ -1815,12 +1815,12 @@ bool _hard;
       AtomConstraint(int a,bool g) : atoms(a),greater(g) {}
       int atoms;
       bool greater;
-      bool check(Property*p){ 
+      bool check(Property*p) override{ 
         CALL("Options::AtomConstraint::check");
         return greater ? p->atoms()>atoms : p->atoms()<atoms;
       }
           
-      vstring msg(){ 
+      vstring msg() override{ 
         vstring m = " not with ";
         if(greater){ m+="more";}else{m+="less";}
         return m+" than "+Lib::Int::toString(atoms)+" atoms";
@@ -1856,8 +1856,8 @@ bool _hard;
       USE_ALLOCATOR(OptionHasValue);
 
       OptionHasValue(vstring ov,vstring v) : option_value(ov),value(v) {}
-      bool check(Property*p);
-      vstring msg(){ return option_value+" has value "+value; } 
+      bool check(Property*p) override;
+      vstring msg() override{ return option_value+" has value "+value; } 
       vstring option_value;
       vstring value; 
     };
@@ -1868,7 +1868,7 @@ bool _hard;
 
       ManyOptionProblemConstraints(bool a) : is_and(a) {}
 
-      bool check(Property*p){
+      bool check(Property*p) override{
         CALL("Options::ManyOptionProblemConstraints::check");
         bool res = is_and;
         Stack<OptionProblemConstraintUP>::Iterator it(cons);
@@ -1877,7 +1877,7 @@ bool _hard;
         return res;
       } 
 
-      vstring msg(){
+      vstring msg() override{
         vstring res="";
         Stack<OptionProblemConstraintUP>::Iterator it(cons);
         if(it.hasNext()){ res=it.next()->msg();}

--- a/Shell/Rectify.hpp
+++ b/Shell/Rectify.hpp
@@ -52,7 +52,7 @@ private:
   typedef pair<unsigned,bool> VarWithUsageInfo;
   typedef List<VarWithUsageInfo> VarUsageTrackingList;
   /** Renaming stores bindings for free and bound variables */
-  class Renaming
+  class Renaming final
     : public Array<VarUsageTrackingList*>
   {
   public:
@@ -62,13 +62,13 @@ private:
     {
       fillInterval(0,15);
     }
-    ~Renaming() override;
+    ~Renaming() final;
     bool tryGetBoundAndMarkUsed (int var,int& boundTo) const;
     VarWithUsageInfo getBoundAndUsage(int var) const;
     unsigned bind (unsigned v);
     void undoBinding(unsigned v);
   private:
-    void fillInterval (size_t start,size_t end) override;
+    void fillInterval (size_t start,size_t end) final;
     /** next variable to rename to */
     unsigned _nextVar;
     /** Variables that already appeared in the formula

--- a/Shell/Rectify.hpp
+++ b/Shell/Rectify.hpp
@@ -62,13 +62,13 @@ private:
     {
       fillInterval(0,15);
     }
-    ~Renaming();
+    ~Renaming() override;
     bool tryGetBoundAndMarkUsed (int var,int& boundTo) const;
     VarWithUsageInfo getBoundAndUsage(int var) const;
     unsigned bind (unsigned v);
     void undoBinding(unsigned v);
   private:
-    virtual void fillInterval (size_t start,size_t end);
+    void fillInterval (size_t start,size_t end) override;
     /** next variable to rename to */
     unsigned _nextVar;
     /** Variables that already appeared in the formula

--- a/Shell/SMTFormula.hpp
+++ b/Shell/SMTFormula.hpp
@@ -192,7 +192,7 @@ private:
 class YicesSolver : public SMTSolver
 {
 public:
-  virtual void run(SMTBenchmark& problem, SMTSolverResult& res, unsigned timeout);
+  void run(SMTBenchmark& problem, SMTSolverResult& res, unsigned timeout) override;
 };
 
 }

--- a/Shell/SMTFormula.hpp
+++ b/Shell/SMTFormula.hpp
@@ -192,7 +192,7 @@ private:
 class YicesSolver : public SMTSolver
 {
 public:
-  void run(SMTBenchmark& problem, SMTSolverResult& res, unsigned timeout) override;
+  void run(SMTBenchmark& problem, SMTSolverResult& res, unsigned timeout) final;
 };
 
 }

--- a/Shell/SubexpressionIterator.hpp
+++ b/Shell/SubexpressionIterator.hpp
@@ -104,7 +104,7 @@ namespace Shell {
       FoolAwareSubformulaIterator(Term* t): _sei(t) {}
       FoolAwareSubformulaIterator(TermList ts): _sei(ts) {}
 
-      bool hasNext() override {
+      bool hasNext() final {
         CALL("FoolAwareSubformulaIterator::hasNext");
         while (_sei.hasNext()) {
           SubexpressionIterator::Expression expression = _sei.next();
@@ -116,7 +116,7 @@ namespace Shell {
         }
         return false;
       }
-      Formula* next() override {
+      Formula* next() final {
         int dummy;
         return next(dummy);
       }
@@ -140,7 +140,7 @@ namespace Shell {
       FoolAwareSubtermIterator(Term* t): _sei(t) {}
       FoolAwareSubtermIterator(TermList ts): _sei(ts) {}
 
-      bool hasNext() override {
+      bool hasNext() final {
         CALL("FoolAwareSubtermIterator::hasNext");
         while (_sei.hasNext()) {
           SubexpressionIterator::Expression expression = _sei.next();
@@ -151,7 +151,7 @@ namespace Shell {
         }
         return false;
       }
-      TermList next() override {
+      TermList next() final {
         return _next;
       }
 

--- a/Shell/SubexpressionIterator.hpp
+++ b/Shell/SubexpressionIterator.hpp
@@ -104,7 +104,7 @@ namespace Shell {
       FoolAwareSubformulaIterator(Term* t): _sei(t) {}
       FoolAwareSubformulaIterator(TermList ts): _sei(ts) {}
 
-      bool hasNext() {
+      bool hasNext() override {
         CALL("FoolAwareSubformulaIterator::hasNext");
         while (_sei.hasNext()) {
           SubexpressionIterator::Expression expression = _sei.next();
@@ -116,7 +116,7 @@ namespace Shell {
         }
         return false;
       }
-      Formula* next() {
+      Formula* next() override {
         int dummy;
         return next(dummy);
       }
@@ -140,7 +140,7 @@ namespace Shell {
       FoolAwareSubtermIterator(Term* t): _sei(t) {}
       FoolAwareSubtermIterator(TermList ts): _sei(ts) {}
 
-      bool hasNext() {
+      bool hasNext() override {
         CALL("FoolAwareSubtermIterator::hasNext");
         while (_sei.hasNext()) {
           SubexpressionIterator::Expression expression = _sei.next();
@@ -151,7 +151,7 @@ namespace Shell {
         }
         return false;
       }
-      TermList next() {
+      TermList next() override {
         return _next;
       }
 

--- a/UnitTests/tArithmeticSubtermGeneralization.cpp
+++ b/UnitTests/tArithmeticSubtermGeneralization.cpp
@@ -42,7 +42,7 @@ public:
   // virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const override
   // { return TestUtils::eqModACVar(lhs, rhs); }
 
-  virtual Kernel::Clause* simplify(Kernel::Clause* in) const override 
+  Kernel::Clause* simplify(Kernel::Clause* in) const override
   {
     auto ord = KBO::testKBO();
     Ordering::trySetGlobalOrdering(SmartPtr<Ordering>(&ord, true));

--- a/UnitTests/tArithmeticSubtermGeneralization.cpp
+++ b/UnitTests/tArithmeticSubtermGeneralization.cpp
@@ -39,10 +39,10 @@ class SimplificationTester : public Test::Simplification::SimplificationTester
 {
 public:
 
-  // virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const override
+  // virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const final
   // { return TestUtils::eqModACVar(lhs, rhs); }
 
-  Kernel::Clause* simplify(Kernel::Clause* in) const override
+  Kernel::Clause* simplify(Kernel::Clause* in) const final
   {
     auto ord = KBO::testKBO();
     Ordering::trySetGlobalOrdering(SmartPtr<Ordering>(&ord, true));

--- a/UnitTests/tGaussianElimination.cpp
+++ b/UnitTests/tGaussianElimination.cpp
@@ -42,7 +42,7 @@ public:
   /**
    * NECESSARY: performs the simplification
    */
-  virtual Kernel::Clause* simplify(Kernel::Clause* in) const override 
+  Kernel::Clause* simplify(Kernel::Clause* in) const override
   {
     KBO ord = KBO::testKBO();
     auto simpl = [](Clause* cl)  -> Clause*
@@ -67,7 +67,7 @@ public:
    * OPTIONAL: override how equality between clauses is checked. 
    * Defaults to TestUtils::eqModAC(Clause const*, Clause const*).
    */
-  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const override
+  bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const override
   {
     return TestUtils::eqModAC(lhs, rhs);
   }

--- a/UnitTests/tGaussianElimination.cpp
+++ b/UnitTests/tGaussianElimination.cpp
@@ -42,7 +42,7 @@ public:
   /**
    * NECESSARY: performs the simplification
    */
-  Kernel::Clause* simplify(Kernel::Clause* in) const override
+  Kernel::Clause* simplify(Kernel::Clause* in) const final
   {
     KBO ord = KBO::testKBO();
     auto simpl = [](Clause* cl)  -> Clause*
@@ -67,7 +67,7 @@ public:
    * OPTIONAL: override how equality between clauses is checked. 
    * Defaults to TestUtils::eqModAC(Clause const*, Clause const*).
    */
-  bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const override
+  bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const final
   {
     return TestUtils::eqModAC(lhs, rhs);
   }

--- a/UnitTests/tUnificationWithAbstraction.cpp
+++ b/UnitTests/tUnificationWithAbstraction.cpp
@@ -187,7 +187,7 @@ static const int NORM_RESULT_BANK=3;
 struct testMismatchHandler : MismatchHandler
 {
 testMismatchHandler(Stack<UnificationConstraint>* c) : _constraints(c) {}
-bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2){
+bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2) override{
     ASS(index1 == NORM_QUERY_BANK && index2 == NORM_RESULT_BANK);
     static unsigned _var = 0;
     unsigned x = _var++;

--- a/UnitTests/tUnificationWithAbstraction.cpp
+++ b/UnitTests/tUnificationWithAbstraction.cpp
@@ -187,7 +187,7 @@ static const int NORM_RESULT_BANK=3;
 struct testMismatchHandler : MismatchHandler
 {
 testMismatchHandler(Stack<UnificationConstraint>* c) : _constraints(c) {}
-bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2) override{
+bool handle(RobSubstitution* subst, TermList query, unsigned index1, TermList node, unsigned index2) final{
     ASS(index1 == NORM_QUERY_BANK && index2 == NORM_RESULT_BANK);
     static unsigned _var = 0;
     unsigned x = _var++;


### PR DESCRIPTION
Vampire uses a fair amount of dynamic dispatch via class hierarchies.

First change: use the C++11 `override` keyword wherever possible. This allows the compiler to detect errors when e.g. a non-virtual function is overridden. I think this is fairly uncontroversial and does not change machine code.

Second change: use `final` instead of `override` wherever possible. The `final` keyword indicates that a method (or whole class) may not be overridden by subclasses. I think the _semantic_ uses for this in Vampire are fairly rare, but it allows the compiler to "devirtualise" calls in some cases, which may improve performance. I added a note to `HACKING.md` to indicate that this may be changed in most cases if we need to override a method. This might be more controversial and does impact generated machine code (although hopefully positively).