### PR TITLE
Improving Vampire higher-order parser

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -365,12 +365,16 @@ vstring TPTP::toString(Tag tag)
     return "-->";
   case T_TYPE_QUANT:
     return "!>";
+  case T_CHOICE:
+    return "@+";
+  case T_POLY_CHOICE:
+    return "@@+";
+  case T_DEF_DESC:
+    return "@-";
+  case T_POLY_DEF_DESC:
+    return "@@-";
   case T_THF_QUANT_SOME:
     return "?*";
-  case T_APP_PLUS:
-    return "@+";
-  case T_APP_MINUS:
-    return "@-";
   case T_TRUE:
     return "$true";
   case T_FALSE:
@@ -578,15 +582,25 @@ bool TPTP::readToken(Token& tok)
     return true;
   case '@':
     if (getChar(1) == '+') {
-      tok.tag = T_APP_PLUS;
+      tok.tag = T_CHOICE;
       resetChars();
       return true;
     }
     if (getChar(1) == '-') {
-      tok.tag = T_APP_MINUS;
+      tok.tag = T_DEF_DESC;
       resetChars();
       return true;
     }
+    if (getChar(1) == '@' && getChar(2) == '+'){
+      tok.tag = T_POLY_CHOICE;
+      resetChars();
+      return true;
+    }
+    if (getChar(1) == '@' && getChar(2) == '-'){
+      tok.tag = T_POLY_DEF_DESC;
+      resetChars();
+      return true;
+    }    
     tok.tag = T_APP;
     shiftChars(1);
     return true;
@@ -1574,6 +1588,14 @@ void TPTP::holFormula()
     return;
   }
 
+  case T_CHOICE:
+  case T_DEF_DESC:
+  case T_POLY_CHOICE:
+  case T_POLY_DEF_DESC:
+  {
+    USER_ERROR("At the moment Vampire HOL cannot parse definite and indefinite description operators");
+  }
+
   case T_STRING:
   case T_INT:
   case T_RAT:
@@ -1748,7 +1770,6 @@ void TPTP::endHolFormula()
     return;
   case PI:
   case SIGMA: {
-    //ASSERTION_VIOLATION;
     USER_ERROR("At the moment Vampire HOL cannot parse pi (!!) and sigma (?\?) operators");
   }
 

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -1536,14 +1536,14 @@ void TPTP::holFormula()
 
   case T_SIGMA:
     resetToks();
-    _connectives.push(SIGMA);
-    _states.push(HOL_FORMULA);
+    readTypeArgs(1);
+    _termLists.push(createFunctionApplication("vSIGMA", 1));    
     return;
   
   case T_PI:
     resetToks();
-    _connectives.push(PI);
-    _states.push(HOL_FORMULA);
+    readTypeArgs(1);
+    _termLists.push(createFunctionApplication("vPI", 1));      
     return;
 
   case T_FORALL:
@@ -1569,22 +1569,9 @@ void TPTP::holFormula()
     
   //higher order syntax wierdly allows (~) @ (...)
   case T_RPAR: {
-    ASS(_connectives.top() == NOT || _connectives.top() == PI ||
-        _connectives.top() == SIGMA);
+    ASS(_connectives.top() == NOT);
     int con = _connectives.pop();
-    if(con == NOT){
-      _termLists.push(createFunctionApplication("vNOT", 0));
-    } else {
-      _states.pop();//pop END_HOL_FORMULA
-      _states.pop();//pop TAG_STATE
-      _connectives.pop();   
-      vstring name = con == PI ? "vPI" : "vSIGMA";
-      resetToks();
-      consumeToken(T_APP);
-      _termLists.push(readArrowSort());
-      _termLists.push(createFunctionApplication(name, 1));
-      //_states.push(END_HOL_FORMULA);
-    }
+    _termLists.push(createFunctionApplication("vNOT", 0));
     return;
   }
 
@@ -1656,15 +1643,35 @@ void TPTP::holTerm()
   resetToks();
 
   vstring name = tok.content;
-
-  //AYB hack
-  if(name.at(0) == '$' && name != "$o" && name != "$i"){
-    USER_ERROR("vampire higher-order is currently not compatible with theory reasoning");
-  }
-
   unsigned arity = _typeArities.find(name) ? _typeArities.get(name) : 0;
 
   switch (tok.tag) {
+
+    case T_BOOL_TYPE:
+    case T_DEFAULT_TYPE: {
+      resetToks();
+      switch (tok.tag) {
+        case T_BOOL_TYPE:
+          _termLists.push(Term::boolSort());
+          break;
+        case T_DEFAULT_TYPE:
+          _termLists.push(Term::defaultSort());
+          break;             
+        default:
+          ASSERTION_VIOLATION;
+      }
+      return;
+    }
+
+    case T_REAL_TYPE:
+    case T_RATIONAL_TYPE: 
+    case T_STRING:
+    case T_INT:
+    case T_REAL:
+    case T_RAT: {
+      USER_ERROR("Vampire higher-order is currently not compatible with theory reasoning");
+    }  
+
     case T_AND:
     case T_OR:
     case T_IMPLY:  
@@ -1676,6 +1683,10 @@ void TPTP::holTerm()
       break;
     }    
     case T_NAME:{
+      //AYB must be a nicer way of dealing with this?
+      if(name.at(0) == '$'){
+        USER_ERROR("Vampire higher-order is currently not compatible with theory reasoning");    
+      }
       readTypeArgs(arity);
       _termLists.push(createFunctionApplication(name, arity)); // arity
       break;
@@ -1688,6 +1699,7 @@ void TPTP::holTerm()
     default:
       PARSE_ERROR("unexpected token", tok);
   }
+
   _lastPushed = TM;
 
 }
@@ -1767,11 +1779,8 @@ void TPTP::endHolFormula()
     _formulas.push(new NegatedFormula(f));
     _lastPushed = FORM;
     _states.push(END_HOL_FORMULA);
+
     return;
-  case PI:
-  case SIGMA: {
-    USER_ERROR("At the moment Vampire HOL cannot parse pi (!!) and sigma (?\?) operators");
-  }
 
   case FORALL:
   case EXISTS:
@@ -1884,7 +1893,7 @@ switch (tag) {
         f = new NegatedFormula(f);
       }
       _formulas.push(f);
-        _lastPushed = FORM;
+      _lastPushed = FORM;
       _states.push(END_HOL_FORMULA);
       return;
 
@@ -2952,9 +2961,6 @@ void TPTP::term()
     case T_INT:
     case T_REAL:
     case T_RAT: {
-      if(/*env.statistics->polymorphic ||*/ env.statistics->higherOrder){
-        USER_ERROR("Polymorphic Vampire is currently not compatible with theory reasoning");
-      }
       resetToks();
       unsigned number;
       switch (tok.tag) {

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -1570,7 +1570,7 @@ void TPTP::holFormula()
   //higher order syntax wierdly allows (~) @ (...)
   case T_RPAR: {
     ASS(_connectives.top() == NOT);
-    int con = _connectives.pop();
+    _connectives.pop();
     _termLists.push(createFunctionApplication("vNOT", 0));
     return;
   }

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -131,10 +131,14 @@ public:
     T_TYPE_QUANT,
     /** ?* */
     T_THF_QUANT_SOME,
-    /** some THF quantifier */
-    T_APP_PLUS,
-    /** some THF quantifier */
-    T_APP_MINUS,
+    /** @+  choice operator */
+    T_CHOICE,
+    /** @- definite description */
+    T_DEF_DESC,
+    /** @@+  choice operator */
+    T_POLY_CHOICE,
+    /** @@- definite description */
+    T_POLY_DEF_DESC,
     /** $true */
     T_TRUE,
     /** $false */


### PR DESCRIPTION
Vampire higher-order parser cannot currently parse definite and indefinite choice operators. This PR provides users with a reasonable error message when faced with problems including these.