### PR TITLE
Common interface for re-using introduced symbols.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -570,6 +570,7 @@ set(VAMPIRE_SHELL_SOURCES
     Shell/CommandLine.cpp
     Shell/CNF.cpp
     Shell/NewCNF.cpp
+    Shell/NameReuse.cpp
     Shell/DistinctProcessor.cpp
     Shell/DistinctGroupExpansion.cpp
     Shell/EqResWithDeletion.cpp
@@ -637,6 +638,7 @@ set(VAMPIRE_SHELL_SOURCES
     Shell/CommandLine.hpp
     Shell/CNF.hpp
     Shell/NewCNF.hpp
+    Shell/NameReuse.hpp
     Shell/DistinctProcessor.hpp
     Shell/DistinctGroupExpansion.hpp
     Shell/EqResWithDeletion.hpp

--- a/Kernel/FormulaVarIterator.hpp
+++ b/Kernel/FormulaVarIterator.hpp
@@ -45,6 +45,7 @@ namespace Kernel {
 class FormulaVarIterator
 {
 public:
+  DECL_ELEMENT_TYPE(unsigned);
   explicit FormulaVarIterator(const Formula*);
   explicit FormulaVarIterator(const Term*);
   explicit FormulaVarIterator(const TermList*);

--- a/Makefile
+++ b/Makefile
@@ -354,6 +354,7 @@ VS_OBJ = Shell/AnswerExtractor.o\
          Shell/CommandLine.o\
          Shell/CNF.o\
          Shell/NewCNF.o\
+         Shell/NameReuse.o\
          Shell/DistinctProcessor.o\
          Shell/DistinctGroupExpansion.o\
          Shell/EqResWithDeletion.o\

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -62,7 +62,7 @@ bool NameReuse::get(const vstring &key, unsigned &symbol)
 void NameReuse::put(vstring key, unsigned symbol)
 {
   CALL("NameReuse::put");
-  // std::cout << "put: " << env.signature->functionName(symbol) << " for " << key << std::endl;
+  //std::cout << "put: " << symbol << " for " << key << std::endl;
   _map.insert(key, symbol);
 }
 

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -22,42 +22,31 @@
 
 namespace Shell {
 
-static NameReuse *make_policy(Options::NameReuse option)
-{
-  CALL("NameReuse::make_policy");
-  switch (option) {
-    case Options::NameReuse::NONE:
-      return new NoNameReuse();
-    case Options::NameReuse::EXACT:
-      return new ExactNameReuse();
-  }
-}
-
 NameReuse *NameReuse::skolemInstance()
 {
   CALL("NameReuse::skolemInstance");
-  static NameReuse *instance = make_policy(env.options->skolemReuse());
+  static NameReuse *instance = new NameReuse();
   return instance;
 }
 
 NameReuse *NameReuse::definitionInstance()
 {
   CALL("NameReuse::definitionInstance");
-  static NameReuse *instance = make_policy(env.options->definitionReuse());
+  static NameReuse *instance = new NameReuse();
   return instance;
 }
 
-Formula *ExactNameReuse::normalise(Formula *f)
+Formula *NameReuse::normalise(Formula *f)
 {
-  CALL("ExactNameReuse::normalise");
+  CALL("NameReuse::normalise");
   //std::cout << "normalise: " << f->toString() << std::endl;
   Rectify rectify;
   return rectify.rectify(f);
 }
 
-bool ExactNameReuse::get(Formula *normalised, unsigned &symbol)
+bool NameReuse::get(Formula *normalised, unsigned &symbol)
 {
-  CALL("ExactNameReuse::get");
+  CALL("NameReuse::get");
   //std::cout << "get: " << normalised->toString() << std::endl;
   return _map.find(normalised->toString(), symbol);
   /*
@@ -69,7 +58,7 @@ bool ExactNameReuse::get(Formula *normalised, unsigned &symbol)
   */
 }
 
-void ExactNameReuse::put(Formula *normalised, unsigned symbol)
+void NameReuse::put(Formula *normalised, unsigned symbol)
 {
   CALL("ExactNameReuse::put");
   //std::cout << "put: " << env.signature->functionName(symbol) << " for " << normalised->toString() << std::endl;

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -66,10 +66,10 @@ void NameReuse::put(vstring key, unsigned symbol)
   _map.insert(key, symbol);
 }
 
-Lib::Stack<unsigned> NameReuse::freeVariablesInKeyOrder(Formula *f)
+VirtualIterator<unsigned> NameReuse::freeVariablesInKeyOrder(Formula *f)
 {
   CALL("NameReuse::freeVariablesInKeyOrder");
-  return Lib::Stack<unsigned>::fromIterator(FormulaVarIterator(f));
+  return pvi(FormulaVarIterator(f));
 }
 
 }; // namespace Shell

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -41,6 +41,21 @@ vstring NameReuse::key(Formula *f)
   Rectify rectify;
   Formula *rectified = rectify.rectify(f);
   vstring key = rectified->toString();
+  // the function could stop here, but some functions are ad-hoc polymorphic
+  // consider:
+  // ![X: $int] ?[Y]: (p(Y) & $less(X, X))
+  // ![X: $real] ?[Y]: (p(Y) & $less(X, X))
+  // therefore: append sort information to free variables to the key
+  FormulaVarIterator freeVars(rectified);
+  while(freeVars.hasNext()) {
+    unsigned free = freeVars.next();
+    TermList sort;
+    if(SortHelper::tryGetVariableSort(free, rectified, sort)) {
+      key.append("#");
+      key.append(Int::toString(free));
+      key.append(sort.term()->toString());
+    }
+  }
   //std::cout << "is: " << key << std::endl;
   return key;
 }

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -9,16 +9,13 @@
  */
 /**
  * @file NameReuse.cpp
- * Defines definition-reuse policies, configured by an option
+ * Attempt to reuse names introduced to represent formulae, e.g. Skolems or naming
  */
 
 #include "NameReuse.hpp"
-#include "Kernel/Formula.hpp"
-#include "Kernel/FormulaUnit.hpp"
-#include "Lib/Environment.hpp"
-#include "Shell/Options.hpp"
+#include "Kernel/FormulaVarIterator.hpp"
+#include "Lib/Stack.hpp"
 #include "Shell/Rectify.hpp"
-#include <iostream>
 
 namespace Shell {
 
@@ -36,33 +33,42 @@ NameReuse *NameReuse::definitionInstance()
   return instance;
 }
 
-Formula *NameReuse::normalise(Formula *f)
+vstring NameReuse::key(Formula *f)
 {
-  CALL("NameReuse::normalise");
-  //std::cout << "normalise: " << f->toString() << std::endl;
+  CALL("NameReuse::key");
+  //std::cout << "key for: " << f->toString() << std::endl;
   Rectify rectify;
-  return rectify.rectify(f);
+  Formula *rectified = rectify.rectify(f);
+  vstring key = rectified->toString();
+  //std::cout << "is: " << key << std::endl;
+  return key;
 }
 
-bool NameReuse::get(Formula *normalised, unsigned &symbol)
+bool NameReuse::get(const vstring &key, unsigned &symbol)
 {
   CALL("NameReuse::get");
-  //std::cout << "get: " << normalised->toString() << std::endl;
-  return _map.find(normalised->toString(), symbol);
+  //std::cout << "get: " << key << std::endl;
+  return _map.find(key, symbol);
   /*
-  if(_map.find(normalised->toString(), symbol)) {
-    std::cout << "hit: " << normalised->toString() << std::endl;
+  if(_map.find(key, symbol)) {
+    std::cout << "hit: " << key << std::endl;
     return true;
   }
   return false;
   */
 }
 
-void NameReuse::put(Formula *normalised, unsigned symbol)
+void NameReuse::put(vstring key, unsigned symbol)
 {
-  CALL("ExactNameReuse::put");
-  //std::cout << "put: " << env.signature->functionName(symbol) << " for " << normalised->toString() << std::endl;
-  _map.insert(normalised->toString(), symbol);
+  CALL("NameReuse::put");
+  // std::cout << "put: " << env.signature->functionName(symbol) << " for " << key << std::endl;
+  _map.insert(key, symbol);
+}
+
+Lib::Stack<unsigned> NameReuse::freeVariablesInKeyOrder(Formula *f)
+{
+  CALL("NameReuse::freeVariablesInKeyOrder");
+  return Lib::Stack<unsigned>::fromIterator(FormulaVarIterator(f));
 }
 
 }; // namespace Shell

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file NameReuse.cpp
+ * Defines definition-reuse policies, configured by an option
+ */
+
+#include "NameReuse.hpp"
+#include "Kernel/Formula.hpp"
+#include "Kernel/FormulaUnit.hpp"
+#include "Lib/Environment.hpp"
+#include "Shell/Options.hpp"
+#include "Shell/Rectify.hpp"
+#include <iostream>
+
+namespace Shell {
+
+static NameReuse *make_policy(Options::NameReuse option)
+{
+  CALL("NameReuse::make_policy");
+  switch (option) {
+    case Options::NameReuse::NONE:
+      return new NoNameReuse();
+    case Options::NameReuse::EXACT:
+      return new ExactNameReuse();
+  }
+}
+
+NameReuse *NameReuse::skolemInstance()
+{
+  CALL("NameReuse::skolemInstance");
+  static NameReuse *instance = make_policy(env.options->skolemReuse());
+  return instance;
+}
+
+NameReuse *NameReuse::definitionInstance()
+{
+  CALL("NameReuse::definitionInstance");
+  static NameReuse *instance = make_policy(env.options->definitionReuse());
+  return instance;
+}
+
+Formula *ExactNameReuse::normalise(Formula *f)
+{
+  CALL("ExactNameReuse::normalise");
+  FormulaUnit *copy =
+      new FormulaUnit(f, Inference(FromInput(UnitInputType::AXIOM)));
+  FormulaUnit *rectified = Rectify::rectify(copy);
+  return rectified->formula();
+}
+
+bool ExactNameReuse::get(Formula *normalised, unsigned &symbol)
+{
+  CALL("ExactNameReuse::get");
+  return _map.find(normalised->toString(), symbol);
+  /*
+  std::cout << "get: " << normalised->toString() << std::endl;
+  if(_map.find(normalised->toString(), symbol)) {
+    std::cout << "XXX: " << normalised->toString() << std::endl;
+    return true;
+  }
+  return false;
+  */
+}
+
+void ExactNameReuse::put(Formula *normalised, unsigned symbol)
+{
+  CALL("ExactNameReuse::put");
+  //std::cout << "put: " << env.signature->functionName(symbol) << " for " << normalised->toString() << std::endl;
+  _map.insert(normalised->toString(), symbol);
+}
+
+}; // namespace Shell

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -50,20 +50,19 @@ NameReuse *NameReuse::definitionInstance()
 Formula *ExactNameReuse::normalise(Formula *f)
 {
   CALL("ExactNameReuse::normalise");
-  FormulaUnit *copy =
-      new FormulaUnit(f, Inference(FromInput(UnitInputType::AXIOM)));
-  FormulaUnit *rectified = Rectify::rectify(copy);
-  return rectified->formula();
+  //std::cout << "normalise: " << f->toString() << std::endl;
+  Rectify rectify;
+  return rectify.rectify(f);
 }
 
 bool ExactNameReuse::get(Formula *normalised, unsigned &symbol)
 {
   CALL("ExactNameReuse::get");
+  //std::cout << "get: " << normalised->toString() << std::endl;
   return _map.find(normalised->toString(), symbol);
   /*
-  std::cout << "get: " << normalised->toString() << std::endl;
   if(_map.find(normalised->toString(), symbol)) {
-    std::cout << "XXX: " << normalised->toString() << std::endl;
+    std::cout << "hit: " << normalised->toString() << std::endl;
     return true;
   }
   return false;

--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -14,6 +14,7 @@
 
 #include "NameReuse.hpp"
 #include "Kernel/FormulaVarIterator.hpp"
+#include "Lib/ScopedPtr.hpp"
 #include "Lib/Stack.hpp"
 #include "Shell/Rectify.hpp"
 
@@ -22,15 +23,15 @@ namespace Shell {
 NameReuse *NameReuse::skolemInstance()
 {
   CALL("NameReuse::skolemInstance");
-  static NameReuse *instance = new NameReuse();
-  return instance;
+  static ScopedPtr<NameReuse> instance(new NameReuse());
+  return instance.ptr();
 }
 
 NameReuse *NameReuse::definitionInstance()
 {
   CALL("NameReuse::definitionInstance");
-  static NameReuse *instance = new NameReuse();
-  return instance;
+  static ScopedPtr<NameReuse> instance(new NameReuse());
+  return instance.ptr();
 }
 
 vstring NameReuse::key(Formula *f)

--- a/Shell/NameReuse.hpp
+++ b/Shell/NameReuse.hpp
@@ -16,6 +16,7 @@
 #define __NameReuse__
 
 #include "Forwards.hpp"
+#include "Shell/Rectify.hpp"
 #include "Lib/DHMap.hpp"
 
 using namespace Kernel;

--- a/Shell/NameReuse.hpp
+++ b/Shell/NameReuse.hpp
@@ -24,56 +24,30 @@ using namespace Kernel;
 namespace Shell {
 
 /**
- * Abstract base class: reuse "definition" terms used in place of formulae
+ * Reuse "definition" terms used in place of formulae.
  * Use for Skolemisation, naming, possibly others.
  */
 class NameReuse {
 public:
-  // singleton: look at env.options and return a suitable policy for...
+  CLASS_NAME(NameReuse)
+  USE_ALLOCATOR(NameReuse)
+
+  // singletons for...
   // skolems
   static NameReuse *skolemInstance();
   // definitions
   static NameReuse *definitionInstance();
 
   // normalise `f` in some way to use as a key: saves recomputing it later
-  virtual Formula *normalise(Formula *f) = 0;
+  Formula *normalise(Formula *f);
 
   // try and reuse a symbol for `normalised`
   // false if not seen before
   // true (and symbol filled out) if we have
-  virtual bool get(Formula *normalised, unsigned &symbol) = 0;
+  bool get(Formula *normalised, unsigned &symbol);
 
   // remember that we've used a symbol to stand for `normalised`
-  virtual void put(Formula *normalised, unsigned symbol) = 0;
-
-  // do we use formulae at all? - only false for NoNameReuse
-  // allows skipping work sometimes
-  virtual bool requiresFormula() { return true; };
-};
-
-/**
- * do not attempt to reuse definitions
- */
-class NoNameReuse : public NameReuse {
-public:
-  CLASS_NAME(NoNameReuse)
-  USE_ALLOCATOR(NoNameReuse)
-  inline Formula *normalise(Formula *f) override { return nullptr; }
-  inline bool get(Formula *normalised, unsigned &symbol) override { return false; }
-  inline void put(Formula *normalised, unsigned symbol) override {}
-  inline bool requiresFormula() override { return false; }
-};
-
-/**
- * reuse definitions if they match exactly
- */
-class ExactNameReuse : public NameReuse {
-public:
-  CLASS_NAME(ExactNameReuse)
-  USE_ALLOCATOR(ExactNameReuse)
-  Formula *normalise(Formula *f) override;
-  bool get(Formula *f, unsigned &symbol) override;
-  void put(Formula *f, unsigned symbol) override;
+  void put(Formula *normalised, unsigned symbol);
 
 private:
   DHMap<vstring, unsigned> _map;

--- a/Shell/NameReuse.hpp
+++ b/Shell/NameReuse.hpp
@@ -1,0 +1,83 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file NameReuse.cpp
+ * Defines definition-reuse policies, configured by an option
+ */
+
+#ifndef __NameReuse__
+#define __NameReuse__
+
+#include "Forwards.hpp"
+#include "Lib/DHMap.hpp"
+
+using namespace Kernel;
+
+namespace Shell {
+
+/**
+ * Abstract base class: reuse "definition" terms used in place of formulae
+ * Use for Skolemisation, naming, possibly others.
+ */
+class NameReuse {
+public:
+  // singleton: look at env.options and return a suitable policy for...
+  // skolems
+  static NameReuse *skolemInstance();
+  // definitions
+  static NameReuse *definitionInstance();
+
+  // normalise `f` in some way to use as a key: saves recomputing it later
+  virtual Formula *normalise(Formula *f) = 0;
+
+  // try and reuse a symbol for `normalised`
+  // false if not seen before
+  // true (and symbol filled out) if we have
+  virtual bool get(Formula *normalised, unsigned &symbol) = 0;
+
+  // remember that we've used a symbol to stand for `normalised`
+  virtual void put(Formula *normalised, unsigned symbol) = 0;
+
+  // do we use formulae at all? - only false for NoNameReuse
+  // allows skipping work sometimes
+  virtual bool requiresFormula() { return true; };
+};
+
+/**
+ * do not attempt to reuse definitions
+ */
+class NoNameReuse : public NameReuse {
+public:
+  CLASS_NAME(NoNameReuse)
+  USE_ALLOCATOR(NoNameReuse)
+  inline Formula *normalise(Formula *f) override { return nullptr; }
+  inline bool get(Formula *normalised, unsigned &symbol) override { return false; }
+  inline void put(Formula *normalised, unsigned symbol) override {}
+  inline bool requiresFormula() override { return false; }
+};
+
+/**
+ * reuse definitions if they match exactly
+ */
+class ExactNameReuse : public NameReuse {
+public:
+  CLASS_NAME(ExactNameReuse)
+  USE_ALLOCATOR(ExactNameReuse)
+  Formula *normalise(Formula *f) override;
+  bool get(Formula *f, unsigned &symbol) override;
+  void put(Formula *f, unsigned symbol) override;
+
+private:
+  DHMap<vstring, unsigned> _map;
+};
+
+} // namespace Shell
+
+#endif

--- a/Shell/NameReuse.hpp
+++ b/Shell/NameReuse.hpp
@@ -8,15 +8,14 @@
  * and in the source directory
  */
 /**
- * @file NameReuse.cpp
- * Defines definition-reuse policies, configured by an option
+ * @file NameReuse.hpp
+ * Attempt to reuse names introduced to represent formulae, e.g. Skolems or naming
  */
 
 #ifndef __NameReuse__
 #define __NameReuse__
 
 #include "Forwards.hpp"
-#include "Shell/Rectify.hpp"
 #include "Lib/DHMap.hpp"
 
 using namespace Kernel;
@@ -38,16 +37,19 @@ public:
   // definitions
   static NameReuse *definitionInstance();
 
-  // normalise `f` in some way to use as a key: saves recomputing it later
-  Formula *normalise(Formula *f);
+  // convert `f` to a string in some way to use as a key: saves recomputing it later
+  vstring key(Formula *f);
 
   // try and reuse a symbol for `normalised`
   // false if not seen before
   // true (and symbol filled out) if we have
-  bool get(Formula *normalised, unsigned &symbol);
+  bool get(const vstring &key, unsigned &symbol);
 
   // remember that we've used a symbol to stand for `normalised`
-  void put(Formula *normalised, unsigned symbol);
+  void put(vstring key, unsigned symbol);
+
+  // free variables in the order they occur in the key for `f`
+  Lib::Stack<unsigned> freeVariablesInKeyOrder(Formula *f);
 
 private:
   DHMap<vstring, unsigned> _map;

--- a/Shell/NameReuse.hpp
+++ b/Shell/NameReuse.hpp
@@ -40,16 +40,16 @@ public:
   // convert `f` to a string in some way to use as a key: saves recomputing it later
   vstring key(Formula *f);
 
-  // try and reuse a symbol for `normalised`
+  // try and reuse a symbol for `key`
   // false if not seen before
   // true (and symbol filled out) if we have
   bool get(const vstring &key, unsigned &symbol);
 
-  // remember that we've used a symbol to stand for `normalised`
+  // remember that we've used a symbol to stand for `key`
   void put(vstring key, unsigned symbol);
 
   // free variables in the order they occur in the key for `f`
-  Lib::Stack<unsigned> freeVariablesInKeyOrder(Formula *f);
+  VirtualIterator<unsigned> freeVariablesInKeyOrder(Formula *f);
 
 private:
   DHMap<vstring, unsigned> _map;

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1139,10 +1139,9 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
   SortHelper::collectVariableSorts(f, varSorts);
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
-  Stack<unsigned> varsInKeyOrder;
+  VirtualIterator<unsigned> keyOrderIt;
   if(name_reuse)
-    varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(f);
-  Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
+    keyOrderIt = name_reuse->freeVariablesInKeyOrder(f);
 
   VList::Iterator vit(freeVars);
   while (name_reuse ? keyOrderIt.hasNext() : vit.hasNext()) {

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -32,6 +32,7 @@
 
 #include "Shell/Statistics.hpp"
 #include "Shell/Options.hpp"
+#include "Shell/NameReuse.hpp"
 
 #include "Indexing/TermSharing.hpp"
 
@@ -1111,6 +1112,11 @@ bool Naming::canBeInDefinition(Formula* f, Where where) {
 Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
   CALL("Naming::getDefinitionLiteral");
 
+  NameReuse *reuse_policy = NameReuse::definitionInstance();
+  Formula *normalised = reuse_policy->normalise(f);
+  unsigned reused;
+  bool reuse = reuse_policy->get(normalised, reused);
+
   unsigned arity = VList::length(freeVars);
 
   static TermStack termVarSorts;
@@ -1146,20 +1152,27 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
   }
 
   if(!_appify){
-    unsigned pred = env.signature->addNamePredicate(arity);
-    Signature::Symbol* predSym = env.signature->getPredicate(pred);
-
-    if (env.colorUsed) {
-      Color fc = f->getColor();
-      if (fc != COLOR_TRANSPARENT) {
-        predSym->addColor(fc);
-      }
-      if (f->getSkip()) {
-        predSym->markSkip();
-      }
+    unsigned pred;
+    if(reuse) {
+      pred = reused;
     }
+    else {
+      pred = env.signature->addNamePredicate(arity);
+      reuse_policy->put(normalised, pred);
+      Signature::Symbol* predSym = env.signature->getPredicate(pred);
 
-    predSym->setType(OperatorType::getPredicateType(arity - typeArgArity, termVarSorts.begin(), typeArgArity));
+      if (!reuse && env.colorUsed) {
+        Color fc = f->getColor();
+        if (fc != COLOR_TRANSPARENT) {
+          predSym->addColor(fc);
+        }
+        if (f->getSkip()) {
+          predSym->markSkip();
+        }
+      }
+
+      predSym->setType(OperatorType::getPredicateType(arity - typeArgArity, termVarSorts.begin(), typeArgArity));
+    }
     return Literal::create(pred, arity, true, false, allVars.begin());
   } else {
     unsigned fun = env.signature->addNameFunction(typeVars.size());

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1152,16 +1152,13 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
   }
 
   if(!_appify){
-    unsigned pred;
-    if(reuse) {
-      pred = reused;
-    }
-    else {
+    unsigned pred = reused;
+    if(!reuse) {
       pred = env.signature->addNamePredicate(arity);
       reuse_policy->put(normalised, pred);
       Signature::Symbol* predSym = env.signature->getPredicate(pred);
 
-      if (!reuse && env.colorUsed) {
+      if (env.colorUsed) {
         Color fc = f->getColor();
         if (fc != COLOR_TRANSPARENT) {
           predSym->addColor(fc);
@@ -1175,10 +1172,14 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
     }
     return Literal::create(pred, arity, true, false, allVars.begin());
   } else {
-    unsigned fun = env.signature->addNameFunction(typeVars.size());
-    TermList sort = AtomicSort::arrowSort(termVarSorts, AtomicSort::boolSort());
-    Signature::Symbol* sym = env.signature->getFunction(fun);
-    sym->setType(OperatorType::getConstantsType(sort, typeArgArity)); 
+    unsigned fun = reused;
+    if(!reuse) {
+      fun = env.signature->addNameFunction(typeVars.size());
+      TermList sort = AtomicSort::arrowSort(termVarSorts, AtomicSort::boolSort());
+      Signature::Symbol* sym = env.signature->getFunction(fun);
+      sym->setType(OperatorType::getConstantsType(sort, typeArgArity)); 
+      reuse_policy->put(normalised, fun);
+    }
     TermList head = TermList(Term::create(fun, typeVars.size(), typeVars.begin()));
     TermList t = ApplicativeHelper::createAppTerm(
                  SortHelper::getResultSort(head.term()), head, termVars);

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1140,13 +1140,13 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
   Stack<unsigned> varsInKeyOrder;
-  if(successfully_reused)
+  if(name_reuse)
     varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(f);
   Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
 
   VList::Iterator vit(freeVars);
-  while (successfully_reused ? keyOrderIt.hasNext() : vit.hasNext()) {
-    unsigned uvar = successfully_reused ? keyOrderIt.next() : vit.next();
+  while (name_reuse ? keyOrderIt.hasNext() : vit.hasNext()) {
+    unsigned uvar = name_reuse ? keyOrderIt.next() : vit.next();
     TermList sort = varSorts.get(uvar, AtomicSort::defaultSort());
     if(sort == AtomicSort::superSort()){
       typeVars.push(TermList(uvar, false));     

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1122,6 +1122,8 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
     reuse_key = name_reuse->key(f);
     successfully_reused = name_reuse->get(reuse_key, reused_symbol);
   }
+  if(successfully_reused)
+    env.statistics->reusedFormulaNames++;
 
   unsigned arity = VList::length(freeVars);
 

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1117,7 +1117,7 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
     : nullptr;
   unsigned reused_symbol = 0;
   bool successfully_reused = false;
-  vstring reuse_key = nullptr;
+  vstring reuse_key;
   if(name_reuse) {
     reuse_key = name_reuse->key(f);
     successfully_reused = name_reuse->get(reuse_key, reused_symbol);

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1007,10 +1007,9 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free, Formula *reuse_formul
     env.statistics->reusedSkolemFunctions++;
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
-  Stack<unsigned> varsInKeyOrder;
+  VirtualIterator<unsigned> keyOrderIt;
   if(name_reuse)
-    varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(reuse_formula);
-  Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
+    keyOrderIt = name_reuse->freeVariablesInKeyOrder(reuse_formula);
 
   VarSet::Iterator vit(*free);
   while(name_reuse ? keyOrderIt.hasNext() : vit.hasNext()) {
@@ -1326,10 +1325,9 @@ Literal* NewCNF::createNamingLiteral(Formula* f, VList* free)
   ensureHavingVarSorts();
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
-  Stack<unsigned> varsInKeyOrder;
+  VirtualIterator<unsigned> keyOrderIt;
   if(name_reuse)
-    varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(f);
-  Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
+    keyOrderIt = name_reuse->freeVariablesInKeyOrder(f);
 
   VList::Iterator vit(free);
   while (name_reuse ? keyOrderIt.hasNext() : vit.hasNext()) {

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1003,6 +1003,8 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free, Formula *reuse_formul
     reuse_key = name_reuse->key(reuse_formula);
     successfully_reused = name_reuse->get(reuse_key, reused_symbol);
   }
+  if(successfully_reused)
+    env.statistics->reusedSkolemFunctions++;
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
   Stack<unsigned> varsInKeyOrder;
@@ -1291,6 +1293,8 @@ Literal* NewCNF::createNamingLiteral(Formula* f, VList* free)
     reuse_key = name_reuse->key(f);
     successfully_reused = name_reuse->get(reuse_key, reused_symbol);
   }
+  if(successfully_reused)
+    env.statistics->reusedFormulaNames++;
 
   unsigned length = VList::length(free);
   unsigned pred = reused_symbol;

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1008,13 +1008,13 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free, Formula *reuse_formul
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
   Stack<unsigned> varsInKeyOrder;
-  if(successfully_reused)
+  if(name_reuse)
     varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(reuse_formula);
   Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
 
   VarSet::Iterator vit(*free);
-  while(successfully_reused ? keyOrderIt.hasNext() : vit.hasNext()) {
-    unsigned uvar = successfully_reused ? keyOrderIt.next() : vit.next();
+  while(name_reuse ? keyOrderIt.hasNext() : vit.hasNext()) {
+    unsigned uvar = name_reuse ? keyOrderIt.next() : vit.next();
     domainSorts.push(_varSorts.get(uvar, AtomicSort::defaultSort()));
     fnArgs.push(TermList(uvar, false));
   }
@@ -1326,13 +1326,13 @@ Literal* NewCNF::createNamingLiteral(Formula* f, VList* free)
 
   // if we re-use a symbol, we _must_ close over free variables in some fixed order
   Stack<unsigned> varsInKeyOrder;
-  if(successfully_reused)
+  if(name_reuse)
     varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(f);
   Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
 
   VList::Iterator vit(free);
-  while (successfully_reused ? keyOrderIt.hasNext() : vit.hasNext()) {
-    unsigned uvar = successfully_reused ? keyOrderIt.next() : vit.next();
+  while (name_reuse ? keyOrderIt.hasNext() : vit.hasNext()) {
+    unsigned uvar = name_reuse ? keyOrderIt.next() : vit.next();
     domainSorts.push(_varSorts.get(uvar, AtomicSort::defaultSort()));
     predArgs.push(TermList(uvar, false));
   }

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1007,11 +1007,8 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free, Formula *reuse_formul
   Term* res;
   bool isPredicate = (rangeSort == AtomicSort::boolSort());
   if (isPredicate) {
-    unsigned pred;
-    if(reuse) {
-      pred = reused;
-    }
-    else {
+    unsigned pred = reused;
+    if(!reuse) {
       pred = Skolem::addSkolemPredicate(arity, domainSorts.begin(), var);
       reuse_policy->put(normalised, pred);
       env.statistics->skolemFunctions++;
@@ -1021,11 +1018,8 @@ Term* NewCNF::createSkolemTerm(unsigned var, VarSet* free, Formula *reuse_formul
     }
     res = Term::createFormula(new AtomicFormula(Literal::create(pred, arity, true, false, fnArgs.begin())));
   } else {
-    unsigned fun;
-    if(reuse) {
-      fun = reused;
-    }
-    else {
+    unsigned fun = reused;
+    if(!reuse) {
       fun = Skolem::addSkolemFunction(arity, domainSorts.begin(), rangeSort, var);
       reuse_policy->put(normalised, fun);
       env.statistics->skolemFunctions++;
@@ -1279,11 +1273,8 @@ Literal* NewCNF::createNamingLiteral(Formula* f, VList* free)
   bool reuse = reuse_policy->get(normalised, reused);
 
   unsigned length = VList::length(free);
-  unsigned pred;
-  if(reuse) {
-    pred = reused;
-  }
-  else {
+  unsigned pred = reused;
+  if(!reuse) {
     pred = env.signature->addNamePredicate(length);
     reuse_policy->put(normalised, pred);
   }

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1121,8 +1121,9 @@ void NewCNF::skolemise(QuantifiedFormula* g, BindingList*& bindings, BindingList
           subst.bind(b.first, b.second);
         }
         reuse_formula = SubstHelper::apply(g, subst);
-        remainingVars = reuse_formula->vars();
-        remainingSorts = reuse_formula->sorts();
+        // could be reuse_formula->vars() but SubstHelper might reorder them
+        remainingVars = g->vars();
+        remainingSorts = g->sorts();
       }
 
       processedBindings = nullptr;

--- a/Shell/NewCNF.hpp
+++ b/Shell/NewCNF.hpp
@@ -576,7 +576,7 @@ private:
 
   void ensureHavingVarSorts();
 
-  Term* createSkolemTerm(unsigned var, VarSet* free);
+  Term* createSkolemTerm(unsigned var, VarSet* free, Formula *reuse);
 
   bool _forInduction;
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -454,6 +454,32 @@ void Options::init()
     _functionDefinitionElimination.addProblemConstraint(hasEquality());
     _functionDefinitionElimination.setRandomChoices({"all","none"});
 
+    _skolemReuse = ChoiceOptionValue<NameReuse>(
+      "skolem_reuse",
+      "skr",
+      NameReuse::NONE,
+      {"none", "exact"}
+    );
+    _skolemReuse.description =
+      "How to re-use skolem symbols. Possible values are:\n"
+      " none: do not attempt to reuse symbols\n"
+      " exact: reuse symbols referring to identical sub-formulae\n";
+    _lookup.insert(&_skolemReuse);
+    _skolemReuse.tag(OptionTag::PREPROCESSING);
+    _skolemReuse.setRandomChoices({"none","exact"});
+
+    _definitionReuse = ChoiceOptionValue<NameReuse>(
+      "definition_reuse",
+      "dr",
+      NameReuse::NONE,
+      {"none", "exact"}
+    );
+    _definitionReuse.description =
+      "How to re-use definition symbols. Same as for Skolem reuse.";
+    _lookup.insert(&_definitionReuse);
+    _definitionReuse.tag(OptionTag::PREPROCESSING);
+    _definitionReuse.setRandomChoices({"none","exact"});
+
     _generalSplitting = ChoiceOptionValue<RuleActivity>("general_splitting","gsp",RuleActivity::OFF,{"input_only","off","on"});
     _generalSplitting.description=
     "Splits clauses in order to reduce number of different variables in each clause. "

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -454,31 +454,18 @@ void Options::init()
     _functionDefinitionElimination.addProblemConstraint(hasEquality());
     _functionDefinitionElimination.setRandomChoices({"all","none"});
 
-    _skolemReuse = ChoiceOptionValue<NameReuse>(
-      "skolem_reuse",
-      "skr",
-      NameReuse::NONE,
-      {"none", "exact"}
-    );
+    _skolemReuse = BoolOptionValue("skolem_reuse", "skr", false);
     _skolemReuse.description =
-      "How to re-use skolem symbols. Possible values are:\n"
-      " none: do not attempt to reuse symbols\n"
-      " exact: reuse symbols referring to identical sub-formulae\n";
+      "Attempt to reuse Skolem symbols.\n"
+      "Symbols are re-used if they represent identical formulae up to renaming.";
     _lookup.insert(&_skolemReuse);
     _skolemReuse.tag(OptionTag::PREPROCESSING);
-    _skolemReuse.setRandomChoices({"none","exact"});
 
-    _definitionReuse = ChoiceOptionValue<NameReuse>(
-      "definition_reuse",
-      "dr",
-      NameReuse::NONE,
-      {"none", "exact"}
-    );
+    _definitionReuse = BoolOptionValue("definition_reuse", "dr", false);
     _definitionReuse.description =
-      "How to re-use definition symbols. Same as for Skolem reuse.";
+      "Reuse definition symbols in a similar fashion to Skolem reuse.";
     _lookup.insert(&_definitionReuse);
     _definitionReuse.tag(OptionTag::PREPROCESSING);
-    _definitionReuse.setRandomChoices({"none","exact"});
 
     _generalSplitting = ChoiceOptionValue<RuleActivity>("general_splitting","gsp",RuleActivity::OFF,{"input_only","off","on"});
     _generalSplitting.description=

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -336,11 +336,6 @@ public:
     UNUSED = 2
   };
 
-  enum class NameReuse : unsigned int {
-    NONE = 0,
-    EXACT = 1
-  };
-
   /**
    *
    *
@@ -2141,8 +2136,8 @@ public:
   bool ignoreConjectureInPreprocessing() const {return _ignoreConjectureInPreprocessing.actualValue;}
 
   FunctionDefinitionElimination functionDefinitionElimination() const { return _functionDefinitionElimination.actualValue; }
-  NameReuse skolemReuse() const { return _skolemReuse.actualValue; }
-  NameReuse definitionReuse() const { return _definitionReuse.actualValue; }
+  bool skolemReuse() const { return _skolemReuse.actualValue; }
+  bool definitionReuse() const { return _definitionReuse.actualValue; }
   bool outputAxiomNames() const { return _outputAxiomNames.actualValue; }
   void setOutputAxiomNames(bool newVal) { _outputAxiomNames.actualValue = newVal; }
   QuestionAnsweringMode questionAnswering() const { return _questionAnswering.actualValue; }
@@ -2438,8 +2433,8 @@ private:
   BoolOptionValue _forwardSubsumptionDemodulation;
   UnsignedOptionValue _forwardSubsumptionDemodulationMaxMatches;
   ChoiceOptionValue<FunctionDefinitionElimination> _functionDefinitionElimination;
-  ChoiceOptionValue<NameReuse> _skolemReuse;
-  ChoiceOptionValue<NameReuse> _definitionReuse;
+  BoolOptionValue _skolemReuse;
+  BoolOptionValue _definitionReuse;
   
   ChoiceOptionValue<RuleActivity> _generalSplitting;
   BoolOptionValue _globalSubsumption;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -336,6 +336,11 @@ public:
     UNUSED = 2
   };
 
+  enum class NameReuse : unsigned int {
+    NONE = 0,
+    EXACT = 1
+  };
+
   /**
    *
    *
@@ -2136,6 +2141,8 @@ public:
   bool ignoreConjectureInPreprocessing() const {return _ignoreConjectureInPreprocessing.actualValue;}
 
   FunctionDefinitionElimination functionDefinitionElimination() const { return _functionDefinitionElimination.actualValue; }
+  NameReuse skolemReuse() const { return _skolemReuse.actualValue; }
+  NameReuse definitionReuse() const { return _definitionReuse.actualValue; }
   bool outputAxiomNames() const { return _outputAxiomNames.actualValue; }
   void setOutputAxiomNames(bool newVal) { _outputAxiomNames.actualValue = newVal; }
   QuestionAnsweringMode questionAnswering() const { return _questionAnswering.actualValue; }
@@ -2431,6 +2438,8 @@ private:
   BoolOptionValue _forwardSubsumptionDemodulation;
   UnsignedOptionValue _forwardSubsumptionDemodulationMaxMatches;
   ChoiceOptionValue<FunctionDefinitionElimination> _functionDefinitionElimination;
+  ChoiceOptionValue<NameReuse> _skolemReuse;
+  ChoiceOptionValue<NameReuse> _definitionReuse;
   
   ChoiceOptionValue<RuleActivity> _generalSplitting;
   BoolOptionValue _globalSubsumption;

--- a/Shell/Rectify.hpp
+++ b/Shell/Rectify.hpp
@@ -48,6 +48,8 @@ public:
   {}
   static FormulaUnit* rectify(FormulaUnit*, bool removeUnusedVars=true);
   static void rectify(UnitList*& units);
+  // for NameReuse
+  Formula* rectify(Formula*);
 private:
   typedef pair<unsigned,bool> VarWithUsageInfo;
   typedef List<VarWithUsageInfo> VarUsageTrackingList;
@@ -82,7 +84,6 @@ private:
 
   unsigned rectifyVar(unsigned v);
 
-  Formula* rectify(Formula*);
   FormulaList* rectify(FormulaList*);
   void bindVars(VList*);
   void unbindVars(VList*);

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -502,7 +502,8 @@ Formula* Skolem::skolemise (Formula* f)
             SortHelper::getResultSort(head.term()), head, termVars).term();      
         }
         _introducedSkolemSyms.push(sym);
-        reuse_policy->put(normalised, sym);
+        if(!reuse)
+          reuse_policy->put(normalised, sym);
 
         env.statistics->skolemFunctions++;
 

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -491,6 +491,8 @@ Formula* Skolem::skolemise (Formula* f)
           reuse_key = name_reuse->key(reuse_formula);
           successfully_reused = name_reuse->get(reuse_key, reused_symbol);
         }
+        if(successfully_reused)
+          env.statistics->reusedSkolemFunctions++;
 
         unsigned sym = reused_symbol;
         if(!_appify || skolemisingTypeVar){

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -458,7 +458,9 @@ Formula* Skolem::skolemise (Formula* f)
       Formula *reuse_formula = before;
       VList *remainingVars = before->vars();
       SList *remainingSorts = before->sorts();
-      NameReuse *reuse_policy = NameReuse::skolemInstance();
+      NameReuse *name_reuse = env.options->skolemReuse()
+        ? NameReuse::skolemInstance()
+        : nullptr;
       while (vs.hasNext()) {
         unsigned v = vs.next();
         TermList rangeSort=_varSorts.get(v, AtomicSort::defaultSort());
@@ -475,19 +477,24 @@ Formula* Skolem::skolemise (Formula* f)
         SortHelper::normaliseSort(typeVars, rangeSort);
         Term* skolemTerm;
 
-        Formula *normalised = reuse_policy->normalise(reuse_formula);
-        unsigned reused;
-        bool reuse = reuse_policy->get(normalised, reused);
-        unsigned sym = reused;
+        bool successfully_reused = false;
+        unsigned reused_symbol = 0;
+        Formula *normalised = nullptr;
+        if(name_reuse) {
+          normalised = name_reuse->normalise(reuse_formula);
+          successfully_reused = name_reuse->get(normalised, reused_symbol);
+        }
+
+        unsigned sym = reused_symbol;
         if(!_appify || skolemisingTypeVar){
           //Not the higher-order case. Create the term
           //sk(typevars, termvars).
           if(skolemisingTypeVar){
-            if(!reuse)
+            if(!successfully_reused)
               sym = addSkolemTypeCon(arity);
             skolemTerm = AtomicSort::create(sym, arity, allVars.begin());    
           } else {
-            if(!reuse)
+            if(!successfully_reused)
               sym = addSkolemFunction(arity, termVarSorts.begin(), rangeSort, v, typeVars.size());
             skolemTerm = Term::create(sym, arity, allVars.begin());    
           }
@@ -495,15 +502,15 @@ Formula* Skolem::skolemise (Formula* f)
           //The higher-order case. Create the term
           //sk(typevars) @ termvar_1 @ termvar_2 @ ... @ termvar_n
           TermList skSymSort = AtomicSort::arrowSort(termVarSorts, rangeSort);
-          if(!reuse)
+          if(!successfully_reused)
             sym = addSkolemFunction(typeVars.size(), 0, skSymSort, v, typeVars.size());
           TermList head = TermList(Term::create(sym, typeVars.size(), typeVars.begin()));
           skolemTerm = ApplicativeHelper::createAppTerm(
             SortHelper::getResultSort(head.term()), head, termVars).term();      
         }
         _introducedSkolemSyms.push(sym);
-        if(!reuse)
-          reuse_policy->put(normalised, sym);
+        if(name_reuse && !successfully_reused)
+          name_reuse->put(normalised, sym);
 
         env.statistics->skolemFunctions++;
 
@@ -515,7 +522,7 @@ Formula* Skolem::skolemise (Formula* f)
         // ?[Y, Z]: F[X->sK0],
         // ?[Z]: F[X->sK0, Y->sK1],
         // but not F[X->sK0, Y->sK1, Z->sK2], since this doesn't need a Skolem term
-        if(reuse_policy->requiresFormula()) {
+        if(name_reuse) {
           remainingVars = remainingVars->tail();
           remainingSorts = remainingSorts ? remainingSorts->tail() : nullptr;
           if(VList::isNonEmpty(remainingVars)) {

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -430,10 +430,9 @@ Formula* Skolem::skolemise (Formula* f)
         : nullptr;
 
       // if we re-use a symbol, we _must_ close over free variables in some fixed order
-      Stack<unsigned> varsInKeyOrder;
+      VirtualIterator<unsigned> keyOrderIt;
       if(name_reuse)
-        varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(before);
-      Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
+        keyOrderIt = name_reuse->freeVariablesInKeyOrder(before);
 
       VarSet::Iterator vuIt(*dep);
       while(name_reuse ? keyOrderIt.hasNext() : vuIt.hasNext()) {

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -425,9 +425,19 @@ Formula* Skolem::skolemise (Formula* f)
       // store updated, for the existentials below us to lookup as well
       depInfo.univ = dep;
 
+      NameReuse *name_reuse = env.options->skolemReuse()
+        ? NameReuse::skolemInstance()
+        : nullptr;
+
+      // if we re-use a symbol, we _must_ close over free variables in some fixed order
+      Stack<unsigned> varsInKeyOrder;
+      if(name_reuse)
+        varsInKeyOrder = name_reuse->freeVariablesInKeyOrder(before);
+      Stack<unsigned>::BottomFirstIterator keyOrderIt(varsInKeyOrder);
+
       VarSet::Iterator vuIt(*dep);
-      while(vuIt.hasNext()) {
-        unsigned uvar = vuIt.next();
+      while(name_reuse ? keyOrderIt.hasNext() : vuIt.hasNext()) {
+        unsigned uvar = name_reuse ? keyOrderIt.next() : vuIt.next();
         TermList sort = _varSorts.get(uvar, AtomicSort::defaultSort());
         if(sort == AtomicSort::superSort()){
           //This a type variable
@@ -458,9 +468,6 @@ Formula* Skolem::skolemise (Formula* f)
       Formula *reuse_formula = before;
       VList *remainingVars = before->vars();
       SList *remainingSorts = before->sorts();
-      NameReuse *name_reuse = env.options->skolemReuse()
-        ? NameReuse::skolemInstance()
-        : nullptr;
       while (vs.hasNext()) {
         unsigned v = vs.next();
         TermList rangeSort=_varSorts.get(v, AtomicSort::defaultSort());
@@ -479,10 +486,10 @@ Formula* Skolem::skolemise (Formula* f)
 
         bool successfully_reused = false;
         unsigned reused_symbol = 0;
-        Formula *normalised = nullptr;
+        vstring reuse_key;
         if(name_reuse) {
-          normalised = name_reuse->normalise(reuse_formula);
-          successfully_reused = name_reuse->get(normalised, reused_symbol);
+          reuse_key = name_reuse->key(reuse_formula);
+          successfully_reused = name_reuse->get(reuse_key, reused_symbol);
         }
 
         unsigned sym = reused_symbol;
@@ -509,10 +516,12 @@ Formula* Skolem::skolemise (Formula* f)
             SortHelper::getResultSort(head.term()), head, termVars).term();      
         }
         _introducedSkolemSyms.push(sym);
-        if(name_reuse && !successfully_reused)
-          name_reuse->put(normalised, sym);
 
-        env.statistics->skolemFunctions++;
+        if(!successfully_reused) {
+          env.statistics->skolemFunctions++;
+          if(name_reuse)
+            name_reuse->put(reuse_key, sym);
+        }
 
         _subst.bind(v,skolemTerm);
 

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -286,7 +286,9 @@ void Statistics::print(ostream& out)
     unusedPredicateDefinitions+functionDefinitions+selectedBySine+
     sineIterations+splitInequalities);
   COND_OUT("Introduced names",formulaNames);
+  COND_OUT("Reused names",reusedFormulaNames);
   COND_OUT("Introduced skolems",skolemFunctions);
+  COND_OUT("Reused skolems",reusedSkolemFunctions);
   COND_OUT("Pure predicates", purePredicates);
   COND_OUT("Trivial predicates", trivialPredicates);
   COND_OUT("Unused predicate definitions", unusedPredicateDefinitions);

--- a/Shell/Statistics.hpp
+++ b/Shell/Statistics.hpp
@@ -64,8 +64,12 @@ public:
   // Preprocessing
   /** number of formula names introduced during preprocessing */
   unsigned formulaNames;
+  /** number of formula names re-used during preprocessing */
+  unsigned reusedFormulaNames;
   /** number of skolem functions (also predicates in FOOL) introduced during skolemization */
   unsigned skolemFunctions;
+  /** number of formula names re-used during preprocessing */
+  unsigned reusedSkolemFunctions;
   /** number of initial clauses */
   unsigned initialClauses;
   /** number of inequality splittings performed */


### PR DESCRIPTION
Do not merge, opening early so people can discuss.

There's several places in Vampire where we introduce new symbols that "represent" some formula (or term?). Examples include Skolemnization (regular CNF, NewCNF, induction (via NewCNF), CNF-on-the-fly), or naming subformulae (aforementioned CNF, FOOL, probably others).

It can be worthwhile to re-use symbols/terms for formulae, up to some re-use criterion on formulae. I have some data for a previous hack if anyone's interested, but this does happen frequently and it can improve proof search. CNF-on-the-fly already does this (thanks @ibnyusuf  for pointing this out).

I'm also interested in this for multi-threaded Vampire, where I'm trying to share AVATAR's solver between threads. If two different proof attempts separately introduce "the same" symbol, it would be nice if they could be treated as such by AVATAR.

So far I've implemented an interface (`Shell::NameReuse`) for re-using symbols, with two implementations so far:
- do not reuse symbols (default)
- re-use symbols if they represent exactly the same formula

I've added an option to select how to re-use Skolem symbols, and patched `Shell::Skolem` and `Shell::NewCNF` accordingly.
In general I've tried to make changes such that we only pay for what we use: the default behaviour of not re-using symbols should be (almost) free.

Some examples of the new behaviour:

```
fof(test, axiom, ?[X, Y]: p(X, Y)).
fof(test, axiom, ?[X, Y]: p(X, Y)).

% default behaviour
% vampire --mode clausify -updr off -skr none
cnf(u3,axiom,p(sK0,sK1)).
cnf(u4,axiom,p(sK2,sK3)).

% "exact" reuse behaviour
% vampire --mode clausify -updr off -skr exact
cnf(u6,axiom,p(sK0,sK1)).
cnf(u10,axiom,p(sK0,sK1)).
```
-----
```
fof(test, axiom, ![X]: ((?[Y]: p(X, Y)) & (?[Y]: p(X, Y)))).

% vampire --mode clausify -updr off -skr none
cnf(u4,axiom,p(X0,sK1(X0))).
cnf(u3,axiom,p(X0,sK0(X0))).

% vampire --mode clausify -updr off -skr exact
cnf(u10,axiom,p(X0,sK0(X0))).
cnf(u9,axiom,p(X0,sK0(X0))).
```
-----

Still left to do:
- [x] discuss the proposed interface and see if we like it
- [x] integrate this everywhere we want it: subformula naming especially
- [x] discuss where we don't
- [x] discuss options and how fine-grained we want these
- [x] come up with new and exciting re-use criteria: CNF-on-the-fly already re-uses _instances_, could consider e.g. associative/commutative operators, reuse-by-CNF-of-formula
- [x] fix variable-order problem
- [x] add statistics
- [x] run some experiments
- [x] decide on whether to make this default (probably not: quadratic behaviour)
- [ ] review implementation