### PR TITLE
z3 does not seem to combine well with polymorphism

### DIFF
--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -411,7 +411,7 @@ void Options::init()
     _equalityProxy.addHardConstraint(If(notEqual(EqualityProxy::OFF)).then(_combinatorySuperposition.is(notEqual(true))));
     _equalityProxy.setRandomChoices(isRandOn(),{"R","RS","RST","RSTC","off","off","off","off","off"}); // wasn't tested, make off more likely
     
-    _useMonoEqualityProxy = BoolOptionValue("mono_ep","mep",false);
+    _useMonoEqualityProxy = BoolOptionValue("mono_ep","mep",true);
     _useMonoEqualityProxy.description="Use the monomorphic version of equality proxy transformation.";
     _lookup.insert(&_useMonoEqualityProxy);
     _useMonoEqualityProxy.tag(OptionTag::PREPROCESSING);

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -454,10 +454,10 @@ void Preprocess::preprocess(Problem& prb)
        env.out() << "equality proxy" << std::endl;
 
      if(_options.useMonoEqualityProxy() && !prb.hasPolymorphicSym()){
+       //default      
        EqualityProxyMono proxy(_options.equalityProxy());
        proxy.apply(prb);
      } else {
-       //default
        EqualityProxy proxy(_options.equalityProxy());
        proxy.apply(prb);
      }


### PR DESCRIPTION
When running with options:

`dis-10_4:1_aac=none:add=off:afp=1000:afq=1.4:amm=off:anc=none:cond=fast:ep=RSTC:gs=on:gsaa=from_current:gsem=on:inw=on:lma=on:nm=64:nwc=4:sas=z3:tha=off:thi=strong:uwa=interpreted_only:updr=off:uhcvi=on_6`

on the attached problem results in error:

```
Running in auto input_syntax mode. Trying SMTLIB2
Z3 exception:
Sort mismatch at argument #2 for function (declare-fun sQ1_eqProxy ($tType X0 X0) Bool) supplied sort is Int

```

I am somewhat surprised that this hasn't been picked up before. 

Obviously this affects theory reasoning for polymorphic problems as in that case we cannot circumvent the polymorphism.

[user-conjecture-1.txt](https://github.com/vprover/vampire/files/7066365/user-conjecture-1.txt)
