### PR TITLE
Normalize interpreted symbols in nested formulas

### DIFF
--- a/Kernel/TermTransformer.hpp
+++ b/Kernel/TermTransformer.hpp
@@ -40,7 +40,7 @@ protected:
   virtual TermList transformSubterm(TermList trm) = 0;
   Term* transformSpecial(Term* specialTerm);
   TermList transform(TermList ts);
-  Formula* transform(Formula* f);
+  virtual Formula* transform(Formula* f);
 };
 
 /**

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -204,7 +204,7 @@ private:
 /**
  * Class that performs literal transformations
  */
-class InterpretedNormalizer::NLiteralTransformer : private TermTransformer
+class InterpretedNormalizer::NLiteralTransformer : public TermTransformer
 {
 public:
   CLASS_NAME(InterpretedNormalizer::NLiteralTransformer);
@@ -268,6 +268,9 @@ public:
       litRes = transl->apply(litRes);
     }
   }
+
+  Formula* transform(Formula* f) override;
+
 protected:
   using TermTransformer::transform;
 
@@ -426,6 +429,12 @@ protected:
 private:
   NLiteralTransformer* _litTransf;
 };
+
+Formula* InterpretedNormalizer::NLiteralTransformer::transform(Formula* f)
+{
+  NFormulaTransformer ttft(this);
+  return ttft.transform(f);
+}
 
 //////////////////////////
 // InterpretedNormalizer


### PR DESCRIPTION
Formulas inside terms were previously not transformed the way they should have been in `NLiteralTransformer` due to `TermTransformer` creating a `TermTransformingFormulaTransformer` which just proxies everything to its outer `TermTransformer`.

The initial fix overrides the `transform(Formula*)` function in `TermTransformer` and creates an `NFormulaTransformer` instead, which applies the right transformations to literals after calling `NLiteralTransformer` on its arguments.

Tested on the following file:
```
(declare-datatypes ((lst 0)) (((nil) (cons (cons0 Int) (cons1 lst)))))
(declare-fun p (lst) Bool)

; worked before
;(assert (p nil))
;(assert (forall ((x Int) (y lst)) (= (p (cons x y)) (>= x 0))))

; did not work before
;(assert (forall ((x0 lst) (x Int) (y lst)) (= (p x0) (ite (= x0 (cons x y)) (>= x 0) true))))

; did not work before
(assert (forall ((x0 lst) (x Int) (y lst)) (= (p x0) (match x0 ((nil true) ((cons x y) (>= x 0)))))))
(assert (not (forall ((x Int) (y lst)) (= (p (cons x y)) (>= x 0)))))
(check-sat)
```