### PR TITLE
retrieve correct z3::func_decls for datatypes with boolean fields

### DIFF
--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -706,7 +706,11 @@ void Z3Interfacing::createTermAlgebra(TermAlgebra& start)
       }
       for (unsigned iDestr = 0; iDestr < ctor->arity(); iDestr++)  {
         auto dtor = z3::func_decl(_context, destr[iDestr]);
-        auto id = FuncOrPredId::function(ctor->destructorFunctor(iDestr));
+        // careful: datatypes can have boolean fields!
+        auto id = FuncOrPredId(
+          ctor->destructorFunctor(iDestr),
+          dtor.range().is_bool()
+        );
         _toZ3.insert(id, dtor);
         _fromZ3.insert(dtor, id);
       }


### PR DESCRIPTION
This was a fun one to track down! Occasionally we may encounter datatypes that have a variant with a boolean field, which means that the "destructor" for that field is a _predicate_, not a function. Because these are treated separately in Vampire (but not in Z3), this causes all kinds of chaos. Fix that.