### PR TITLE
Bug fixes

### DIFF
--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -314,9 +314,8 @@ Ordering::Result PrecedenceOrdering::compare(Literal* l1, Literal* l2) const
 int PrecedenceOrdering::predicateLevel (unsigned pred) const
 {
   int basic=pred >= _predicates ? 1 : _predicateLevels[pred];
-  if(NONINTERPRETED_LEVEL_BOOST && !env.signature->getPredicate(pred)->interpreted() && pred != 0) {
-    //ASS(!Signature::isEqualityPredicate(pred)); //equality is always interpreted
-    //TODO remove the final condition once interpreted equality is reintroduced
+  if(NONINTERPRETED_LEVEL_BOOST && !env.signature->getPredicate(pred)->interpreted()) {
+    ASS(!Signature::isEqualityPredicate(pred)); //equality is always interpreted
     basic+=NONINTERPRETED_LEVEL_BOOST;
   }
   if(env.signature->predicateColored(pred)) {

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -235,13 +235,6 @@ Signature::Signature ():
 {
   CALL("Signature::Signature");
 
-  /*bool added;
-  addPredicate("=", 2, added);
-  ASS(added);
-  ASS_EQ(predicateName(0), "=");
-  getPredicate(0)->markSkip();
-  getPredicate(0)->markProtected();*/
-
   unsigned aux;
   aux = createDistinctGroup();
   ASS_EQ(STRING_DISTINCT_GROUP, aux);

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -198,18 +198,19 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
 {
   CALL("TPTPPrinter::outputSymbolTypeDefinitions");
 
-  bool function = symType == SymbolType::FUNC;
+  bool func = symType == SymbolType::FUNC;
+  bool typCon = symType == SymbolType::TYPE_CON;
 
-  Signature::Symbol* sym = function ?
+  Signature::Symbol* sym = (func || typCon) ?
       env.signature->getFunction(symNumber) : env.signature->getPredicate(symNumber);
-  OperatorType* type = function ? sym->fnType() : sym->predType();
+  OperatorType* type = (func || typCon)  ? sym->fnType() : sym->predType();
 
   if(type->isAllDefault()) {
     return;
   }
-  if(function && theory->isInterpretedConstant(symNumber)) { return; }
+  if(func && theory->isInterpretedConstant(symNumber)) { return; }
 
-  if (function && sym->overflownConstant()) { return; }
+  if (func && sym->overflownConstant()) { return; }
 
   if(sym->interpreted()) {
     Interpretation interp = static_cast<Signature::InterpretedSymbol*>(sym)->getInterpretation();
@@ -230,9 +231,9 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   }
 
   vstring st = "func";
-  if(symType == SymbolType::PRED){
+  if(!func && !typCon){
     st = "pred"; 
-  } else if(symType == SymbolType::TYPE_CON){
+  } else if(typCon){
     st = "sort";
   }
 


### PR DESCRIPTION
This PR achieves the following:

1. Fixes a bug in TPTPPrinter which resulted in trying to access a predicate symbol using a function symbol number
2. Remove useless code from Ordering.cpp that related to a time when equality was not an interpreted predicate
3. Remove commented code from Signature.cpp that dates from the same time