### PR TITLE
SMTLIB2 parser: record formula label on ParserResult

### DIFF
--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -292,6 +292,9 @@ private:
 
     TermList sort;
     bool formula;
+    /** The label assigned to this formula using the ":named" annotation of SMT-LIB2;
+     * empty string means no label. */
+    vstring label;
     union {
       Formula* frm;
       TermList trm;
@@ -309,6 +312,17 @@ private:
      * and return its vampire sort (which may be Sorts::SRT_BOOL).
      */
     TermList asTerm(TermList& resTrm);
+    /**
+     * Records a label for the formula represented by this `ParserResult`,
+     * resulting from a ":named" SMT-LIB2 annotation.
+     */
+    void setLabel(vstring l){ label = l; }
+    /**
+     * Helper that attaches a label to a `Formula`
+     * if a label is recorded for this `ParserResult`.
+     * Returns the formula.
+     */
+    Formula* attachLabelToFormula(Formula* frm);
 
     vstring toString();
   };


### PR DESCRIPTION
In the SMTLIB2 parser, when a `:named` annotation is parsed, record the label on the `ParserResult` object only; attach the label to the underlying `Formula` object right before it's returned by the `SMTLIB2::ParseResult::asFormula` method.

Fixes #276.