### PR TITLE
fix assertion violation for minus-without-digit in TPTP parser

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -1175,7 +1175,6 @@ int TPTP::decimal(int pos)
   case '9':
     break;
   default:
-    ASSERTION_VIOLATION_REP(getChar(pos));
     PARSE_ERROR("wrong number format",_gpos);
   }
 


### PR DESCRIPTION
Fixes #261. Seems to have been introduced some years ago in [7a8bb55cc84a1f3c880c67be6106381d24f2a65a](https://github.com/vprover/vampire/commit/7a8bb55cc84a1f3c880c67be6106381d24f2a65a) - looks like it just debugging, since the very next line throws a parse error anyway.