### PR TITLE
fix cygwin compilation (without timer support)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -862,6 +862,10 @@ elseif(CMAKE_BUILD_TYPE STREQUAL Release)
   add_compile_definitions(VDEBUG=0)
 endif()
 
+if (CYGWIN)
+ add_compile_definitions(_BSD_SOURCE)
+endif()
+                    
 # configure warning flags
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
   add_compile_options(-Wall)


### PR DESCRIPTION
Cygwin's gcc/glibc does not define some constants and functions without explicitly enabling them as a feature via -D_BSD_SOURCE. See also https://man7.org/linux/man-pages/man7/feature_test_macros.7.html .