### PR TITLE
Complete the printing of SZS status in modes that do not use schedules

### DIFF
--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -213,6 +213,51 @@ void Statistics::explainRefutationNotFound(ostream& out)
 
 void Statistics::print(ostream& out)
 {
+  switch(env.options->mode()) {
+    case Options::Mode::CASC:
+    case Options::Mode::CASC_HOL:
+    case Options::Mode::CASC_SAT:
+    case Options::Mode::SMTCOMP:
+    case Options::Mode::PORTFOLIO:
+      break;
+    default:
+      if (szsOutputMode()) {
+        // SZS ontology: http://www.tptp.org/TPTP/TPTPTParty/2007/PositionStatements/GeoffSutcliffe_SZS.html
+        out << "% SZS status ";
+        switch(env.statistics->terminationReason) {
+          case Statistics::REFUTATION:
+          case Statistics::SAT_UNSATISFIABLE:
+            out << (UIHelper::haveConjecture() ? ( UIHelper::haveConjectureInProof() ? "Theorem" : "ContradictoryAxioms" ) : "Unsatisfiable");
+            break;
+          case Statistics::TIME_LIMIT:
+            out << "Timeout";
+            break;
+          case Statistics::MEMORY_LIMIT:
+            out << "MemoryOut";
+            break;
+          case Statistics::ACTIVATION_LIMIT:
+            out << "ResourceOut";
+            break;
+          case Statistics::REFUTATION_NOT_FOUND:
+            out << "Incomplete";
+            break;
+          case Statistics::SATISFIABLE:
+          case Statistics::SAT_SATISFIABLE:
+            out << ( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" );
+            break;
+          case Statistics::UNKNOWN:
+            out << "Unknown";
+            break;
+          case Statistics::INAPPROPRIATE:
+            out << "Inappropriate";
+            break;
+          default:
+           ASSERTION_VIOLATION;
+        }
+        out << " for " << env.options->problemName() << endl;
+      }
+  }
+
   if (env.options->statistics()==Options::Statistics::NONE) {
     return;
   }

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -405,10 +405,6 @@ void UIHelper::outputResult(ostream& out)
     }
     addCommentSignForSZS(out);
     out << "Refutation found. Thanks to " << env.options->thanks() << "!\n";
-    if (szsOutputMode()) {
-      out << "% SZS status " << (UIHelper::haveConjecture() ? ( UIHelper::haveConjectureInProof() ? "Theorem" : "ContradictoryAxioms" ) : "Unsatisfiable")
-	  << " for " << env.options->problemName() << endl;
-    }
     if (env.options->questionAnswering()!=Options::QuestionAnsweringMode::OFF) {
       ASS(env.statistics->refutation->isClause());
       AnswerExtractor::tryOutputAnswer(static_cast<Clause*>(env.statistics->refutation));
@@ -565,10 +561,6 @@ void UIHelper::outputSatisfiableResult(ostream& out)
   CALL("UIHelper::outputSatisfiableResult");
 
   //out << "Satisfiable!\n";
-  if (szsOutputMode() && !satisfiableStatusWasAlreadyOutput) {
-    out << "% SZS status " << ( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
-	  <<" for " << env.options->problemName() << endl;
-  }
   if (!env.statistics->model.empty()) {
     if (szsOutputMode()) {
 	out << "% SZS output start FiniteModel for " << env.options->problemName() << endl;


### PR DESCRIPTION
The printing is moved to `Statistics::print` so that it is invoked when time or memory limit is reached.

This pull request may change the order of the output lines.