### PR TITLE
fix Z3 threading build problems (?)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -903,6 +903,12 @@ else ()
     link_libraries(${Z3_LIBRARIES})
   endif()
 
+  # Z3 needs threads now
+  set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+  set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+  find_package(Threads REQUIRED)
+  link_libraries(Threads::Threads)
+
   add_library(Z3 SHARED IMPORTED)
   set_property(TARGET Z3 PROPERTY IMPORTED_LOCATION ${Z3_LIBRARY})
   add_compile_definitions(VZ3=1)

--- a/README.md
+++ b/README.md
@@ -25,11 +25,6 @@ Vampire is built with the help of [CMake](cmake.org).
 CMake does not run any build commands directly: instead, it can generate a number of different [output formats](https://cmake.org/cmake/help/latest/manual/cmake-generators.7.html), such as UNIX Makefiles.
 If you are completely new to CMake, there is a [tutorial](https://cmake.org/cmake/help/latest/guide/user-interaction/index.html) for end-users.
 
-Vampire can optionally link to a fixed version of the external Z3 library.
-If you wish to do this, [initialise the `z3` submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules#_cloning_submodules) in the Vampire source directory.
-Then follow the Z3 [CMake instructions](https://github.com/Z3Prover/z3/blob/master/README-CMake.md) to build the Z3 libraries into Vampire's tree at `z3/build/`.
-This is where Vampire's build system will look for Z3: if it finds it, it will automatically link to Z3.
-
 A typical build on a UNIX-like system might look like this:
 ```sh
 # make a clean directory to build Vampire into
@@ -66,6 +61,25 @@ $ make
 $ ls bin/
 vampire_z3_rel_master_4933
 $
+```
+
+### Adding Z3
+Vampire can optionally link to a fixed version of the external Z3 library.
+If you wish to do this, [initialise the `z3` submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules#_cloning_submodules) in the Vampire source directory.
+Then follow the Z3 [CMake instructions](https://github.com/Z3Prover/z3/blob/master/README-CMake.md) to build the Z3 libraries into Vampire's tree at `z3/build/`.
+This is where Vampire's build system will look for Z3: if it finds it, it will automatically link to Z3.
+A reasonable Z3 build might look like this:
+```sh
+# Build Z3 into vampire/z3/build
+$ mkdir -p /path/to/vampire/z3/build && cd /path/to/vampire/z3/build
+
+# Configure single-threaded build, no debug symbols
+$ cmake .. -DZ3_SINGLE_THREADED=1 -DCMAKE_BUILD_TYPE=Release
+<snip>
+
+# Build Z3, in this case with make(1)
+$ make
+<snip>
 ```
 
 ### Build Configuration


### PR DESCRIPTION
@quickbeam123 has recently had some problems linking the Z3 submodule to Vampire on some platforms - it seems newer versions of Z3 require a threading support library. Fix that (testing appreciated!) and add some comments to the README about building Z3.