### PR TITLE
Fix KBOForEPR polymorphism bug

### DIFF
--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -130,6 +130,7 @@ Ordering* Ordering::create(Problem& prb, const Options& opt)
     // - user specified symbol weights
     // TODO fix this! 
     if(prb.getProperty()->maxFunArity()==0 
+        && prb.getProperty()->maxTypeConArity() == 0
         && !env.colorUsed
         && env.options->predicateWeights() == ""
         && env.options->functionWeights() == ""
@@ -145,6 +146,7 @@ Ordering* Ordering::create(Problem& prb, const Options& opt)
   default:
     ASSERTION_VIOLATION;
   }
+  //TODO currently do not show SKIKBO
   if (opt.showSimplOrdering()) {
     env.beginOutput();
     out->show(env.out());

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -169,7 +169,7 @@ public:
         return true;
 
       // compare sort arguments
-      for(int i = 0; i < l.forSorts->numTypeArguments(); i++)
+      for(unsigned i = 0; i < l.forSorts->numTypeArguments(); i++)
         // sorts are perfectly shared
         if(!l.forSorts->nthArgument(i)->sameContent(r.forSorts->nthArgument(i)))
           return false;
@@ -185,7 +185,7 @@ public:
           : env.signature->getFunction(self.id)->name()
       );
       if(self.forSorts)
-        for(int i = 0; i < self.forSorts->numTypeArguments(); i++)
+        for(unsigned i = 0; i < self.forSorts->numTypeArguments(); i++)
           out << " " << self.forSorts->nthArgument(i)->toString();
       return out;
     }
@@ -281,7 +281,7 @@ namespace std {
       size_t operator()(SAT::Z3Interfacing::FuncOrPredId const& self) {
         unsigned hash = Lib::HashUtils::combine(self.id, self.isPredicate);
         if(self.forSorts)
-          for(int i = 0; i < self.forSorts->numTypeArguments(); i++)
+          for(unsigned i = 0; i < self.forSorts->numTypeArguments(); i++)
             hash = Lib::HashUtils::combine(hash, self.forSorts->nthArgument(i)->content());
         return hash;
       }

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -723,10 +723,7 @@ void Property::scan(TermList ts,bool unit,bool goal)
       _hasLogicalProxy = true;
     }
 
-    // TODO change this to use Term::numOfTypeArgs() once
-    // Micahel's PR is merged
-    OperatorType* type = func->fnType();
-    if(!t->isApplication() && type->typeArgsArity()){
+    if(!t->isApplication() && t->numTypeArguments() > 0){
       _hasPolymorphicSym = true;
     }
 

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -685,8 +685,9 @@ void Property::scan(TermList ts,bool unit,bool goal)
     }
   } else {
     if(t->isSort()){
-      if(t->arity() > _maxTypeConArity)
-      _maxTypeConArity = t->arity();
+      if(t->arity() > _maxTypeConArity){
+        _maxTypeConArity = t->arity();
+      }
       return;
     }
 

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -66,6 +66,7 @@ Property::Property()
     _groundGoals(0),
     _maxFunArity(0),
     _maxPredArity(0),
+    _maxTypeConArity(0),
     _totalNumberOfVariables(0),
     _maxVariablesInClause(0),
     _props(0),
@@ -683,13 +684,9 @@ void Property::scan(TermList ts,bool unit,bool goal)
         break;
     }
   } else {
-    int arity = t->arity();
-
-    if (arity > _maxFunArity) {
-      _maxFunArity = arity;
-    }
-
     if(t->isSort()){
+      if(t->arity() > _maxTypeConArity)
+      _maxTypeConArity = t->arity();
       return;
     }
 
@@ -725,15 +722,23 @@ void Property::scan(TermList ts,bool unit,bool goal)
       _hasLogicalProxy = true;
     }
 
+    // TODO change this to use Term::numOfTypeArgs() once
+    // Micahel's PR is merged
     OperatorType* type = func->fnType();
     if(!t->isApplication() && type->typeArgsArity()){
       _hasPolymorphicSym = true;
     }
 
+    int arity = t->arity();
+
+    if (arity > _maxFunArity) {
+      _maxFunArity = arity;
+    }
+
     for (int i = 0; i < arity; i++) {
       scanSort(SortHelper::getArgSort(t, i));
     }
-    scanSort(SortHelper::getResultSort(t));
+    scanSort(SortHelper::getResultSort(t));  
   }
 }
 

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -656,10 +656,6 @@ void Property::scan(TermList ts,bool unit,bool goal)
     return;
   }
 
-  if(ts.term()->isSort()){
-    return;
-  }
-
   ASS(ts.isTerm());
   Term* t = ts.term();
 
@@ -687,6 +683,16 @@ void Property::scan(TermList ts,bool unit,bool goal)
         break;
     }
   } else {
+    int arity = t->arity();
+
+    if (arity > _maxFunArity) {
+      _maxFunArity = arity;
+    }
+
+    if(t->isSort()){
+      return;
+    }
+
     scanForInterpreted(t);
 
     _symbolsInFormula.insert(t->functor());
@@ -724,15 +730,10 @@ void Property::scan(TermList ts,bool unit,bool goal)
       _hasPolymorphicSym = true;
     }
 
-    int arity = t->arity();
     for (int i = 0; i < arity; i++) {
       scanSort(SortHelper::getArgSort(t, i));
     }
     scanSort(SortHelper::getResultSort(t));
-
-    if (arity > _maxFunArity) {
-      _maxFunArity = arity;
-    }
   }
 }
 

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -187,6 +187,8 @@ public:
   bool hasFormulas() const { return _axiomFormulas || _goalFormulas; }
   /** Maximal arity of a function in the problem */
   int maxFunArity() const { return _maxFunArity; }
+  /** Maximal arity of a type con in the problem */
+  int maxTypeConArity() const { return _maxTypeConArity; }
   /** Total number of variables in problem */
   int totalNumberOfVariables() const { return _totalNumberOfVariables;}
 
@@ -303,6 +305,7 @@ public:
   int _groundGoals;
   int _maxFunArity;
   int _maxPredArity;
+  int _maxTypeConArity;
 
   /** Number of variables in this clause, used during counting */
   int _variablesInThisClause;

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -188,7 +188,7 @@ public:
   /** Maximal arity of a function in the problem */
   int maxFunArity() const { return _maxFunArity; }
   /** Maximal arity of a type con in the problem */
-  int maxTypeConArity() const { return _maxTypeConArity; }
+  unsigned maxTypeConArity() const { return _maxTypeConArity; }
   /** Total number of variables in problem */
   int totalNumberOfVariables() const { return _totalNumberOfVariables;}
 
@@ -305,7 +305,7 @@ public:
   int _groundGoals;
   int _maxFunArity;
   int _maxPredArity;
-  int _maxTypeConArity;
+  unsigned _maxTypeConArity;
 
   /** Number of variables in this clause, used during counting */
   int _variablesInThisClause;

--- a/Shell/SubexpressionIterator.hpp
+++ b/Shell/SubexpressionIterator.hpp
@@ -52,10 +52,8 @@ namespace Shell {
        * we first propagate the negative polarity from the formula to its underlying
        * boolean term, and then from the boolean terms to their underlying formulas.
        *
-       * NOTE: this iterator returns sort terms as well. As of 08/07/2021, the only 
-       * use of this iterator is in Property.cpp where sorts are NOT required. 
-       * However, sorts are sub-expressions, so to keep the iterator intuitive we
-       * leave the code as is.
+       * NOTE: this iterator returns sort terms as well. As of 25/11/2021, the only 
+       * use of this iterator is in Property.cpp.
        */
       class Expression {
         public:


### PR DESCRIPTION
KBOForEPR assumes that all arguments to a predicate symbol are either variables or constants. We were not checking this properly for polymorphic predicate symbols previously. This PR should fix the bug. 