### PR TITLE
Drop quote  symbols in quoted string when lexing

### DIFF
--- a/Shell/LispLexer.cpp
+++ b/Shell/LispLexer.cpp
@@ -180,6 +180,7 @@ void LispLexer::readQuotedString(Token& token, char opening, char closing, char 
   CALL("LispLexer::readQuotedString");
 
   bool escape=false;
+  // Don't save this char so that the final string doesn't contain the quote symbol
   //saveLastChar();
 
   while (readNextChar()) {
@@ -191,6 +192,7 @@ void LispLexer::readQuotedString(Token& token, char opening, char closing, char 
         readNextChar();
       }
       else{
+        // Don't save this char so that the final string doesn't contain the quote symbol
         //saveLastChar();
         saveTokenText(token);
         readNextChar();

--- a/Shell/LispLexer.cpp
+++ b/Shell/LispLexer.cpp
@@ -180,7 +180,7 @@ void LispLexer::readQuotedString(Token& token, char opening, char closing, char 
   CALL("LispLexer::readQuotedString");
 
   bool escape=false;
-  saveLastChar();
+  //saveLastChar();
 
   while (readNextChar()) {
     if (_lastCharacter == escapeChar && !escape && closing != escapeChar) {
@@ -191,7 +191,7 @@ void LispLexer::readQuotedString(Token& token, char opening, char closing, char 
         readNextChar();
       }
       else{
-        saveLastChar();
+        //saveLastChar();
         saveTokenText(token);
         readNextChar();
         token.tag = TT_NAME;


### PR DESCRIPTION
@quickbeam123  - I think this is the change to the LispLexer required to drop the quote symbols when lexing a quoted string.

On my problem

```
(set-logic UF)
(declare-sort |T| 0)
(declare-fun  |f| (T) T)
(declare-const |a| T)
(assert (= a (f a)))
(check-sat)
```

I get the following clauses

```
tff(type_def_5, type, 'T()': $tType).
tff(func_def_0, type, f: ('T()') > 'T()').
tff(func_def_1, type, a: 'T()').
cnf(u2,hypothesis,
    a = f(a)).
```
i.e. the | is dropped. This could have issues in some output but I'm not sure we are free of issues when quoted symbols are concerned anyway...