### PR TITLE
Print result before property is deleted

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -136,7 +136,7 @@ bool PortfolioMode::searchForProof()
     Normalisation().normalise(*_prb);
     
     //TheoryFinder cannot cope with polymorphic input
-    if(!env.statistics->polymorphic){
+    if(!env.property->hasPolymorphicSym()){
       TheoryFinder(_prb->units(),property).search();
     }
   }
@@ -236,7 +236,7 @@ void PortfolioMode::getExtraSchedules(Property& prop, Schedule& old, Schedule& e
    //extra_opts.push("etr=on");         // equational_tautology_removal
    extra_opts.push("av=on:atotf=0.5");     // turn AVATAR off
 
-   if(!env.statistics->higherOrder){
+   if(!prop.higherOrder()){
      //these options are not currently HOL compatible
      extra_opts.push("bsd=on:fsd=on"); // subsumption demodulation
      extra_opts.push("to=lpo");           // lpo

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -145,7 +145,7 @@ Index* IndexManager::create(IndexType t)
   bool isGenerating;
   static bool const useConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
   static bool const extByAbs = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) &&
-                    env.statistics->higherOrder;
+                    env.property->higherOrder();
                     
   switch(t) {
   case GENERATING_SUBST_TREE:

--- a/Indexing/LiteralSubstitutionTree.cpp
+++ b/Indexing/LiteralSubstitutionTree.cpp
@@ -35,7 +35,7 @@ LiteralSubstitutionTree::LiteralSubstitutionTree(bool useC)
   //However, there is no need to guard aginst it, as equalityProxy removes all
   //equality literals. The flag below is only used during the unification of 
   //equality literals.
-  _polymorphic = env.statistics->polymorphic || env.statistics->higherOrder;
+  _polymorphic = env.property->hasPolymorphicSym() || env.property->higherOrder();
 }
 
 void LiteralSubstitutionTree::insert(Literal* lit, Clause* cls)

--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -82,8 +82,8 @@ void TermSharing::setPoly()
 
   //combinatory superposiiton can introduce polymorphism into a 
   //monomorphic problem
-  _poly = env.statistics->higherOrder ||
-          env.statistics->polymorphic ||
+  _poly = env.property->higherOrder() ||
+          env.property->hasPolymorphicSym() ||
           env.options->equalityProxy() != Options::EqualityProxy::OFF ||
           env.options->saturationAlgorithm() == Options::SaturationAlgorithm::INST_GEN;
 }

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -116,7 +116,7 @@ struct EqualityFactoring::ResultFn
     ASS_NEQ(sLit, fLit);
 
     static Options::FunctionExtensionality ext = env.options->functionExtensionality();
-    bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) && env.statistics->higherOrder;
+    bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) && env.property->higherOrder();
 
     if(use_ho_handler){
       TermList sLHSreplaced = sLHS;

--- a/Inferences/EqualityResolution.cpp
+++ b/Inferences/EqualityResolution.cpp
@@ -78,7 +78,7 @@ struct EqualityResolution::ResultFn
     static Options::FunctionExtensionality ext = env.options->functionExtensionality();
     bool use_uwa_handler = uwa != Options::UnificationWithAbstraction::OFF;
     bool use_ho_handler = (ext == Options::FunctionExtensionality::ABSTRACTION) &&
-                          env.statistics->higherOrder;
+                          env.property->higherOrder();
 
     if(use_ho_handler){
       TermList sort = SortHelper::getEqualityArgumentSort(lit);

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -195,7 +195,7 @@ ClauseIterator Superposition::generateClauses(Clause* premise)
   //TODO probably shouldn't go here!
   static bool withConstraints = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
   static bool extByAbstraction = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION)
-                               && env.statistics->higherOrder;
+                               && env.property->higherOrder();
 
   auto itf1 = premise->getSelectedLiteralIterator();
 

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -171,8 +171,8 @@ vstring getQuantifiedStr(const VarContainer& vars, vstring inner, DHMap<unsigned
     vstring ty="";
     TermList t;
 
-    if(t_map.find(var,t) && env.statistics->hasTypes){
-      //hasTypes is true if the problem that contains a sort
+    if(t_map.find(var,t) && env.property->hasNonDefaultSorts()){
+      //hasNonDefaultSorts is true if the problem contains a sort
       //that is not $i and not a variable
       ty=" : " + t.toString();
     }
@@ -670,7 +670,7 @@ protected:
     CALL("InferenceStore::TPTPProofPrinter::getFofString");
 
     vstring kind = "fof";
-    if(env.statistics->hasTypes){ kind="tff"; }
+    if(env.property->hasNonDefaultSorts()){ kind="tff"; }
     if(env.property->higherOrder()){ kind="thf"; }
 
     return kind+"("+id+","+getRole(rule,origin)+",("+"\n"
@@ -964,7 +964,7 @@ protected:
     UIHelper::outputSymbolDeclarations(out);
 
     vstring kind = "fof";
-    if(env.statistics->hasTypes){ kind="tff"; } 
+    if(env.property->hasNonDefaultSorts()){ kind="tff"; } 
     if(env.property->higherOrder()){ kind="thf"; }
 
     out << kind

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -671,7 +671,7 @@ protected:
 
     vstring kind = "fof";
     if(env.statistics->hasTypes){ kind="tff"; }
-    if(env.statistics->higherOrder){ kind="thf"; }
+    if(env.property->higherOrder()){ kind="thf"; }
 
     return kind+"("+id+","+getRole(rule,origin)+",("+"\n"
 	+"  "+formula+"),\n"
@@ -965,7 +965,7 @@ protected:
 
     vstring kind = "fof";
     if(env.statistics->hasTypes){ kind="tff"; } 
-    if(env.statistics->higherOrder){ kind="thf"; }
+    if(env.property->higherOrder()){ kind="thf"; }
 
     out << kind
         << "(r"<<_is->getUnitIdStr(cs)

--- a/Kernel/MainLoop.cpp
+++ b/Kernel/MainLoop.cpp
@@ -110,13 +110,13 @@ MainLoop* MainLoop::createFromOptions(Problem& prb, const Options& opt)
 
   switch (opt.saturationAlgorithm()) {
   case Options::SaturationAlgorithm::INST_GEN:
-    if(env.statistics->polymorphic || env.statistics->higherOrder){
+    if(env.property->hasPolymorphicSym() || env.property->higherOrder()){
       USER_ERROR("The inst gen calculus is currently not compatible with polymorphism or higher-order constructs");       
     }
     res = new IGAlgorithm(prb, opt);
     break;
   case Options::SaturationAlgorithm::FINITE_MODEL_BUILDING:
-    if(env.statistics->polymorphic || env.statistics->higherOrder){
+    if(env.property->hasPolymorphicSym() || env.property->higherOrder()){
       USER_ERROR("Finite model buillding is currently not compatible with polymorphism or higher-order constructs");       
     }
     if(env.options->outputMode() == Shell::Options::Output::UCORE){

--- a/Kernel/Problem.hpp
+++ b/Kernel/Problem.hpp
@@ -119,6 +119,7 @@ public:
   bool hasAppliedVar() const;
   bool hasPolymorphicSym() const;
   bool quantifiesOverPolymorphicVar() const;
+  bool higherOrder() const;
 
   bool mayHaveEquality() const { return _mayHaveEquality; }
   bool mayHaveFormulas() const { return _mayHaveFormulas; }
@@ -232,6 +233,7 @@ private:
   mutable MaybeBool _hasPolymorphicSym;
   mutable MaybeBool _quantifiesOverPolymorphicVar;
   mutable MaybeBool _hasBoolVar; 
+  mutable MaybeBool _higherOrder; 
 
   SMTLIBLogic _smtlibLogic;
 

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -486,7 +486,7 @@ bool RobSubstitution::unify(TermSpec t1, TermSpec t2,MismatchHandler* hndlr)
               // mechanism used by higher-order logic to pruduce constraints.
               // until then the first condition ensures that the handler is never called
               // incorrectly. HOL also uses a handler, but it shouldn't be called here.
-              if(env.statistics->higherOrder || !hndlr || !hndlr->handle(this,tsss.term,tsss.index,tstt.term,tstt.index)){
+              if(env.property->higherOrder() || !hndlr || !hndlr->handle(this,tsss.term,tsss.index,tstt.term,tstt.index)){
                 mismatch=true;
                 break;
               }

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -246,9 +246,9 @@ Signature::Signature ():
     _integers(0),
     _rationals(0),
     _reals(0),
-    _arrayCon(0),
-    _arrowCon(0),
-    _appFun(0),
+    _arrayCon(UINT_MAX),
+    _arrowCon(UINT_MAX),
+    _appFun(UINT_MAX),
     _termAlgebras()
 {
   CALL("Signature::Signature");

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -607,15 +607,15 @@ class Signature
   bool isArrayCon(unsigned con) const{
     //second part of conditions ensures that _arrayCon
     //has been initialised.
-    return (con == _arrayCon && _arrayCon != 0);    
+    return (con == _arrayCon && _arrayCon != UINT_MAX);    
   }
 
   bool isArrowCon(unsigned con) const{
-    return (con == _arrowCon && _arrowCon != 0);    
+    return (con == _arrowCon && _arrowCon != UINT_MAX);    
   }
   
   bool isAppFun(unsigned fun) const{
-    return (fun == _appFun && _appFun != 0);
+    return (fun == _appFun && _appFun != UINT_MAX);
   }
 
   bool tryGetFunctionNumber(const vstring& name, unsigned arity, unsigned& out) const;

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -38,6 +38,7 @@
 #include "OperatorType.hpp"
 #include "Theory.hpp"
 
+#include <climits>
 
 namespace Kernel {
 

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -821,7 +821,7 @@ vstring Literal::toString() const
     }
 
     vstring res = s + lhs->next()->toString();
-    if (env.statistics->higherOrder || 
+    if (env.property->higherOrder() || 
        (SortHelper::getEqualityArgumentSort(this) == AtomicSort::boolSort())){
       res = "("+res+")";
     }

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -58,6 +58,7 @@ Environment::Environment()
   statistics = new Statistics;  
   signature = new Signature;
   sharing = new TermSharing;
+  property = new Property;
 
   //view comment in Signature.cpp
   signature->addEquality();
@@ -94,6 +95,7 @@ Environment::~Environment()
   delete sharing;
   delete signature;
   delete statistics;
+  delete property;
   if (predicateSineLevels) delete predicateSineLevels;
   {
     BYPASSING_ALLOCATOR; // use of std::function in options

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -89,6 +89,7 @@ TPTP::TPTP(istream& in)
     _in(&in),
     _includeDirectory(""),
     _isThf(false),
+    _containsPolymorphism(false),
     _currentColor(COLOR_TRANSPARENT),
     _lastPushed(TM),
     _modelDefinition(false),
@@ -137,7 +138,6 @@ void TPTP::parse()
       break;
     case THF:
       _isThf = true;
-      env.statistics->higherOrder = true;
     case TFF:
       _isFof = false;
       tff();
@@ -2318,10 +2318,6 @@ void TPTP::funApp()
       return;
 
     case T_ITE:
-      if(env.statistics->higherOrder){
-        //Does higher-order even use this code? I dont think so.
-        USER_ERROR("Higher-order Vampire is currently not compatible with FOOL reasoning");
-      }
       consumeToken(T_LPAR);
       addTagState(T_RPAR);
       _states.push(TERM);
@@ -2332,10 +2328,6 @@ void TPTP::funApp()
       return;
 
     case T_LET: {
-      if(env.statistics->higherOrder){
-        //Does higher-order even use this code? I dont think so.        
-        USER_ERROR("Higher-order  Vampire is currently not compatible with FOOL reasoning");
-      }
       consumeToken(T_LPAR);
       addTagState(T_RPAR);
       _states.push(TERM);
@@ -3975,7 +3967,7 @@ OperatorType* TPTP::constructOperatorType(Type* t, VList* vars)
   bool isPredicate = resultSort == AtomicSort::boolSort();
   unsigned arity = (unsigned)argumentSorts.size();
 
-  if(env.statistics->polymorphic){
+  if(_containsPolymorphism){
     SortHelper::normaliseArgSorts(vars, argumentSorts);
     SortHelper::normaliseSort(vars, resultSort);
   }
@@ -4251,7 +4243,7 @@ void TPTP::simpleType()
   Token& tok = getTok(0);
 
   if(tok.tag == T_TYPE_QUANT) {
-    env.statistics->polymorphic = true;
+    _containsPolymorphism = true;
     resetToks();
     _typeTags.push(TT_QUANTIFIED);
     consumeToken(T_LBRA);

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -589,6 +589,8 @@ private:
   bool _isFof;
   /** */
   bool _isThf;
+  /** */
+  bool _containsPolymorphism;
   /** various strings saved during parsing */
   Stack<vstring> _strings;
   /** various connectives saved during parsing */ // they must be int, since non-existing value -1 can be used

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1537,13 +1537,13 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if(prb.hasFOOL() &&
-    env.statistics->higherOrder && env.options->booleanEqTrick()){
+    prb.higherOrder() && env.options->booleanEqTrick()){
   //  gie->addFront(new ProxyElimination::NOTRemovalGIE());
     gie->addFront(new BoolEqToDiseq());
   }
 
   if(opt.complexBooleanReasoning() && prb.hasBoolVar() &&
-     env.statistics->higherOrder && !opt.lambdaFreeHol()){
+     prb.higherOrder() && !opt.lambdaFreeHol()){
     gie->addFront(new PrimitiveInstantiation()); //TODO only add in some cases
     gie->addFront(new ElimLeibniz());
   }
@@ -1570,7 +1570,7 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) &&
-      env.statistics->higherOrder && !prb.quantifiesOverPolymorphicVar()){
+      prb.higherOrder() && !prb.quantifiesOverPolymorphicVar()){
     if(env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
        env.options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
       gie->addFront(new LazyClausificationGIE());
@@ -1628,7 +1628,7 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   //create simplification engine
 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) &&
-      env.statistics->higherOrder && !prb.quantifiesOverPolymorphicVar()){
+      prb.higherOrder() && !prb.quantifiesOverPolymorphicVar()){
     if(env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
        env.options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
       res->addSimplifierToFront(new LazyClausification());
@@ -1763,7 +1763,7 @@ ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, cons
   }
 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) &&
-      env.statistics->higherOrder && !env.options->addProxyAxioms()){
+      prb.higherOrder() && !env.options->addProxyAxioms()){
     if(env.options->cnfOnTheFly() == Options::CNFOnTheFly::EAGER){
       /*res->addFrontMany(new ProxyISE());
       res->addFront(new OrImpAndProxyISE());

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -213,7 +213,7 @@ Formula* FOOLElimination::process(Formula* formula) {
        */
 
       if (literal->isEquality() && 
-         (!env.statistics->higherOrder || env.options->equalityToEquivalence())) { 
+         (!env.property->higherOrder() || env.options->equalityToEquivalence())) { 
         ASS_EQ(literal->arity(), 2);
         TermList lhs = *literal->nthArgument(0);
         TermList rhs = *literal->nthArgument(1);

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -104,7 +104,7 @@ Formula* Flattening::innerFlatten (Formula* f)
     {
       Literal* lit = f->literal();
 
-      if (env.options->newCNF() && !env.statistics->higherOrder &&
+      if (env.options->newCNF() && !env.property->higherOrder() &&
           !env.property->hasPolymorphicSym()) {
         // Convert equality between boolean FOOL terms to equivalence
         if (lit->isEquality()) {

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -893,13 +893,13 @@ FunctionDefinition::defines (Term* lhs, Term* rhs)
     }
     //Higher-order often contains definitions of the form
     //f = ^x^y...
-    if (rhs->arity() && !env.statistics->higherOrder) { // c = f(...)
+    if (rhs->arity() && !env.property->higherOrder()) { // c = f(...)
       return 0;
     }
     if (rhs->functor() == f) {
       return 0;
     }
-    if(!env.statistics->higherOrder){
+    if(!env.property->higherOrder()){
       return new Def(lhs,rhs,true,true);
     }
   }

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3118,7 +3118,7 @@ bool Options::complete(const Problem& prb) const
 {
   CALL("Options::complete");
 
-  if(env.statistics->higherOrder){
+  if(prb.higherOrder()){
     //safer for competition
     return false;
   }

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -132,11 +132,11 @@ void Preprocess::preprocess(Problem& prb)
     }
   }
 
-  if (prb.hasFOOL() || env.statistics->higherOrder) {//or lambda
+  if (prb.hasFOOL() || prb.higherOrder()) {
     // This is the point to extend the signature with $$true and $$false
     // If we don't have fool then these constants get in the way (a lot)
 
-    if (!_options.newCNF() || env.statistics->polymorphic || env.statistics->higherOrder) {
+    if (!_options.newCNF() || prb.hasPolymorphicSym() || prb.higherOrder()) {
       if (env.options->showPreprocessing())
         env.out() << "FOOL elimination" << std::endl;
   
@@ -244,14 +244,14 @@ void Preprocess::preprocess(Problem& prb)
   }
 
   if (prb.mayHaveFormulas() && _options.newCNF() && 
-     !prb.hasPolymorphicSym() && !env.statistics->higherOrder) {
+     !prb.hasPolymorphicSym() && !prb.higherOrder()) {
     if (env.options->showPreprocessing())
       env.out() << "newCnf" << std::endl;
 
     newCnf(prb);
   } else {
     if (prb.mayHaveFormulas() && _options.newCNF()) { // TODO: update newCNF to deal with polymorphism / higher-order
-      ASS(prb.hasPolymorphicSym() || env.statistics->higherOrder);
+      ASS(prb.hasPolymorphicSym() || prb.higherOrder());
       if (outputAllowed()) {
         env.beginOutput();
         addCommentSignForSZS(env.out());
@@ -348,7 +348,7 @@ void Preprocess::preprocess(Problem& prb)
 */
 
    if (_options.generalSplitting()!=Options::RuleActivity::OFF) {
-     if (env.statistics->higherOrder || prb.hasPolymorphicSym()) {  // TODO: extend GeneralSplitting to support polymorphism (would higher-order make sense?)
+     if (prb.higherOrder() || prb.hasPolymorphicSym()) {  // TODO: extend GeneralSplitting to support polymorphism (would higher-order make sense?)
        if (outputAllowed()) {
          env.beginOutput();
          addCommentSignForSZS(env.out());
@@ -365,7 +365,7 @@ void Preprocess::preprocess(Problem& prb)
      }
    }
 
-   if (!env.statistics->higherOrder && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
+   if (!prb.higherOrder() && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
      env.statistics->phase=Statistics::EQUALITY_PROXY;
      if (env.options->showPreprocessing())
        env.out() << "equality proxy" << std::endl;
@@ -463,7 +463,7 @@ void Preprocess::preprocess1 (Problem& prb)
     fu = Rectify::rectify(fu);
     FormulaUnit* rectFu = fu;
     // Simplify the formula if it contains true or false
-    if (!_options.newCNF() || env.statistics->higherOrder || prb.hasPolymorphicSym()) {
+    if (!_options.newCNF() || prb.higherOrder() || prb.hasPolymorphicSym()) {
       // NewCNF effectively implements this simplification already (but could have been skipped if higherOrder || hasPolymorphicSym)
       fu = SimplifyFalseTrue::simplify(fu);
     }
@@ -530,7 +530,7 @@ void Preprocess::naming(Problem& prb)
   env.statistics->phase=Statistics::NAMING;
   UnitList::DelIterator us(prb.units());
   //TODO fix the below
-  Naming naming(_options.naming(),false, env.statistics->higherOrder); // For now just force eprPreservingNaming to be false, should update Naming
+  Naming naming(_options.naming(),false, prb.higherOrder()); // For now just force eprPreservingNaming to be false, should update Naming
   while (us.hasNext()) {
     Unit* u = us.next();
     if (u->isClause()) {
@@ -660,7 +660,7 @@ void Preprocess::preprocess3 (Problem& prb)
   UnitList::DelIterator us(prb.units());
   while (us.hasNext()) {
     Unit* u = us.next();
-    Unit* v = preprocess3(u, env.statistics->higherOrder);
+    Unit* v = preprocess3(u, prb.higherOrder());
     if (u!=v) {
       us.replace(v);
       modified = true;

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -516,8 +516,7 @@ void Property::scanSort(TermList sort)
     return;
   }
   _hasNonDefaultSorts = true;
-  env.statistics->hasTypes=true;
-
+  
   if(sort.isArraySort()){
     // an array sort is infinite, if the index or value sort is infinite
     // we rely on the recursive calls setting appropriate flags

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -79,6 +79,7 @@ Property::Property()
     _hasAppliedVar(false),
     _hasBoolVar(false),
     _hasLogicalProxy(false),
+    _hasLambda(false),
     _hasPolymorphicSym(false),
     _quantifiesOverPolymorphicVar(false),
     _onlyFiniteDomainDatatypes(true),
@@ -89,7 +90,6 @@ Property::Property()
     _smtlibLogic(SMTLIBLogic::SMT_UNDEFINED)
 {
   _interpretationPresence.init(Theory::instance()->numberOfFixedInterpretations(), false);
-  env.property = this;
 } // Property::Property
 
 /**
@@ -123,9 +123,7 @@ Property::~Property()
 {
   CALL("Property::~Property");
 
-  if (this == env.property) {
-    env.property = 0;
-  }
+  ASS(this == env.property);
 }
 
 /**
@@ -504,7 +502,7 @@ void Property::scanSort(TermList sort)
     return;
   }
 
-  if(!env.statistics->higherOrder && !_hasPolymorphicSym){
+  if(!higherOrder() && !hasPolymorphicSym()){
     //used sorts is for FMB which is not compatible with 
     //higher-order or polymorphism
     unsigned sortU = sort.term()->functor();
@@ -678,6 +676,10 @@ void Property::scan(TermList ts,bool unit,bool goal)
 
       case Term::SF_MATCH:
         _hasFOOL = true;
+        break;
+
+      case Term::SF_LAMBDA:
+        _hasLambda = true;
         break;
 
       default:

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -156,6 +156,8 @@ public:
   CLASS_NAME(Property);
   USE_ALLOCATOR(Property);
 
+  // constructor, operators new and delete
+  explicit Property();
   static Property* scan(UnitList*);
   void add(UnitList*);
   ~Property();
@@ -229,6 +231,7 @@ public:
   bool hasBoolVar() const { return _hasBoolVar; }
   bool hasLogicalProxy() const { return _hasLogicalProxy; }
   bool hasPolymorphicSym() const { return _hasPolymorphicSym; }
+  bool higherOrder() const { return hasCombs() || hasApp() || hasLogicalProxy() || _hasLambda; }
   bool quantifiesOverPolymorphicVar() const { return _quantifiesOverPolymorphicVar; }
   bool usesSort(unsigned sort) const { 
     CALL("Property::usesSort");
@@ -251,9 +254,6 @@ public:
   bool allNonTheoryClausesGround(){ return _allNonTheoryClausesGround; }
 
  private:
-  // constructor, operators new and delete
-  explicit Property();
-
   static bool hasXEqualsY(const Clause* c);
   static bool hasXEqualsY(const Formula*);
 
@@ -343,6 +343,7 @@ public:
   bool _hasAppliedVar;
   bool _hasBoolVar;
   bool _hasLogicalProxy;
+  bool _hasLambda;
   bool _hasPolymorphicSym;
   bool _quantifiesOverPolymorphicVar;
 

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -43,7 +43,6 @@ using namespace Shell;
 Statistics::Statistics()
   : inputClauses(0),
     inputFormulas(0),
-    hasTypes(false),
     formulaNames(0),
     initialClauses(0),
     splitInequalities(0),

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -147,8 +147,6 @@ Statistics::Statistics()
     taInjectivitySimplifications(0),
     taNegativeInjectivitySimplifications(0),
     taAcyclicityGeneratedDisequalities(0),
-    higherOrder(0),
-    polymorphic(0),
     generatedClauses(0),
     passiveClauses(0),
     activeClauses(0),

--- a/Shell/Statistics.hpp
+++ b/Shell/Statistics.hpp
@@ -58,8 +58,6 @@ public:
   unsigned inputClauses;
   /** number of input formulas */
   unsigned inputFormulas;
-  /** has types */
-  bool hasTypes;
 
   // Preprocessing
   /** number of formula names introduced during preprocessing */

--- a/Shell/Statistics.hpp
+++ b/Shell/Statistics.hpp
@@ -242,11 +242,6 @@ public:
   unsigned taNegativeInjectivitySimplifications;
   unsigned taAcyclicityGeneratedDisequalities;
 
-  //to be moved to the property object once that
-  //is controlled by environment
-  bool higherOrder;
-  bool polymorphic;
-
   // Saturation
   /** all clauses ever occurring in the unprocessed queue */
   unsigned generatedClauses;

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -234,7 +234,7 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   }
 
   vstring cat = "tff(";
-  if(env.statistics->higherOrder){
+  if(env.property->higherOrder()){
     cat = "thf(";
   }
 

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -666,7 +666,7 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, 
 
   //don't output type of app. It is an internal Vampire thing
   if(!(function && env.signature->isAppFun(symNumber))){
-    out << (env.statistics->higherOrder ? "thf(" : "tff(")
+    out << (env.property->higherOrder() ? "thf(" : "tff(")
         << (function ? "func" : (typeCon ?  "type" : "pred")) 
         << "_def_" << symNumber << ", type, "
         << sym->name() << ": ";

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -196,6 +196,15 @@ void doProving()
   //env.options->checkProblemOptionConstraints(prb->getProperty()); 
 
   ProvingHelper::runVampireSaturation(*prb, *env.options);
+
+  if(env.options->mode() == Options::Mode::VAMPIRE){
+    // we don't want to print the proof in SPIDER mode
+    // but we do want to print the proof prior to the deletion of
+    // the problem object
+    env.beginOutput();
+    UIHelper::outputResult(env.out());
+    env.endOutput();
+  }
 }
 
 /**
@@ -454,10 +463,6 @@ void vampireMode()
   }
 
   doProving();
-
-  env.beginOutput();
-  UIHelper::outputResult(env.out());
-  env.endOutput();
 
   if (env.statistics->terminationReason == Statistics::REFUTATION
       || env.statistics->terminationReason == Statistics::SATISFIABLE) {

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -415,7 +415,7 @@ void modelCheckMode()
   env.options->setOutputAxiomNames(true);
   Problem* prb = UIHelper::getInputProblem(*env.options);
 
-  if(env.statistics->polymorphic || env.statistics->higherOrder){
+  if(env.property->hasPolymorphicSym() || env.property->higherOrder()){
     USER_ERROR("Polymorphic Vampire is not yet compatible with theory reasoning");
   }
 

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -196,15 +196,6 @@ void doProving()
   //env.options->checkProblemOptionConstraints(prb->getProperty()); 
 
   ProvingHelper::runVampireSaturation(*prb, *env.options);
-
-  if(env.options->mode() == Options::Mode::VAMPIRE){
-    // we don't want to print the proof in SPIDER mode
-    // but we do want to print the proof prior to the deletion of
-    // the problem object
-    env.beginOutput();
-    UIHelper::outputResult(env.out());
-    env.endOutput();
-  }
 }
 
 /**
@@ -463,6 +454,10 @@ void vampireMode()
   }
 
   doProving();
+
+  env.beginOutput();
+  UIHelper::outputResult(env.out());
+  env.endOutput();
 
   if (env.statistics->terminationReason == Statistics::REFUTATION
       || env.statistics->terminationReason == Statistics::SATISFIABLE) {


### PR DESCRIPTION
This PR resolves the issue wherein the `env.property` object is deleted prior to proof printing when running in Vampire mode. 

However, it does not reolve the somewhat odd ownership of the `property` object. Unlike the `options`, `signature` etc. objects, the environment only mantains a pointer to the property object and [does not own it](https://github.com/vprover/vampire/blob/dd79494d88a52a3c92bd32f5fd5c3cd7fcdc28a9/Shell/Property.cpp#L92). 

Is this something that we look to change?