### PR TITLE
Fix LPO returning INCOMPARABLE for some comparable cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -763,6 +763,7 @@ set(UNIT_TESTS
     UnitTests/tBinaryHeap.cpp
     UnitTests/tSafeRecursion.cpp
     UnitTests/tKBO.cpp
+    UnitTests/tLPO.cpp
     UnitTests/tRatioKeeper.cpp
     UnitTests/tTwoVampires.cpp
     UnitTests/tOptionConstraints.cpp

--- a/Kernel/LPO.cpp
+++ b/Kernel/LPO.cpp
@@ -10,8 +10,9 @@
 /**
  * @file LPO.cpp
  * Implements class LPO for instances of the lexicographic path
- * ordering
- *
+ * ordering based on Bernd Loechner's thesis "Advances in
+ * Equational Theorem Proving - Architecture, Algorithms, and
+ * Redundancy Avoidance" Section 4.2
  */
 
 #include "Debug/Tracer.hpp"
@@ -100,7 +101,8 @@ Ordering::Result LPO::clpo(Term* t1, TermList tl2) const
     ASSERTION_VIOLATION;
     // shouldn't happen because symbol precedence is assumed to be
     // total, but if it is not then the following call is correct
-    return cAA(t1, t2, t1->args(), t2->args(), t1->arity(), t2->arity());
+    //
+    // return cAA(t1, t2, t1->args(), t2->args(), t1->arity(), t2->arity());
   }
 }
 
@@ -242,7 +244,9 @@ Ordering::Result LPO::lexMAE(Term* s, Term* t, TermList* sl, TermList* tl, unsig
       ASSERTION_VIOLATION;
     }
   }
-  return GREATER;
+  // reached only when the terms are equal but this is checked already
+  // at the start of LPO::lpo, which is the only caller of this function
+  ASSERTION_VIOLATION;
 }
 
 // greater if s is greater than every term in tl

--- a/Kernel/LPO.cpp
+++ b/Kernel/LPO.cpp
@@ -176,11 +176,11 @@ Ordering::Result LPO::alpha(TermList* sl, unsigned arity, Term *t) const
   ASS(t->shared());
 
   for (unsigned i = 0; i < arity; i++) {
-    switch (lpo(t, *(sl - i))) {
+    switch (lpo(*(sl - i), TermList(t))) {
     case EQUAL:
-    case LESS:
-      return GREATER;
     case GREATER:
+      return GREATER;
+    case LESS:
     case INCOMPARABLE:
       break;
     default:
@@ -196,30 +196,26 @@ Ordering::Result LPO::lpo(TermList tl1, TermList tl2) const
 {
   CALL("LPO::lpo(TermList, TermList)");
 
+  if(tl1==tl2) {
+    return EQUAL;
+  }
   if(tl1.isOrdinaryVar()) {
     return INCOMPARABLE;
   }
   ASS(tl1.isTerm());
-  return lpo(tl1.term(), tl2);
-}
-
-// used when the first term is not a variable
-Ordering::Result LPO::lpo(Term* t1, TermList tl2) const
-{
-  CALL("LPO::lpo(Term*, TermList)");
-
+  Term* t1 = tl1.term();
   ASS(t1->shared());
 
   if(tl2.isOrdinaryVar()) {
     return t1->containsSubterm(tl2) ? GREATER : INCOMPARABLE;
   }
-  
+
   ASS(tl2.isTerm());
   Term* t2=tl2.term();
 
   switch (compareFunctionPrecedences(t1->functor(), t2->functor())) {
   case EQUAL:
-    lexMAE(t1, t2, t1->args(), t2->args(), t1->arity());
+    return lexMAE(t1, t2, t1->args(), t2->args(), t1->arity());
   case GREATER:
     return majo(t1, t2->args(), t2->arity());
   default:
@@ -257,7 +253,7 @@ Ordering::Result LPO::majo(Term* s, TermList* tl, unsigned arity) const
   ASS(s->shared());
 
   for (unsigned i = 0; i < arity; i++) {
-    switch(lpo(s, *(tl - i))) {
+    switch(lpo(TermList(s), *(tl - i))) {
     case GREATER:
       break;
     case EQUAL:

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -39,6 +39,14 @@ public:
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}
+  LPO(Problem& prb, const Options& opt, DArray<int> funcPrec) :
+    PrecedenceOrdering(
+      funcPrec,
+      predPrecFromOpts(prb, opt),
+      predLevelsFromOptsAndPrec(prb,opt,predPrecFromOpts(prb, opt)),
+      opt.literalComparisonMode()==Shell::Options::LiteralComparisonMode::REVERSE
+    )
+  {}
   virtual ~LPO() {}
 
   using PrecedenceOrdering::compare;
@@ -53,7 +61,6 @@ protected:
   Result alpha(TermList* tl, unsigned arity, Term *t) const;
   Result clpo(Term* t1, TermList tl2) const;
   Result lpo(TermList tl1, TermList tl2) const;
-  Result lpo(Term* t1, TermList tl2) const;
   Result lexMAE(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
   Result majo(Term* s, TermList* tl, unsigned arity) const;
 

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -39,15 +39,10 @@ public:
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}
-  LPO(Problem& prb, const Options& opt, DArray<int> funcPrec) :
-    PrecedenceOrdering(
-      funcPrec,
-      predPrecFromOpts(prb, opt),
-      predLevelsFromOptsAndPrec(prb,opt,predPrecFromOpts(prb, opt)),
-      opt.literalComparisonMode()==Shell::Options::LiteralComparisonMode::REVERSE
-    )
+  LPO(const DArray<int>& funcPrec, const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM) :
+    PrecedenceOrdering(funcPrec, predPrec, predLevels, reverseLCM)
   {}
-  virtual ~LPO() {}
+  ~LPO() override = default;
 
   using PrecedenceOrdering::compare;
   Result compare(TermList tl1, TermList tl2) const override;

--- a/UnitTests/tLPO.cpp
+++ b/UnitTests/tLPO.cpp
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+#include "Test/UnitTesting.hpp"
+#include "Test/SyntaxSugar.hpp"
+#include "Kernel/LPO.hpp"
+#include "Kernel/Ordering.hpp"
+#include "Kernel/Problem.hpp"
+
+DArray<int> lpoFuncPrec() {
+  unsigned num = env.signature->functions();
+  DArray<int> out(num);
+  out.initFromIterator(getRangeIterator(0u, num));
+  return out;
+}
+
+inline void compareTwoWays(const Ordering& ord, TermSugar t1, TermSugar t2) {
+  ASS_EQ(ord.compare(t1, t2), Ordering::Result::GREATER);
+  ASS_EQ(ord.compare(t2, t1), Ordering::Result::LESS);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////// TEST CASES //////////////////////////////////
+//
+// How to read the test cases in this file:
+//
+TEST_FUN(lpo_test01) {
+  DECL_DEFAULT_VARS              // <- macro to initialize some syntax sugar for creating terms over a single uninterpreted sort
+  DECL_SORT(srt)                 // <- declares a function symbol with arity 1
+  DECL_FUNC (f, {srt, srt}, srt) // <- declares a function symbol with arity 2
+  DECL_FUNC (g, {srt, srt}, srt) // <- declares a function symbol with arity 2
+  DECL_CONST(c, srt)             // <- declares a constant symbol
+ 
+  // !!! The declaration order of function and constant symbols will define their precedence relation !!!
+  Problem p;
+  Options o;
+
+  auto ord = LPO(p, o, lpoFuncPrec());
+  compareTwoWays(ord, g(f(x,y),c), c);
+}
+
+TEST_FUN(lpo_test02) {
+  DECL_DEFAULT_VARS
+  DECL_SORT(srt)
+  DECL_FUNC (s, {srt}, srt)
+  DECL_FUNC (plus, {srt, srt}, srt)
+  DECL_FUNC (mult, {srt, srt}, srt)
+  DECL_CONST(zero, srt)
+
+  Problem p;
+  Options o;
+
+  auto ord = LPO(p, o, lpoFuncPrec());
+  compareTwoWays(ord, plus(zero,x), x);
+  compareTwoWays(ord, mult(zero,x), zero);
+  compareTwoWays(ord, s(x),         x);
+  compareTwoWays(ord, plus(s(x),y), s(plus(x,y)));
+  compareTwoWays(ord, mult(s(x),y), plus(mult(x,y),y));
+}
+
+TEST_FUN(lpo_test03) {
+  DECL_DEFAULT_VARS
+  DECL_SORT(srt)
+  DECL_FUNC (g, {srt, srt}, srt)
+  DECL_FUNC (f, {srt, srt}, srt)
+
+  Problem p;
+  Options o;
+
+  auto ord = LPO(p, o, lpoFuncPrec());
+  compareTwoWays(ord, f(x,g(y,z)), g(f(x,y),f(x,z)));
+  compareTwoWays(ord, f(g(x,y),z), g(f(x,z),f(y,z)));
+  compareTwoWays(ord, g(g(x,y),z), g(x,g(y,z)));
+}
+
+TEST_FUN(lpo_test04) {
+  DECL_DEFAULT_VARS
+  DECL_SORT(srt)
+  DECL_FUNC (g, {srt}, srt)
+  DECL_FUNC (f, {srt, srt}, srt)
+
+  Problem p;
+  Options o;
+
+  auto ord = LPO(p, o, lpoFuncPrec());
+  compareTwoWays(ord, f(g(x),y), g(f(x,f(x,y))));
+  compareTwoWays(ord, f(x,x),    g(g(x)));
+}
+
+TEST_FUN(lpo_test05) {
+  DECL_DEFAULT_VARS
+  DECL_SORT(srt)
+  DECL_FUNC (g, {srt, srt}, srt)
+  DECL_FUNC (f, {srt, srt}, srt)
+
+  Problem p;
+  Options o;
+
+  auto ord = LPO(p, o, lpoFuncPrec());
+  ASS_EQ(ord.compare(x, y),                Ordering::Result::INCOMPARABLE);
+  ASS_EQ(ord.compare(f(x,y), z),           Ordering::Result::INCOMPARABLE);
+  ASS_EQ(ord.compare(g(x,y), f(f(z,z),z)), Ordering::Result::INCOMPARABLE);
+}

--- a/UnitTests/tLPO.cpp
+++ b/UnitTests/tLPO.cpp
@@ -21,9 +21,26 @@ DArray<int> lpoFuncPrec() {
   return out;
 }
 
+DArray<int> lpoPredPrec() {
+  unsigned num = env.signature->predicates();
+  DArray<int> out(num);
+  out.initFromIterator(getRangeIterator(0u, num));
+  return out;
+}
+
+DArray<int> lpoPredLevels() {
+  DArray<int> out(env.signature->predicates());
+  out.init(out.size(), 1);
+  return out;
+}
+
 inline void compareTwoWays(const Ordering& ord, TermSugar t1, TermSugar t2) {
   ASS_EQ(ord.compare(t1, t2), Ordering::Result::GREATER);
   ASS_EQ(ord.compare(t2, t1), Ordering::Result::LESS);
+}
+
+LPO lpo() {
+  return LPO(lpoFuncPrec(), lpoPredPrec(), lpoPredLevels(), false /* reverseLCM */);
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -39,10 +56,7 @@ TEST_FUN(lpo_test01) {
   DECL_CONST(c, srt)             // <- declares a constant symbol
  
   // !!! The declaration order of function and constant symbols will define their precedence relation !!!
-  Problem p;
-  Options o;
-
-  auto ord = LPO(p, o, lpoFuncPrec());
+  auto ord = lpo();
   compareTwoWays(ord, g(f(x,y),c), c);
 }
 
@@ -54,10 +68,7 @@ TEST_FUN(lpo_test02) {
   DECL_FUNC (mult, {srt, srt}, srt)
   DECL_CONST(zero, srt)
 
-  Problem p;
-  Options o;
-
-  auto ord = LPO(p, o, lpoFuncPrec());
+  auto ord = lpo();
   compareTwoWays(ord, plus(zero,x), x);
   compareTwoWays(ord, mult(zero,x), zero);
   compareTwoWays(ord, s(x),         x);
@@ -71,10 +82,7 @@ TEST_FUN(lpo_test03) {
   DECL_FUNC (g, {srt, srt}, srt)
   DECL_FUNC (f, {srt, srt}, srt)
 
-  Problem p;
-  Options o;
-
-  auto ord = LPO(p, o, lpoFuncPrec());
+  auto ord = lpo();
   compareTwoWays(ord, f(x,g(y,z)), g(f(x,y),f(x,z)));
   compareTwoWays(ord, f(g(x,y),z), g(f(x,z),f(y,z)));
   compareTwoWays(ord, g(g(x,y),z), g(x,g(y,z)));
@@ -86,10 +94,7 @@ TEST_FUN(lpo_test04) {
   DECL_FUNC (g, {srt}, srt)
   DECL_FUNC (f, {srt, srt}, srt)
 
-  Problem p;
-  Options o;
-
-  auto ord = LPO(p, o, lpoFuncPrec());
+  auto ord = lpo();
   compareTwoWays(ord, f(g(x),y), g(f(x,f(x,y))));
   compareTwoWays(ord, f(x,x),    g(g(x)));
 }
@@ -100,10 +105,7 @@ TEST_FUN(lpo_test05) {
   DECL_FUNC (g, {srt, srt}, srt)
   DECL_FUNC (f, {srt, srt}, srt)
 
-  Problem p;
-  Options o;
-
-  auto ord = LPO(p, o, lpoFuncPrec());
+  auto ord = lpo();
   ASS_EQ(ord.compare(x, y),                Ordering::Result::INCOMPARABLE);
   ASS_EQ(ord.compare(f(x,y), z),           Ordering::Result::INCOMPARABLE);
   ASS_EQ(ord.compare(g(x,y), f(f(z,z),z)), Ordering::Result::INCOMPARABLE);


### PR DESCRIPTION
This PR contains some fixes for the LPO ordering implementation. The original "bug" was that term 1. should have been GREATER than term 2. by the subterm property but it was in fact INCOMPARABLE with precedence f < g < c:

1. g(f(x,y),c)
2. c

This was caused by two issues:
1. the function `LPO::lpo` failed to meet its specification, namely to return the correct result whenever its first argument is greater or equal than its second, it never returned EQUAL when the two terms were equal and it didn't return anything in one branch.
2. in the function `LPO::alpha`, the above function `LPO::lpo` was called with arguments switched, so it sometimes returned INCOMPARABLE when it was actually GREATER.

Additionally, some base unit tests were added including the original "bug".

Regression tests with `-t 10 --forced_options to=lpo`, format "solved (unique)":
| Benchmark set | master | this branch | total |
| -------------------- | --------- | --------------- | ----- |
| TPTP (`--mode casc`) | 11754 (40) | 11958 (244) | 23291 |
| SMT-LIB (`--mode smtcomp`*) | 55843 (128) | 56062 (347) | 93519 |

* single-core, time limit is overriden
  