### PR TITLE
Fix sym counter

### DIFF
--- a/Shell/SymCounter.cpp
+++ b/Shell/SymCounter.cpp
@@ -298,7 +298,6 @@ void SymCounter::count(Term* term, int polarity, int add)
     NonVariableIterator nvi(term);
     while (nvi.hasNext()) {
       Term *t = nvi.next().term();
-      ASS(t != term);
       int fun = t->functor();
       if(!t->isSort()){      
         ASS_REP(_noOfFuns > fun, t->toString());

--- a/Shell/SymCounter.cpp
+++ b/Shell/SymCounter.cpp
@@ -166,7 +166,7 @@ void SymCounter::count (Formula* f,int polarity,int add)
 
     case BOOL_TERM: {
       TermList ts = f->getBooleanTerm();
-      if (!ts.isTerm()) return;     
+      if (!ts.isTerm()) return;
       count (ts.term(), polarity, add);
       return;
     }
@@ -231,7 +231,7 @@ void SymCounter::count(Term* term, int polarity, int add)
 {
   CALL("SymCounter::count(Term*)");
 
-  if (!term->shared()) { 
+  if (!term->shared()) {
     if (term->isSpecial()) {
       Term::SpecialTermData *sd = term->getSpecialData();
       switch (sd->getType()) {
@@ -254,7 +254,7 @@ void SymCounter::count(Term* term, int polarity, int add)
           break;
         }
         case Term::SF_LAMBDA: {
-          TermList lambdaExp = sd->getLambdaExp();      
+          TermList lambdaExp = sd->getLambdaExp();
           if(lambdaExp.isTerm()){
             count(lambdaExp.term(), polarity, add);
           }


### PR DESCRIPTION
The symbol counter contained a number of hidden bugs which Spider brought to notice.

Leading amongst these was the use of an iterator over all subterms for non-shared terms which could result in an exponential number of calls to` count(..)` function.