### PR TITLE
Fix order of premises in integer induction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -754,6 +754,7 @@ set(UNIT_TESTS
     UnitTests/tRebalance.cpp
     UnitTests/tDisagreement.cpp
     UnitTests/tDynamicHeap.cpp
+    UnitTests/tInduction.cpp
     UnitTests/tIntegerConstantType.cpp
     UnitTests/tSATSolver.cpp
     UnitTests/tArithCompare.cpp

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -225,12 +225,11 @@ Literal* LiteralSubsetReplacement::transformSubset(InferenceRule& rule) {
   CALL("LiteralSubsetReplacement::transformSubset");
   // Increment _iteration, since it either is 0, or was already used.
   _iteration++;
-  static unsigned maxSubsetSize = env.options->maxInductionGenSubsetSize();
   // Note: __builtin_popcount() is a GCC built-in function.
   unsigned setBits = __builtin_popcount(_iteration);
   // Skip this iteration if not all bits are set, but more than maxSubset are set.
   while ((_iteration <= _maxIterations) &&
-         ((maxSubsetSize > 0) && (setBits < _occurrences) && (setBits > maxSubsetSize))) {
+         ((_maxSubsetSize > 0) && (setBits < _occurrences) && (setBits > _maxSubsetSize))) {
     _iteration++;
     setBits = __builtin_popcount(_iteration);
   }
@@ -289,7 +288,7 @@ ClauseIterator Induction::generateClauses(Clause* premise)
 {
   CALL("Induction::generateClauses");
 
-  return pvi(InductionClauseIterator(premise, InductionHelper(_comparisonIndex, _inductionTermIndex, _salg->getSplitter())));
+  return pvi(InductionClauseIterator(premise, InductionHelper(_comparisonIndex, _inductionTermIndex, _salg->getSplitter()), getOptions()));
 }
 
 void InductionClauseIterator::processClause(Clause* premise)
@@ -312,13 +311,13 @@ void InductionClauseIterator::processLiteral(Clause* premise, Literal* lit)
 {
   CALL("Induction::ClauseIterator::processLiteral");
 
-  if(env.options->showInduction()){
+  if(_opt.showInduction()){
     env.beginOutput();
     env.out() << "[Induction] process " << lit->toString() << " in " << premise->toString() << endl;
     env.endOutput();
   }
 
-  static bool generalize = env.options->inductionGen();
+  static bool generalize = _opt.inductionGen();
 
   if(InductionHelper::isInductionLiteral(lit)){
       Set<Term*> ta_terms;
@@ -357,16 +356,16 @@ void InductionClauseIterator::processLiteral(Clause* premise, Literal* lit)
       Set<Term*>::Iterator citer2(ta_terms);
       while(citer2.hasNext()){
         Term* t = citer2.next();
-        static bool one = env.options->structInduction() == Options::StructuralInductionKind::ONE ||
-                          env.options->structInduction() == Options::StructuralInductionKind::ALL; 
-        static bool two = env.options->structInduction() == Options::StructuralInductionKind::TWO ||
-                          env.options->structInduction() == Options::StructuralInductionKind::ALL; 
-        static bool three = env.options->structInduction() == Options::StructuralInductionKind::THREE ||
-                          env.options->structInduction() == Options::StructuralInductionKind::ALL;
+        static bool one = _opt.structInduction() == Options::StructuralInductionKind::ONE ||
+                          _opt.structInduction() == Options::StructuralInductionKind::ALL;
+        static bool two = _opt.structInduction() == Options::StructuralInductionKind::TWO ||
+                          _opt.structInduction() == Options::StructuralInductionKind::ALL;
+        static bool three = _opt.structInduction() == Options::StructuralInductionKind::THREE ||
+                          _opt.structInduction() == Options::StructuralInductionKind::ALL;
         if(notDone(lit,t)){
           InferenceRule rule = InferenceRule::INDUCTION_AXIOM;
           Term* inductionTerm = generalize ? getPlaceholderForTerm(t) : t;
-          Kernel::LiteralSubsetReplacement subsetReplacement(lit, t, TermList(inductionTerm));
+          Kernel::LiteralSubsetReplacement subsetReplacement(lit, t, TermList(inductionTerm), _opt.maxInductionGenSubsetSize());
           Literal* ilit = generalize ? subsetReplacement.transformSubset(rule) : lit;
           ASS(ilit != nullptr);
           do {
@@ -406,7 +405,7 @@ void InductionClauseIterator::performIntInductionForEligibleBounds(Clause* premi
       }
     }
   }
-  static bool useDefaultBound = env.options->integerInductionDefaultBound();
+  static bool useDefaultBound = _opt.integerInductionDefaultBound();
   if (useDefaultBound && _helper.isInductionForInfiniteIntervalsOn()) {
     static TermQueryResult defaultBound(TermList(theory->representConstant(IntegerConstantType(0))), nullptr, nullptr);
     if (notDoneInt(origLit, origTerm, increasing, defaultBound.term.term(), /*optionalBound2=*/nullptr, /*fromComparison=*/false)) {
@@ -416,7 +415,7 @@ void InductionClauseIterator::performIntInductionForEligibleBounds(Clause* premi
 }
 
 void InductionClauseIterator::generalizeAndPerformIntInduction(Clause* premise, Literal* origLit, Term* origTerm, List<pair<Literal*, InferenceRule>>*& indLits, Term* indTerm, bool increasing, TermQueryResult& bound1, TermQueryResult* optionalBound2) {
-  static bool generalize = env.options->inductionGen();
+  static bool generalize = _opt.inductionGen();
   // If induction literals were not computed yet, compute them now.
   if (List<pair<Literal*, InferenceRule>>::isEmpty(indLits)) {
     bool finite = ((optionalBound2 != nullptr) && (optionalBound2->literal != nullptr));
@@ -426,7 +425,7 @@ void InductionClauseIterator::generalizeAndPerformIntInduction(Clause* premise, 
             : (increasing ? (finite ? InferenceRule::INT_FIN_UP_INDUCTION_AXIOM : InferenceRule::INT_INF_UP_INDUCTION_AXIOM)
                           : (finite ? InferenceRule::INT_FIN_DOWN_INDUCTION_AXIOM : InferenceRule::INT_INF_DOWN_INDUCTION_AXIOM));
     if (generalize) {
-      Kernel::LiteralSubsetReplacement subsetReplacement(origLit, origTerm, TermList(indTerm));
+      Kernel::LiteralSubsetReplacement subsetReplacement(origLit, origTerm, TermList(indTerm), _opt.maxInductionGenSubsetSize());
       indLits = subsetReplacement.getListOfTransformedLiterals(rule);
     } else {
       indLits = new List<pair<Literal*, InferenceRule>>(make_pair(origLit, rule));
@@ -453,7 +452,7 @@ void InductionClauseIterator::processIntegerComparison(Clause* premise, Literal*
   ASS(greaterTL != nullptr);
   Term* lt = lesserTL->term();
   Term* gt = greaterTL->term();
-  static bool generalize = env.options->inductionGen();
+  static bool generalize = _opt.inductionGen();
   DHMap<Term*, TermQueryResult> grBound;
   addToMapFromIterator(grBound, _helper.getGreaterEqual(gt));
   addToMapFromIterator(grBound, _helper.getGreater(gt));
@@ -530,7 +529,7 @@ void InductionClauseIterator::produceClauses(Clause* premise, Literal* origLit, 
           // we apply binary resolution on it.
           _helper.callSplitterOnNewClause(c);
         }
-        c = BinaryResolution::generateClause(c,litAndSLQR.first,litAndSLQR.second,*env.options);
+        c = BinaryResolution::generateClause(c,litAndSLQR.first,litAndSLQR.second,_opt);
         resolved = true;
       }
     }
@@ -710,17 +709,17 @@ void InductionClauseIterator::performIntInduction(Clause* premise, Literal* orig
   }
 
   // Create pairs of Literal* and SLQueryResult for resolving L[y] and Y>=b (or Y<=b or Y>b or Y<b)
-  static ScopedPtr<RobSubstitution> subst(new RobSubstitution());
+  static RobSubstitution subst;
   // When producing clauses, 'y' should be unified with 'term'
-  ALWAYS(subst->unify(TermList(term), 0, y, 1));
-  ResultSubstitutionSP resultSubst = ResultSubstitution::fromSubstitution(subst.ptr(), 1, 0);
+  ALWAYS(subst.unify(TermList(term), 0, y, 1));
+  ResultSubstitutionSP resultSubst = ResultSubstitution::fromSubstitution(&subst, 1, 0);
   List<pair<Literal*, SLQueryResult>>::push(make_pair(
       Ly->literal(),
       SLQueryResult(origLit, premise, resultSubst)),
     toResolve);
   produceClauses(premise, lit, hyp, rule, toResolve);
   List<pair<Literal*, SLQueryResult>>::destroy(toResolve);
-  subst->reset();
+  subst.reset();
 }
 
 /**

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -89,10 +89,16 @@ public:
 
   Induction() {}
 
-  void attach(SaturationAlgorithm* salg);
-  void detach();
+  void attach(SaturationAlgorithm* salg) override;
+  void detach() override;
 
-  ClauseIterator generateClauses(Clause* premise);
+  ClauseIterator generateClauses(Clause* premise) override;
+
+#if VDEBUG
+  void setTestIndices(const Stack<Index*>& indices) override {
+    _comparisonIndex = static_cast<LiteralIndex*>(indices[0]);
+  }
+#endif // VDEBUG
 
 private:
   // The following pointers can be null if int induction is off.

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -51,8 +51,8 @@ private:
 
 class LiteralSubsetReplacement : TermTransformer {
 public:
-  LiteralSubsetReplacement(Literal* lit, Term* o, TermList r)
-      : _lit(lit), _o(o), _r(r) {
+  LiteralSubsetReplacement(Literal* lit, Term* o, TermList r, const unsigned maxSubsetSize)
+      : _lit(lit), _o(o), _r(r), _maxSubsetSize(maxSubsetSize) {
     _occurrences = _lit->countSubtermOccurrences(TermList(_o));
     _maxIterations = pow(2, _occurrences);
   }
@@ -78,6 +78,7 @@ private:
   Literal* _lit;
   Term* _o;
   TermList _r;
+  const unsigned _maxSubsetSize;
 };
 
 class Induction
@@ -110,8 +111,8 @@ class InductionClauseIterator
 {
 public:
   // all the work happens in the constructor!
-  InductionClauseIterator(Clause* premise, InductionHelper helper)
-      : _helper(helper)
+  InductionClauseIterator(Clause* premise, InductionHelper helper, const Options& opt)
+      : _helper(helper), _opt(opt)
   {
     processClause(premise);
   }
@@ -123,7 +124,7 @@ public:
   inline bool hasNext() { return _clauses.isNonEmpty(); }
   inline OWN_ELEMENT_TYPE next() { 
     Clause* c = _clauses.pop();
-    if(env.options->showInduction()){
+    if(_opt.showInduction()){
       env.beginOutput();
       env.out() << "[Induction] generate " << c->toString() << endl; 
       env.endOutput();
@@ -169,6 +170,7 @@ private:
 
   Stack<Clause*> _clauses;
   InductionHelper _helper;
+  const Options& _opt;
 };
 
 };

--- a/Inferences/InductionHelper.cpp
+++ b/Inferences/InductionHelper.cpp
@@ -121,8 +121,7 @@ TermQueryResultIterator InductionHelper::getTQRsForInductionTerm(TermList induct
 
 void InductionHelper::callSplitterOnNewClause(Clause* c) {
   CALL("InductionHelper::callSplitterOnNewClause");
-  static bool splitting = env.options->splitting();
-  if (splitting) _splitter->onNewClause(c);
+  if (_splitter) _splitter->onNewClause(c);
 }
 
 bool InductionHelper::isIntegerComparison(Clause* c) {

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -29,6 +29,9 @@
 #include "Lib/Allocator.hpp"
 #include "Kernel/Inference.hpp"
 #include "Lib/Coproduct.hpp"
+#if VDEBUG
+#include "Indexing/Index.hpp"
+#endif
 
 namespace Inferences
 {
@@ -77,6 +80,15 @@ public:
   bool attached() const { return _salg; }
 
   virtual const Options& getOptions() const;
+#if VDEBUG
+  /**
+   * Normally indices are managed by `IndexManager`, which is contained in the saturation algorithm class.
+   * This is unfortunate for unit testing, as it requires to instantiate the whole SaturationAlgorithm
+   * machinery for unit testing a single rule if that rule uses a term index. In order to circumvent this
+   * issue we add this method in debug mode.
+   * */
+  virtual void setTestIndices(Stack<Indexing::Index*> const&) {}
+#endif // VDEBUG
 protected:
   SaturationAlgorithm* _salg;
 };

--- a/Test/GenerationTester.hpp
+++ b/Test/GenerationTester.hpp
@@ -49,17 +49,12 @@ class TestCase;
 template<class Rule>
 class GenerationTester
 {
-  Rule* _rule;
+  Rule _rule;
 
 public:
-  GenerationTester(Rule* rule)
-    : _rule(rule)
+  GenerationTester()
+    : _rule()
   {}
-
-  ~GenerationTester()
-  {
-    delete _rule;
-  }
 
   virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs)
   { return TestUtils::eqModAC(lhs, rhs); }
@@ -121,9 +116,9 @@ public:
       env.options->set(kv.first, kv.second);
     }
     MockedSaturationAlgorithm alg(p, o);
-    SimplifyingGeneratingInference* rule = _rule.unwrapOrElse([&](){ return simpl._rule; });
-    rule->setTestIndices(_indices);
-    rule->InferenceEngine::attach(&alg);
+    SimplifyingGeneratingInference& rule = *_rule.unwrapOrElse([&](){ return &simpl._rule; });
+    rule.setTestIndices(_indices);
+    rule.InferenceEngine::attach(&alg);
     for (auto i : _indices) {
       i->attachContainer(&container);
     }
@@ -136,7 +131,7 @@ public:
 
     // run rule
     _input->setStore(Clause::ACTIVE);
-    auto res = rule->generateSimplify(_input);
+    auto res = rule.generateSimplify(_input);
 
     // run checks
     auto& sExp = this->_expected;
@@ -152,13 +147,13 @@ public:
     }
 
     // tear down saturation algorithm
-    rule->InferenceEngine::detach();
+    rule.InferenceEngine::detach();
   }
 };
 
 #define __CREATE_GEN_TESTER CAT(__createGenTester_, UNIT_ID)
 
-#define REGISTER_GEN_TESTER(t, ...) auto __CREATE_GEN_TESTER() { return Test::Generation::GenerationTester<t>(new t(__VA_ARGS__)); }
+#define REGISTER_GEN_TESTER(t, ...) auto __CREATE_GEN_TESTER() { return Test::Generation::GenerationTester<t>(); }
 
 #define TEST_GENERATION(name, ...)                                                                            \
         TEST_GENERATION_WITH_SUGAR(name, MY_SYNTAX_SUGAR, __VA_ARGS__) 

--- a/Test/GenerationTester.hpp
+++ b/Test/GenerationTester.hpp
@@ -39,20 +39,29 @@ Stack<ClausePattern> exactly(As... as)
   return out;
 }
 
+inline Stack<ClausePattern> none() {
+  return Stack<ClausePattern>();
+}
+
 namespace Generation {
 class TestCase;
 
 template<class Rule>
 class GenerationTester
 {
-  Rule _rule;
+  Rule* _rule;
 
 public:
-  GenerationTester() 
-    : _rule() 
+  GenerationTester(Rule* rule)
+    : _rule(rule)
   {}
 
-  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const 
+  ~GenerationTester()
+  {
+    delete _rule;
+  }
+
+  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs)
   { return TestUtils::eqModAC(lhs, rhs); }
 
   friend class TestCase;
@@ -61,14 +70,20 @@ public:
 class TestCase
 {
   using Clause = Kernel::Clause;
+  using OptionMap = Stack<pair<vstring,vstring>>;
   Option<SimplifyingGeneratingInference*> _rule;
   Clause* _input;
   Stack<ClausePattern> _expected;
+  Stack<Clause*> _context;
   bool _premiseRedundant;
+  Stack<Indexing::Index*> _indices;
+  OptionMap _options;
 
   template<class Is, class Expected>
   void testFail(Is const& is, Expected const& expected) {
       cout  << endl;
+      cout << "[  context ]: " << pretty(_context) << endl;
+      cout << "[  options ]: " << pretty(_options) << endl;
       cout << "[     case ]: " << pretty(*_input) << endl;
       cout << "[       is ]: " << pretty(is) << endl;
       cout << "[ expected ]: " << pretty(expected) << endl;
@@ -77,7 +92,7 @@ class TestCase
 
 public:
 
-  TestCase() : _rule(), _input(NULL), _expected(), _premiseRedundant(false) {}
+  TestCase() : _rule(), _input(NULL), _expected(), _premiseRedundant(false), _options() {}
 
 #define BUILDER_METHOD(type, field)                                                                           \
   TestCase field(type field)                                                                                  \
@@ -87,60 +102,70 @@ public:
   }                                                                                                           \
 
   BUILDER_METHOD(Clause*, input)
+  BUILDER_METHOD(Stack<Clause*>, context)
   BUILDER_METHOD(Stack<ClausePattern>, expected)
   BUILDER_METHOD(bool, premiseRedundant)
   BUILDER_METHOD(SimplifyingGeneratingInference*, rule)
+  BUILDER_METHOD(Stack<Indexing::Index*>, indices)
+  BUILDER_METHOD(OptionMap, options)
 
   template<class Rule>
   void run(GenerationTester<Rule>& simpl) {
 
     // set up saturation algorithm
+    auto container = PlainClauseContainer();
     Problem p;
     Options o;
+    for (const auto& kv : _options) {
+      o.set(kv.first, kv.second);
+      env.options->set(kv.first, kv.second);
+    }
     MockedSaturationAlgorithm alg(p, o);
-    SimplifyingGeneratingInference& rule = *_rule.unwrapOrElse([&](){ return &simpl._rule; });
-    rule.attach(&alg);
+    SimplifyingGeneratingInference* rule = _rule.unwrapOrElse([&](){ return simpl._rule; });
+    rule->setTestIndices(_indices);
+    rule->InferenceEngine::attach(&alg);
+    for (auto i : _indices) {
+      i->attachContainer(&container);
+    }
+
+    // add the clauses to the index
+    for (auto c : _context) {
+      c->setStore(Clause::ACTIVE);
+      container.add(c);
+    }
 
     // run rule
-    auto res = rule.generateSimplify(_input);
+    _input->setStore(Clause::ACTIVE);
+    auto res = rule->generateSimplify(_input);
 
     // run checks
     auto& sExp = this->_expected;
     auto  sRes = Stack<Kernel::Clause*>::fromIterator(res.clauses);
 
-    auto iExp = getArrayishObjectIterator<mut_ref_t>(sExp);
-    auto iRes = getArrayishObjectIterator<mut_ref_t>(sRes);
-
-    while (iRes.hasNext() && iExp.hasNext()) {
-      auto& exp = iExp.next();
-      auto& res = iRes.next();
-      if (!exp.matches(simpl, res)) {
-        testFail(sRes, sExp);
-      }
-    }
-
-    if (iExp.hasNext() || iRes.hasNext()) {
+    if (!TestUtils::permEq(sExp, sRes, [&](auto exp, auto res) { return exp.matches(simpl, res); })) {
       testFail(sRes, sExp);
     }
 
     if (_premiseRedundant != res.premiseRedundant) {
-      auto wrapStr = [](bool b) -> vstring { return b ? "premise is redundant" : "premis not redundant"; };
+      auto wrapStr = [](bool b) -> vstring { return b ? "premise is redundant" : "premise is not redundant"; };
       testFail( wrapStr(res.premiseRedundant), wrapStr(_premiseRedundant));
     }
 
     // tear down saturation algorithm
-    rule.detach();
+    rule->InferenceEngine::detach();
   }
 };
 
-#define REGISTER_GEN_TESTER(t) using __GenerationTester = t;
+#define __CREATE_GEN_TESTER CAT(__createGenTester_, UNIT_ID)
+
+#define REGISTER_GEN_TESTER(t, ...) auto __CREATE_GEN_TESTER() { return Test::Generation::GenerationTester<t>(new t(__VA_ARGS__)); }
 
 #define TEST_GENERATION(name, ...)                                                                            \
         TEST_GENERATION_WITH_SUGAR(name, MY_SYNTAX_SUGAR, __VA_ARGS__) 
 
 #define TEST_GENERATION_WITH_SUGAR(name, syntax_sugar, ...)                                                   \
   TEST_FUN(name) {                                                                                            \
-    __GenerationTester tester;                                                                                \
+    auto tester = __CREATE_GEN_TESTER();                                                                      \
     __ALLOW_UNUSED(syntax_sugar)                                                                              \
     auto test = __VA_ARGS__;                                                                                  \
     test.run(tester);                                                                                         \

--- a/Test/SyntaxSugar.hpp
+++ b/Test/SyntaxSugar.hpp
@@ -317,7 +317,7 @@ public:
 
   static TermSugar createConstant(const char* name, SortSugar s) {
     unsigned f = env.signature->addFunction(name,0);                                                                
-    env.signature->getFunction(f)->setType(OperatorType::getFunctionType({}, s.sortId())); 
+    env.signature->getFunction(f)->setType(OperatorType::getFunctionType({}, s.sortId()));
     return TermSugar(TermList(Term::createConstant(f)));                                                          
   }                                                                                                                 
 };
@@ -473,8 +473,8 @@ public:
 class ConstSugar : public TermSugar, public FuncSugar
 {
 public:
-  ConstSugar(const char* name, SortSugar s) 
-    : TermSugar(TermSugar::createConstant(name, s).toTerm()) 
+  ConstSugar(const char* name, SortSugar s)
+    : TermSugar(TermSugar::createConstant(name, s).toTerm())
     , FuncSugar(functor())
   { }
   unsigned functor() const { return this->toTerm().term()->functor(); }

--- a/Test/TestUtils.cpp
+++ b/Test/TestUtils.cpp
@@ -51,51 +51,11 @@ SAT::SATClause* TestUtils::buildSATClause(unsigned len,...)
   return SATClause::fromStack(lits);
 }
 
-template<class List, class Eq>
-bool __permEq(const List& lhs, const List& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
-  auto checkPerm = [&] (const List& lhs, const List& rhs, DArray<unsigned>& perm) {
-    ASS_EQ(lhs.size(), perm.size());
-    ASS_EQ(rhs.size(), perm.size());
-
-    for (unsigned i = 0; i < perm.size(); i++) {
-      if (!elemEq(lhs[i], rhs[perm[i]])) return false;
-    }
-    return true;
-  };
-  if (checkPerm(lhs, rhs, perm)) {
-    return true;
-  }
-  for (unsigned i = idx; i < perm.size(); i++) {
-    swap(perm[i], perm[idx]);
-
-
-    if (__permEq(lhs,rhs, elemEq, perm, idx+1)) return true;
-
-    swap(perm[i], perm[idx]);
-  }
-
-  return false;
-}
-
-
-template<class List, class Eq>
-bool TestUtils::permEq(const List& lhs, const List& rhs, Eq elemEq) 
-{
-  if (lhs.size() != rhs.size()) return false;
-  // ASS_EQ(lhs.size(), rhs.size());
-  DArray<unsigned> perm(lhs.size());
-  for (unsigned i = 0; i < lhs.size(); i++) {
-    perm[i] = i;
-  }
-  return __permEq(lhs, rhs, elemEq, perm, 0);
-}
-
 std::ostream& printOp(std::ostream& out, const Term* t, const char* op) {
   auto l = *t->nthArgument(0);
   auto r = *t->nthArgument(1);
   return out << "(" << pretty(l) << " " << op << " " << pretty(r) << ")";
 }
-
 
 template<>
 std::ostream& Pretty<Kernel::TermList>::prettyPrint(std::ostream& out) const

--- a/Test/TestUtils.hpp
+++ b/Test/TestUtils.hpp
@@ -254,14 +254,6 @@ bool TestUtils::permEq(L1& lhs, L2& rhs, Eq elemEq)
   return __permEq(lhs, rhs, elemEq, perm, 0);
 }
 
-inline void setOptions(std::initializer_list<pair<vstring,vstring>> opts) {
-  for (const auto& kv : opts) {
-    env.options->set(kv.first, kv.second);
-  }
-}
-
-#define SET_OPTIONS(...) Test::setOptions(__VA_ARGS__);
-
 } // namespace Test
 
 #endif // __TestUtils__

--- a/Test/TestUtils.hpp
+++ b/Test/TestUtils.hpp
@@ -211,6 +211,8 @@ public:
   { return out << pretty(_self.first) << " : " << pretty(_self.second); }
 };
 
+// Helper function for permEq -- checks whether lhs is a permutation of
+// rhs via initial permutation perm with elements [0,idx) fixed.
 template<class L1, class L2, class Eq>
 bool __permEq(L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
   auto checkPerm = [] (L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
@@ -222,8 +224,8 @@ bool __permEq(L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx)
     }
     return true;
   };
-  // these are elements are fixed in the permutation, so check
-  // them only once and do not recurse if one of them is false
+  // These are elements fixed in the permutation, so check
+  // them only once and do not recurse if one of them is false.
   for (unsigned i = 0; i < idx; i++) {
     if (!elemEq(lhs[i], rhs[perm[i]])) return false;
   }

--- a/Test/TestUtils.hpp
+++ b/Test/TestUtils.hpp
@@ -62,6 +62,18 @@ public:
 
 
 
+  /**
+   * Tests whether there is a permutation pi s.t. pi(lhs) == rhs, where elements are compared by
+   * elemEq(l,r)
+   * `List` must provide methods
+   *    - `elem_type operator[](unsigned)`
+   *    - `unsigned size()`
+   * `Eq`   must provide methods
+   *    - `bool operator(const elem_type&, const elem_type&)`
+   */
+  template<class L1, class L2, class Eq>
+  static bool permEq(L1& lhs, L2& rhs, Eq elemEq);
+
 private:
 
   struct RectMap
@@ -83,18 +95,6 @@ private:
   // static bool eqModACVar(Kernel::TermList lhs, Kernel::TermList rhs, RectMap& r);
   template<class Comparisons>
   static bool eqModAC_(Kernel::TermList lhs, Kernel::TermList rhs, Comparisons c);
-
-  /**
-   * Tests whether there is a permutation pi s.t. pi(lhs) == rhs, where elements are compared by
-   * elemEq(l,r)
-   * `List` must provide methods 
-   *    - `elem_type operator[](unsigned)` 
-   *    - `unsigned size()`
-   * `Eq`   must provide methods
-   *    - `bool operator(const elem_type&, const elem_type&)`
-   */
-  template<class List, class Eq> 
-  static bool permEq(const List& lhs, const List& rhs, Eq elemEq);
 
   /** returns whether the function f is associative and commutative */
   static bool isAC(Kernel::Theory::Interpretation f);
@@ -200,7 +200,66 @@ public:
   { return out << pretty(*_self); }
 };
 
+template<class A, class B>
+class Pretty<pair<A,B>> {
+  pair<A,B> const& _self;
 
+public:
+  Pretty(pair<A,B> const& self) : _self(self) {}
+
+  std::ostream& prettyPrint(std::ostream& out) const
+  { return out << pretty(_self.first) << " : " << pretty(_self.second); }
+};
+
+template<class L1, class L2, class Eq>
+bool __permEq(L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
+  auto checkPerm = [] (L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
+    ASS_EQ(lhs.size(), perm.size());
+    ASS_EQ(rhs.size(), perm.size());
+
+    for (unsigned i = idx; i < perm.size(); i++) {
+      if (!elemEq(lhs[i], rhs[perm[i]])) return false;
+    }
+    return true;
+  };
+  // these are elements are fixed in the permutation, so check
+  // them only once and do not recurse if one of them is false
+  for (unsigned i = 0; i < idx; i++) {
+    if (!elemEq(lhs[i], rhs[perm[i]])) return false;
+  }
+  if (checkPerm(lhs, rhs, elemEq, perm, idx)) {
+    return true;
+  }
+  for (unsigned i = idx; i < perm.size(); i++) {
+    swap(perm[i], perm[idx]);
+
+    if (__permEq(lhs,rhs, elemEq, perm, idx+1)) return true;
+
+    swap(perm[i], perm[idx]);
+  }
+
+  return false;
 }
+
+template<class L1, class L2, class Eq>
+bool TestUtils::permEq(L1& lhs, L2& rhs, Eq elemEq)
+{
+  if (lhs.size() != rhs.size()) return false;
+  DArray<unsigned> perm(lhs.size());
+  for (unsigned i = 0; i < lhs.size(); i++) {
+    perm[i] = i;
+  }
+  return __permEq(lhs, rhs, elemEq, perm, 0);
+}
+
+inline void setOptions(std::initializer_list<pair<vstring,vstring>> opts) {
+  for (const auto& kv : opts) {
+    env.options->set(kv.first, kv.second);
+  }
+}
+
+#define SET_OPTIONS(...) Test::setOptions(__VA_ARGS__);
+
+} // namespace Test
 
 #endif // __TestUtils__

--- a/UnitTests/tEqualityResolution.cpp
+++ b/UnitTests/tEqualityResolution.cpp
@@ -18,7 +18,7 @@
 
 using namespace Test;
 
-REGISTER_GEN_TESTER(Test::Generation::GenerationTester<Inferences::EqualityResolution>)
+REGISTER_GEN_TESTER(EqualityResolution)
 
 /**
  * NECESSARY: We neet to tell the tester which syntax sugar to import for creating terms & clauses. 

--- a/UnitTests/tGaussianElimination.cpp
+++ b/UnitTests/tGaussianElimination.cpp
@@ -160,7 +160,7 @@ TEST_SIMPLIFY(gve_test_div,
 /////////////////////////////////////
 
 
-REGISTER_GEN_TESTER(Test::Generation::GenerationTester<LfpRule<GaussianVariableElimination>>)
+REGISTER_GEN_TESTER(LfpRule<GaussianVariableElimination>)
 
 TEST_GENERATION(test_redundancy_01,
     Generation::TestCase()

--- a/UnitTests/tInduction.cpp
+++ b/UnitTests/tInduction.cpp
@@ -1,0 +1,460 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+
+#include "Test/UnitTesting.hpp"
+#include "Test/SyntaxSugar.hpp"
+#include "Test/TestUtils.hpp"
+#include "Test/GenerationTester.hpp"
+
+#include "Indexing/TermIndex.hpp"
+#include "Indexing/LiteralSubstitutionTree.hpp"
+#include "Kernel/RobSubstitution.hpp"
+
+#include "Inferences/Induction.hpp"
+
+using namespace Test;
+using namespace Test::Generation;
+
+#define VARS 100
+
+LiteralIndex* comparisonIndex() {
+  return new UnitIntegerComparisonLiteralIndex(new LiteralSubstitutionTree());
+}
+
+template<class Rule>
+class GenerationTesterInduction
+  : public GenerationTester<Rule>
+{
+public:
+  GenerationTesterInduction(Rule* rule)
+    : GenerationTester<Rule>(rule), _subst()
+  {}
+
+  bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) override
+  {
+    BacktrackData btd;
+    _subst.bdRecord(btd);
+    if (!TestUtils::permEq(*lhs, *rhs, [this](Literal* l, Literal* r) -> bool {
+      if (l->polarity() != r->polarity()) {
+        return false;
+      }
+      if (!_subst.match(Kernel::TermList(r), 0, Kernel::TermList(l), 1)) {
+        if (l->isEquality() && r->isEquality()) {
+          return _subst.match(*r->nthArgument(0), 0, *l->nthArgument(1), 1) &&
+            _subst.match(*r->nthArgument(1), 0, *l->nthArgument(0), 1);
+        }
+        return false;
+      }
+      // since we may have non-ground hypothesis, and checking those might give false
+      // positive matches where multiple variables are mapped to the same term unintentionally,
+      // we check whether all variables within a possible range have different mapped values
+      DHMap<TermList, unsigned> inverse;
+      for (unsigned i = 0; i < VARS; i++) {
+        if (!_subst.isUnbound(i, 0)) {
+          auto t = _subst.apply(TermList(i,false),0);
+          unsigned v;
+          if (inverse.find(t,v)) {
+            return false;
+          } else {
+            inverse.insert(t,i);
+          }
+        }
+      }
+      return true;
+    })) {
+      _subst.bdDone();
+      btd.backtrack();
+      return false;
+    }
+    _subst.bdDone();
+    return true;
+  }
+
+private:
+  Kernel::RobSubstitution _subst;
+};
+
+#define TEST_GENERATION_INDUCTION(name, ...)                                                                  \
+  TEST_FUN(name) {                                                                                            \
+    GenerationTesterInduction<Induction> tester(new Induction());                                             \
+    __ALLOW_UNUSED(MY_SYNTAX_SUGAR)                                                                           \
+    auto test = __VA_ARGS__;                                                                                  \
+    test.run(tester);                                                                                         \
+  }                                                                                                           \
+
+/**
+ * NECESSARY: We need to tell the tester which syntax sugar to import for creating terms & clauses.
+ * See Test/SyntaxSugar.hpp for which kinds of syntax sugar are available
+ */
+#define MY_SYNTAX_SUGAR                                                                    \
+  DECL_DEFAULT_VARS                                                                        \
+  DECL_VAR(x3,3)                                                                           \
+  DECL_VAR(x4,4)                                                                           \
+  DECL_VAR(x5,5)                                                                           \
+  DECL_VAR(x6,6)                                                                           \
+  DECL_VAR(x7,7)                                                                           \
+  DECL_VAR(x8,8)                                                                           \
+  DECL_VAR(x9,9)                                                                           \
+  DECL_VAR(x10,10)                                                                         \
+  DECL_VAR(x11,11)                                                                         \
+  DECL_VAR(x12,12)                                                                         \
+  DECL_VAR(x13,13)                                                                         \
+  DECL_VAR(x14,14)                                                                         \
+  DECL_VAR(x15,15)                                                                         \
+  DECL_VAR(x16,16)                                                                         \
+  DECL_VAR(x17,17)                                                                         \
+  DECL_VAR(x18,18)                                                                         \
+  DECL_VAR(x19,19)                                                                         \
+  DECL_VAR(x20,20)                                                                         \
+  DECL_VAR(x21,21)                                                                         \
+  DECL_SORT(s)                                                                             \
+  DECL_SORT(u)                                                                             \
+  DECL_CONST(sK1, s)                                                                       \
+  DECL_CONST(sK2, s)                                                                       \
+  DECL_CONST(sK3, s)                                                                       \
+  DECL_CONST(sK4, s)                                                                       \
+  DECL_CONST(sK5, u)                                                                       \
+  DECL_CONST(b, s)                                                                         \
+  DECL_FUNC(r, {s}, s)                                                                     \
+  DECL_TERM_ALGEBRA(s, {b, r})                                                             \
+  __ALLOW_UNUSED(                                                                          \
+    auto r0 = r.dtor(0);                                                                   \
+  )                                                                                        \
+  DECL_CONST(b1, u)                                                                        \
+  DECL_CONST(b2, u)                                                                        \
+  DECL_FUNC(r1, {s, u, u}, u)                                                              \
+  DECL_FUNC(r2, {u, s}, u)                                                                 \
+  DECL_TERM_ALGEBRA(u, {b1, b2, r1, r2})                                                   \
+  DECL_FUNC(f, {s, s}, s)                                                                  \
+  DECL_FUNC(g, {s}, s)                                                                     \
+  DECL_PRED(p, {s})                                                                        \
+  DECL_PRED(q, {u})                                                                        \
+  NUMBER_SUGAR(Int)                                                                        \
+  DECL_PRED(pi, {Int})                                                                     \
+  DECL_FUNC(fi, {Int, s}, Int)                                                             \
+  DECL_CONST(sK6, Int)                                                                     \
+  DECL_CONST(sK7, Int)                                                                     \
+  DECL_CONST(sK8, Int)                                                                     \
+  DECL_CONST(bi, Int)
+
+// positive literals are not considered 1
+TEST_GENERATION_INDUCTION(test_01,
+    Generation::TestCase()
+      .options({ { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  p(f(sK1,sK2)) }))
+      .expected(none())
+    )
+
+// positive literals are not considered 2
+TEST_GENERATION_INDUCTION(test_02,
+    Generation::TestCase()
+      .options({ { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  f(sK1,sK2) == g(sK1) }))
+      .expected(none())
+    )
+
+// non-ground literals are not considered
+TEST_GENERATION_INDUCTION(test_03,
+    Generation::TestCase()
+      .options({ { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  f(sK1,x) != g(sK1) }))
+      .expected(none())
+    )
+
+// normal case sik=one
+TEST_GENERATION_INDUCTION(test_04,
+    Generation::TestCase()
+      .options({ { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  ~p(f(sK1,sK2)) }))
+      .expected({
+        clause({ ~p(f(b,sK2)), p(f(x,sK2)) }),
+        clause({ ~p(f(b,sK2)), ~p(f(r(x),sK2)) }),
+        clause({ ~p(f(sK1,b)), p(f(sK1,y)) }),
+        clause({ ~p(f(sK1,b)), ~p(f(sK1,r(y))) }),
+      })
+    )
+
+// normal case sik=two
+TEST_GENERATION_INDUCTION(test_05,
+    Generation::TestCase()
+      .options({ { "induction", "struct" }, { "structural_induction_kind", "two" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  ~p(f(sK1,sK2)) }))
+      .expected({
+        clause({ x != r(r0(x)), p(f(r0(x),sK2)) }),
+        clause({ ~p(f(x,sK2)) }),
+        clause({ y != r(r0(y)), p(f(sK1,r0(y))) }),
+        clause({ ~p(f(sK1,y)) }),
+      })
+    )
+
+// TODO this case is a bit hard to test since new predicates are introduced
+// // normal case sik=three
+// TEST_GENERATION_INDUCTION(test_06,
+//     Generation::TestCase()
+//       .options({ { "induction", "struct" }, { "structural_induction_kind", "three" } })
+//       .indices({ comparisonIndex() })
+//       .input( clause({  f(sK1,sK2) != g(sK1) }))
+//       .expected({
+//         clause({ f(b,sK2) != g(b), f(x,sK2) == g(x) }),
+//         clause({ f(b,sK2) != g(b), f(r(x),sK2) != g(r(x)) }),
+//         clause({ f(sK1,b) != g(sK1), f(sK1,y) == g(sK1) }),
+//         clause({ f(sK1,b) != g(sK1), f(sK1,r(y)) != g(sK1) }),
+//       })
+//     )
+
+// generalizations
+TEST_GENERATION_INDUCTION(test_07,
+    Generation::TestCase()
+      .options({ { "induction_gen", "on" }, { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }) )
+      .expected({
+        // sK1 100
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(x),f(sK2,sK4)),sK1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(r(x)),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }),
+
+        // sK1 010
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),y) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),r(y)) != g(f(sK1,f(sK2,sK3))) }),
+
+        // sK1 001
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(z,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(r(z),f(sK2,sK3))) }),
+
+        // sK1 110
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(x3),f(sK2,sK4)),x3) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(r(x3)),f(sK2,sK4)),r(x3)) != g(f(sK1,f(sK2,sK3))) }),
+
+        // sK1 101
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(x4),f(sK2,sK4)),sK1) == g(f(x4,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(r(x4)),f(sK2,sK4)),sK1) != g(f(r(x4),f(sK2,sK3))) }),
+
+        // sK1 011
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),x5) == g(f(x5,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),r(x5)) != g(f(r(x5),f(sK2,sK3))) }),
+
+        // sK1 111
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(x6),f(sK2,sK4)),x6) == g(f(x6,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(r(x6)),f(sK2,sK4)),r(x6)) != g(f(r(x6),f(sK2,sK3))) }),
+
+        // sK2 10
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(x7,sK4)),sK1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(r(x7),sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }),
+
+        // sK2 01
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(sK1,f(x8,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(r(x8),sK3))) }),
+
+        // sK2 11
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(x9,sK4)),sK1) == g(f(sK1,f(x9,sK3))) }),
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(r(x9),sK4)),sK1) != g(f(sK1,f(r(x9),sK3))) }),
+
+        // sK3 1
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,b))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(sK1,f(sK2,x10))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,b))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,r(x10)))) }),
+
+        // sK4 1
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,x11)),sK1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,r(x11))),sK1) != g(f(sK1,f(sK2,sK3))) }),
+      })
+    )
+
+// complex terms
+TEST_GENERATION_INDUCTION(test_08,
+    Generation::TestCase()
+      .options({ { "induction_on_complex_terms", "on" }, { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,g(sK1)))) }) )
+      .expected({
+        // sK1
+        clause({ f(f(g(b),f(sK2,sK3)),b) != g(f(b,f(sK2,g(b)))), f(f(g(x),f(sK2,sK3)),x) == g(f(x,f(sK2,g(x)))) }),
+        clause({ f(f(g(b),f(sK2,sK3)),b) != g(f(b,f(sK2,g(b)))), f(f(g(r(x)),f(sK2,sK3)),r(x)) != g(f(r(x),f(sK2,g(r(x))))) }),
+
+        // sK2
+        clause({ f(f(g(sK1),f(b,sK3)),sK1) != g(f(sK1,f(b,g(sK1)))), f(f(g(sK1),f(y,sK3)),sK1) == g(f(sK1,f(y,g(sK1)))) }),
+        clause({ f(f(g(sK1),f(b,sK3)),sK1) != g(f(sK1,f(b,g(sK1)))), f(f(g(sK1),f(r(y),sK3)),sK1) != g(f(sK1,f(r(y),g(sK1)))) }),
+
+        // sK3
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),f(sK2,x3)),sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),f(sK2,r(x3))),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
+
+        // g(sK1)
+        clause({ f(f(b,f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,b))), f(f(x4,f(sK2,sK3)),sK1) == g(f(sK1,f(sK2,x4))) }),
+        clause({ f(f(b,f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,b))), f(f(r(x4),f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,r(x4)))) }),
+
+        // f(sK2,sK3)
+        clause({ f(f(g(sK1),b),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),x5),sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(f(g(sK1),b),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),r(x5)),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
+
+        // f(g(sK1),f(sK2,sK3))
+        clause({ f(b,sK1) != g(f(sK1,f(sK2,g(sK1)))), f(x6,sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(b,sK1) != g(f(sK1,f(sK2,g(sK1)))), f(r(x6),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
+
+        // f(f(g(sK1),f(sK2,sK3)),sK1)
+        clause({ b != g(f(sK1,f(sK2,g(sK1)))), x7 == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ b != g(f(sK1,f(sK2,g(sK1)))), r(x7) != g(f(sK1,f(sK2,g(sK1)))) }),
+
+        // f(sK2,g(sK1))
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,b)), f(f(g(sK1),f(sK2,sK3)),sK1) == g(f(sK1,x8)) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,b)), f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,r(x8))) }),
+
+        // f(sK1,f(sK2,g(sK1)))
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(b), f(f(g(sK1),f(sK2,sK3)),sK1) == g(x9) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(b), f(f(g(sK1),f(sK2,sK3)),sK1) != g(r(x9)) }),
+
+        // g(f(sK1,f(sK2,g(sK1))))
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != b, f(f(g(sK1),f(sK2,sK3)),sK1) == x10 }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != b, f(f(g(sK1),f(sK2,sK3)),sK1) != r(x10) }),
+      })
+    )
+
+// positive literals are considered 1
+TEST_GENERATION_INDUCTION(test_09,
+    Generation::TestCase()
+      .options({ { "induction_neg_only", "off" }, { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  p(sK1) }))
+      .expected({
+        clause({ p(b), ~p(x), }),
+        clause({ p(b), p(r(x)), }),
+      })
+    )
+
+// positive literals are considered 2
+TEST_GENERATION_INDUCTION(test_10,
+    Generation::TestCase()
+      .options({ { "induction_neg_only", "off" }, { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  sK1 == g(sK1) }))
+      .expected({
+        clause({ b == g(b), x != g(x), }),
+        clause({ b == g(b), r(x) == g(r(x)), }),
+      })
+    )
+
+// non-unit clauses are considered
+TEST_GENERATION_INDUCTION(test_11,
+    Generation::TestCase()
+      .options({ { "induction_unit_only", "off" }, { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  sK1 != g(sK1), p(g(sK2)), ~p(f(sK1,sK2)) }))
+      .expected({
+        // 1. literal sK1
+        clause({ b != g(b), x == g(x), p(g(sK2)), ~p(f(sK1,sK2)) }),
+        clause({ b != g(b), r(x) != g(r(x)), p(g(sK2)), ~p(f(sK1,sK2)) }),
+
+        // 3. literal sK1
+        clause({ ~p(f(b,sK2)), p(f(y,sK2)), p(g(sK2)), sK1 != g(sK1) }),
+        clause({ ~p(f(b,sK2)), ~p(f(r(y),sK2)), p(g(sK2)), sK1 != g(sK1) }),
+
+        // 3. literal sK2
+        clause({ ~p(f(sK1,b)), p(f(sK1,x3)), p(g(sK2)), sK1 != g(sK1) }),
+        clause({ ~p(f(sK1,b)), ~p(f(sK1,r(x3))), p(g(sK2)), sK1 != g(sK1) }),
+      })
+    )
+
+// "same induction" (i.e. generalized literal is same) is not done twice
+//
+// TODO: this should be done with two inputs rather than with a non-unit clause
+TEST_GENERATION_INDUCTION(test_12,
+    Generation::TestCase()
+      .options({ { "induction_unit_only", "off" }, { "induction", "struct" } })
+      .indices({ comparisonIndex() })
+      .input( clause({  sK1 != g(sK1), sK2 != g(sK2) }))
+      .expected({
+        clause({ b != g(b), x == g(x), sK2 != g(sK2) }),
+        clause({ b != g(b), r(x) != g(r(x)), sK2 != g(sK2) }),
+      })
+    )
+
+TEST_GENERATION_INDUCTION(test_13,
+    Generation::TestCase()
+      .options({ { "induction", "int" } })
+      .context({ clause({ ~(sK6 < num(1)) }) })
+      .indices({ comparisonIndex() })
+      .input( clause({ ~pi(sK6) }) )
+      .expected({
+        clause({ ~pi(1), ~(x < num(1)) }),
+        clause({ ~pi(1), pi(x) }),
+        clause({ ~pi(1), ~pi(x+1) }),
+      })
+    )
+
+// use bounds for upward+downward infinite interval integer induction
+TEST_GENERATION_INDUCTION(test_14,
+    Generation::TestCase()
+      .options({ { "induction", "int" }, { "int_induction_interval", "infinite" } })
+      .context({ clause({ ~(sK6 < num(1)) }), clause({ ~(bi < sK6) }) })
+      .indices({ comparisonIndex() })
+      .input( clause({ ~pi(sK6) }) )
+      .expected({
+        // upward induction
+        clause({ ~pi(1), ~(x < num(1)) }),
+        clause({ ~pi(1), pi(x) }),
+        clause({ ~pi(1), ~pi(x+1) }),
+
+        // downard induction
+        clause({ ~pi(bi), ~(bi < y) }),
+        clause({ ~pi(bi), pi(y) }),
+        clause({ ~pi(bi), ~pi(y+num(-1)) }),
+      })
+    )
+
+// use bounds for upward+downward finite interval integer induction
+TEST_GENERATION_INDUCTION(test_15,
+    Generation::TestCase()
+      .options({ { "induction", "int" }, { "int_induction_interval", "finite" } })
+      .context({ clause({ ~(sK6 < num(1)) }), clause({ ~(bi < sK6) }) })
+      .indices({ comparisonIndex() })
+      .input( clause({ ~pi(sK6) }) )
+      .expected({
+        // upward induction
+        clause({ ~pi(1), ~(x < num(1)) }),
+        clause({ ~pi(1), x < bi }),
+        clause({ ~pi(1), pi(x) }),
+        clause({ ~pi(1), ~pi(x+1) }),
+
+        // downard induction
+        clause({ ~pi(bi), num(1) < y }),
+        clause({ ~pi(bi), ~(bi < y) }),
+        clause({ ~pi(bi), pi(y) }),
+        clause({ ~pi(bi), ~pi(y+num(-1)) }),
+      })
+    )
+
+// use default bound for downward integer induction,
+// but for upward use the bound from index
+TEST_GENERATION_INDUCTION(test_16,
+    Generation::TestCase()
+      .options({ { "induction", "int" },
+                 { "int_induction_interval", "infinite" },
+                 { "int_induction_default_bound", "on" } })
+      .context({ clause({ ~(sK6 < num(0)) }) })
+      .indices({ comparisonIndex() })
+      .input( clause({ ~pi(sK6) }) )
+      .expected({
+        // upward induction
+        clause({ ~pi(0), ~(x < num(0)) }),
+        clause({ ~pi(0), pi(x) }),
+        clause({ ~pi(0), ~pi(x+1) }),
+
+        // downard induction: resulting clauses contain "0 < sK6",
+        // since there is no bound to resolve it against
+        clause({ ~pi(0), ~(num(0) < y), 0 < sK6 }),
+        clause({ ~pi(0), pi(y), 0 < sK6 }),
+        clause({ ~pi(0), ~pi(y+num(-1)), 0 < sK6 }),
+      })
+    )

--- a/UnitTests/tInduction.cpp
+++ b/UnitTests/tInduction.cpp
@@ -29,13 +29,12 @@ LiteralIndex* comparisonIndex() {
   return new UnitIntegerComparisonLiteralIndex(new LiteralSubstitutionTree());
 }
 
-template<class Rule>
 class GenerationTesterInduction
-  : public GenerationTester<Rule>
+  : public GenerationTester<Induction>
 {
 public:
-  GenerationTesterInduction(Rule* rule)
-    : GenerationTester<Rule>(rule), _subst()
+  GenerationTesterInduction()
+    : GenerationTester<Induction>(), _subst()
   {}
 
   /**
@@ -95,7 +94,7 @@ private:
 
 #define TEST_GENERATION_INDUCTION(name, ...)                                                                  \
   TEST_FUN(name) {                                                                                            \
-    GenerationTesterInduction<Induction> tester(new Induction());                                             \
+    GenerationTesterInduction tester;                                                                         \
     __ALLOW_UNUSED(MY_SYNTAX_SUGAR)                                                                           \
     auto test = __VA_ARGS__;                                                                                  \
     test.run(tester);                                                                                         \
@@ -461,7 +460,7 @@ TEST_GENERATION_INDUCTION(test_16,
         clause({ ~pi(0), pi(x) }),
         clause({ ~pi(0), ~pi(x+1) }),
 
-        // downard induction: resulting clauses contain "0 < sK6",
+        // downward induction: resulting clauses contain "0 < sK6",
         // since there is no bound to resolve it against
         clause({ ~pi(0), ~(num(0) < y), 0 < sK6 }),
         clause({ ~pi(0), pi(y), 0 < sK6 }),

--- a/UnitTests/tTheoryInstAndSimp.cpp
+++ b/UnitTests/tTheoryInstAndSimp.cpp
@@ -94,7 +94,7 @@ TheoryInstAndSimp* theoryInstAndSimp(Options::TheoryInstSimp mode, bool withGene
 }
 
 using Shell::Int;
-REGISTER_GEN_TESTER(Test::Generation::GenerationTester<TheoryInstAndSimp>)
+REGISTER_GEN_TESTER(TheoryInstAndSimp)
 
 TEST_GENERATION(test_01,
     Generation::TestCase()


### PR DESCRIPTION
The main change in this PR is that for bounded induction a certain order of premises was expected during binary resolution with the clausified induction formula so that binary resolution can find the right instantiated literals to resolve:

1. the main premise is binary resolved with substitution `{ x -> t }` where `x` is the induction variable and `t` is the induction term
2. the bounds are resolved with empty substitution since 1. instantiates `x` to `t` in the rest of clause

This order was not maintained and hence most bounded inductions were not properly resolved, possibly delaying the necessary binary resolution forever.

The second contribution is unit testing for the current induction framework (including tests not related to the bug):

1. Bounded induction has multiple premises from indices, so we cherry picked parts of unit testing code from branch `inequality-resolution` to allow for adding clauses to indices.
2. Induction creates possibly many clauses, so the permutation matching algorithm matching the generated clauses to expected clauses was improved to work on many clauses without timeouting.