### PR TITLE
warn if fail to use Ordering::Result

### DIFF
--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -45,19 +45,19 @@ public:
   ~LPO() override = default;
 
   using PrecedenceOrdering::compare;
-  Result compare(TermList tl1, TermList tl2) const override;
+  VWARN_UNUSED Result compare(TermList tl1, TermList tl2) const override;
   void showConcrete(ostream&) const override;
 protected:
-  Result comparePredicates(Literal* l1, Literal* l2) const override;
+  VWARN_UNUSED Result comparePredicates(Literal* l1, Literal* l2) const override;
 
-  Result cLMA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
-  Result cMA(Term* t, TermList* tl, unsigned arity) const;
-  Result cAA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity1, unsigned arity2) const;
-  Result alpha(TermList* tl, unsigned arity, Term *t) const;
-  Result clpo(Term* t1, TermList tl2) const;
-  Result lpo(TermList tl1, TermList tl2) const;
-  Result lexMAE(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
-  Result majo(Term* s, TermList* tl, unsigned arity) const;
+  VWARN_UNUSED Result cLMA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
+  VWARN_UNUSED Result cMA(Term* t, TermList* tl, unsigned arity) const;
+  VWARN_UNUSED Result cAA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity1, unsigned arity2) const;
+  VWARN_UNUSED Result alpha(TermList* tl, unsigned arity, Term *t) const;
+  VWARN_UNUSED Result clpo(Term* t1, TermList tl2) const;
+  VWARN_UNUSED Result lpo(TermList tl1, TermList tl2) const;
+  VWARN_UNUSED Result lexMAE(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
+  VWARN_UNUSED Result majo(Term* s, TermList* tl, unsigned arity) const;
 
 };
 

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -55,7 +55,7 @@ public:
     LESS_EQ=4,
     EQUAL=5,
     INCOMPARABLE=6
-  };
+  } VWARN_UNUSED;
 
   Ordering();
   virtual ~Ordering();

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -48,14 +48,14 @@ public:
    * in the @c ArgumentOrderVals enum, so that one can convert between the
    * enums using static_cast.
    */
-  enum Result {
+  enum VWARN_UNUSED_TYPE Result {
     GREATER=1,
     LESS=2,
     GREATER_EQ=3,
     LESS_EQ=4,
     EQUAL=5,
     INCOMPARABLE=6
-  } VWARN_UNUSED;
+  };
 
   Ordering();
   virtual ~Ordering();

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -36,4 +36,12 @@
 #define ARCH_X86 1
 #endif
 
+// enable warnings for unused results
+// C++17: replace this with [[nodiscard]]
+#ifdef __GNUC__
+#define VWARN_UNUSED __attribute__((warn_unused_result))
+#else
+#define VWARN_UNUSED
+#endif
+
 #endif /*__Portability__*/

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -39,9 +39,16 @@
 // enable warnings for unused results
 // C++17: replace this with [[nodiscard]]
 #ifdef __GNUC__
-#define VWARN_UNUSED __attribute__((warn_unused_result))
+#define VWARN_UNUSED [[gnu::warn_unused_result]]
 #else
 #define VWARN_UNUSED
+#endif
+
+// clang can attach to class, struct etc, but GCC cannot
+#ifdef __clang__
+#define VWARN_UNUSED_TYPE [[clang::warn_unused_result]]
+#else
+#define VWARN_UNUSED_TYPE
 #endif
 
 #endif /*__Portability__*/


### PR DESCRIPTION
In #311, we had a bug in which a computed `Ordering::Result` was not used as intended. Introduce a `VWARN_UNUSED` macro (GCC, Clang) to warn about unused values and apply it to `Ordering::Result` so that it warns about similar code (and would have produced warnings for the recent bug).

Also open to suggestions about what else we could apply this to. Container types?