### PR TITLE
faster, leaner implementation of key function

### DIFF
--- a/Shell/NameReuse.cpp
+++ b/Shell/NameReuse.cpp
@@ -13,10 +13,10 @@
  */
 
 #include "NameReuse.hpp"
+#include "Kernel/TermIterators.hpp"
 #include "Kernel/FormulaVarIterator.hpp"
+#include "Kernel/SubformulaIterator.hpp"
 #include "Lib/ScopedPtr.hpp"
-#include "Lib/Stack.hpp"
-#include "Shell/Rectify.hpp"
 
 namespace Shell {
 
@@ -34,28 +34,124 @@ NameReuse *NameReuse::definitionInstance()
   return instance.ptr();
 }
 
+// generate key for only this term and not its subterms
+void NameReuse::key(vstringstream &buf, TermList ts)
+{
+  CALL("NameReuse::key(vstringstream &, TermList)");
+  if(ts.isVar())
+    // need to rename variables occuring in terms, sorts
+    buf << 'x' << _renaming.getOrBind(ts.var());
+  else
+    // all functors realised as fN, where N is the functor's index
+    // sorts are known to be sorts from their context, so this is OK
+    // as there is exactly one function arity per symbols, don't need parentheses
+    buf << 'f' << ts.term()->functor();
+}
+
+// generate key only for the subterms
+void NameReuse::key(vstringstream &buf, Term *t)
+{
+  CALL("NameReuse::key(vstringstream &, Term *)");
+  SubtermIterator subterms(t);
+  while(subterms.hasNext())
+    key(buf, subterms.next());
+}
+
+// generate a "key" for `f` that identifies it up to alpha-equivalence
+// assumes that `f` has been rectified at some point
+// looks a bit like `toString()`, but more compact and necessarily has some differences
 vstring NameReuse::key(Formula *f)
 {
-  CALL("NameReuse::key");
+  CALL("NameReuse::key(Formula *)");
   //std::cout << "key for: " << f->toString() << std::endl;
-  Rectify rectify;
-  Formula *rectified = rectify.rectify(f);
-  vstring key = rectified->toString();
-  // the function could stop here, but some functions are ad-hoc polymorphic
-  // consider:
-  // ![X: $int] ?[Y]: (p(Y) & $less(X, X))
-  // ![X: $real] ?[Y]: (p(Y) & $less(X, X))
-  // therefore: append sort information to free variables to the key
-  FormulaVarIterator freeVars(rectified);
-  while(freeVars.hasNext()) {
-    unsigned free = freeVars.next();
-    TermList sort;
-    if(SortHelper::tryGetVariableSort(free, rectified, sort)) {
-      key.append("#");
-      key.append(Int::toString(free));
-      key.append(sort.term()->toString());
+  vstringstream buf;
+  // reset the canonical renaming for this formula
+  // variables will be renamed in order of traversal
+  _renaming.reset();
+
+  // depth-first traversal of `f`
+  Kernel::SubformulaIterator subformulae(f);
+  while(subformulae.hasNext()) {
+    Formula *subformula = subformulae.next();
+    Connective connective = subformula->connective();
+    switch(connective) {
+      // literals are basically terms for our purposes
+      case LITERAL: {
+        Literal *l = subformula->literal();
+        if (!l->polarity())
+          buf << '~';
+        buf << 'p' << l->functor();
+        key(buf, l);
+
+        // special case: if we have X = Y, can't work out what sort '=' is applied to from context
+        if(l->isTwoVarEquality()) {
+          // luckily, we already keep it, so add it after the variables
+          TermList sort = l->twoVarEqSort();
+          key(buf, sort);
+          if (sort.isTerm())
+            key(buf, sort.term());
+        }
+        break;
+      }
+      // AND and OR have a variable number of subformulae, so include that information
+      case AND:
+        buf << '&' << FormulaList::length(subformula->args());
+        break;
+      case OR:
+        buf << '|' << FormulaList::length(subformula->args());
+        break;
+      // other connectives have a known number of subformulae
+      // probably shouldn't get here: we expect ENNF
+      case IMP:
+        buf << '>';
+        break;
+      case XOR:
+        buf << '+';
+        break;
+      case IFF:
+        buf << '=';
+        break;
+      // probably shouldn't get here: we expect ENNF
+      case NOT:
+        buf << '~';
+        break;
+      // FORALL AND EXISTS: need to include bound variables
+      case FORALL:
+      case EXISTS:
+      {
+        buf << (connective == FORALL ? '!' : '?');
+        // no sorts required for bound variables, can infer sort from where they are used
+        // unless they're not used, but in that case it's OK anyway
+        VList::Iterator vars(subformula->vars());
+        while(vars.hasNext())
+          buf << 'x' << _renaming.getOrBind(vars.next());
+        break;
+      }
+      case BOOL_TERM:
+      {
+        buf << 'b';
+        TermList boolean = subformula->getBooleanTerm();
+        key(buf, boolean);
+        if(boolean.isTerm())
+          key(buf, boolean.term());
+        break;
+      }
+      case TRUE:
+        buf << 't';
+        break;
+      case FALSE:
+        buf << 'f';
+        break;
+      // shouldn't happen
+      case NAME:
+        buf << 'n' << static_cast<NamedFormula *>(subformula)->name();
+        break;
+      case NOCONN:
+        ASSERTION_VIOLATION;
     }
   }
+
+  vstring key = buf.str();
   //std::cout << "is: " << key << std::endl;
   return key;
 }

--- a/Shell/NameReuse.hpp
+++ b/Shell/NameReuse.hpp
@@ -16,6 +16,7 @@
 #define __NameReuse__
 
 #include "Forwards.hpp"
+#include "Kernel/Renaming.hpp"
 #include "Lib/DHMap.hpp"
 
 using namespace Kernel;
@@ -37,7 +38,7 @@ public:
   // definitions
   static NameReuse *definitionInstance();
 
-  // convert `f` to a string in some way to use as a key: saves recomputing it later
+  // convert `f` to a string in some way to use as a key
   vstring key(Formula *f);
 
   // try and reuse a symbol for `key`
@@ -52,6 +53,15 @@ public:
   VirtualIterator<unsigned> freeVariablesInKeyOrder(Formula *f);
 
 private:
+  // convert `ts` to a string in some way to use as a key, writing into `buf`
+  void key(vstringstream &buf, TermList ts);
+  // convert `t`'s arguments to a string in some way to use as a key, writing into `buf`
+  void key(vstringstream &buf, Term *t);
+
+  // canonical renaming, reset in every call to key(Formula *)
+  Renaming _renaming;
+
+  // map from keys to ids
   DHMap<vstring, unsigned> _map;
 };
 


### PR DESCRIPTION
Refer to #269 for the original idea. This implements a much faster key function which eliminates some of the performance impact of the original.

Essentially:
- just one pass over the formula, no auxiliaries created
- use a compressed key format, doesn't need to be human-readable
- we don't need to do as much work for sorts as previously

See inline comments for details. Performance still not great (quadratic) but now solves many of the previous timeout examples in less than 10 seconds.