### PR TITLE
fixes found by clang-tidy

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -582,7 +582,7 @@ void PortfolioMode::runSlice(Options& strategyOpt)
   if(outputResult) { // this get only true for the first child to find a proof
     ASS(!resultValue);
 
-    if (outputAllowed() && (Lib::env.options && Lib::env.options->multicore() != 1)) {
+    if (outputAllowed() && env.options->multicore() != 1) {
       env.beginOutput();
       addCommentSignForSZS(env.out()) << "First to succeed." << endl;
       env.endOutput();

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -549,7 +549,7 @@ void KBO::checkAdmissibility(HandleError handle) const
   for (FunctionSymbol i = 0; i < nFunctions; i++) {
     auto sort = env.signature->getFunction(i)->fnType()->result();
     /* register min function */
-    auto maxFn = maximalFunctions.getOrInit(std::move(sort), [&](){ return i; } );
+    auto maxFn = maximalFunctions.getOrInit(sort, [&](){ return i; } );
     if (compareFunctionPrecedences(maxFn, i) == LESS) {
       maximalFunctions.replace(sort, i);
     }

--- a/Kernel/PolynomialNormalizer.cpp
+++ b/Kernel/PolynomialNormalizer.cpp
@@ -192,6 +192,7 @@ Option<NormalizationResult> normalizeSpecializedFractional(Interpretation i, Nor
 {
   switch (i) {
     case NumTraits::divI:
+      ASS(ts != nullptr);
       return normalizeDiv<NumTraits>(ts[0], ts[1]);
     default:
       return Option<NormalizationResult>();
@@ -286,10 +287,13 @@ NormalizationResult normalizeNumSort(TermList t, NormalizationResult* ts)
     if (fn.isInterpreted()) {
       switch(fn.interpretation()) {
         case NumTraits::mulI:
+          ASS(ts != nullptr);
           return normalizeMul<NumTraits>(ts[0], ts[1]);
         case NumTraits::addI:
+          ASS(ts != nullptr);
           return normalizeAdd<NumTraits>(ts[0], ts[1]);
         case NumTraits::minusI:
+          ASS(ts != nullptr);
           return normalizeMinus<NumTraits>(ts[0]);
         default:
         {

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -46,7 +46,7 @@ public:
   CLASS_NAME(RobSubstitution);
   USE_ALLOCATOR(RobSubstitution);
   
-  RobSubstitution() : _nextUnboundAvailable(0) {} //,_nextAuxAvailable(0) {}
+  RobSubstitution() : _funcSubtermMap(nullptr), _nextUnboundAvailable(0) {}
 
   SubstIterator matches(Literal* base, int baseIndex,
 	  Literal* instance, int instanceIndex, bool complementary);

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -80,12 +80,9 @@ public:
   static Literal* apply(Literal* lit, Applicator& applicator)
   {
     CALL("SubstHelper::apply(Literal*...)");
-    TermList sort;
-    if(lit->isTwoVarEquality()){
-      sort = lit->twoVarEqSort();
-    }
     Literal* subbedLit = static_cast<Literal*>(apply(static_cast<Term*>(lit),applicator));
     if(subbedLit->isTwoVarEquality()){ //either nothing's changed or variant
+      TermList sort = lit->twoVarEqSort();
       TermList newSort = apply(sort, applicator);
       if((sort != newSort)){
         subbedLit = Literal::createEquality(subbedLit->polarity(), *subbedLit->nthArgument(0), *subbedLit->nthArgument(1), newSort);

--- a/Kernel/TermIterators.hpp
+++ b/Kernel/TermIterators.hpp
@@ -469,7 +469,7 @@ public:
     } 
     _stack.push(term);
     if (!includeSelf) {
-      next();
+      FirstOrderSubtermIt::next();
     }
   }
 
@@ -691,7 +691,7 @@ public:
     CALL("NonVariableNonTypeIterator::NonVariableNonTypeIterator");
     _stack.push(term);
     if (!includeSelf) {
-      next();
+      NonVariableNonTypeIterator::next();
     }
   }
   // NonVariableIterator(TermList ts);

--- a/Lib/Coproduct.hpp
+++ b/Lib/Coproduct.hpp
@@ -234,7 +234,7 @@ namespace CoproductImpl {
       using Ts = TL::List<As...>;                                                                             \
       auto unwrap = Unwrap<acc, Ts>{};                                                                        \
       if (acc == idx) {                                                                                       \
-        ::new (&self) TL::Get<acc,Ts>(unwrap(MOVE(value)));                                                   \
+        ::new (&self._head) TL::Get<acc,Ts>(unwrap(MOVE(value)));                                             \
         return;                                                                                               \
       }                                                                                                       \
       InitDynamicTag<acc + 1, size, TL::List<As...>>{}(self, idx, MOVE(value));                               \
@@ -275,8 +275,8 @@ class Coproduct<A, As...>
   using Self = Coproduct<A, As...>;
   using Content = decltype(_content);
 
-  /** unsafe default constructor. tag as well as content will be uninit */
-  Coproduct() {}
+  /** unsafe default constructor, content will be uninit */
+  Coproduct() : _tag(std::numeric_limits<unsigned>::max()) {}
 
 public:
   CLASS_NAME(Coproduct)

--- a/Lib/List.hpp
+++ b/Lib/List.hpp
@@ -649,6 +649,7 @@ public:
 	return;
       }
 
+      ASS_NEQ(_prev,0);
       // not the first element
       _prev->setTail(_cur->tail());
       delete _cur;

--- a/Lib/Option.hpp
+++ b/Lib/Option.hpp
@@ -33,7 +33,7 @@ template<class T>
 struct MaybeUninit {
   union Value { 
     T init; int uninint[0]; 
-     Value() {};
+    Value() : uninint{} {};
     ~Value() {};
   } _elem;
 
@@ -45,7 +45,7 @@ struct MaybeUninit {
   { return MV(_elem.init); }                                                                                  \
                                                                                                               \
   void init(T REF content)                                                                                    \
-  { ::new(&_elem)T(MV(content)); }                                                                            \
+  { ::new(&_elem.init)T(MV(content)); }                                                                       \
                                                                                                               \
   MaybeUninit& operator=(T REF content)                                                                       \
   {                                                                                                           \

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -436,8 +436,10 @@ struct EvaluateInModel
     } else if (expr.is_app()) {
       auto f = expr.decl();
       auto vfunc = self._fromZ3.get(f);
-      Stack<TermList> args(f.arity());
-      for (unsigned i = 0; i < f.arity(); i++) {
+      unsigned arity = f.arity();
+      ASS(arity == 0 || evaluatedArgs != nullptr)
+      Stack<TermList> args(arity);
+      for (unsigned i = 0; i < arity; i++) {
         if (evaluatedArgs[i].isNone()) {
           // evaluation failed somewhere in a recursive call
           return Result();

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -167,6 +167,7 @@ public:
         return false;
       if(!l.forSorts)
         return true;
+      ASS(r.forSorts != nullptr);
 
       // compare sort arguments
       for(unsigned i = 0; i < l.forSorts->numTypeArguments(); i++)

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -1147,6 +1147,7 @@ void NewCNF::skolemise(QuantifiedFormula* g, BindingList*& bindings, BindingList
         // ?[Z]: F[X->sK0, Y->sK1],
         // but not F[X->sK0, Y->sK1, Z->sK2], since this doesn't need a Skolem term
         if(env.options->skolemReuse()) {
+          ASS(remainingVars != nullptr);
           remainingVars = remainingVars->tail();
           remainingSorts = remainingSorts ? remainingSorts->tail() : nullptr;
           if(VList::isNonEmpty(remainingVars)) {

--- a/Test/SimplificationTester.hpp
+++ b/Test/SimplificationTester.hpp
@@ -41,7 +41,7 @@ class Success
   Option<ClausePattern> _expected;
 
 public:
-  Success() {}
+  Success() : _input(nullptr) {}
 
   Success input(Kernel::Clause* x) 
   {

--- a/UnitTests/tBottomUpEvaluation.cpp
+++ b/UnitTests/tBottomUpEvaluation.cpp
@@ -58,15 +58,12 @@ TEST_FUN(example_02__compute_size) {
   /* syntax sugar imports */
   DECL_DEFAULT_VARS
   DECL_SORT(s)
-  DECL_CONST(a, s)
   DECL_FUNC(f, {s}, s)
   DECL_FUNC(g, {s,s}, s)
 
   /* defines how to evaluate bottom up. 
    * computes the size of the term (number of function & variable symbols) */
   struct Eval {
-    TermList replacement;
-
     using Arg    = TermList;
     using Result = unsigned;
 
@@ -74,8 +71,13 @@ TEST_FUN(example_02__compute_size) {
       if (toEval.isVar()) {
         return 1;
       } else {
+        // clang-tidy thought that evaluatedChildren could be nullptr and toEval.term()->arity > 0
+        // it's wrong, but it's a nice thing to check
+        unsigned arity = toEval.term()->arity();
+        ASS(arity == 0 || evaluatedChildren);
+
         unsigned out = 1;
-        for (unsigned i = 0; i < toEval.term()->arity(); i++) {
+        for (unsigned i = 0; i < arity; i++) {
           out += evaluatedChildren[i];
         }
         return out;
@@ -90,7 +92,7 @@ TEST_FUN(example_02__compute_size) {
 
   /* actual evaluation */
   Memo::Hashed<TermList, unsigned> memo{};
-  auto size =  evaluateBottomUp(input, Eval{a}, memo);
+  auto size =  evaluateBottomUp(input, Eval{}, memo);
 
   ASS_EQ(size, 6)
 }

--- a/UnitTests/tGaussianElimination.cpp
+++ b/UnitTests/tGaussianElimination.cpp
@@ -54,7 +54,7 @@ public:
     static GaussianVariableElimination gve = GaussianVariableElimination();
 
     /* applies gve and evaluation until they're not applicable anymore */
-    Kernel::Clause* last = simpl(in);
+    Kernel::Clause* last = nullptr;
     Kernel::Clause* latest = simpl(in);
     do {
       last = latest;

--- a/UnitTests/tOption.cpp
+++ b/UnitTests/tOption.cpp
@@ -126,7 +126,7 @@ public:
     _moved = o._moved;
     return *this; 
   }
-  LeaqueChecker()  { instances++; }
+  LeaqueChecker() : _moved(false) { instances++; }
   ~LeaqueChecker() { if (!_moved) deletes++;   }
 };
 


### PR DESCRIPTION
I ran `clang-tidy` again, and both Vampire and the tool have changed so I found some more (potential) problems. Mostly these are just opportunities for adding assertions, but there's one or two places where something is dubious. I will add comments here to help reviewers.