### PR TITLE
check quantifier variable/sort pairs in SMTLIB parser

### DIFF
--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1815,7 +1815,13 @@ void SMTLIB2::parseQuantBegin(LExpr* exp)
     LispListReader pRdr(pair);
 
     vstring vName = pRdr.readAtom();
+    if(!pRdr.hasNext()) {
+      USER_ERROR("No associated sort for "+vName+" in quantification "+exp->toString());
+    }
     TermList vSort = declareSort(pRdr.readNext());
+    if(pRdr.hasNext()) {
+      USER_ERROR("More than one sort for "+vName+" in quantification "+exp->toString());
+    }
 
     pRdr.acceptEOL();
 


### PR DESCRIPTION
Currently the SMTLIB input

```
(assert (forall ((x)) true))
```
causes an assertion violation, because the user forgot the sort of `x`. This seems like quite a common mistake, make it a `USER_ERROR` instead.