### PR TITLE
remove references to EGSubst

### DIFF
--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -205,10 +205,6 @@ class RobSubstitution;
 typedef VirtualIterator<RobSubstitution*> SubstIterator;
 typedef Lib::SmartPtr<RobSubstitution> RobSubstitutionSP;
 
-class EGSubstitution;
-typedef VirtualIterator<EGSubstitution*> RSubstIterator;
-typedef Lib::SmartPtr<EGSubstitution> EGSubstitutionSP;
-
 class Matcher;
 typedef VirtualIterator<Matcher*> MatchIterator;
 
@@ -216,7 +212,6 @@ class TermTransformer;
 class TermTransformerTransformTransformed;
 class FormulaTransformer;
 class FormulaUnitTransformer;
-
 
 class LiteralSelector;
 typedef Lib::SmartPtr<LiteralSelector> LiteralSelectorSP;

--- a/Indexing/ResultSubstitution.hpp
+++ b/Indexing/ResultSubstitution.hpp
@@ -138,8 +138,6 @@ public:
 
   static ResultSubstitutionSP fromSubstitution(RobSubstitution* s,
 	  int queryBank, int resultBank);
-//  static ResultSubstitutionSP fromSubstitution(EGSubstitution* s,
-//	  int queryBank, int resultBank);
 #if VDEBUG
   virtual vstring toString(){ NOT_IMPLEMENTED; }
 #endif

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -53,9 +53,6 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
-#define SUBST_CLASS RobSubstitution
-//#define SUBST_CLASS EGSubstitution
-
 #define UARR_INTERMEDIATE_NODE_MAX_SIZE 4
 
 #define REORDERING 1
@@ -870,7 +867,7 @@ public:
     static const int NORM_QUERY_BANK=2;
     static const int NORM_RESULT_BANK=3;
 
-    SUBST_CLASS subst;
+    RobSubstitution subst;
     VarStack svStack;
 
   private:


### PR DESCRIPTION
Back in the dawn of time, there was [apparently](https://link.springer.com/chapter/10.1007%2F978-3-642-04617-9_55) several unification algorithms in Vampire. Remove references to an old one.