### PR TITLE
cleanup unused stuff in RobSubstitution

### DIFF
--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -12,46 +12,23 @@
  * Implements polynomial modification of the Robinson unification algorithm.
  */
 
-#include "Lib/Environment.hpp"
-#include "Shell/Options.hpp"
-
-#include "Lib/Hash.hpp"
-#include "Lib/DArray.hpp"
-#include "Lib/List.hpp"
-#include "Lib/Random.hpp"
-#include "Lib/DHSet.hpp"
-#include "Lib/DHMap.hpp"
-#include "Lib/SkipList.hpp"
-#include "Lib/Int.hpp"
-
-#include "Clause.hpp"
-#include "Renaming.hpp"
-#include "SortHelper.hpp"
-#include "Term.hpp"
-#include "TermIterators.hpp"
-#include "Shell/Statistics.hpp"
-
-#include "Indexing/TermSharing.hpp"
 
 #include "RobSubstitution.hpp"
 
-#if VDEBUG
-#include "Kernel/Signature.hpp"
+#include "Lib/DArray.hpp"
+#include "Lib/DHSet.hpp"
+#include "Lib/DHMap.hpp"
 #include "Lib/Int.hpp"
-#include "Debug/Tracer.hpp"
-#include <iostream>
-using namespace Debug;
-#endif
 
-#define DEBUG_RESULT_WEIGHT_COMPUTATION 0
+#include "Renaming.hpp"
+#include "SortHelper.hpp"
+#include "TermIterators.hpp"
 
 namespace Kernel
 {
 
-using namespace std;
 using namespace Lib;
 
-//const int RobSubstitution::AUX_INDEX=-3;
 const int RobSubstitution::SPECIAL_INDEX=-2;
 const int RobSubstitution::UNBOUND_INDEX=-1;
 
@@ -270,57 +247,6 @@ RobSubstitution::VarSpec RobSubstitution::root(VarSpec v) const
     v=getVarSpec(binding);
   }
 }
-
-/* Not currently used
-
-void RobSubstitution::makeEqual(VarSpec v1, VarSpec v2, TermSpec target)
-{
-  CALL("RobSubstitution::makeEqual");
-
-  v1=root(v1);
-  v2=root(v2);
-  if(v1==v2) {
-    bind(v2,target);
-    return;
-  }
-  if(Random::getBit()) {
-    bindVar(v1,v2);
-    bind(v2,target);
-  } else {
-    bindVar(v2,v1);
-    bind(v1,target);
-  }
-}
-*/
-
-/* Not currently used
-void RobSubstitution::unifyUnbound(VarSpec v, TermSpec ts)
-{
-  CALL("RobSubstitution::unifyUnbound");
-
-  v=root(v);
-
-  ASS(isUnbound(v));
-
-  if(ts.isVar()) {
-    VarSpec v2=root(getVarSpec(ts));
-    if(v!=v2) {
-    	makeEqual(v, v2, deref(v2));
-    }
-  } else {
-    bind(v,ts);
-  }
-}
-*/
-
-
-void RobSubstitution::swap(TermSpec& ts1, TermSpec& ts2)
-{
-  TermSpec aux=ts1;
-  ts1=ts2;
-  ts2=aux;
-}
-
 
 bool RobSubstitution::occurs(VarSpec vs, TermSpec ts)
 {
@@ -863,9 +789,6 @@ size_t RobSubstitution::getApplicationResultWeight(Literal* lit, int index) cons
     size_t argWeight = getApplicationResultWeight(*args,index);
     res += argWeight;
   }
-#if VDEBUG && DEBUG_RESULT_WEIGHT_COMPUTATION
-  ASS_REP2(apply(lit, index)->weight()==res, res, lit->toString()+"   "+apply(lit, index)->toString());
-#endif
   return res;
 }
 

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -16,27 +16,19 @@
 #ifndef __RobSubstitution__
 #define __RobSubstitution__
 
-#include <utility>
-
 #include "Forwards.hpp"
-#include "Lib/DHMap.hpp"
 #include "Lib/Backtrackable.hpp"
-#include "Lib/Set.hpp"
-#include "Lib/BiMap.hpp"
 #include "Term.hpp"
 #include "MismatchHandler.hpp"
 
 #if VDEBUG
-
 #include <iostream>
 #include "Lib/VString.hpp"
-
 #endif
 
 namespace Kernel
 {
 
-using namespace std;
 using namespace Lib;
 
 class RobSubstitution
@@ -63,15 +55,10 @@ public:
   {
     return isUnbound(VarSpec(var,index));
   }
-  bool isSpecialUnbound(unsigned var, int index) const
-  {
-    return isUnbound(VarSpec(var,SPECIAL_INDEX));
-  }
   void reset()
   {
     _funcSubtermMap = 0;
     _bank.reset();
-    //_nextAuxAvailable=0;
     _nextUnboundAvailable=0;
   }
 
@@ -222,7 +209,6 @@ private:
   RobSubstitution& operator=(const RobSubstitution& obj);
 
 
-  //static const int AUX_INDEX;
   static const int SPECIAL_INDEX;
   static const int UNBOUND_INDEX;
 
@@ -236,51 +222,27 @@ private:
   VarSpec root(VarSpec v) const;
   bool match(TermSpec base, TermSpec instance);
   bool unify(TermSpec t1, TermSpec t2,MismatchHandler* hndlr);
-  //bool handleDifferentTops(TermSpec t1, TermSpec t2, Stack<TTPair>& toDo, TermList* ct);
-  //void makeEqual(VarSpec v1, VarSpec v2, TermSpec target);
-  //void unifyUnbound(VarSpec v, TermSpec ts);
   bool occurs(VarSpec vs, TermSpec ts);
 
-/* Not currently used
-  VarSpec getAuxVar(VarSpec target)
-  {
-    CALL("RobSubstitution::getAuxVar");
-    if(target.index==AUX_INDEX) {
-      return target;
-    }
-    VarSpec res(_nextAuxAvailable++,AUX_INDEX);
-    bindVar(res, target);
-    return res;
-  }
-*/
   inline
   VarSpec getVarSpec(TermSpec ts) const
   {
     return getVarSpec(ts.term, ts.index);
   }
+
   VarSpec getVarSpec(TermList tl, int index) const
   {
     CALL("RobSubstitution::getVarSpec");
     ASS(tl.isVar());
-    if(tl.isSpecialVar()) {
-      return VarSpec(tl.var(), SPECIAL_INDEX);
-    } else {
-      //ASS(index!=AUX_INDEX || tl.var()<_nextAuxAvailable);
-      return VarSpec(tl.var(), index);
-    }
+    index = tl.isSpecialVar() ? SPECIAL_INDEX : index;
+    return VarSpec(tl.var(), index);
   }
-  static void swap(TermSpec& ts1, TermSpec& ts2);
 
   typedef DHMap<VarSpec,TermSpec,VarSpec::Hash1, VarSpec::Hash2> BankType;
 
   FuncSubtermMap* _funcSubtermMap;
-  mutable BankType _bank;
-
-  // Unused
-  //DHMap<int, int> _denormIndexes;
-
+  BankType _bank;
   mutable unsigned _nextUnboundAvailable;
-  //unsigned _nextAuxAvailable;
 
   class BindingBacktrackObject
   : public BacktrackObject


### PR DESCRIPTION
See #157. There's some unused stuff in `RobSubstitution`: code, includes, debugging...clean it up a bit without changing behaviour.