### PR TITLE
Higher-order proof output fix

### DIFF
--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -1171,7 +1171,7 @@ bool Signature::symbolNeedsQuoting(vstring name, bool interpreted, unsigned arit
   //also don't want them to be treated as interpreted symbols
   //hence the hack below, AYB
   if(name=="$int" || name=="$real" || name=="$rat" || 
-     name=="$i" || name=="$o" || name==">"){
+     name=="$i" || name=="$o"){
     return false;
   }
 

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -714,7 +714,7 @@ class Signature
 
   unsigned getArrowConstructor(){
     bool added = false;
-    unsigned arrow = addTypeCon("fun",2, added);
+    unsigned arrow = addTypeCon("sTfun",2, added);
     if(added){
       _arrowCon = arrow;
       TermList ss = AtomicSort::superSort();

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -714,7 +714,7 @@ class Signature
 
   unsigned getArrowConstructor(){
     bool added = false;
-    unsigned arrow = addTypeCon(">",2, added);
+    unsigned arrow = addTypeCon("fun",2, added);
     if(added){
       _arrowCon = arrow;
       TermList ss = AtomicSort::superSort();


### PR DESCRIPTION
Using > as a type constructor symbol name is not TPTP compliant.