### PR TITLE
cleanup Term: unused stuff, comments, type-correctness, C++11 unions

### DIFF
--- a/Indexing/ClauseVariantIndex.cpp
+++ b/Indexing/ClauseVariantIndex.cpp
@@ -350,9 +350,9 @@ struct HashingClauseVariantIndex::VariableIgnoringComparator {
       return Int::compare(t1->weight(),t2->weight());
     }
 
-    if(t1->vars()!=t2->vars()) {
+    if(t1->getVariableOccurrences()!=t2->getVariableOccurrences()) {
       // number of variable occurrences
-      return Int::compare(t1->vars(),t2->vars());
+      return Int::compare(t1->getVariableOccurrences(),t2->getVariableOccurrences());
     }
 
     if (t1->ground()) {
@@ -376,9 +376,9 @@ struct HashingClauseVariantIndex::VariableIgnoringComparator {
       return Int::compare(l1->weight(),l2->weight());
     }
 
-    if(l1->vars()!=l2->vars()) {
+    if(l1->getVariableOccurrences()!=l2->getVariableOccurrences()) {
       // number of variable occurrences
-      return Int::compare(l1->vars(),l2->vars());
+      return Int::compare(l1->getVariableOccurrences(),l2->getVariableOccurrences());
     }
 
     if (l1->ground()) {

--- a/Indexing/ClauseVariantIndex.cpp
+++ b/Indexing/ClauseVariantIndex.cpp
@@ -350,9 +350,9 @@ struct HashingClauseVariantIndex::VariableIgnoringComparator {
       return Int::compare(t1->weight(),t2->weight());
     }
 
-    if(t1->getVariableOccurrences()!=t2->getVariableOccurrences()) {
+    if(t1->numVarOccs()!=t2->numVarOccs()) {
       // number of variable occurrences
-      return Int::compare(t1->getVariableOccurrences(),t2->getVariableOccurrences());
+      return Int::compare(t1->numVarOccs(),t2->numVarOccs());
     }
 
     if (t1->ground()) {
@@ -376,9 +376,9 @@ struct HashingClauseVariantIndex::VariableIgnoringComparator {
       return Int::compare(l1->weight(),l2->weight());
     }
 
-    if(l1->getVariableOccurrences()!=l2->getVariableOccurrences()) {
+    if(l1->numVarOccs()!=l2->numVarOccs()) {
       // number of variable occurrences
-      return Int::compare(l1->getVariableOccurrences(),l2->getVariableOccurrences());
+      return Int::compare(l1->numVarOccs(),l2->numVarOccs());
     }
 
     if (l1->ground()) {

--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -174,7 +174,7 @@ Term* TermSharing::insert(Term* t)
         
         Term* r = tt->term();
   
-        vars += r->getVariableOccurrences();
+        vars += r->numVarOccs();
         weight += r->weight();
         if (env.colorUsed) {
             color = static_cast<Color>(color | r->color());
@@ -186,7 +186,7 @@ Term* TermSharing::insert(Term* t)
     }
     t->markShared();
     t->setId(_totalTerms);
-    t->setVariableOccurrences(vars);
+    t->setNumVarOccs(vars);
     t->setWeight(weight);
     if (env.colorUsed) {
       Color fcolor = env.signature->getFunction(t->functor())->color();
@@ -246,13 +246,13 @@ AtomicSort* TermSharing::insert(AtomicSort* sort)
         
         Term* r = tt->term();
   
-        vars += r->getVariableOccurrences();
+        vars += r->numVarOccs();
         weight += r->weight();
       }
     }
     sort->markShared();
     sort->setId(_totalSorts);
-    sort->setVariableOccurrences(vars);
+    sort->setNumVarOccs(vars);
     sort->setWeight(weight);
       
     _totalSorts++;
@@ -314,7 +314,7 @@ Literal* TermSharing::insert(Literal* t)
       else {
         ASS_REP(tt->term()->shared(), tt->term()->toString());
         Term* r = tt->term();
-        vars += r->getVariableOccurrences();
+        vars += r->numVarOccs();
         weight += r->weight();
 
         if(_poly && t->isEquality()){
@@ -333,7 +333,7 @@ Literal* TermSharing::insert(Literal* t)
     }
     t->markShared();
     t->setId(_totalLiterals);
-    t->setVariableOccurrences(vars);
+    t->setNumVarOccs(vars);
     t->setWeight(weight);
     if (env.colorUsed) {
       Color fcolor = env.signature->getPredicate(t->functor())->color();

--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -174,7 +174,7 @@ Term* TermSharing::insert(Term* t)
         
         Term* r = tt->term();
   
-        vars += r->vars();
+        vars += r->getVariableOccurrences();
         weight += r->weight();
         if (env.colorUsed) {
             color = static_cast<Color>(color | r->color());
@@ -186,7 +186,7 @@ Term* TermSharing::insert(Term* t)
     }
     t->markShared();
     t->setId(_totalTerms);
-    t->setVars(vars);
+    t->setVariableOccurrences(vars);
     t->setWeight(weight);
     if (env.colorUsed) {
       Color fcolor = env.signature->getFunction(t->functor())->color();
@@ -246,13 +246,13 @@ AtomicSort* TermSharing::insert(AtomicSort* sort)
         
         Term* r = tt->term();
   
-        vars += r->vars();
+        vars += r->getVariableOccurrences();
         weight += r->weight();
       }
     }
     sort->markShared();
     sort->setId(_totalSorts);
-    sort->setVars(vars);
+    sort->setVariableOccurrences(vars);
     sort->setWeight(weight);
       
     _totalSorts++;
@@ -314,7 +314,7 @@ Literal* TermSharing::insert(Literal* t)
       else {
         ASS_REP(tt->term()->shared(), tt->term()->toString());
         Term* r = tt->term();
-        vars += r->vars();
+        vars += r->getVariableOccurrences();
         weight += r->weight();
 
         if(_poly && t->isEquality()){
@@ -333,7 +333,7 @@ Literal* TermSharing::insert(Literal* t)
     }
     t->markShared();
     t->setId(_totalLiterals);
-    t->setVars(vars);
+    t->setVariableOccurrences(vars);
     t->setWeight(weight);
     if (env.colorUsed) {
       Color fcolor = env.signature->getPredicate(t->functor())->color();

--- a/Kernel/FlatTerm.cpp
+++ b/Kernel/FlatTerm.cpp
@@ -66,7 +66,7 @@ FlatTerm::FlatTerm(size_t length)
 size_t FlatTerm::getEntryCount(Term* t)
 {
   //functionEntryCount entries per function and one per variable
-  return t->weight()*functionEntryCount-(functionEntryCount-1)*t->vars();
+  return t->weight()*functionEntryCount-(functionEntryCount-1)*t->getVariableOccurrences();
 }
 
 FlatTerm* FlatTerm::create(Term* t)

--- a/Kernel/FlatTerm.cpp
+++ b/Kernel/FlatTerm.cpp
@@ -66,7 +66,7 @@ FlatTerm::FlatTerm(size_t length)
 size_t FlatTerm::getEntryCount(Term* t)
 {
   //functionEntryCount entries per function and one per variable
-  return t->weight()*functionEntryCount-(functionEntryCount-1)*t->getVariableOccurrences();
+  return t->weight()*functionEntryCount-(functionEntryCount-1)*t->numVarOccs();
 }
 
 FlatTerm* FlatTerm::create(Term* t)

--- a/Kernel/Grounder.cpp
+++ b/Kernel/Grounder.cpp
@@ -169,10 +169,10 @@ struct GlobalSubsumptionGrounder::OrderNormalizingComparator
     Literal* la = _lits[a];
     Literal* lb = _lits[b];
     if(la==lb) { return false; }
-    if(la->getVariableOccurrences()!=lb->getVariableOccurrences()) {
+    if(la->numVarOccs()!=lb->numVarOccs()) {
       //first, we want literals with less variables to appear in the
       //beginning as there is better chance to get some sharing across clauses
-      return la->getVariableOccurrences()<lb->getVariableOccurrences();
+      return la->numVarOccs()<lb->numVarOccs();
     }
     if(la->weight()!=lb->weight()) {
       return la->weight()<lb->weight();

--- a/Kernel/Grounder.cpp
+++ b/Kernel/Grounder.cpp
@@ -169,10 +169,10 @@ struct GlobalSubsumptionGrounder::OrderNormalizingComparator
     Literal* la = _lits[a];
     Literal* lb = _lits[b];
     if(la==lb) { return false; }
-    if(la->vars()!=lb->vars()) {
+    if(la->getVariableOccurrences()!=lb->getVariableOccurrences()) {
       //first, we want literals with less variables to appear in the
       //beginning as there is better chance to get some sharing across clauses
-      return la->vars()<lb->vars();
+      return la->getVariableOccurrences()<lb->getVariableOccurrences();
     }
     if(la->weight()!=lb->weight()) {
       return la->weight()<lb->weight();

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -170,7 +170,7 @@ struct LeastVariables : public LiteralComparator
 {
   Comparison compare(Literal* l1, Literal* l2)
   {
-    return Int::compare(l2->vars(), l1->vars());
+    return Int::compare(l2->getVariableOccurrences(), l1->getVariableOccurrences());
   }
 };
 

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -170,7 +170,7 @@ struct LeastVariables : public LiteralComparator
 {
   Comparison compare(Literal* l1, Literal* l2)
   {
-    return Int::compare(l2->getVariableOccurrences(), l1->getVariableOccurrences());
+    return Int::compare(l2->numVarOccs(), l1->numVarOccs());
   }
 };
 

--- a/Kernel/MLVariant.cpp
+++ b/Kernel/MLVariant.cpp
@@ -342,7 +342,7 @@ MatchingData* getMatchingData(Literal* const * baseLits0, unsigned baseLen, Clau
   size_t altBindingsCnt=0;
   for(unsigned i=0;i<baseLen;i++) {
 //    unsigned distVars=(*base)[i]->distinctVars();
-    unsigned distVars=baseLits[i]->getVariableOccurrences(); //an upper estimate is enough
+    unsigned distVars=baseLits[i]->numVarOccs(); //an upper estimate is enough
     baseLitVars+=distVars;
     unsigned currAltCnt=0;
     LiteralList::Iterator ait(altsArr[i]);

--- a/Kernel/MLVariant.cpp
+++ b/Kernel/MLVariant.cpp
@@ -342,7 +342,7 @@ MatchingData* getMatchingData(Literal* const * baseLits0, unsigned baseLen, Clau
   size_t altBindingsCnt=0;
   for(unsigned i=0;i<baseLen;i++) {
 //    unsigned distVars=(*base)[i]->distinctVars();
-    unsigned distVars=baseLits[i]->vars(); //an upper estimate is enough
+    unsigned distVars=baseLits[i]->getVariableOccurrences(); //an upper estimate is enough
     baseLitVars+=distVars;
     unsigned currAltCnt=0;
     LiteralList::Iterator ait(altsArr[i]);

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -248,13 +248,13 @@ Ordering::Result Ordering::getEqualityArgumentOrder(Literal* eq) const
 
   Result res;
   ArgumentOrderVals precomputed = static_cast<ArgumentOrderVals>(eq->getArgumentOrderValue());
-  if(precomputed!=0) {
+  if(precomputed!=AO_UNKNOWN) {
     res = static_cast<Result>(precomputed);
     ASS_EQ(res, compare(*eq->nthArgument(0), *eq->nthArgument(1)));
   }
   else {
     res = compare(*eq->nthArgument(0), *eq->nthArgument(1));
-    eq->setArgumentOrderValue(res);
+    eq->setArgumentOrderValue(static_cast<ArgumentOrderVals>(res));
   }
   return res;
 }

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -277,7 +277,7 @@ Ordering::Result PrecedenceOrdering::compare(Literal* l1, Literal* l2) const
   unsigned p2 = l2->functor();
 
   if( (l1->isNegative() ^ l2->isNegative()) && (p1==p2) &&
-	  l1->weight()==l2->weight() && l1->vars()==l2->vars() &&  //this line is just optimization, so we don't check whether literals are opposite when they cannot be
+	  l1->weight()==l2->weight() && l1->getVariableOccurrences()==l2->getVariableOccurrences() &&  //this line is just optimization, so we don't check whether literals are opposite when they cannot be
 	  l1==env.sharing->tryGetOpposite(l2)) {
     return l1->isNegative() ? LESS : GREATER;
   }

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -277,7 +277,7 @@ Ordering::Result PrecedenceOrdering::compare(Literal* l1, Literal* l2) const
   unsigned p2 = l2->functor();
 
   if( (l1->isNegative() ^ l2->isNegative()) && (p1==p2) &&
-	  l1->weight()==l2->weight() && l1->getVariableOccurrences()==l2->getVariableOccurrences() &&  //this line is just optimization, so we don't check whether literals are opposite when they cannot be
+	  l1->weight()==l2->weight() && l1->numVarOccs()==l2->numVarOccs() &&  //this line is just optimization, so we don't check whether literals are opposite when they cannot be
 	  l1==env.sharing->tryGetOpposite(l2)) {
     return l1->isNegative() ? LESS : GREATER;
   }

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -110,30 +110,6 @@ protected:
   Result compareEqualities(Literal* eq1, Literal* eq2) const;
 
 private:
-
-  enum ArgumentOrderVals {
-    /**
-     * Values representing order of arguments in equality,
-     * to be stores in the term sharing structure.
-     *
-     * The important thing is that the UNKNOWN value is
-     * equal to 0, as this will be the default value inside
-     * the term objects
-     *
-     * Values of elements must be equal to values of corresponding elements
-     * in the @c Result enum, so that one can convert between the
-     * enums using static_cast.
-     */
-    AO_UNKNOWN=0,
-    AO_GREATER=1,
-    AO_LESS=2,
-    AO_GREATER_EQ=3,
-    AO_LESS_EQ=4,
-    AO_EQUAL=5,
-    AO_INCOMPARABLE=6
-  };
-
-
   void createEqualityComparator();
   void destroyEqualityComparator();
 

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -863,7 +863,6 @@ Literal* Literal::apply(Substitution& subst)
   return SubstHelper::apply(this, subst);
 } // Literal::apply
 
-
 /**
  * Return the hash function of the top-level of a complex term.
  * @pre The term must be non-variable

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -11,9 +11,9 @@
  * @file Term.hpp
  * Defines class Term (also serving as term arguments)
  *
- * The way terms are laid out in memory is "cute".
+ * The way terms are laid out in memory is partly historical and certainly non-trivial.
  * Here are a few salient points to help you navigate:
- * - a "Term" is a function (unsigned, see Kernel::Signature) applied to some number of arguments
+ * - a "Term" represents a function (unsigned, see Kernel::Signature) applied to some number of arguments
  * - usually Terms are "perfectly shared" (see Indexing::TermSharing)
  * - the arguments are "TermList"s, i.e. a variable or a Term*
  * - TermList is a tagged union that relies on Term* being aligned (!) to achieve pointer tagging
@@ -238,7 +238,8 @@ private:
       mutable unsigned distinctVars : TERM_DIST_VAR_BITS;
 #if ARCH_X64
       /** reserved for whatever */
-      // ^ not exactly: note that this cannot be removed, otherwise the bitfield layout might shift
+      // ^ not exactly: this should not be removed without care,
+      // otherwise the bitfield layout might shift, resulting in broken pointer tagging
       unsigned reserved : 32;
 #endif
     } _info;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -236,12 +236,11 @@ private:
        * to TERM_DIST_VAR_UNKNOWN if the number has not been
        * computed yet. */
       mutable unsigned distinctVars : TERM_DIST_VAR_BITS;
-#if ARCH_X64
-      /** reserved for whatever */
-      // ^ not exactly: this should not be removed without care,
+      static_assert(ARCH_X64,"this version of vampire is X64 only");
+      /** term id hiding in this _info */
+      // this should not be removed without care,
       // otherwise the bitfield layout might shift, resulting in broken pointer tagging
-      unsigned reserved : 32;
-#endif
+      unsigned id : 32;
     } _info;
   };
   friend class Indexing::TermSharing;
@@ -522,14 +521,14 @@ public:
   /** Set term id */
   void setId(unsigned id)
   {
-    _id = id;
+    _args[0]._info.id = id;
   } // setWeight
 
   /** Set (shared) term's id */
   unsigned getId() const
   {
     ASS(shared());
-    return _id;
+    return _args[0]._info.id;
   }
   
   void setMaxRedLen(int rl)

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -477,7 +477,7 @@ public:
   bool ground() const
   {
     ASS(_args[0]._info.shared);
-    return getVariableOccurrences() == 0;
+    return numVarOccs() == 0;
   } // ground
 
   /** True if the term is shared */
@@ -538,9 +538,9 @@ public:
   } // setWeight
 
   /** Set the number of variable _occurrences_ */
-  void setVariableOccurrences(unsigned v)
+  void setNumVarOccs(unsigned v)
   {
-    CALL("Term::setVariableOccurrences");
+    CALL("Term::setNumVarOccs");
 
     if(_isTwoVarEquality) {
       ASS_EQ(v,2);
@@ -550,12 +550,12 @@ public:
   } // setVars
 
   /** Return the number of variable _occurrences_ */
-  unsigned getVariableOccurrences() const
+  unsigned numVarOccs() const
   {
-    CALL("Term::getVariableOccurrences");
+    CALL("Term::numVarOccs");
     ASS(shared());
     if(_isTwoVarEquality) {
-      return _sort.isVar() ? 3 : 2 + _sort.term()->getVariableOccurrences();
+      return _sort.isVar() ? 3 : 2 + _sort.term()->numVarOccs();
     }
     return _vars;
   } // vars()

--- a/Shell/LambdaElimination.cpp
+++ b/Shell/LambdaElimination.cpp
@@ -72,8 +72,8 @@ bool LambdaElimination::TermListComparator::lessThan(TermList t1, TermList t2)
   if(trm1->weight()!=trm2->weight()) {
     return trm1->weight()<trm2->weight();
   }
-  if(trm1->vars()!=trm2->vars()) {
-    return trm1->vars()<trm2->vars();
+  if(trm1->getVariableOccurrences()!=trm2->getVariableOccurrences()) {
+    return trm1->getVariableOccurrences()<trm2->getVariableOccurrences();
   }
 
   //To avoid non-determinism, now we'll compare the terms lexicographicaly.

--- a/Shell/LambdaElimination.cpp
+++ b/Shell/LambdaElimination.cpp
@@ -72,8 +72,8 @@ bool LambdaElimination::TermListComparator::lessThan(TermList t1, TermList t2)
   if(trm1->weight()!=trm2->weight()) {
     return trm1->weight()<trm2->weight();
   }
-  if(trm1->getVariableOccurrences()!=trm2->getVariableOccurrences()) {
-    return trm1->getVariableOccurrences()<trm2->getVariableOccurrences();
+  if(trm1->numVarOccs()!=trm2->numVarOccs()) {
+    return trm1->numVarOccs()<trm2->numVarOccs();
   }
 
   //To avoid non-determinism, now we'll compare the terms lexicographicaly.

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -342,7 +342,7 @@ Comparison Normalisation::compare (Literal* l1, Literal* l2)
       return comp;
     }
     if (l1->shared() && l2->shared()) {
-      comp = compare((int)l1->getVariableOccurrences(),(int)l2->getVariableOccurrences());
+      comp = compare((int)l1->numVarOccs(),(int)l2->numVarOccs());
       if (comp != EQUAL) {
         return comp;
       }
@@ -541,7 +541,7 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
       return comp;
     }
 
-    comp = compare((int)t1->getVariableOccurrences(),(int)t2->getVariableOccurrences());
+    comp = compare((int)t1->numVarOccs(),(int)t2->numVarOccs());
     if (comp != EQUAL) {
       return comp;
     }

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -342,7 +342,7 @@ Comparison Normalisation::compare (Literal* l1, Literal* l2)
       return comp;
     }
     if (l1->shared() && l2->shared()) {
-      comp = compare((int)l1->vars(),(int)l2->vars());
+      comp = compare((int)l1->getVariableOccurrences(),(int)l2->getVariableOccurrences());
       if (comp != EQUAL) {
         return comp;
       }
@@ -541,7 +541,7 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
       return comp;
     }
 
-    comp = compare((int)t1->vars(),(int)t2->vars());
+    comp = compare((int)t1->getVariableOccurrences(),(int)t2->getVariableOccurrences());
     if (comp != EQUAL) {
       return comp;
     }


### PR DESCRIPTION
- remove some unused functions/includes/etc from `Term`
- move `ArgumentOrderVals` to `Term`: this allows using more descriptive types and enumeration values
- where possible, use non-POD types in unions since we're allowed to now
- add some comments about the hazardous bits