### PR TITLE
Fix max sort sizes

### DIFF
--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1585,18 +1585,22 @@ MainLoopResult FiniteModelBuilder::runImpl()
 #if VTRACE_FMB
       doPrinting = true;
 #endif
-      vstring res = "[";
+      vstring min_res = "[";
+      vstring max_res = "[";
       for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){
         if(_distinctSortMaxs[s]==UINT_MAX){
-          res+="max";
+          max_res+="max";
         }else{
-          res+=Lib::Int::toString(_distinctSortMaxs[s]);
+          max_res+=Lib::Int::toString(_distinctSortMaxs[s]);
           doPrinting=true;
         }
-        if(s+1 < _sortedSignature->distinctSorts) res+=",";
+	if(_distinctSortMins[s]!=1){ doPrinting=true;}
+        min_res+=Lib::Int::toString(_distinctSortMins[s]);
+        if(s+1 < _sortedSignature->distinctSorts){ max_res+=","; min_res+=",";}
       }
       if(doPrinting){
-        cout << "Detected maximum model sizes of " << res << "]" << endl;
+        cout << "Detected minimum model sizes of " << min_res << "]" << endl;
+        cout << "Detected maximum model sizes of " << max_res << "]" << endl;
       }
   }
 


### PR DESCRIPTION
This adds functionality to FMB to detect maximum sort sizes in particular circumstances. The idea is that if we have a clause like `X = a | X = b` then we know that the cardinality of the sort of X is at most 2.

These maximum sort sizes are not required for the soundness of finding models but (i) can improve efficiency when enumerating sort size vectors, and (ii) can allow us to return unsat when we know we are complete. We have one mechanism for detecting maximum sort sizes (only constants,  no positive equality). This PR adds a new method.

About 5 years ago we tried adding this generally and there were some bugs due to trying to capture all cases. We never reintroduced it. This time I focus just on the case where we have a clause of the form `{ X = t_i }` for some `X` and some terms `t_i`. In such a case the cardinality of the sort of `X` is bound by `i`. Of course, there are scenarios where it may be lower. There are also cases where we might miss a bound by being too simplistic.

We detect this sort bound during sort inference. When scanning clauses we look for clauses consisting only of positive equalities where every literal contains exactly one shared variable. There is some complication in mapping this bound back to the meta-sorts used in the finite model building process.