### PR TITLE
Do not create additional units when displaying theory axioms

### DIFF
--- a/Shell/TheoryAxioms.cpp
+++ b/Shell/TheoryAxioms.cpp
@@ -55,14 +55,9 @@ void TheoryAxioms::addAndOutputTheoryUnit(Unit* unit, unsigned level)
   if(opt_level != Options::TheoryAxiomLevel::ON && level != CHEAP){ return; }
 
   if (env.options->showTheoryAxioms()) {
-    Unit* qunit = unit;
-    Formula* f = 0;
-    if(unit->isClause()){
-      f = Formula::fromClause(static_cast<Clause*>(unit));
-      qunit = new FormulaUnit(f,unit->inference());
-    }
-    cout << "% Theory " << (unit->isClause() ? "clause" : "formula" ) << ": " << qunit->toString() << "\n";
-    if(f){ f->destroy(); } 
+    env.beginOutput();
+    env.out() << "% Theory " << (unit->isClause() ? "clause" : "formula" ) << ": " << unit->toString() << endl;
+    env.endOutput();
   }
   if(!unit->isClause()){
     _prb.reportFormulasAdded();


### PR DESCRIPTION
The motivation for this is mainly that when `--show_theory_axioms` (or `--show_everything`) is on, more units are added and the unit numbers slightly change, making it harder to track two diverging proofs.

Question: the original code avoided outputting a clause (calling `Clause::toString`) directly, is there any reason to do this? If so, I can live without merging this PR.