### PR TITLE
remove UNIX_USE_SIGALRM, improve signal safety

### DIFF
--- a/CASC/CLTBMode.cpp
+++ b/CASC/CLTBMode.cpp
@@ -673,7 +673,6 @@ void CLTBProblem::searchForProof(int terminationTime,int timeLimit,const Categor
   // special reporting in Timer.cpp
   UIHelper::portfolioParent = true;
 
-  env.timer->makeChildrenIncluded();
   TimeCounter::reinitialize();
 
   env.options->setInputFile(problemFile);

--- a/CASC/CLTBModeLearning.cpp
+++ b/CASC/CLTBModeLearning.cpp
@@ -828,7 +828,6 @@ void CLTBProblemLearning::searchForProof(int terminationTime,int timeLimit, Sche
 
   System::registerForSIGHUPOnParentDeath();
 
-  env.timer->makeChildrenIncluded();
   TimeCounter::reinitialize();
 
   env.options->setInputFile(problemFile);

--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -118,7 +118,6 @@ bool PortfolioMode::searchForProof()
 {
   CALL("PortfolioMode::searchForProof");
 
-  env.timer->makeChildrenIncluded();
   TimeCounter::reinitialize();
 
   _prb = UIHelper::getInputProblem(*env.options);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -806,7 +806,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 # set preprocessor defines
 add_compile_definitions(CHECK_LEAKS=0)
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
-  add_compile_definitions(VDEBUG=1 UNIX_USE_SIGALRM=1)
+  add_compile_definitions(VDEBUG=1)
 elseif(CMAKE_BUILD_TYPE STREQUAL Release)
   add_compile_definitions(VDEBUG=0)
 endif()

--- a/Lib/Hash.hpp
+++ b/Lib/Hash.hpp
@@ -226,7 +226,7 @@ public:
     CALL("Hash::hash(const unsigned char *, size_t, unsigned)");
     ASS(size > 0);
 
-    for (int i = 0; i < size; i++) {
+    for (size_t i = 0; i < size; i++) {
       hash = (hash ^ val[i]) * FNV32_PRIME;
     }
     return hash;

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -85,9 +85,11 @@ unsigned Timer::elapsedMegaInstructions() {
       env.out() << "Proof not found in time ";
       Timer::printMSString(env.out(),env.timer->elapsedMilliseconds());
 
+#ifdef __linux__
       if (last_instruction_count_read > -1) {
         env.out() << " nor after " << last_instruction_count_read << " (user) instruction executed.";
       }
+#endif
       env.out() << endl;
 
       if (szsOutputMode()) {

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -12,74 +12,53 @@
  * Implements class Timer.
  */
 
-#include <ctime>
-#include <unistd.h>
-#include <atomic>
-#include <sys/types.h>
-
-#include "Debug/Assertion.hpp"
-#include "Debug/Tracer.hpp"
-
-#include "Environment.hpp"
-#include "Int.hpp"
-#include "Portability.hpp"
-#include "System.hpp"
-#include "TimeCounter.hpp"
-
-#include "Shell/UIHelper.hpp"
-#include "Shell/Options.hpp"
-#include "Shell/Statistics.hpp"
-
-#include "Timer.hpp"
-
-#ifdef __linux__ // preration for checking instruction count
-#include <cstdio>
-#include <sys/ioctl.h>
-#include <linux/perf_event.h>
-#include <asm/unistd.h>
-
-// conveniece wrapper around a syscall (cf. https://linux.die.net/man/2/perf_event_open )
-long perf_event_open(struct perf_event_attr *hw_event, pid_t pid, int cpu, int group_fd, unsigned long flags)
-{
-  int ret = syscall(__NR_perf_event_open, hw_event, pid, cpu,group_fd, flags);
-  return ret;
-}
-
-int perf_fd = -1; // the file descriptor we later read the info from
-
-#endif // #ifdef __linux__
-
-#define DEBUG_TIMER_CHANGES 0
-
-using namespace std;
-using namespace Lib;
-
-bool Timer::s_limitEnforcement = true;
-
-#if UNIX_USE_SIGALRM
-
-#include <cerrno>
-#include <unistd.h>
-#include <cstdlib>
 #include <csignal>
+#include <unistd.h>
 #include <sys/time.h>
 #include <sys/times.h>
 
-#include "Lib/Sys/Multiprocessing.hpp"
+// for checking instruction count
+#ifdef __linux__
+#include <sys/ioctl.h>
+#include <linux/perf_event.h>
+#include <asm/unistd.h>
+#endif
 
+#include "Environment.hpp"
+#include "System.hpp"
+#include "Sys/Multiprocessing.hpp"
+#include "Shell/Statistics.hpp"
 #include "Shell/UIHelper.hpp"
 
-int timer_sigalrm_counter=-1;
-long long last_instruction_count_read = -1;
+#include "Timer.hpp"
 
+#define DEBUG_TIMER_CHANGES 0
 #define MILLION 1000000
 
-unsigned Timer::elapsedMegaInstructions() {
-  return (last_instruction_count_read >= MILLION) ? last_instruction_count_read/MILLION : 0;
-}
+// things that need to be signal-safe because they are used in timer_sigalrm_handler
+// in principle we also need is_lock_free() to avoid deadlock as well
+// not sure it's worth assertion-failing over
+std::atomic<int> timer_sigalrm_counter{-1};
+std::atomic<unsigned> protectingTimeout{0};
+std::atomic<unsigned char> callLimitReachedLater{0}; // 1 for a timelimit, 2 for an instruction limit
+std::atomic<bool> Timer::s_limitEnforcement{true};
+
+// TODO probably these should also be atomics, but not sure
+#ifdef __linux__
+int perf_fd = -1; // the file descriptor we later read the info from
+long long last_instruction_count_read = -1;
+#endif
 
 long Timer::s_ticksPerSec;
 int Timer::s_initGuarantedMiliseconds;
+
+unsigned Timer::elapsedMegaInstructions() {
+#ifdef __linux__
+  return (last_instruction_count_read >= MILLION) ? last_instruction_count_read/MILLION : 0;
+#else
+  return 0;
+#endif
+}
 
 [[noreturn]] void limitReached(unsigned char whichLimit)
 {
@@ -122,22 +101,6 @@ int Timer::s_initGuarantedMiliseconds;
   env.endOutput();
 
   System::terminateImmediately(1);
-}
-
-std::atomic<unsigned> protectingTimeout{0};
-std::atomic<unsigned char> callLimitReachedLater{0}; // 1 for a timelimit, 2 for an instruction limit
-
-TimeoutProtector::TimeoutProtector() {
-  protectingTimeout++;
-}
-
-TimeoutProtector::~TimeoutProtector() {
-  protectingTimeout--;
-  if (!protectingTimeout && callLimitReachedLater) {
-    unsigned howToCall = callLimitReachedLater;
-    callLimitReachedLater = 0; // to prevent recursion (should limitReached itself reach TimeoutProtector)
-    limitReached(howToCall);
-  }
 }
 
 void
@@ -187,7 +150,7 @@ timer_sigalrm_handler (int sig)
 }
 
 /** number of miliseconds (of CPU time) passed since some moment */
-int Lib::Timer::miliseconds()
+int Timer::miliseconds()
 {
   CALL("Timer::miliseconds");
   ASS_GE(timer_sigalrm_counter, 0);
@@ -195,7 +158,7 @@ int Lib::Timer::miliseconds()
   return timer_sigalrm_counter;
 }
 
-int Lib::Timer::guaranteedMilliseconds()
+int Timer::guaranteedMilliseconds()
 {
   tms aux;
   clock_t ticks=times(&aux);
@@ -211,7 +174,7 @@ int Lib::Timer::guaranteedMilliseconds()
   return static_cast<long long>(ticks)*1000/s_ticksPerSec;
 }
 
-void Lib::Timer::suspendTimerBeforeFork()
+void Timer::suspendTimerBeforeFork()
 {
   //if we use SIGALRM, we must disable it before forking and the restore it
   //afterwards (in both processes)
@@ -227,7 +190,7 @@ void Lib::Timer::suspendTimerBeforeFork()
   }
 }
 
-void Lib::Timer::restoreTimerAfterFork()
+void Timer::restoreTimerAfterFork()
 {
   itimerval tv1, tv2;
   tv2.it_interval.tv_usec = 1000;
@@ -241,7 +204,16 @@ void Lib::Timer::restoreTimerAfterFork()
   }
 }
 
-void Lib::Timer::ensureTimerInitialized()
+#ifdef __linux__
+// conveniece wrapper around a syscall (cf. https://linux.die.net/man/2/perf_event_open )
+long perf_event_open(struct perf_event_attr *hw_event, pid_t pid, int cpu, int group_fd, unsigned long flags)
+{
+  int ret = syscall(__NR_perf_event_open, hw_event, pid, cpu,group_fd, flags);
+  return ret;
+}
+#endif
+
+void Timer::ensureTimerInitialized()
 {
   CALL("Timer::ensureTimerInitialized");
   
@@ -294,7 +266,7 @@ void Lib::Timer::ensureTimerInitialized()
   Sys::Multiprocessing::instance()->registerForkHandlers(suspendTimerBeforeFork, restoreTimerAfterFork, restoreTimerAfterFork);
 }
 
-void Lib::Timer::deinitializeTimer()
+void Timer::deinitializeTimer()
 {
   CALL("Timer::deinitializeTimer");
 
@@ -308,7 +280,7 @@ void Lib::Timer::deinitializeTimer()
   signal (SIGALRM, SIG_IGN); // unregister the handler (and ignore the rest of SIGALRMs, should they still come) 
 }
 
-void Lib::Timer::syncClock()
+void Timer::syncClock()
 {
   static bool reportedProblem = false;
   if(s_initGuarantedMiliseconds==-1) {
@@ -334,76 +306,6 @@ void Lib::Timer::syncClock()
     timer_sigalrm_counter=newVal;
   }
 }
-
-void Lib::Timer::makeChildrenIncluded()
-{
-  //here are children always included as we measure the wall clock time
-}
-
-#else
-
-#include <sys/time.h>
-#include <sys/resource.h>
-
-/** number of miliseconds (of CPU time) passed since some moment */
-int Lib::Timer::miliseconds()
-{
-  struct timeval tim;
-  struct rusage ru;
-  getrusage(RUSAGE_SELF, &ru);
-  tim=ru.ru_utime;
-  int t=tim.tv_sec*1000 + tim.tv_usec / 1000;
-  tim=ru.ru_stime;
-  t+=tim.tv_sec*1000 + tim.tv_usec / 1000;
-
-  if(_mustIncludeChildren) {
-    getrusage(RUSAGE_CHILDREN, &ru);
-    tim=ru.ru_utime;
-    t+=tim.tv_sec*1000 + tim.tv_usec / 1000;
-    tim=ru.ru_stime;
-    t+=tim.tv_sec*1000 + tim.tv_usec / 1000;
-  }
-  return t;
-//  return (int)( ((long long)clock())*1000/CLOCKS_PER_SEC );
-}
-
-void Lib::Timer::syncClock()
-{
-}
-
-void Lib::Timer::ensureTimerInitialized()
-{
-}
-
-void Lib::Timer::deinitializeTimer()
-{
-}
-
-void Lib::Timer::makeChildrenIncluded()
-{
-  CALL("Lib::Timer::makeChildrenIncluded");
-
-  if(_mustIncludeChildren) {
-    return;
-  }
-
-  if(_running) {
-    struct timeval tim;
-    struct rusage ru;
-    getrusage(RUSAGE_CHILDREN, &ru);
-    tim=ru.ru_utime;
-    _start+=tim.tv_sec*1000 + tim.tv_usec / 1000;
-    tim=ru.ru_stime;
-    _start+=tim.tv_sec*1000 + tim.tv_usec / 1000;
-  }
-  _mustIncludeChildren=true;
-}
-
-
-#endif
-
-namespace Lib
-{
 
 vstring Timer::msToSecondsString(int ms)
 {
@@ -446,38 +348,20 @@ void Timer::printMSString(ostream& str, int ms)
 
 Timer* Timer::instance()
 {
-  static ScopedPtr<Timer> inst(new Timer());
-  
-  return inst.ptr();
+  static Timer inst;
+  return &inst;
+
 }
 
-};
+TimeoutProtector::TimeoutProtector() {
+  protectingTimeout++;
+}
 
-//#include <iostream>
-//
-//int main (int argc, char* argv [])
-//{
-//  int counter = 0;
-//  Lib::Timer timer;
-//  int last = -1;
-//  timer.start();
-//
-//  for (;;) {
-//    counter++;
-//    int current = timer.elapsedDeciseconds();
-//    if (current <= last) {
-//      continue;
-//    }
-//    last = current;
-////      cout << current << "\n";
-//    if (current == 100) {
-//      cout << "Total calls to clock() during "
-//	   << current
-//	   << " deciseconds is "
-//	   << counter
-//	   << '\n';
-//      return 0;
-//    }
-//  }
-//}
-//
+TimeoutProtector::~TimeoutProtector() {
+  protectingTimeout--;
+  if (!protectingTimeout && callLimitReachedLater) {
+    unsigned howToCall = callLimitReachedLater;
+    callLimitReachedLater = 0; // to prevent recursion (should limitReached itself reach TimeoutProtector)
+    limitReached(howToCall);
+  }
+}

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -16,33 +16,13 @@
 #ifndef __Timer__
 #define __Timer__
 
-#include <iostream>
-
+#include <atomic>
 #include "Debug/Assertion.hpp"
-#include "Forwards.hpp"               // to declare checked_delete a fried for ScopedPtr's destruction to work
 #include "Allocator.hpp"
 #include "VString.hpp"
 
-#ifndef UNIX_USE_SIGALRM
-//SIGALRM causes some problems with debugging
-//[one problem might have been removed, so it's worth checking if the demand for UNIX_USE_SIGALRM in VDEBUG arises]
-#define UNIX_USE_SIGALRM 1 // MS: only the UNIX_USE_SIGALRM seems to be working currently (experiment with SMTCOMP mode); the problem with debugging under UNIX_USE_SIGALRM might have really gone, so let's try
-#endif
-
-//we don't need SIGALRM in Api, and it causes problems debugging
-#ifdef VAPI_LIBRARY
-#if VAPI_LIBRARY
-
-#undef UNIX_USE_SIGALRM
-#define UNIX_USE_SIGALRM 0
-
-#endif
-#endif
-
 namespace Lib
 {
-
-using namespace std;
 
 /**
  * Class implementing timers.
@@ -50,17 +30,10 @@ using namespace std;
  */
 class Timer
 {
-  Timer(bool mustIncludeChildren=false)
-    :
-    _mustIncludeChildren(mustIncludeChildren),
-    _running(false),
-    _elapsed(0)
-  { (void)_mustIncludeChildren; // MS: to get it of the unused private field warning when UNIX_USE_SIGALRM
-    ensureTimerInitialized(); }
-
+  Timer() : _running(false), _elapsed(0) { ensureTimerInitialized(); }
   ~Timer() { deinitializeTimer(); }
   friend void ::checked_delete<Timer>(Timer*);
-  
+ 
 public:
   CLASS_NAME(Timer);
   USE_ALLOCATOR(Timer);
@@ -108,8 +81,6 @@ public:
     return elapsed();
   }
 
-  void makeChildrenIncluded();
-
   static void ensureTimerInitialized();
   static void deinitializeTimer();
   static vstring msToSecondsString(int ms);
@@ -124,12 +95,8 @@ public:
   // (when instruction counting is supported and an instruction limit is set)
   static unsigned elapsedMegaInstructions();
 
-  static bool s_limitEnforcement;
+  static std::atomic<bool> s_limitEnforcement;
 private:
-
-  /** true if the timer must account for the time spent in
-   * children (otherwise it may or may not) */
-  bool _mustIncludeChildren;
   /** true if the timer is running */
   bool _running;
   /** last start time */
@@ -139,7 +106,6 @@ private:
 
   int miliseconds();
 
-#if UNIX_USE_SIGALRM
   static void suspendTimerBeforeFork();
   static void restoreTimerAfterFork();
 
@@ -147,7 +113,6 @@ private:
 
   static long s_ticksPerSec;
   static int s_initGuarantedMiliseconds;
-#endif
 
   /** elapsed time in ticks */
   inline

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,9 @@
 #   VDEBUG           - the debug mode
 #   VTEST            - testing procedures will also be compiled
 #   CHECK_LEAKS      - test for memory leaks (debugging mode only)
-#   UNIX_USE_SIGALRM - the SIGALRM timer will be used even in debug mode
 #   VZ3              - compile with Z3
 
-DBG_FLAGS = -g -DVDEBUG=1 -DCHECK_LEAKS=0 -DUNIX_USE_SIGALRM=1 # debugging for spider 
+DBG_FLAGS = -g -DVDEBUG=1 -DCHECK_LEAKS=0 # debugging for spider 
 # DELETEMEin2017: the bug with gcc-6.2 and problems in ClauseQueue could be also fixed by adding -fno-tree-ch
 REL_FLAGS = -O6 -DVDEBUG=0 # no debugging
 GCOV_FLAGS = -O0 --coverage #-pedantic
@@ -61,12 +60,12 @@ XFLAGS = -Wfatal-errors -g -DVDEBUG=1 -DCHECK_LEAKS=0 -DUSE_SYSTEM_ALLOCATION=1 
 #XFLAGS = -O6 -DVDEBUG=1 -DCHECK_LEAKS=0 -g # debugging and optimized
 
 #XFLAGS = -O6 -DVDEBUG=0 -g # Cachegrind
-#XFLAGS = -O6 -DVDEBUG=0 -DUNIX_USE_SIGALRM=0 -g # Cachegrind
+#XFLAGS = -O6 -DVDEBUG=0 -g # Cachegrind
 #XFLAGS = -O2 -DVDEBUG=0 -fno-inline-functions -fno-inline-functions-called-once -fno-default-inline -fno-inline-small-functions -fno-early-inlining -g # Callgrind
 #XFLAGS = -O6 -DVDEBUG=0 -fno-inline-functions -fno-inline-functions-called-once -fno-default-inline -fno-early-inlining -g # Callgrind
-#XFLAGS = -O0 -DVDEBUG=0 -DUNIX_USE_SIGALRM=0 -fno-inline-functions -fno-inline-functions-called-once -fno-default-inline -fno-early-inlining -g # Callgrind
+#XFLAGS = -O0 -DVDEBUG=0 -fno-inline-functions -fno-inline-functions-called-once -fno-default-inline -fno-early-inlining -g # Callgrind
 #XFLAGS = -O2 -DVDEBUG=0 -fno-inline-functions -fno-inline-functions-called-once -fno-default-inline -fno-early-inlining -g # Callgrind
-#XFLAGS = -O6 -DVDEBUG=0 -DUNIX_USE_SIGALRM=0 -fno-inline -g # Callgrind
+#XFLAGS = -O6 -DVDEBUG=0 -fno-inline -g # Callgrind
 #XFLAGS = -O0 -DVDEBUG=0 -DUSE_SYSTEM_ALLOCATION=1 -fno-inline -fno-default-inline -g # Valgrind
 #XFLAGS = -O0 -DVDEBUG=0 -DUSE_SYSTEM_ALLOCATION=1 -DVALGRIND=1 -fno-inline -g #Valgrind
 #XFLAGS = -O0 -DVDEBUG=0 -DUSE_SYSTEM_ALLOCATION=1 -DVALGRIND=1 -g #Valgrind


### PR DESCRIPTION
It was decided that `UNIX_USE_SIGALRM` was now going to be always true, the debugging problems are over (?). This allows simplifying the code a lot. Also, some variables ought to be signal-safe that weren't, improve matters there. Finally, move some code blocks around a bit to improve navigation.