### PR TITLE
Refine induction unit testing

### DIFF
--- a/Test/ClausePattern.hpp
+++ b/Test/ClausePattern.hpp
@@ -46,7 +46,7 @@ public:
       }) {}
 
   template<class EqualityOperator>
-  bool matches(EqualityOperator& equality, Kernel::Clause const* result);
+  bool matches(EqualityOperator& equality, Kernel::Clause const* result, BacktrackData& btd);
   friend ostream& operator<<(ostream& out, ClausePattern const& self);
 };
 
@@ -61,14 +61,14 @@ inline ostream& operator<<(ostream& out, ClausePattern const& self)
 }
 
 template<class EqualityOperator>
-bool ClausePattern::matches(EqualityOperator& equality, Kernel::Clause const* result)
+bool ClausePattern::matches(EqualityOperator& equality, Kernel::Clause const* result, BacktrackData& btd)
 {
   return match(
       [&](Kernel::Clause const*& self) 
-      { return equality.eq(result, self); },
+      { return equality.eq(result, self, btd); },
 
       [&](AnyOf& self) 
-      { return self.lhs->matches(equality, result) || self.rhs->matches(equality, result); });
+      { return self.lhs->matches(equality, result, btd) || self.rhs->matches(equality, result, btd); });
 }
 
 inline ClausePattern anyOf(Kernel::Clause const* lhs) 

--- a/Test/GenerationTester.hpp
+++ b/Test/GenerationTester.hpp
@@ -56,7 +56,7 @@ public:
     : _rule()
   {}
 
-  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs)
+  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs, BacktrackData& btd)
   { return TestUtils::eqModAC(lhs, rhs); }
 
   friend class TestCase;
@@ -137,7 +137,7 @@ public:
     auto& sExp = this->_expected;
     auto  sRes = Stack<Kernel::Clause*>::fromIterator(res.clauses);
 
-    if (!TestUtils::permEq(sExp, sRes, [&](auto exp, auto res) { return exp.matches(simpl, res); })) {
+    if (!TestUtils::permEq(sExp, sRes, [&](auto exp, auto res, BacktrackData& btd) { return exp.matches(simpl, res, btd); })) {
       testFail(sRes, sExp);
     }
 

--- a/Test/SimplificationTester.hpp
+++ b/Test/SimplificationTester.hpp
@@ -31,7 +31,7 @@ class SimplificationTester
 public:
   virtual Kernel::Clause* simplify(Kernel::Clause*) const = 0;
 
-  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const 
+  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs, BacktrackData& btd) const 
   { return TestUtils::eqModAC(lhs, rhs); }
 };
 
@@ -58,6 +58,7 @@ public:
   void run(const SimplificationTester& simpl) {
     auto res = simpl.simplify(_input);
 
+    BacktrackData btd;
     if (!res) {
       cout  << endl;
       cout << "[     case ]: " << pretty(*_input) << endl;
@@ -65,7 +66,7 @@ public:
       cout << "[ expected ]: " << pretty(_expected) << endl;
       exit(-1);
 
-    } else if (!_expected.unwrap().matches(simpl, res)) {
+    } else if (!_expected.unwrap().matches(simpl, res, btd)) {
       cout  << endl;
       cout << "[     case ]: " << pretty(*_input) << endl;
       cout << "[       is ]: " << pretty(*res) << endl;

--- a/Test/TestUtils.cpp
+++ b/Test/TestUtils.cpp
@@ -196,7 +196,7 @@ bool TestUtils::isAC(Theory::Interpretation i)
 }
 
 bool TestUtils::eqModAC(const Kernel::Clause* lhs, const Kernel::Clause* rhs)
-{ return permEq(*lhs, *rhs, [](Literal* l, Literal* r) -> bool { return TestUtils::eqModAC(l, r); }); }
+{ return permEq(*lhs, *rhs, [](Literal* l, Literal* r, BacktrackData& btd) -> bool { return TestUtils::eqModAC(l, r); }); }
 
 bool TestUtils::eqModAC(Kernel::Literal* lhs, Kernel::Literal* rhs)
 { return TestUtils::eqModAC(TermList(lhs), TermList(rhs)); }
@@ -241,7 +241,7 @@ bool TestUtils::eqModAC_(TermList lhs, TermList rhs, Comparisons comp)
     if (isAC(&l)) {
       Stack<TermList> lstack = collect(fun, &l);
       Stack<TermList> rstack = collect(fun, &r);
-      return permEq(lstack, rstack, [&](TermList l, TermList r) -> bool {
+      return permEq(lstack, rstack, [&](TermList l, TermList r, BacktrackData& btd) -> bool {
             return comp.subterm(l, r);
       });
     } else {

--- a/Test/TestUtils.hpp
+++ b/Test/TestUtils.hpp
@@ -215,21 +215,29 @@ public:
 // rhs via initial permutation perm with elements [0,idx) fixed.
 template<class L1, class L2, class Eq>
 bool __permEq(L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
-  auto checkPerm = [] (L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
+  auto checkPerm = [] (L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx, BacktrackData& btd) {
     ASS_EQ(lhs.size(), perm.size());
     ASS_EQ(rhs.size(), perm.size());
 
     for (unsigned i = idx; i < perm.size(); i++) {
-      if (!elemEq(lhs[i], rhs[perm[i]])) return false;
+      if (!elemEq(lhs[i], rhs[perm[i]], btd)) {
+        btd.backtrack();
+        return false;
+      }
     }
     return true;
   };
+  BacktrackData btd;
   // These are elements fixed in the permutation, so check
   // them only once and do not recurse if one of them is false.
   for (unsigned i = 0; i < idx; i++) {
-    if (!elemEq(lhs[i], rhs[perm[i]])) return false;
+    if (!elemEq(lhs[i], rhs[perm[i]], btd)) {
+      btd.backtrack();
+      return false;
+    }
   }
-  if (checkPerm(lhs, rhs, elemEq, perm, idx)) {
+  if (checkPerm(lhs, rhs, elemEq, perm, idx, btd)) {
+    btd.drop();
     return true;
   }
   for (unsigned i = idx; i < perm.size(); i++) {

--- a/UnitTests/tGaussianElimination.cpp
+++ b/UnitTests/tGaussianElimination.cpp
@@ -67,7 +67,7 @@ public:
    * OPTIONAL: override how equality between clauses is checked. 
    * Defaults to TestUtils::eqModAC(Clause const*, Clause const*).
    */
-  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) const override
+  virtual bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs, BacktrackData& btd) const override
   {
     return TestUtils::eqModAC(lhs, rhs);
   }

--- a/UnitTests/tInduction.cpp
+++ b/UnitTests/tInduction.cpp
@@ -23,7 +23,8 @@
 using namespace Test;
 using namespace Test::Generation;
 
-#define VARS 100
+#define SKOLEM_VAR_MIN 100
+#define DECL_SKOLEM_VAR(x, i) DECL_VAR(x, i+SKOLEM_VAR_MIN)
 
 LiteralIndex* comparisonIndex() {
   return new UnitIntegerComparisonLiteralIndex(new LiteralSubstitutionTree());
@@ -43,38 +44,47 @@ public:
    * of the constants we cannot predefine, and require that these variables
    * are mapped bijectively to the new Skolem constants, hence this override.
    */
-  bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs) override
+  bool eq(Kernel::Clause const* lhs, Kernel::Clause const* rhs, BacktrackData& btd) override
   {
     // there can be false positive matches which later (in a different literal
     // or clause) can turn out to be the wrong ones and we have to backtrack
-    BacktrackData btd;
+    // TODO: are all of these backtracking calls necessary?
     _subst.bdRecord(btd);
-    if (!TestUtils::permEq(*lhs, *rhs, [this](Literal* l, Literal* r) -> bool {
+    if (!TestUtils::permEq(*lhs, *rhs, [this](Literal* l, Literal* r, BacktrackData& btd) -> bool {
       if (l->polarity() != r->polarity()) {
         return false;
       }
-      if (!_subst.match(Kernel::TermList(r), 0, Kernel::TermList(l), 1)) {
-        if (!l->isEquality() || !r->isEquality() ||
-          !_subst.match(*r->nthArgument(0), 0, *l->nthArgument(1), 1) ||
-          !_subst.match(*r->nthArgument(1), 0, *l->nthArgument(0), 1))
-        {
-          return false;
+      VList::Iterator vit(r->freeVariables());
+      while (vit.hasNext()) {
+        auto v = vit.next();
+        if (!_varsMatched.count(v)) {
+          btd.addBacktrackObject(new MatchedVarBacktrackObject(_varsMatched, v));
+          _varsMatched.insert(v);
         }
       }
-      // we check that so far each variable is mapped to a unique Skolem constant
-      DHMap<TermList, unsigned> inverse;
-      for (unsigned i = 0; i < VARS; i++) {
-        if (!_subst.isUnbound(i, 0)) {
-          auto t = _subst.apply(TermList(i,false),0);
-          unsigned v;
-          if (inverse.find(t,v)) {
-            return false;
-          } else {
-            inverse.insert(t,i);
-          }
+      _subst.bdRecord(btd);
+      if (_subst.match(Kernel::TermList(r), 0, Kernel::TermList(l), 1)) {
+        if (matchAftercheck()) {
+          _subst.bdDone();
+          return true;
         }
       }
-      return true;
+
+      _subst.bdDone();
+      btd.backtrack();
+      _subst.bdRecord(btd);
+      if (l->isEquality() && r->isEquality() &&
+        _subst.match(*r->nthArgument(0), 0, *l->nthArgument(1), 1) &&
+        _subst.match(*r->nthArgument(1), 0, *l->nthArgument(0), 1))
+      {
+        if (matchAftercheck()) {
+          _subst.bdDone();
+          return true;
+        }
+      }
+      _subst.bdDone();
+      btd.backtrack();
+      return false;
     })) {
       _subst.bdDone();
       btd.backtrack();
@@ -85,7 +95,46 @@ public:
   }
 
 private:
+  bool matchAftercheck() {
+    DHMap<TermList, unsigned> inverse;
+    for (const auto& i : _varsMatched) {
+      auto t = _subst.apply(TermList(i,false),0);
+      unsigned v;
+      // we check that each variable encountered so far from
+      // the expected set is bijectively mapped to something
+      if (inverse.find(t,v)) {
+        return false;
+      } else {
+        inverse.insert(t,i);
+      }
+      // "Skolem" variables should bind to Skolem constants
+      if (i >= SKOLEM_VAR_MIN) {
+        if (t.isVar() || !env.signature->getFunction(t.term()->functor())->skolem()) {
+          return false;
+        }
+      // normal variables should bind to variables
+      } else {
+        if (t.isTerm()) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
   Kernel::RobSubstitution _subst;
+  unordered_set<unsigned> _varsMatched;
+
+  class MatchedVarBacktrackObject : public BacktrackObject {
+  public:
+    MatchedVarBacktrackObject(unordered_set<unsigned>& s, unsigned i) : _s(s), _i(i) {}
+    void backtrack() override {
+      _s.erase(_i);
+    }
+  private:
+    unordered_set<unsigned>& _s;
+    unsigned _i;
+  };
 };
 
 #define TEST_GENERATION_INDUCTION(name, ...)                                                                  \
@@ -102,25 +151,24 @@ private:
  */
 #define MY_SYNTAX_SUGAR                                                                    \
   DECL_DEFAULT_VARS                                                                        \
+  DECL_SKOLEM_VAR(skx0,0)                                                                  \
+  DECL_SKOLEM_VAR(skx1,1)                                                                  \
+  DECL_SKOLEM_VAR(skx2,2)                                                                  \
+  DECL_SKOLEM_VAR(skx3,3)                                                                  \
+  DECL_SKOLEM_VAR(skx4,4)                                                                  \
+  DECL_SKOLEM_VAR(skx5,5)                                                                  \
+  DECL_SKOLEM_VAR(skx6,6)                                                                  \
+  DECL_SKOLEM_VAR(skx7,7)                                                                  \
+  DECL_SKOLEM_VAR(skx8,8)                                                                  \
+  DECL_SKOLEM_VAR(skx9,9)                                                                  \
+  DECL_SKOLEM_VAR(skx10,10)                                                                \
+  DECL_SKOLEM_VAR(skx11,11)                                                                \
+  DECL_SKOLEM_VAR(skx12,12)                                                                \
+  DECL_SKOLEM_VAR(skx13,13)                                                                \
+  DECL_SKOLEM_VAR(skx14,14)                                                                \
   DECL_VAR(x3,3)                                                                           \
   DECL_VAR(x4,4)                                                                           \
   DECL_VAR(x5,5)                                                                           \
-  DECL_VAR(x6,6)                                                                           \
-  DECL_VAR(x7,7)                                                                           \
-  DECL_VAR(x8,8)                                                                           \
-  DECL_VAR(x9,9)                                                                           \
-  DECL_VAR(x10,10)                                                                         \
-  DECL_VAR(x11,11)                                                                         \
-  DECL_VAR(x12,12)                                                                         \
-  DECL_VAR(x13,13)                                                                         \
-  DECL_VAR(x14,14)                                                                         \
-  DECL_VAR(x15,15)                                                                         \
-  DECL_VAR(x16,16)                                                                         \
-  DECL_VAR(x17,17)                                                                         \
-  DECL_VAR(x18,18)                                                                         \
-  DECL_VAR(x19,19)                                                                         \
-  DECL_VAR(x20,20)                                                                         \
-  DECL_VAR(x21,21)                                                                         \
   DECL_SORT(s)                                                                             \
   DECL_SORT(u)                                                                             \
   DECL_SKOLEM_CONST(sK1, s)                                                                \
@@ -151,6 +199,32 @@ private:
   DECL_CONST(sK8, Int)                                                                     \
   DECL_CONST(bi, Int)
 
+TEST_FUN(test_tester) {
+  __ALLOW_UNUSED(MY_SYNTAX_SUGAR);
+  GenerationTesterInduction tester;
+  BacktrackData btd;
+  // first literal is matched both ways but none of them works
+  ASS(!tester.eq(
+    clause({ r(sK1) == r(x), f(r(sK1),y) != z }),
+    clause({ r(skx1) == r(x3), f(r(x3),x4) != x5 }),
+    btd));
+  // second clause cannot be matched because of x4
+  ASS(!tester.eq(
+    clause({ r(sK1) == r(x), f(r(sK1),y) != z }),
+    clause({ r(skx1) == r(x3), f(r(skx1),x4) != x4 }),
+    btd));
+  // y is matched to both y4 and y5
+  ASS(!tester.eq(
+    clause({ r(sK1) == r(x), f(r(sK1),y) != y }),
+    clause({ r(skx1) == r(x3), f(r(skx1),x4) != x5 }),
+    btd));
+  // normal match
+  ASS(tester.eq(
+    clause({ r(sK1) == r(x), f(r(sK1),y) != z }),
+    clause({ r(skx1) == r(x3), f(r(skx1),x4) != x5 }),
+    btd));
+}
+
 // positive literals are not considered 1
 TEST_GENERATION_INDUCTION(test_01,
     Generation::TestCase()
@@ -174,7 +248,7 @@ TEST_GENERATION_INDUCTION(test_03,
     Generation::TestCase()
       .options({ { "induction", "struct" } })
       .indices({ comparisonIndex() })
-      .input( clause({  f(sK1,x) != g(sK1) }))
+      .input( clause({  f(sK1,skx0) != g(sK1) }))
       .expected(none())
     )
 
@@ -185,10 +259,10 @@ TEST_GENERATION_INDUCTION(test_04,
       .indices({ comparisonIndex() })
       .input( clause({  ~p(f(sK1,sK2)) }))
       .expected({
-        clause({ ~p(f(b,sK2)), p(f(x,sK2)) }),
-        clause({ ~p(f(b,sK2)), ~p(f(r(x),sK2)) }),
-        clause({ ~p(f(sK1,b)), p(f(sK1,y)) }),
-        clause({ ~p(f(sK1,b)), ~p(f(sK1,r(y))) }),
+        clause({ ~p(f(b,sK2)), p(f(skx0,sK2)) }),
+        clause({ ~p(f(b,sK2)), ~p(f(r(skx0),sK2)) }),
+        clause({ ~p(f(sK1,b)), p(f(sK1,skx1)) }),
+        clause({ ~p(f(sK1,b)), ~p(f(sK1,r(skx1))) }),
       })
     )
 
@@ -199,10 +273,10 @@ TEST_GENERATION_INDUCTION(test_05,
       .indices({ comparisonIndex() })
       .input( clause({  ~p(f(sK1,sK2)) }))
       .expected({
-        clause({ x != r(r0(x)), p(f(r0(x),sK2)) }),
-        clause({ ~p(f(x,sK2)) }),
-        clause({ y != r(r0(y)), p(f(sK1,r0(y))) }),
-        clause({ ~p(f(sK1,y)) }),
+        clause({ skx0 != r(r0(skx0)), p(f(r0(skx0),sK2)) }),
+        clause({ ~p(f(skx0,sK2)) }),
+        clause({ skx1 != r(r0(skx1)), p(f(sK1,r0(skx1))) }),
+        clause({ ~p(f(sK1,skx1)) }),
       })
     )
 
@@ -228,52 +302,52 @@ TEST_GENERATION_INDUCTION(test_07,
       .input( clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }) )
       .expected({
         // sK1 100
-        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(x),f(sK2,sK4)),sK1) == g(f(sK1,f(sK2,sK3))) }),
-        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(r(x)),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(skx0),f(sK2,sK4)),sK1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(r(skx0)),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }),
 
         // sK1 010
-        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),y) == g(f(sK1,f(sK2,sK3))) }),
-        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),r(y)) != g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),skx1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),r(skx1)) != g(f(sK1,f(sK2,sK3))) }),
 
         // sK1 001
-        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(z,f(sK2,sK3))) }),
-        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(r(z),f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(skx2,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(r(skx2),f(sK2,sK3))) }),
 
         // sK1 110
-        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(x3),f(sK2,sK4)),x3) == g(f(sK1,f(sK2,sK3))) }),
-        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(r(x3)),f(sK2,sK4)),r(x3)) != g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(skx3),f(sK2,sK4)),skx3) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(sK1,f(sK2,sK3))), f(f(g(r(skx3)),f(sK2,sK4)),r(skx3)) != g(f(sK1,f(sK2,sK3))) }),
 
         // sK1 101
-        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(x4),f(sK2,sK4)),sK1) == g(f(x4,f(sK2,sK3))) }),
-        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(r(x4)),f(sK2,sK4)),sK1) != g(f(r(x4),f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(skx4),f(sK2,sK4)),sK1) == g(f(skx4,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),sK1) != g(f(b,f(sK2,sK3))), f(f(g(r(skx4)),f(sK2,sK4)),sK1) != g(f(r(skx4),f(sK2,sK3))) }),
 
         // sK1 011
-        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),x5) == g(f(x5,f(sK2,sK3))) }),
-        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),r(x5)) != g(f(r(x5),f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),skx5) == g(f(skx5,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(sK1),f(sK2,sK4)),r(skx5)) != g(f(r(skx5),f(sK2,sK3))) }),
 
         // sK1 111
-        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(x6),f(sK2,sK4)),x6) == g(f(x6,f(sK2,sK3))) }),
-        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(r(x6)),f(sK2,sK4)),r(x6)) != g(f(r(x6),f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(skx6),f(sK2,sK4)),skx6) == g(f(skx6,f(sK2,sK3))) }),
+        clause({ f(f(g(b),f(sK2,sK4)),b) != g(f(b,f(sK2,sK3))), f(f(g(r(skx6)),f(sK2,sK4)),r(skx6)) != g(f(r(skx6),f(sK2,sK3))) }),
 
         // sK2 10
-        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(x7,sK4)),sK1) == g(f(sK1,f(sK2,sK3))) }),
-        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(r(x7),sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(skx7,sK4)),sK1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(r(skx7),sK4)),sK1) != g(f(sK1,f(sK2,sK3))) }),
 
         // sK2 01
-        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(sK1,f(x8,sK3))) }),
-        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(r(x8),sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(sK1,f(skx8,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(r(skx8),sK3))) }),
 
         // sK2 11
-        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(x9,sK4)),sK1) == g(f(sK1,f(x9,sK3))) }),
-        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(r(x9),sK4)),sK1) != g(f(sK1,f(r(x9),sK3))) }),
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(skx9,sK4)),sK1) == g(f(sK1,f(skx9,sK3))) }),
+        clause({ f(f(g(sK1),f(b,sK4)),sK1) != g(f(sK1,f(b,sK3))), f(f(g(sK1),f(r(skx9),sK4)),sK1) != g(f(sK1,f(r(skx9),sK3))) }),
 
         // sK3 1
-        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,b))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(sK1,f(sK2,x10))) }),
-        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,b))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,r(x10)))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,b))), f(f(g(sK1),f(sK2,sK4)),sK1) == g(f(sK1,f(sK2,skx10))) }),
+        clause({ f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,b))), f(f(g(sK1),f(sK2,sK4)),sK1) != g(f(sK1,f(sK2,r(skx10)))) }),
 
         // sK4 1
-        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,x11)),sK1) == g(f(sK1,f(sK2,sK3))) }),
-        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,r(x11))),sK1) != g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,skx11)),sK1) == g(f(sK1,f(sK2,sK3))) }),
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,sK3))), f(f(g(sK1),f(sK2,r(skx11))),sK1) != g(f(sK1,f(sK2,sK3))) }),
       })
     )
 
@@ -285,44 +359,44 @@ TEST_GENERATION_INDUCTION(test_08,
       .input( clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,g(sK1)))) }) )
       .expected({
         // sK1
-        clause({ f(f(g(b),f(sK2,sK3)),b) != g(f(b,f(sK2,g(b)))), f(f(g(x),f(sK2,sK3)),x) == g(f(x,f(sK2,g(x)))) }),
-        clause({ f(f(g(b),f(sK2,sK3)),b) != g(f(b,f(sK2,g(b)))), f(f(g(r(x)),f(sK2,sK3)),r(x)) != g(f(r(x),f(sK2,g(r(x))))) }),
+        clause({ f(f(g(b),f(sK2,sK3)),b) != g(f(b,f(sK2,g(b)))), f(f(g(skx0),f(sK2,sK3)),skx0) == g(f(skx0,f(sK2,g(skx0)))) }),
+        clause({ f(f(g(b),f(sK2,sK3)),b) != g(f(b,f(sK2,g(b)))), f(f(g(r(skx0)),f(sK2,sK3)),r(skx0)) != g(f(r(skx0),f(sK2,g(r(skx0))))) }),
 
         // sK2
-        clause({ f(f(g(sK1),f(b,sK3)),sK1) != g(f(sK1,f(b,g(sK1)))), f(f(g(sK1),f(y,sK3)),sK1) == g(f(sK1,f(y,g(sK1)))) }),
-        clause({ f(f(g(sK1),f(b,sK3)),sK1) != g(f(sK1,f(b,g(sK1)))), f(f(g(sK1),f(r(y),sK3)),sK1) != g(f(sK1,f(r(y),g(sK1)))) }),
+        clause({ f(f(g(sK1),f(b,sK3)),sK1) != g(f(sK1,f(b,g(sK1)))), f(f(g(sK1),f(skx1,sK3)),sK1) == g(f(sK1,f(skx1,g(sK1)))) }),
+        clause({ f(f(g(sK1),f(b,sK3)),sK1) != g(f(sK1,f(b,g(sK1)))), f(f(g(sK1),f(r(skx1),sK3)),sK1) != g(f(sK1,f(r(skx1),g(sK1)))) }),
 
         // sK3
-        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),f(sK2,x3)),sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
-        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),f(sK2,r(x3))),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),f(sK2,skx3)),sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(f(g(sK1),f(sK2,b)),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),f(sK2,r(skx3))),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
 
         // g(sK1)
-        clause({ f(f(b,f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,b))), f(f(x4,f(sK2,sK3)),sK1) == g(f(sK1,f(sK2,x4))) }),
-        clause({ f(f(b,f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,b))), f(f(r(x4),f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,r(x4)))) }),
+        clause({ f(f(b,f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,b))), f(f(skx4,f(sK2,sK3)),sK1) == g(f(sK1,f(sK2,skx4))) }),
+        clause({ f(f(b,f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,b))), f(f(r(skx4),f(sK2,sK3)),sK1) != g(f(sK1,f(sK2,r(skx4)))) }),
 
         // f(sK2,sK3)
-        clause({ f(f(g(sK1),b),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),x5),sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
-        clause({ f(f(g(sK1),b),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),r(x5)),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(f(g(sK1),b),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),skx5),sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(f(g(sK1),b),sK1) != g(f(sK1,f(sK2,g(sK1)))), f(f(g(sK1),r(skx5)),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
 
         // f(g(sK1),f(sK2,sK3))
-        clause({ f(b,sK1) != g(f(sK1,f(sK2,g(sK1)))), f(x6,sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
-        clause({ f(b,sK1) != g(f(sK1,f(sK2,g(sK1)))), f(r(x6),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(b,sK1) != g(f(sK1,f(sK2,g(sK1)))), f(skx6,sK1) == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ f(b,sK1) != g(f(sK1,f(sK2,g(sK1)))), f(r(skx6),sK1) != g(f(sK1,f(sK2,g(sK1)))) }),
 
         // f(f(g(sK1),f(sK2,sK3)),sK1)
-        clause({ b != g(f(sK1,f(sK2,g(sK1)))), x7 == g(f(sK1,f(sK2,g(sK1)))) }),
-        clause({ b != g(f(sK1,f(sK2,g(sK1)))), r(x7) != g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ b != g(f(sK1,f(sK2,g(sK1)))), skx7 == g(f(sK1,f(sK2,g(sK1)))) }),
+        clause({ b != g(f(sK1,f(sK2,g(sK1)))), r(skx7) != g(f(sK1,f(sK2,g(sK1)))) }),
 
         // f(sK2,g(sK1))
-        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,b)), f(f(g(sK1),f(sK2,sK3)),sK1) == g(f(sK1,x8)) }),
-        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,b)), f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,r(x8))) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,b)), f(f(g(sK1),f(sK2,sK3)),sK1) == g(f(sK1,skx8)) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,b)), f(f(g(sK1),f(sK2,sK3)),sK1) != g(f(sK1,r(skx8))) }),
 
         // f(sK1,f(sK2,g(sK1)))
-        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(b), f(f(g(sK1),f(sK2,sK3)),sK1) == g(x9) }),
-        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(b), f(f(g(sK1),f(sK2,sK3)),sK1) != g(r(x9)) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(b), f(f(g(sK1),f(sK2,sK3)),sK1) == g(skx9) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != g(b), f(f(g(sK1),f(sK2,sK3)),sK1) != g(r(skx9)) }),
 
         // g(f(sK1,f(sK2,g(sK1))))
-        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != b, f(f(g(sK1),f(sK2,sK3)),sK1) == x10 }),
-        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != b, f(f(g(sK1),f(sK2,sK3)),sK1) != r(x10) }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != b, f(f(g(sK1),f(sK2,sK3)),sK1) == skx10 }),
+        clause({ f(f(g(sK1),f(sK2,sK3)),sK1) != b, f(f(g(sK1),f(sK2,sK3)),sK1) != r(skx10) }),
       })
     )
 
@@ -333,8 +407,8 @@ TEST_GENERATION_INDUCTION(test_09,
       .indices({ comparisonIndex() })
       .input( clause({  p(sK1) }))
       .expected({
-        clause({ p(b), ~p(x), }),
-        clause({ p(b), p(r(x)), }),
+        clause({ p(b), ~p(skx0), }),
+        clause({ p(b), p(r(skx0)), }),
       })
     )
 
@@ -345,8 +419,8 @@ TEST_GENERATION_INDUCTION(test_10,
       .indices({ comparisonIndex() })
       .input( clause({  sK1 == g(sK1) }))
       .expected({
-        clause({ b == g(b), x != g(x), }),
-        clause({ b == g(b), r(x) == g(r(x)), }),
+        clause({ b == g(b), skx0 != g(skx0), }),
+        clause({ b == g(b), r(skx0) == g(r(skx0)), }),
       })
     )
 
@@ -358,16 +432,16 @@ TEST_GENERATION_INDUCTION(test_11,
       .input( clause({  sK1 != g(sK1), p(g(sK2)), ~p(f(sK1,sK2)) }))
       .expected({
         // 1. literal sK1
-        clause({ b != g(b), x == g(x), p(g(sK2)), ~p(f(sK1,sK2)) }),
-        clause({ b != g(b), r(x) != g(r(x)), p(g(sK2)), ~p(f(sK1,sK2)) }),
+        clause({ b != g(b), skx0 == g(skx0), p(g(sK2)), ~p(f(sK1,sK2)) }),
+        clause({ b != g(b), r(skx0) != g(r(skx0)), p(g(sK2)), ~p(f(sK1,sK2)) }),
 
         // 3. literal sK1
-        clause({ ~p(f(b,sK2)), p(f(y,sK2)), p(g(sK2)), sK1 != g(sK1) }),
-        clause({ ~p(f(b,sK2)), ~p(f(r(y),sK2)), p(g(sK2)), sK1 != g(sK1) }),
+        clause({ ~p(f(b,sK2)), p(f(skx1,sK2)), p(g(sK2)), sK1 != g(sK1) }),
+        clause({ ~p(f(b,sK2)), ~p(f(r(skx1),sK2)), p(g(sK2)), sK1 != g(sK1) }),
 
         // 3. literal sK2
-        clause({ ~p(f(sK1,b)), p(f(sK1,x3)), p(g(sK2)), sK1 != g(sK1) }),
-        clause({ ~p(f(sK1,b)), ~p(f(sK1,r(x3))), p(g(sK2)), sK1 != g(sK1) }),
+        clause({ ~p(f(sK1,b)), p(f(sK1,skx2)), p(g(sK2)), sK1 != g(sK1) }),
+        clause({ ~p(f(sK1,b)), ~p(f(sK1,r(skx2))), p(g(sK2)), sK1 != g(sK1) }),
       })
     )
 
@@ -380,8 +454,8 @@ TEST_GENERATION_INDUCTION(test_12,
       .indices({ comparisonIndex() })
       .input( clause({  sK1 != g(sK1), sK2 != g(sK2) }))
       .expected({
-        clause({ b != g(b), x == g(x), sK2 != g(sK2) }),
-        clause({ b != g(b), r(x) != g(r(x)), sK2 != g(sK2) }),
+        clause({ b != g(b), skx0 == g(skx0), sK2 != g(sK2) }),
+        clause({ b != g(b), r(skx0) != g(r(skx0)), sK2 != g(sK2) }),
       })
     )
 
@@ -392,9 +466,9 @@ TEST_GENERATION_INDUCTION(test_13,
       .indices({ comparisonIndex() })
       .input( clause({ ~pi(sK6) }) )
       .expected({
-        clause({ ~pi(1), ~(x < num(1)) }),
-        clause({ ~pi(1), pi(x) }),
-        clause({ ~pi(1), ~pi(x+1) }),
+        clause({ ~pi(1), ~(skx0 < num(1)) }),
+        clause({ ~pi(1), pi(skx0) }),
+        clause({ ~pi(1), ~pi(skx0+1) }),
       })
     )
 
@@ -407,14 +481,14 @@ TEST_GENERATION_INDUCTION(test_14,
       .input( clause({ ~pi(sK6) }) )
       .expected({
         // upward induction
-        clause({ ~pi(1), ~(x < num(1)) }),
-        clause({ ~pi(1), pi(x) }),
-        clause({ ~pi(1), ~pi(x+1) }),
+        clause({ ~pi(1), ~(skx0 < num(1)) }),
+        clause({ ~pi(1), pi(skx0) }),
+        clause({ ~pi(1), ~pi(skx0+1) }),
 
         // downard induction
-        clause({ ~pi(bi), ~(bi < y) }),
-        clause({ ~pi(bi), pi(y) }),
-        clause({ ~pi(bi), ~pi(y+num(-1)) }),
+        clause({ ~pi(bi), ~(bi < skx1) }),
+        clause({ ~pi(bi), pi(skx1) }),
+        clause({ ~pi(bi), ~pi(skx1+num(-1)) }),
       })
     )
 
@@ -427,16 +501,16 @@ TEST_GENERATION_INDUCTION(test_15,
       .input( clause({ ~pi(sK6) }) )
       .expected({
         // upward induction
-        clause({ ~pi(1), ~(x < num(1)) }),
-        clause({ ~pi(1), x < bi }),
-        clause({ ~pi(1), pi(x) }),
-        clause({ ~pi(1), ~pi(x+1) }),
+        clause({ ~pi(1), ~(skx0 < num(1)) }),
+        clause({ ~pi(1), skx0 < bi }),
+        clause({ ~pi(1), pi(skx0) }),
+        clause({ ~pi(1), ~pi(skx0+1) }),
 
         // downard induction
-        clause({ ~pi(bi), num(1) < y }),
-        clause({ ~pi(bi), ~(bi < y) }),
-        clause({ ~pi(bi), pi(y) }),
-        clause({ ~pi(bi), ~pi(y+num(-1)) }),
+        clause({ ~pi(bi), num(1) < skx1 }),
+        clause({ ~pi(bi), ~(bi < skx1) }),
+        clause({ ~pi(bi), pi(skx1) }),
+        clause({ ~pi(bi), ~pi(skx1+num(-1)) }),
       })
     )
 
@@ -452,15 +526,15 @@ TEST_GENERATION_INDUCTION(test_16,
       .input( clause({ ~pi(sK6) }) )
       .expected({
         // upward induction
-        clause({ ~pi(0), ~(x < num(0)) }),
-        clause({ ~pi(0), pi(x) }),
-        clause({ ~pi(0), ~pi(x+1) }),
+        clause({ ~pi(0), ~(skx0 < num(0)) }),
+        clause({ ~pi(0), pi(skx0) }),
+        clause({ ~pi(0), ~pi(skx0+1) }),
 
         // downward induction: resulting clauses contain "0 < sK6",
         // since there is no bound to resolve it against
-        clause({ ~pi(0), ~(num(0) < y), 0 < sK6 }),
-        clause({ ~pi(0), pi(y), 0 < sK6 }),
-        clause({ ~pi(0), ~pi(y+num(-1)), 0 < sK6 }),
+        clause({ ~pi(0), ~(num(0) < skx1), 0 < sK6 }),
+        clause({ ~pi(0), pi(skx1), 0 < sK6 }),
+        clause({ ~pi(0), ~pi(skx1+num(-1)), 0 < sK6 }),
       })
     )
 
@@ -473,16 +547,16 @@ TEST_GENERATION_INDUCTION(test_17,
       .input( clause({ f(sK1,sK2) != g(sK3) }) )
       .expected({
         // sK1
-        clause({ f(b,x) != g(y), f(x3,x4) == g(x5) }),
-        clause({ f(b,x) != g(y), f(r(x3),x6) != g(x7) }),
+        clause({ f(b,skx0) != g(skx1), f(skx2,x) == g(y) }),
+        clause({ f(b,skx0) != g(skx1), f(r(skx2),skx3) != g(skx4) }),
 
         // sK2
-        clause({ f(x8,b) != g(x9), f(x10,x11) == g(x12) }),
-        clause({ f(x8,b) != g(x9), f(x13,r(x11)) != g(x14) }),
+        clause({ f(skx5,b) != g(skx6), f(z,skx7) == g(x3) }),
+        clause({ f(skx5,b) != g(skx6), f(skx8,r(skx7)) != g(skx9) }),
 
         // sK3
-        clause({ f(x15,x16) != g(b), f(x17,x18) == g(x19) }),
-        clause({ f(x15,x16) != g(b), f(x20,x21) != g(r(x19)) }),
+        clause({ f(skx10,skx11) != g(b), f(x4,x5) == g(skx12) }),
+        clause({ f(skx10,skx11) != g(b), f(skx13,skx14) != g(r(skx12)) }),
       })
     )
 
@@ -495,15 +569,15 @@ TEST_GENERATION_INDUCTION(test_18,
       .input( clause({ f(sK1,sK2) != g(sK3) }) )
       .expected({
         // sK1
-        clause({ x != r(r0(x)), f(r0(x),y) == g(z) }),
-        clause({ f(x,x4) != g(x5) }),
+        clause({ skx0 != r(r0(skx0)), f(r0(skx0),x) == g(y) }),
+        clause({ f(skx0,skx1) != g(skx2) }),
 
         // sK2
-        clause({ x6 != r(r0(x6)), f(x7,r0(x6)) == g(x8) }),
-        clause({ f(x9,x6) != g(x10) }),
+        clause({ skx3 != r(r0(skx3)), f(z,r0(skx3)) == g(x3) }),
+        clause({ f(skx4,skx3) != g(skx5) }),
 
         // sK3
-        clause({ x11 != r(r0(x11)), f(x12,x13) == g(r0(x11)) }),
-        clause({ f(x14,x15) != g(x11) }),
+        clause({ skx6 != r(r0(skx6)), f(x4,x5) == g(r0(skx6)) }),
+        clause({ f(skx7,skx8) != g(skx6) }),
       })
     )


### PR DESCRIPTION
Two issues are hopefully solved with this PR regarding unit testing `Induction`:

1. Induction introduces new Skolem symbols, which we detect by matching them to variables with a `RobSubstitution`, but we haven't really checked that these variables are indeed matched to Skolem constants. Since also variables are matched variables in case of induction hypothesis strengthening, there was a need to exactly tell what we matched. Now, there are two distinct sets of variables, one that have to bind to Skolems and one that binds to variables.
2. As explained above, we use a substitution during the permutation matching of expected and result clauses, which means we have to backtrack sometimes. So far we only backtracked the current clause match, but this was not enough and caused some flakiness, or that some orders for expected clauses did not work. Now, we can "fully backtrack" as the permutation check is given a `BacktrackData` object.

Note: The backtracking solution might be a bit over-engineered, if someone has a better and simpler idea, please share.

~~Note2: Due to a quantification bug which is to be resolved either in `Induction` or `Formula::quantify`, this PR cannot yet be merged and two unit tests are expected to fail.~~ Bug solved.

