### PR TITLE
Make TheoryInstAndSimp aware of interpreted functions it should ignore

### DIFF
--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -15,7 +15,7 @@
 #if VZ3
 #define DEBUG(...)  //DBG(__VA_ARGS__)
 
-#define DPRINT 1
+#define DPRINT 0
 
 #include "Debug/RuntimeStatistics.hpp"
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -15,7 +15,7 @@
 #if VZ3
 #define DEBUG(...)  //DBG(__VA_ARGS__)
 
-#define DPRINT 0
+#define DPRINT 1
 
 #include "Debug/RuntimeStatistics.hpp"
 
@@ -149,6 +149,17 @@ bool TheoryInstAndSimp::isSupportedLiteral(Literal* lit) {
       return false;
   }
 
+  //check if this is an interpreted predicate that is not supported by Z3Interfacing
+  switch(theory->interpretPredicate(lit->functor())){
+    case Theory::INT_IS_RAT:
+    case Theory::INT_IS_REAL:
+    case Theory::RAT_IS_RAT:
+    case Theory::RAT_IS_REAL:
+    case Theory::REAL_IS_RAT:
+    case Theory::REAL_IS_REAL:
+	return false;
+  }
+
   return true;
 }
 
@@ -167,6 +178,11 @@ bool TheoryInstAndSimp::isSupportedFunction(Theory::Interpretation itp) {
     case Theory::ARRAY_BOOL_SELECT:
     case Theory::ARRAY_SELECT:
     case Theory::ARRAY_STORE:
+    case Theory::INT_SUCCESSOR:
+    case Theory::INT_TO_INT:
+    case Theory::RAT_TO_RAT:
+    case Theory::REAL_TO_RAT:
+    case Theory::REAL_TO_REAL:
       return false;
     default: return true;
   }


### PR DESCRIPTION
Theory instantiation was treating some functions and predicates as interpreted even though they were being treated as uninterpreted by Z3Interfacing. This is unsound. It was found because equality proxy has recently been extended to make use of one of those functions (is_rat).