### PR TITLE
Make LRS also respond to instruction limit 

### DIFF
--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -819,7 +819,7 @@ bool ClauseCodeTree::ClauseMatcher::checkCandidate(Clause* cl, int& resolvedQuer
     }
     newMatches|=lm->doEagerMatching();
   }
-
+  (void)newMatches; // to prevent a warning
   return matchGlobalVars(resolvedQueryLit);
 //  return newMatches && matchGlobalVars(resolvedQueryLit);
 }

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -33,7 +33,7 @@
 #include "Timer.hpp"
 
 #define DEBUG_TIMER_CHANGES 0
-#define MILLION (1 << 20)
+#define MEGA (1 << 20)
 
 // things that need to be signal-safe because they are used in timer_sigalrm_handler
 // in principle we also need is_lock_free() to avoid deadlock as well
@@ -54,7 +54,7 @@ int Timer::s_initGuarantedMiliseconds;
 
 unsigned Timer::elapsedMegaInstructions() {
 #ifdef __linux__
-  return (last_instruction_count_read >= 0) ? last_instruction_count_read/MILLION : 0;
+  return (last_instruction_count_read >= 0) ? last_instruction_count_read/MEGA : 0;
 #else
   return 0;
 #endif
@@ -131,7 +131,7 @@ timer_sigalrm_handler (int sig)
     // to get info about instructions burned even when not instruction limiting
     read(perf_fd, &last_instruction_count_read, sizeof(long long));
     
-    if (last_instruction_count_read >= MILLION*(long long)env.options->instructionLimit()) {
+    if (last_instruction_count_read >= MEGA*(long long)env.options->instructionLimit()) {
       Timer::setLimitEnforcement(false);
       if (protectingTimeout) {
         callLimitReachedLater = 2; // 2 for an instr limit

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -33,7 +33,7 @@
 #include "Timer.hpp"
 
 #define DEBUG_TIMER_CHANGES 0
-#define MILLION 1000000
+#define MILLION (1 << 20)
 
 // things that need to be signal-safe because they are used in timer_sigalrm_handler
 // in principle we also need is_lock_free() to avoid deadlock as well
@@ -54,7 +54,7 @@ int Timer::s_initGuarantedMiliseconds;
 
 unsigned Timer::elapsedMegaInstructions() {
 #ifdef __linux__
-  return (last_instruction_count_read >= MILLION) ? last_instruction_count_read/MILLION : 0;
+  return (last_instruction_count_read >= 0) ? last_instruction_count_read/MILLION : 0;
 #else
   return 0;
 #endif

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -787,6 +787,7 @@ void SaturationAlgorithm::init()
   }
 
   _startTime=env.timer->elapsedMilliseconds();
+  _startInstrs=env.timer->elapsedMegaInstructions();
 }
 
 Clause* SaturationAlgorithm::doImmediateSimplification(Clause* cl0)

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -171,8 +171,10 @@ private:
   static SaturationAlgorithm* s_instance;
 protected:
 
-  bool _completeOptionSettings;
   int _startTime;
+  int _startInstrs;
+
+  bool _completeOptionSettings;  
   bool _clauseActivationInProgress;
 
   RCClauseStack _newClauses;

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -704,7 +704,6 @@ void Splitter::init(SaturationAlgorithm* sa)
 
   if (opts.splittingAvatimer() < 1.0) {
     _stopSplittingAtTime = opts.splittingAvatimer() * opts.timeLimitInDeciseconds() * 100;
-    _stopSplittingAtInst = 0;
 #ifdef __linux__
     _stopSplittingAtInst = opts.splittingAvatimer() * opts.instructionLimit();
 #endif

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -703,9 +703,16 @@ void Splitter::init(SaturationAlgorithm* sa)
 #endif
 
   if (opts.splittingAvatimer() < 1.0) {
-    _stopSplittingAt = opts.splittingAvatimer() * opts.timeLimitInDeciseconds() * 100;
+    _stopSplittingAtTime = opts.splittingAvatimer() * opts.timeLimitInDeciseconds() * 100;
+    _stopSplittingAtInst = 0;
+#ifdef __linux__
+    _stopSplittingAtInst = opts.splittingAvatimer() * opts.instructionLimit();
+#endif
   } else {
-    _stopSplittingAt = 0;
+    _stopSplittingAtTime = 0;
+#ifdef __linux__
+    _stopSplittingAtInst = 0;
+#endif
   }
 
   _fastRestart = opts.splittingFastRestart();
@@ -1093,7 +1100,11 @@ bool Splitter::doSplitting(Clause* cl)
   if (hasStopped) {
     return false;
   }
-  if (_stopSplittingAt && (unsigned)env.timer->elapsedMilliseconds() >= _stopSplittingAt) {
+  if (_stopSplittingAtTime && (unsigned)env.timer->elapsedMilliseconds() >= _stopSplittingAtTime
+#ifdef __linux__
+    || _stopSplittingAtInst && env.timer->elapsedMegaInstructions() >= _stopSplittingAtInst
+#endif
+    ) {
     if (_showSplitting) {
       env.beginOutput();
       env.out() << "[AVATAR] Stopping the splitting process."<< std::endl;

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -291,7 +291,12 @@ private:
   /** true if there was a refutation added to the SAT solver */
   bool _haveBranchRefutation;
 
-  unsigned _stopSplittingAt; // time elapsed in milliseconds
+  /* as there can be both limits, it's hard to covert between them,
+   * and we terminate at the earlier one, let's just keep checking both. */
+  unsigned _stopSplittingAtTime; // time elapsed in milliseconds
+#ifdef __linux__
+  unsigned _stopSplittingAtInst; // mega-instructions elapsed
+#endif
 
   bool _fastRestart; // option's value copy
   /**

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2148,7 +2148,7 @@ public:
   size_t memoryLimit() const { return _memoryLimit.actualValue; }
   void setMemoryLimitOptionValue(size_t newVal) { _memoryLimit.actualValue = newVal; }
 #ifdef __linux__
-  size_t instructionLimit() const { return _instructionLimit.actualValue; }
+  unsigned instructionLimit() const { return _instructionLimit.actualValue; }
 #endif
   int inequalitySplitting() const { return _inequalitySplitting.actualValue; }
   int ageRatio() const { return _ageWeightRatio.actualValue; }


### PR DESCRIPTION
What needs to be considered:
1) both time limit and instruction limit can be 0, which effectively stands from infinity (so it complicates the arithmetic with some if-then-elses)
2) when both limits are active, we plan to terminate when the earlier hits, so the smaller estimate is used.

(Similarly, do the same also for `avatar_turn_off_time_frac`.)