### PR TITLE
remove ARCH_X*, add static assertions to check stuff we rely on

### DIFF
--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -236,7 +236,6 @@ private:
        * to TERM_DIST_VAR_UNKNOWN if the number has not been
        * computed yet. */
       mutable unsigned distinctVars : TERM_DIST_VAR_BITS;
-      static_assert(ARCH_X64,"this version of vampire is X64 only");
       /** term id hiding in this _info */
       // this should not be removed without care,
       // otherwise the bitfield layout might shift, resulting in broken pointer tagging

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -9,6 +9,7 @@
  */
 #ifndef __Portability__
 #define __Portability__
+#include <climits>
 
 //////////////////////////////////////////////////////
 // Detect compiler
@@ -22,19 +23,18 @@
 #endif
 
 //////////////////////////////////////////////////////
-// Detect architecture
+// architecture sanity check
 
-#ifdef _LP64
-#define ARCH_X64 1
-#define ARCH_X86 0
-#elif _M_X64
-//this should handle MS C++ compiler
-#define ARCH_X64 1
-#define ARCH_X86 0
-#else
-#define ARCH_X64 0
-#define ARCH_X86 1
-#endif
+static_assert(
+    CHAR_BIT == 8,
+    "Vampire assumes that there are 8 bits in a `char`"
+);
+
+static_assert(
+    sizeof(void *) == 8,
+    "Vampire assumes that the size of a pointer is 8 bytes for efficiency reasons. "
+    "This may be fixed/relaxed in future, but for the moment expect problems if running on other architectures."
+);
 
 // enable warnings for unused results
 // C++17: replace this with [[nodiscard]]


### PR DESCRIPTION
See previous discussions about `Term`. Vampire is not especially portable, and more-or-less assumes 64-bit Intelesque platforms. We want to improve this, but in the meantime we also want to know if there's a portability hazard _before_ we get a weird bug report. Remove `ARCH_X64`, `ARCH_X32`, and statically assert that there are 8 bits in a `char` (not guaranteed!) and that pointers have 8 bytes. This is not all we assume, but it's a good start.