### PR TITLE
update CI checkout to v3, try with GCC again

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,6 +19,8 @@ jobs:
     - name: Configure Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug
+      env:
+        CXX: clang++
     - name: Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: make -j8
@@ -27,6 +29,8 @@ jobs:
     - name: Configure Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug
+      env:
+        CXX: clang++
     - name: Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: make -j8

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Tree
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         submodules: true
     - name: Check Copyright Headers
@@ -19,8 +19,6 @@ jobs:
     - name: Configure Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug
-      env:
-        CXX: clang++
     - name: Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
       run: make -j8
@@ -29,8 +27,6 @@ jobs:
     - name: Configure Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: cmake .. -DCMAKE_BUILD_TYPE=Debug
-      env:
-        CXX: clang++
     - name: Build
       working-directory: ${{runner.workspace}}/vampire/build
       run: make -j8

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -84,7 +84,7 @@ public:
   static void ensureTimerInitialized();
   static void deinitializeTimer();
   static vstring msToSecondsString(int ms);
-  static void printMSString(ostream& str, int ms);
+  static void printMSString(std::ostream& str, int ms);
 
   static void setLimitEnforcement(bool enabled)
   { s_limitEnforcement = enabled; }


### PR DESCRIPTION
There is a new version of the GitHub script that checks out the Vampire repository. Update it and see if anything breaks. Also at some point GCC broke the unit tests so we swapped to Clang, but let's see if that's still true...