### PR TITLE
Martin fix mono ep for complex sorts

### DIFF
--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -80,12 +80,9 @@ void TermSharing::setPoly()
 {
   CALL("TermSharing::setPoly()");
 
-  //combinatory superposiiton can introduce polymorphism into a 
-  //monomorphic problem
-  _poly = env.property->higherOrder() ||
-          env.property->hasPolymorphicSym() ||
-          (env.options->equalityProxy() != Options::EqualityProxy::OFF && !env.options->useMonoEqualityProxy()) ||
-          env.options->saturationAlgorithm() == Options::SaturationAlgorithm::INST_GEN;
+  //combinatory superposiiton can introduce polymorphism into a monomorphic problem
+  _poly = env.property->higherOrder() || env.property->hasPolymorphicSym() ||
+    (env.options->equalityProxy() != Options::EqualityProxy::OFF && !env.options->useMonoEqualityProxy());
 }
 
 /**

--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -84,7 +84,7 @@ void TermSharing::setPoly()
   //monomorphic problem
   _poly = env.property->higherOrder() ||
           env.property->hasPolymorphicSym() ||
-          env.options->equalityProxy() != Options::EqualityProxy::OFF ||
+          (env.options->equalityProxy() != Options::EqualityProxy::OFF && !env.options->useMonoEqualityProxy()) ||
           env.options->saturationAlgorithm() == Options::SaturationAlgorithm::INST_GEN;
 }
 

--- a/Shell/EqualityProxyMono.cpp
+++ b/Shell/EqualityProxyMono.cpp
@@ -36,7 +36,7 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
-ZIArray<unsigned> EqualityProxyMono::s_proxyPredicates;
+DHMap<TermList,unsigned> EqualityProxyMono::s_proxyPredicates;
 DHMap<unsigned,TermList> EqualityProxyMono::s_proxyPredicateSorts;
 ZIArray<Unit*> EqualityProxyMono::s_proxyPremises;
 
@@ -156,11 +156,9 @@ void EqualityProxyMono::addAxioms(UnitList*& units)
     addCongruenceAxioms(units);
   }
 
-  unsigned proxyPredArrSz = s_proxyPredicates.size();
-  for (unsigned sort=0; sort<proxyPredArrSz; sort++) {
-    if (haveProxyPredicate(sort)) {
-      addLocalAxioms(units, TermList(AtomicSort::createConstant(sort)));
-    }
+  DHMap<TermList,unsigned>::Iterator it(s_proxyPredicates);
+  while(it.hasNext()) {
+    addLocalAxioms(units, it.nextKey());
   }
 } // addAxioms
 
@@ -184,7 +182,7 @@ bool EqualityProxyMono::getArgumentEqualityLiterals(unsigned cnt, LiteralStack& 
     TermList v1(2*i, false);
     TermList v2(2*i+1, false);
     TermList sort = symbolType->arg(i);
-    if (!skipSortsWithoutEquality || haveProxyPredicate(sort.term()->functor())) {
+    if (!skipSortsWithoutEquality || haveProxyPredicate(sort)) {
       lits.push(makeProxyLiteral(false, v1, v2, sort));
       vars1.push(v1);
       vars2.push(v2);
@@ -328,10 +326,10 @@ Literal* EqualityProxyMono::apply(Literal* lit)
  * @author Andrei Voronkov
  * @since 16/05/2014 Manchester
  */
-bool EqualityProxyMono::haveProxyPredicate(unsigned sort) const
+bool EqualityProxyMono::haveProxyPredicate(TermList sort) const
 {
   CALL("EqualityProxyMono::haveProxyPredicate");
-  return s_proxyPredicates[sort] != 0;
+  return s_proxyPredicates.find(sort);
 } // haveProxyPredicate
 
 /**
@@ -345,16 +343,22 @@ unsigned EqualityProxyMono::getProxyPredicate(TermList sort)
 {
   CALL("EqualityProxyMono::getProxyPredicate");
 
-  if (s_proxyPredicates[sort.term()->functor()] != 0) {
-    return s_proxyPredicates[sort.term()->functor()];
+  unsigned pred;
+  if (s_proxyPredicates.find(sort,pred)) {
+    return pred;
   }
+
   unsigned newPred = env.signature->addFreshPredicate(2,"sQ","eqProxy");
   Signature::Symbol* predSym = env.signature->getPredicate(newPred);
   OperatorType* predType = OperatorType::getPredicateType({sort, sort});
   predSym->setType(predType);
   predSym->markEqualityProxy();
 
-  s_proxyPredicates[sort.term()->functor()] = newPred;
+  ASS(sort.isTerm());
+  ASS(sort.term()->shared());
+  ASS(sort.term()->ground());
+
+  ALWAYS(s_proxyPredicates.insert(sort,newPred));
   s_proxyPredicateSorts.insert(newPred,sort);
 
   Literal* proxyLit = Literal::create2(newPred,true,TermList(0,false),TermList(1,false));

--- a/Shell/EqualityProxyMono.hpp
+++ b/Shell/EqualityProxyMono.hpp
@@ -74,7 +74,7 @@ private:
   Literal* apply(Literal* lit);
   Literal* makeProxyLiteral(bool polarity, TermList arg0, TermList arg1, TermList sort);
 
-  bool haveProxyPredicate(unsigned sort) const;
+  bool haveProxyPredicate(TermList sort) const;
   unsigned getProxyPredicate(TermList sort);
   Clause* createEqProxyAxiom(const LiteralStack& literalIt);
 
@@ -82,11 +82,10 @@ private:
   Options::EqualityProxy _opt;
 
   /**
-   * Proxy predicate numbers for each sort. If element on at the position
-   * of a predicate is zero, it means the proxy predicate for that sort was not
-   * added yet.
+   * Proxy predicate numbers for each sort (which can be a complex term, even in mono - think arrays)
+   * but must be ground (and shared).
    */
-  static ZIArray<unsigned> s_proxyPredicates;
+  static DHMap<TermList,unsigned> s_proxyPredicates;
   /** equality proxy predicate sorts */
   static DHMap<unsigned,TermList> s_proxyPredicateSorts;
   /** array of proxy definitions E(x,y) <=> x = y  */


### PR DESCRIPTION
Fixes the bug:

SMTLIB/vampire_z3_rel_master_6127 german154.smt2 --decode dis+10_1:1_ep=RS_300
% Running in auto input_syntax mode. Trying SMTLIB2
User error: Immediate (shared) subterms of term/literal sQ18_eqProxy('chan3$1',$store(chan3,'recv_invack$i','c_msg$type'(empty,m_data($select(chan3,'recv_invack$i'))))) have different types/not well-typed!