### PR TITLE
Fix higher-order saturation

### DIFF
--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -75,6 +75,7 @@ Property::Property()
     _sortsUsed(0),
     _hasFOOL(false),
     _hasCombs(false),
+    _hasArrowSort(false),
     _hasApp(false),
     _hasAppliedVar(false),
     _hasBoolVar(false),
@@ -505,6 +506,10 @@ void Property::scanSort(TermList sort)
 
   if(sort.term()->isSuper()){
     return;
+  }
+
+  if(sort.isArrowSort()){
+    _hasArrowSort = true;
   }
 
   if(!higherOrder() && !hasPolymorphicSym()){

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -227,12 +227,14 @@ public:
   bool hasNonDefaultSorts() const { return _hasNonDefaultSorts; }
   bool hasFOOL() const { return _hasFOOL; }
   bool hasCombs() const { return _hasCombs;}
+  bool hasArrowSort() const { return _hasArrowSort; }
   bool hasApp() const { return _hasApp; }
   bool hasAppliedVar() const { return _hasAppliedVar; }
   bool hasBoolVar() const { return _hasBoolVar; }
   bool hasLogicalProxy() const { return _hasLogicalProxy; }
   bool hasPolymorphicSym() const { return _hasPolymorphicSym; }
-  bool higherOrder() const { return hasCombs() || hasApp() || hasLogicalProxy() || _hasLambda; }
+  bool higherOrder() const { return hasCombs() || hasApp() || hasLogicalProxy() ||
+                                    hasArrowSort() || _hasLambda; }
   bool quantifiesOverPolymorphicVar() const { return _quantifiesOverPolymorphicVar; }
   bool usesSort(unsigned sort) const { 
     CALL("Property::usesSort");
@@ -329,6 +331,7 @@ public:
 
   bool _hasFOOL;
   bool _hasCombs;
+  bool _hasArrowSort;
   bool _hasApp;
   bool _hasAppliedVar;
   bool _hasBoolVar;


### PR DESCRIPTION
When running on a higher-order problem, we should not saturate. This PR recognises that curried types are a higher-order feature in whose presence we should not saturate.