### PR TITLE
disequation flattening

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/BackwardSubsumptionResolution.cpp
     Inferences/BinaryResolution.cpp
     Inferences/Condensation.cpp
+    Inferences/DisequationFlattening.cpp
     Inferences/DistinctEqualitySimplifier.cpp
     Inferences/EqualityFactoring.cpp
     Inferences/EqualityResolution.cpp
@@ -434,6 +435,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/BackwardSubsumptionResolution.hpp
     Inferences/BinaryResolution.hpp
     Inferences/Condensation.hpp
+    Inferences/DisequationFlattening.hpp
     Inferences/DistinctEqualitySimplifier.hpp
     Inferences/EqualityFactoring.hpp
     Inferences/EqualityResolution.hpp

--- a/Inferences/DisequationFlattening.cpp
+++ b/Inferences/DisequationFlattening.cpp
@@ -1,0 +1,55 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+#include "Kernel/Clause.hpp"
+#include "Kernel/SortHelper.hpp"
+
+#include "DisequationFlattening.hpp"
+
+using Kernel::Clause;
+
+Inferences::DisequationFlattening::~DisequationFlattening() {}
+
+Indexing::ClauseIterator Inferences::DisequationFlattening::generateClauses(Clause *cl) {
+  for(unsigned i = 0; i < cl->size(); i++) {
+    Literal *l = cl->literals()[i];
+    if(l->isPositive() || !l->isEquality() || l->isTwoVarEquality())
+      continue;
+
+    TermList ltl = *l->nthArgument(0);
+    TermList rtl = *l->nthArgument(1);
+    if(ltl == rtl || ltl.isVar() || rtl.isVar() || !TermList::sameTopFunctor(ltl, rtl))
+      continue;
+
+    Stack<Literal *> out;
+    for(unsigned j = 0; j < i; j++)
+      out.push(cl->literals()[j]);
+
+    Term *lt = ltl.term();
+    Term *rt = rtl.term();
+    for(unsigned j = 0; j < lt->arity(); j++)
+      out.push(Literal::createEquality(
+        false,
+        *lt->nthArgument(j),
+        *rt->nthArgument(j),
+        SortHelper::getArgSort(lt, j)
+      ));
+
+    for(unsigned j = i + 1; j < cl->size(); j++)
+      out.push(cl->literals()[j]);
+
+    Clause *result = Clause::fromStack(
+      out,
+      SimplifyingInference1(InferenceRule::DISEQUATION_FLATTENING, cl)
+    );
+    return pvi(getSingletonIterator(result));
+  }
+  return ClauseIterator::getEmpty();
+}

--- a/Inferences/DisequationFlattening.cpp
+++ b/Inferences/DisequationFlattening.cpp
@@ -8,6 +8,8 @@
  * and in the source directory
  */
 
+#include "Forwards.hpp"
+
 #include "Kernel/Clause.hpp"
 #include "Kernel/SortHelper.hpp"
 
@@ -17,7 +19,7 @@ using Kernel::Clause;
 
 Inferences::DisequationFlattening::~DisequationFlattening() {}
 
-Indexing::ClauseIterator Inferences::DisequationFlattening::generateClauses(Clause *cl)
+Kernel::ClauseIterator Inferences::DisequationFlattening::generateClauses(Clause *cl)
 {
   static Stack<Clause *> results;
   static Stack<Literal *> out;

--- a/Inferences/DisequationFlattening.hpp
+++ b/Inferences/DisequationFlattening.hpp
@@ -23,6 +23,7 @@ public:
   USE_ALLOCATOR(DisequationFlattening);
 
   virtual ~DisequationFlattening();
+  static bool eligibleForFlattening(Literal *l);
   ClauseIterator generateClauses(Clause* cl);
 };
 

--- a/Inferences/DisequationFlattening.hpp
+++ b/Inferences/DisequationFlattening.hpp
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+
+#ifndef __DISEQUATION_FLATTENING_H__
+#define __DISEQUATION_FLATTENING_H__
+
+#include "InferenceEngine.hpp"
+
+namespace Inferences {
+
+class DisequationFlattening : public GeneratingInferenceEngine
+{
+public:
+  CLASS_NAME(DisequationFlattening);
+  USE_ALLOCATOR(DisequationFlattening);
+
+  virtual ~DisequationFlattening();
+  ClauseIterator generateClauses(Clause* cl);
+};
+
+};
+
+#endif /* __DISEQUATION_FLATTENING_H__ */

--- a/Inferences/EqualityResolution.cpp
+++ b/Inferences/EqualityResolution.cpp
@@ -37,6 +37,7 @@
 
 
 #include "EqualityResolution.hpp"
+#include "DisequationFlattening.hpp"
 #include "Shell/UnificationWithAbstractionConfig.hpp"
 
 #if VDEBUG
@@ -68,6 +69,9 @@ struct EqualityResolution::ResultFn
 
     ASS(lit->isEquality());
     ASS(lit->isNegative());
+
+    if(env.options->disequationFlattening() && DisequationFlattening::eligibleForFlattening(lit))
+      return 0;
 
     FuncSubtermMap funcSubtermMap;
 

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -887,6 +887,8 @@ vstring Kernel::ruleName(InferenceRule rule)
     return "global subsumption";
   case InferenceRule::SAT_INSTGEN_REFUTATION:
     return "sat instgen refutation";
+  case InferenceRule::DISEQUATION_FLATTENING:
+    return "disequation flattening";
   case InferenceRule::DISTINCT_EQUALITY_REMOVAL:
     return "distinct equality removal";
   case InferenceRule::EXTERNAL:

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -246,6 +246,8 @@ enum class InferenceRule : unsigned char {
   HYPER_SUPERPOSITION_SIMPLIFYING, // not used at the moment
   /** global subsumption */
   GLOBAL_SUBSUMPTION, // CEREFUL: the main premise is not necessarily the first one!
+  /** disequation flattening */
+  DISEQUATION_FLATTENING,
   /** distinct equality removal */
   DISTINCT_EQUALITY_REMOVAL,
   /** simplification eliminating variables by rewriting arithmetic equalities: e.g.: 6 = 3 x \/ L[x] => L[2] */

--- a/Makefile
+++ b/Makefile
@@ -297,6 +297,7 @@ VINF_OBJ=Inferences/BackwardDemodulation.o\
          Inferences/Superposition.o\
          Inferences/TautologyDeletionISE.o\
          Inferences/TermAlgebraReasoning.o\
+         Inferences/DisequationFlattening.o\
          Inferences/Induction.o\
          Inferences/InductionHelper.o\
          Inferences/URResolution.o\

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1523,7 +1523,8 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
     if(env.options->superposition()){
       gie->addFront(new Superposition());
     }
-    gie->addFront(new DisequationFlattening);
+    if(env.options->disequationFlattening())
+      gie->addFront(new DisequationFlattening);
   } else if(opt.unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF){
     gie->addFront(new EqualityResolution()); 
   }

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -48,6 +48,7 @@
 #include "Inferences/Condensation.hpp"
 #include "Inferences/FastCondensation.hpp"
 #include "Inferences/DistinctEqualitySimplifier.hpp"
+#include "Inferences/DisequationFlattening.hpp"
 
 #include "Inferences/InferenceEngine.hpp"
 #include "Inferences/BackwardDemodulation.hpp"
@@ -1522,6 +1523,7 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
     if(env.options->superposition()){
       gie->addFront(new Superposition());
     }
+    gie->addFront(new DisequationFlattening);
   } else if(opt.unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF){
     gie->addFront(new EqualityResolution()); 
   }
@@ -1786,6 +1788,7 @@ ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, cons
   if(prb.hasEquality() && env.signature->hasDistinctGroups()) {
     res->addFront(new DistinctEqualitySimplifier());
   }
+
   if(prb.hasEquality() && env.signature->hasTermAlgebras()) {
     if (opt.termAlgebraInferences()) {
       res->addFront(new DistinctnessISE());
@@ -1822,7 +1825,6 @@ ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, cons
     if (env.options->pushUnaryMinus()) {
       res->addFront(new PushUnaryMinus()); 
     }
-
   }
   if(prb.hasEquality()) {
     res->addFront(new TrivialInequalitiesRemovalISE());

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1552,6 +1552,17 @@ void Options::init()
     _extensionalityResolution.onlyUsefulWith(_inequalitySplitting.is(equal(0)));
     _extensionalityResolution.setRandomChoices({"filter","known","off","off"});
 
+    _disequationFlattening = BoolOptionValue("disequation_flattening", "df", false);
+    _disequationFlattening.description =
+      "Turns on the following inference rule:\n"
+      " f(t1, t2, ..., tn) != f(s1, s2, ..., sn) \\/ C\n"
+      "--------------------------------------------------\n"
+      " t1 != s1 \\/ t2 != s2 \\/ ... tn != sn \\/ C\n"
+      "This is not necessary, but may be helpful in some cases.\n"
+      "Unit-equality problems may have non-unit proofs with this option.";
+    _disequationFlattening.tag(OptionTag::INFERENCES);
+    _lookup.insert(&_disequationFlattening);
+
     _FOOLParamodulation = BoolOptionValue("fool_paramodulation","foolp",false);
     _FOOLParamodulation.description=
       "Turns on the following inference rule:\n"

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2258,6 +2258,7 @@ public:
   TACyclicityCheck termAlgebraCyclicityCheck() const { return _termAlgebraCyclicityCheck.actualValue; }
   unsigned extensionalityMaxLength() const { return _extensionalityMaxLength.actualValue; }
   bool extensionalityAllowPosEq() const { return _extensionalityAllowPosEq.actualValue; }
+  bool disequationFlattening() const { return _disequationFlattening.actualValue; }
   unsigned nongoalWeightCoefficientNumerator() const { return _nonGoalWeightCoefficient.numerator; }
   unsigned nongoalWeightCoefficientDenominator() const { return _nonGoalWeightCoefficient.denominator; }
   bool restrictNWCtoGC() const { return _restrictNWCtoGC.actualValue; }
@@ -2542,6 +2543,7 @@ private:
   ChoiceOptionValue<ExtensionalityResolution> _extensionalityResolution;
   UnsignedOptionValue _extensionalityMaxLength;
   BoolOptionValue _extensionalityAllowPosEq;
+  BoolOptionValue _disequationFlattening;
 
   BoolOptionValue _FOOLParamodulation;
 


### PR DESCRIPTION
Add a new inference to "flatten" disequations with the same top symbol, sometimes resulting in a smaller or more-splittable clause after simplification. I'm not aware of an existing option in Vampire to do this, but there could well be - `Injectivity` looked promising, but seems to do something HOLish and more complex. The inference can be expressed with congruence clauses injected with equality proxy, but equality proxy has its own performance characteristics. Suggestions for a better name welcome.

Naturally, this inference is not necessary: all proofs found with it can in principle be found without it. However, it's relatively cheap, simple, and it partially turns unit-equality problems into regular first-order problems that can use more of Vampire's capabilities (although you might question whether this is desirable).

I'm not sure whether this should be merged. I found quite a few problems within a few minutes of CPU time for which the eventual proof used the new inference. Of these, the unit-equality problems `GRP489-1` and `COL044-1` are of particular interest: `GRP489-1` is solved much more quickly with the new option, and `COL044-1` cannot be solved (in the default mode - the CASC portfolio gets it almost immediately by setting `-nwc 2`) without the new option, and the resulting proof constructs terms that are visibly smaller than the proof found by `-nwc 2`. If people are interested we can push this further.