### PR TITLE
CI: don't build Z3 binary

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       run: mkdir z3/build
     - name: Configure Z3 Build
       working-directory: ${{runner.workspace}}/vampire/z3/build
-      run: cmake .. -DCMAKE_BUILD_TYPE=Debug
+      run: cmake .. -DCMAKE_BUILD_TYPE=Debug -DZ3_BUILD_EXECUTABLE=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF
       env:
         CXX: clang++
     - name: Z3 Build


### PR DESCRIPTION
Z3's build system is not supposed to build the main Z3 binary if built as a submodule, but it does anyway on CI for some reason. Tell it not to for some CI speedup.