### PR TITLE
delay reporting the error until we can check instruction limiting has been actually requested

### DIFF
--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -127,7 +127,7 @@ timer_sigalrm_handler (int sig)
   }
 
 #ifdef __linux__
-  if(Timer::s_limitEnforcement && env.options->instructionLimit())) {
+  if(Timer::s_limitEnforcement && env.options->instructionLimit()) {
     if (perf_fd >= 0) {
       // we could also decide not to guard this read by env.options->instructionLimit(),
       // to get info about instructions burned even when not instruction limiting


### PR DESCRIPTION
@MichaelRawson, do you have access to a unix machine without "perf-ing" enabled? This new version should print an error there, but only once and only if `-i something_greater_zero` is requested. Cheers!