### PR TITLE
Allow loading schedule from a file

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -178,6 +178,10 @@ bool PortfolioMode::performStrategy(Shell::Property* property)
     schedules.push(main);
   }
 
+  if (all_of(schedules.begin(), schedules.end(), [](const Schedule& schedule){ return schedule.isEmpty(); })) {
+    USER_ERROR("The schedule is empty.");
+  }
+
   int remainingTime = env.remainingTime()/100;
 
   while(remainingTime > 0) {
@@ -300,6 +304,9 @@ void PortfolioMode::getSchedules(Property& prop, Schedule& quick, Schedule& fall
   CALL("PortfolioMode::getSchedules");
 
   switch(env.options->schedule()) {
+  case Options::Schedule::FILE:
+    Schedules::getScheduleFromFile(env.options->scheduleFile(), quick);
+    break;
   case Options::Schedule::CASC_2019:
   case Options::Schedule::CASC:
     Schedules::getCasc2019Schedule(prop,quick,fallback);

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -39,8 +39,8 @@ void Schedules::getScheduleFromFile(const vstring& filename, Schedule& quick)
   while (getline(schedule_file, line)) {
     // Allow structuring the schedule file with empty lines.
     // Allow documenting the schedule file with line comments.
-    // Interpret lines that start with '#' as comments.
-    if (line == "" or line[0] == '#') {
+    // Interpret lines that start with '%' as comments, following the TPTP convention.
+    if (line == "" or line[0] == '%') {
       continue;
     }
     Options opts;

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -37,6 +37,12 @@ void Schedules::getScheduleFromFile(const vstring& filename, Schedule& quick)
   ASS(schedule_file.is_open());
   vstring line;
   while (getline(schedule_file, line)) {
+    // Allow structuring the schedule file with empty lines.
+    // Allow documenting the schedule file with line comments.
+    // Interpret lines that start with '#' as comments.
+    if (line == "" or line[0] == '#') {
+      continue;
+    }
     Options opts;
     try {
       opts.readFromEncodedOptions(line);

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -16,9 +16,28 @@
 
 #include "Schedules.hpp"
 
+#include <fstream>
+
 using namespace Lib;
 using namespace Shell;
 using namespace CASC;
+
+void Schedules::getScheduleFromFile(const vstring& filename, Schedule& quick)
+{
+  if (filename == "") {
+    USER_ERROR("Schedule file was not set.");
+  }
+  BYPASSING_ALLOCATOR;
+  ifstream schedule_file (filename.c_str());
+  if (schedule_file.fail()) {
+    USER_ERROR("Cannot open schedule file: " + filename);
+  }
+  ASS(schedule_file.is_open());
+  vstring line;
+  while (getline(schedule_file, line)) {
+    quick.push(line);
+  }
+}
 
 /**
  * Get schedules for a problem of given property.

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -16,6 +16,8 @@
 
 #include "Schedules.hpp"
 
+#include "Shell/Options.hpp"
+
 #include <fstream>
 
 using namespace Lib;
@@ -35,6 +37,14 @@ void Schedules::getScheduleFromFile(const vstring& filename, Schedule& quick)
   ASS(schedule_file.is_open());
   vstring line;
   while (getline(schedule_file, line)) {
+    Options opts;
+    try {
+      opts.readFromEncodedOptions(line);
+      opts.checkGlobalOptionConstraints();
+    }
+    catch (...) {
+      USER_ERROR("Bad strategy: " + line);
+    }
     quick.push(line);
   }
 }

--- a/CASC/Schedules.hpp
+++ b/CASC/Schedules.hpp
@@ -25,6 +25,8 @@ typedef Lib::Stack<Lib::vstring> Schedule;
 class Schedules
 {
 public:
+  static void getScheduleFromFile(const vstring& filename, Schedule& quick);
+
   static void getHigherOrderSchedule2020(Schedule& quick, Schedule& fallback);
   static void getCasc2019Schedule(const Shell::Property& property, Schedule& quick, Schedule& fallback);
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -145,6 +145,7 @@ void Options::init()
          "casc_sat",
          "casc_sat_2019",
          "casc_hol_2020",
+         "file",
          "induction",
          "integer_induction",
          "ltb_default_2017",
@@ -155,9 +156,14 @@ void Options::init()
          "smtcomp",
          "smtcomp_2018",
          "struct_induction"});
-    _schedule.description = "Schedule to be run by the portfolio mode. casc and smtcomp usually point to the most recent schedule in that category. Note that some old schedules may contain option values that are no longer supported - see ignore_missing.";
+    _schedule.description = "Schedule to be run by the portfolio mode. casc and smtcomp usually point to the most recent schedule in that category. file loads the schedule from a file specified in --schedule_file. Note that some old schedules may contain option values that are no longer supported - see ignore_missing.";
     _lookup.insert(&_schedule);
     _schedule.reliesOn(UsingPortfolioTechnology());
+
+    _scheduleFile = StringOptionValue("schedule_file", "", "");
+    _scheduleFile.description = "Path to the input schedule file. Each line contains an encoded strategy. Disabled unless `--schedule file` is set.";
+    _lookup.insert(&_scheduleFile);
+    _scheduleFile.onlyUsefulWith(_schedule.is(equal(Schedule::FILE)));
 
     _multicore = UnsignedOptionValue("cores","",1);
     _multicore.description = "When running in portfolio modes (including casc or smtcomp modes) specify the number of cores, set to 0 to use maximum";

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -404,6 +404,7 @@ public:
     CASC_SAT,
     CASC_SAT_2019,
     CASC_HOL_2020,
+    FILE,
     INDUCTION,
     INTEGER_INDUCTION,
     LTB_DEFAULT_2017,
@@ -2090,6 +2091,7 @@ public:
   Schedule schedule() const { return _schedule.actualValue; }
   vstring scheduleName() const { return _schedule.getStringOfValue(_schedule.actualValue); }
   void setSchedule(Schedule newVal) {  _schedule.actualValue = newVal; }
+  vstring scheduleFile() const { return _scheduleFile.actualValue; }
   unsigned multicore() const { return _multicore.actualValue; }
   void setMulticore(unsigned newVal) { _multicore.actualValue = newVal; }
   float slowness() const {return _slowness.actualValue; }
@@ -2645,6 +2647,7 @@ private:
   UnsignedOptionValue _memoryLimit; // should be size_t, making an assumption
   ChoiceOptionValue<Mode> _mode;
   ChoiceOptionValue<Schedule> _schedule;
+  StringOptionValue _scheduleFile;
   UnsignedOptionValue _multicore;
   FloatOptionValue _slowness;
 


### PR DESCRIPTION
Call `vampire --schedule file --schedule_file schedule.txt` to load the schedule from the input file "schedule.txt". Each line of "schedule.txt" is an encoded strategy.

# Known issues
- [x] If the input schedule file contains a line that is not a valid encoding of a strategy, Vampire fails in a dirty manner.