### PR TITLE
fix bug temporarily by increasing `SPEC_UPPER_BOUND`

### DIFF
--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -92,7 +92,8 @@ bool operator<(const TermList& lhs, const TermList& rhs);
 class TermList {
 public:
   CLASS_NAME(TermList)
-  static const unsigned SPEC_UPPER_BOUND = 10000000;
+  // divide by 4 because of the tag, by 2 to split the space evenly
+  static const unsigned SPEC_UPPER_BOUND = (UINT_MAX / 4) / 2;
   /** dummy constructor, does nothing */
   TermList() {}
   /** creates a term list and initialises its content with data */


### PR DESCRIPTION
As Martin reports, we get some crashes on long runs of Vampire. The symptom is a segfault in indices where something impossible happens. It looks like it might be a double-delete or suchlike, but the problem is actually that we exceed the constant `TermList::SPEC_UPPER_BOUND` which is used to differentiate between `isSpecialVar` and `isVSpecialVar` (aside: Vampire special var? Very special var?). This has unfortunate consequences.

Fix this temporarily by increasing the constant to the midpoint of its range. Given how much time/memory even these runs use on my machine I expect this to work for at least a few years. However, it would be nice to have a proper fix. I believe @ibnyusuf introduced `VSpecialVar`s for his work with applicative encodings. Any ideas?