### PR TITLE
do not reinterpret `SkipList<T>::Node` to `List<T>`

### DIFF
--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -219,7 +219,6 @@ public:
 
 
   typedef VirtualIterator<Node**> NodeIterator;
-  typedef List<Node*> NodeList;
   class IntermediateNode;
     
     //We can remove this class once we deal with UWA uniformly for

--- a/Indexing/SubstitutionTree_FastGen.cpp
+++ b/Indexing/SubstitutionTree_FastGen.cpp
@@ -541,10 +541,10 @@ main_loop_start:
 	}
       } else {
 	ASS_EQ(parentType,SKIP_LIST)
-	NodeList* alts=static_cast<NodeList*>(currAlt);
+	auto alts = static_cast<SListIntermediateNode::NodeSkipList::Node *>(currAlt);
 	if(alts->head()->term.isVar()) {
 	  curr=alts->head();
-	  if(alts->tail() && alts->second()->term.isVar()) {
+	  if(alts->tail() && alts->tail()->head()->term.isVar()) {
 	    _alternatives.push(alts->tail());
 	    sibilingsRemain=true;
 	  } else {
@@ -675,9 +675,8 @@ bool SubstitutionTree::FastGeneralizationsIterator::enterNode(Node*& curr)
       return true;
     }
   } else {
-    NodeList* nl;
     ASS_EQ(currType, SKIP_LIST);
-    nl=static_cast<SListIntermediateNode*>(inode)->_nodes.toList();
+    auto nl=static_cast<SListIntermediateNode*>(inode)->_nodes.listLike();
     if(binding.isTerm()) {
       Node** byTop=inode->childByTop(binding, false);
       if(byTop) {

--- a/Indexing/SubstitutionTree_FastInst.cpp
+++ b/Indexing/SubstitutionTree_FastInst.cpp
@@ -746,7 +746,7 @@ main_loop_start:
 	}
       } else {
 	ASS_EQ(parentType,SKIP_LIST)
-	NodeList* alts=static_cast<NodeList*>(currAlt);
+	auto alts = static_cast<SListIntermediateNode::NodeSkipList::Node *>(currAlt);
 	ASS(alts);
 
 	curr=alts->head();
@@ -882,9 +882,8 @@ bool SubstitutionTree::FastInstancesIterator::enterNode(Node*& curr)
       return true;
     }
   } else {
-    NodeList* nl;
     ASS_EQ(currType, SKIP_LIST);
-    nl=static_cast<SListIntermediateNode*>(inode)->_nodes.toList();
+    auto nl=static_cast<SListIntermediateNode*>(inode)->_nodes.listLike();
     ASS(nl); //inode is not empty
     if(query.isTerm()) {
       //only term with the same top functor will be matched by a term

--- a/Lib/SkipList.hpp
+++ b/Lib/SkipList.hpp
@@ -49,6 +49,11 @@ public:
   public:
     Value value;
     Node* nodes[1];
+
+    // façade to look a bit like a List<Value>
+    // used by Substitution_Fast*
+    inline Value head() const { return value; }
+    inline Node *tail() const { return nodes[0]; }
   };
   /**
    * Insert an element in the skip list.
@@ -500,29 +505,9 @@ public:
     }
   }
 
-  inline
-  List<Value>* toList()
-  {
-    // TODO: just make SkipList::Node a List<Value>?
-    //!!! Assuming that SkipList::Node can be reinterpreted to List object !!!
-
-    //Compiler gives this warning here:
-    //
-    //warning: dereferencing type-punned pointer will break strict-aliasing rules
-    //
-    //It (hopefully) shouldn't cause any problems if no values get modified
-    //through pointer retrieved from this method and the underlying SkipList
-    //doesn't change either.
-    if(_left->nodes[0]) {
-      ASS_EQ(reinterpret_cast<List<Value>*&>(_left->nodes[0])->headPtr(), &_left->nodes[0]->value);
-      ASS_EQ((void*)&(reinterpret_cast<List<Value>*&>(_left->nodes[0])->tailReference()),
-	      (void*)&_left->nodes[0]->nodes[0]);
-    }
-
-
-    return reinterpret_cast<List<Value>*&>(_left->nodes[0]);
-  }
-
+  // allow iterating over something like a List<Value>
+  // used by SubstitutionTree_Fast*
+  inline Node *listLike() { return _left->nodes[0]; }
 
   /**
    * Create a skip list and initialise its left-most node to a node of the


### PR DESCRIPTION
`SkipList<T>` currently has a method `toList` that exploits the fact that `SkipList<T>::Node` has the same memory representation as `List<T>`...probably. As it happens, the consumers of this method only actually need something that looks a bit like a list.

Remove the `toList` method and replace it with a `listLike` accessor that does not do any casting. Add a couple of wrapper methods on `SkipList<T>::Node` that make it look like a `List<T>`.