### PR TITLE
disable deallocating the allocator

### DIFF
--- a/Lib/Allocator.hpp
+++ b/Lib/Allocator.hpp
@@ -230,6 +230,7 @@ public:
     /** true if it is a page allocated to store other objects */
     unsigned page : 1;
     Descriptor();
+    ~Descriptor();
 
     friend std::ostream& operator<<(std::ostream& out, const Descriptor& d);
 
@@ -425,14 +426,16 @@ std::ostream& operator<<(std::ostream& out, const Allocator::Descriptor& d);
     (Lib::Allocator::current->reallocateUnknown(obj,newsize,className))
 #define DEALLOC_UNKNOWN(obj,className)		                \
   (Lib::Allocator::current->deallocateUnknown(obj,className))
-         
-#define BYPASSING_ALLOCATOR_(SEED) Allocator::AllowBypassing _tmpBypass_##SEED;
+
+#define __CAT(x,y) x ## y
+
+#define BYPASSING_ALLOCATOR_(SEED) Allocator::AllowBypassing __CAT(_tmpBypass_, SEED);
 #define BYPASSING_ALLOCATOR BYPASSING_ALLOCATOR_(__LINE__)
 
-#define START_CHECKING_FOR_BYPASSES(SEED) Allocator::EnableBypassChecking _tmpBypass_##SEED;
+#define START_CHECKING_FOR_BYPASSES(SEED) Allocator::EnableBypassChecking __CAT(_tmpBypass_, SEED);
 #define START_CHECKING_FOR_ALLOCATOR_BYPASSES START_CHECKING_FOR_BYPASSES(__LINE__)
 
-#define STOP_CHECKING_FOR_BYPASSES(SEED) Allocator::DisableBypassChecking _tmpBypass_##SEED;
+#define STOP_CHECKING_FOR_BYPASSES(SEED) Allocator::DisableBypassChecking __CAT(_tmpBypass_, SEED);
 #define STOP_CHECKING_FOR_ALLOCATOR_BYPASSES STOP_CHECKING_FOR_BYPASSES(__LINE__)
 
 #else


### PR DESCRIPTION
We cannot make sure that static objects are being deallocated in a certain order.
This leads to the issue that on some platforms after exiting main, our allocator gets destroyed before tidying up libraries (i.e. `libz3`).
Afterwards when `libz3`'s static objects are being destroyed they attempt to call our allocator still, which leads to a segfault.
This is in particular problematic in portfolio mode because there child processes crash after finding a proof, which means that the parent process won't read the proof but think that there was none found.

This PR mitigates this issue by leaking the allocator, which is not problematic because there is only one instance per process.