### PR TITLE
Cleaning up KBO

### DIFF
--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -562,13 +562,16 @@ KBO KBO::testKBO()
 }
 
 void KBO::zeroWeightForMaximalFunc() {
+  CALL("KBO::zeroWeightForMaximalFunc");
   // actually, it's non-constant maximal func, as constants cannot be weight 0
 
   using FunctionSymbol = unsigned;
   auto nFunctions = _funcWeights._weights.size();
+  if (!nFunctions) {
+    return;
+  }
 
   FunctionSymbol maxFn = 0;
-
   for (FunctionSymbol i = 1; i < nFunctions; i++) {
     if (compareFunctionPrecedences(maxFn, i) == LESS) {
       maxFn = i;
@@ -578,14 +581,10 @@ void KBO::zeroWeightForMaximalFunc() {
   auto symb = env.signature->getFunction(maxFn);
   auto arity = symb->numTermArguments();
 
-  // skip constants here (they can't be smaller than $var)
+  // skip constants here (they mustn't be lighter than $var)
   if (arity != 0){
-    // TODO: we could also have remembered the "second largest" symbol, if a constant was the largest
-    // (but we could not use them if they were of arity 1)
-
     _funcWeights._weights[maxFn] = 0;
   }
-  
 }
 
 template<class HandleError>

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -592,8 +592,8 @@ void KBO::checkAdmissibility(HandleError handle) const
 {
   using FunctionSymbol = unsigned;
   auto nFunctions = _funcWeights._weights.size();
-  FunctionSymbol maxFn = 0;
 
+  FunctionSymbol maxFn = 0; // only properly initialized when (nFunctions > 0)
   for (FunctionSymbol i = 1; i < nFunctions; i++) {
     if (compareFunctionPrecedences(maxFn, i) == LESS) {
       maxFn = i;

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -604,9 +604,9 @@ void KBO::checkAdmissibility(HandleError handle) const
   // TODO remove unary minus check once new 
   // theory calculus goes into master
   auto isUnaryMinus = [](unsigned functor){
-    return functor == IntTraits::minusF() ||
-           functor == RatTraits::minusF() ||
-           functor == RealTraits::minusF();
+    return theory->isInterpretedFunction(functor, IntTraits::minusI) ||
+           theory->isInterpretedFunction(functor, RatTraits::minusI) ||
+           theory->isInterpretedFunction(functor, RealTraits::minusI);
   };
 
   ////////////////// check kbo-releated constraints //////////////////
@@ -961,9 +961,9 @@ bool KboSpecialWeights<FuncSigTraits>::tryGetWeight(unsigned functor, unsigned& 
   if (sym->rationalConstant()) { weight = _numRat;  return true; }
   if (sym->realConstant())     { weight = _numReal; return true; }
   if (env.options->pushUnaryMinus()) {
-    if (functor == IntTraits ::minusF()) { weight = 0; return true; }
-    if (functor == RatTraits ::minusF()) { weight = 0; return true; }
-    if (functor == RealTraits::minusF()) { weight = 0; return true; }
+    if (theory->isInterpretedFunction(functor, IntTraits ::minusI)) { weight = 0; return true; }
+    if (theory->isInterpretedFunction(functor, RatTraits ::minusI)) { weight = 0; return true; }
+    if (theory->isInterpretedFunction(functor, RealTraits::minusI)) { weight = 0; return true; }
   }
   return false;
 }

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -543,27 +543,6 @@ KBO::KBO(
 KBO KBO::testKBO() 
 {
 
-  auto funcPrec = []() -> DArray<int>{
-    unsigned num = env.signature->functions();
-    DArray<int> out(num);
-    out.initFromIterator(getRangeIterator(0u, num));
-    return out;
-  };
-
-  auto typeConPrec = []() -> DArray<int>{
-    unsigned num = env.signature->typeCons();
-    DArray<int> out(num);
-    out.initFromIterator(getRangeIterator(0u, num));
-    return out;
-  };
-
-  auto predPrec = []() -> DArray<int>{
-    unsigned num = env.signature->predicates();
-    DArray<int> out(num);
-    out.initFromIterator(getRangeIterator(0u, num));
-    return out;
-  };
-
   auto predLevels = []() -> DArray<int>{
     DArray<int> out(env.signature->predicates());
     out.init(out.size(), 1);
@@ -575,9 +554,9 @@ KBO KBO::testKBO()
 #if __KBO__CUSTOM_PREDICATE_WEIGHTS__
       KboWeightMap<PredSigTraits>::randomized(), 
 #endif
-      funcPrec(),
-      typeConPrec(),
-      predPrec(),
+      DArray<int>::fromIterator(getRangeIterator(0, (int)env.signature->functions())),
+      DArray<int>::fromIterator(getRangeIterator(0, (int)env.signature->typeCons())),
+      DArray<int>::fromIterator(getRangeIterator(0, (int)env.signature->predicates())),
       predLevels(),
       false);
 }

--- a/Kernel/KBO.hpp
+++ b/Kernel/KBO.hpp
@@ -141,6 +141,7 @@ public:
 
       // precedence ordering params
       DArray<int> funcPrec, 
+      DArray<int> typeConPrec,       
       DArray<int> predPrec, 
       DArray<int> predLevels,
 
@@ -153,7 +154,7 @@ public:
   void showConcrete(ostream&) const override;
   template<class HandleError>
   void checkAdmissibility(HandleError handle) const;
-  void zeroOutWeightForMaximalFuncs();
+  void zeroWeightForMaximalFunc();
 
   using PrecedenceOrdering::compare;
   Result compare(TermList tl1, TermList tl2) const override;

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -39,8 +39,9 @@ public:
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}
-  LPO(const DArray<int>& funcPrec, const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM) :
-    PrecedenceOrdering(funcPrec, predPrec, predLevels, reverseLCM)
+  LPO(const DArray<int>& funcPrec, const DArray<int>& typeConPrec, 
+      const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM) :
+    PrecedenceOrdering(funcPrec, typeConPrec, predPrec, predLevels, reverseLCM)
   {}
   ~LPO() override = default;
 

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -551,7 +551,7 @@ struct BoostWrapper : public SymbolComparator
 };
 
 struct OccurenceTiebreak {
-  OccurenceTiebreak(SymbolType) {} // the bool is a dummy argument, required by the template recursion convention
+  OccurenceTiebreak(SymbolType) {} // here the SymbolType is a dummy argument, required by the template recursion convention
 
   Comparison compare(unsigned s1, unsigned s2) {  return Int::compare(s1,s2); }
 };

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -361,13 +361,13 @@ Ordering::Result PrecedenceOrdering::compareFunctionPrecedences(unsigned fun1, u
   if (fun1 == fun2)
     return EQUAL;
 
-  if (fun1 == IntTraits::minusF()) { return GREATER; } 
-  if (fun1 == RatTraits::minusF()) { return GREATER; }
-  if (fun1 == RealTraits::minusF()) { return GREATER; }
+  if (theory->isInterpretedFunction(fun1, IntTraits::minusI)) { return GREATER; } 
+  if (theory->isInterpretedFunction(fun1, RatTraits::minusI)) { return GREATER; }
+  if (theory->isInterpretedFunction(fun1, RealTraits::minusI)) { return GREATER; }
 
-  if (fun2 == IntTraits::minusF()) { return LESS; }
-  if (fun2 == RatTraits::minusF()) { return LESS; }
-  if (fun2 == RealTraits::minusF()) { return LESS; }
+  if (theory->isInterpretedFunction(fun2, IntTraits::minusI)) { return LESS; }
+  if (theory->isInterpretedFunction(fun2, RatTraits::minusI)) { return LESS; }
+  if (theory->isInterpretedFunction(fun2, RealTraits::minusI)) { return LESS; }
 
   // $$false is the smallest
   if (env.signature->isFoolConstantSymbol(false,fun1)) {
@@ -706,8 +706,6 @@ PrecedenceOrdering::PrecedenceOrdering(Problem& prb, const Options& opt)
        // Make sure we (re-)compute usageCnt's for all the symbols;
        // in particular, the sP's (the Tseitin predicates) and sK's (the Skolem functions), which only exists since preprocessing.
        prb.getProperty(),
-       // also, fetch the unary minuses, we intruduce later anyway
-       (void)IntTraits::minusF(),(void)RatTraits::minusF(),(void)RealTraits::minusF(), 
        predPrecFromOpts(prb, opt)))
 {
   CALL("PrecedenceOrdering::PrecedenceOrdering(Problem&,const Options&)");

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -903,55 +903,40 @@ void PrecedenceOrdering::show(ostream& out) const
 {
   CALL("PrecedenceOrdering::show(ostream& out)");
 
-  {
-    out << "% Type constructor precedences, smallest symbols first (line format: `<name> <arity>`) " << std::endl;
-    out << "% ===== begin of type constructor precedences ===== " << std::endl;
-    DArray<unsigned> typeCons;
+  auto _show = [&](const char* precKind, unsigned cntFunctors, auto getSymbol, auto compareFunctors)
+    {
+      out << "% " << precKind << " precedences, smallest symbols first (line format: `<name> <arity>`) " << std::endl;
+      out << "% ===== begin of " << precKind << " precedences ===== " << std::endl;
+      DArray<unsigned> functors;
 
-    typeCons.initFromIterator(getRangeIterator(0u,env.signature->typeCons()),env.signature->typeCons());
-    typeCons.sort(closureComparator([&](unsigned l, unsigned r){ return intoComparison(compareFunctionPrecedences(l,r)); }));
-    for (unsigned i = 0; i < typeCons.size(); i++) {
-      auto sym = env.signature->getTypeCon(typeCons[i]);
-      out << "% " << sym->name() << " " << sym->arity() << std::endl;
-    }
+      functors.initFromIterator(getRangeIterator(0u, cntFunctors), cntFunctors);
+      functors.sort(closureComparator(compareFunctors));
+      for (unsigned i = 0; i < cntFunctors; i++) {
+        auto sym = getSymbol(functors[i]);
+        out << "% " << sym->name() << " " << sym->arity() << std::endl;
+      }
 
-    out << "% ===== end of type constructor precedences ===== " << std::endl;
-  }
+      out << "% ===== end of " << precKind << " precedences ===== " << std::endl;
 
+      out << "%" << std::endl;
+    };
 
-  {
-    out << "% Function precedences, smallest symbols first (line format: `<name> <arity>`) " << std::endl;
-    out << "% ===== begin of function precedences ===== " << std::endl;
-    DArray<unsigned> functors;
+  _show("type constructor", 
+      env.signature->typeCons(), 
+      [](unsigned f) { return env.signature->getTypeCon(f); },
+      [&](unsigned l, unsigned r){ return intoComparison(compareFunctionPrecedences(l,r)); });
 
-    functors.initFromIterator(getRangeIterator(0u,env.signature->functions()),env.signature->functions());
-    functors.sort(closureComparator([&](unsigned l, unsigned r){ return intoComparison(compareFunctionPrecedences(l,r)); }));
-    for (unsigned i = 0; i < functors.size(); i++) {
-      auto sym = env.signature->getFunction(functors[i]);
-      out << "% " << sym->name() << " " << sym->arity() << std::endl;
-    }
+  _show("function", 
+      env.signature->functions(),
+      [](unsigned f) { return env.signature->getFunction(f); },
+      [&](unsigned l, unsigned r){ return intoComparison(compareFunctionPrecedences(l,r)); }
+      );
 
-    out << "% ===== end of function precedences ===== " << std::endl;
-  }
+  _show("predicate", 
+      env.signature->predicates(),
+      [](unsigned f) { return env.signature->getPredicate(f); },
+      [&](unsigned l, unsigned r) { return Int::compare(_predicatePrecedences[l], _predicatePrecedences[r]); });
 
-  out << "%" << std::endl;
-
-  {
-    out << "% Predicate precedences, smallest symbols first (line format `<name> <arity>`) " << std::endl;
-    out << "% ===== begin of predicate precedences ===== " << std::endl;
-
-    DArray<unsigned> functors;
-    functors.initFromIterator(getRangeIterator(0u,env.signature->predicates()),env.signature->predicates());
-    functors.sort(closureComparator([&](unsigned l, unsigned r) { return Int::compare(_predicatePrecedences[l], _predicatePrecedences[r]); }));
-    for (unsigned i = 0; i < functors.size(); i++) {
-      auto sym = env.signature->getPredicate(functors[i]);
-      out << "% " << sym->name() << " " << sym->arity() << std::endl;
-    }
-
-    out << "% ===== end of predicate precedences ===== " << std::endl;
-  }
-
-  out << "%" << std::endl;
 
   {
     out << "% Predicate levels (line format: `<name> <arity> <level>`)" << std::endl;
@@ -966,7 +951,7 @@ void PrecedenceOrdering::show(ostream& out) const
       out << "% " << sym->name() << " " << sym->arity() << " " << _predicateLevels[i] << std::endl;
     }
 
-    out << "% ===== end of predicate precedences ===== " << std::endl;
+    out << "% ===== end of predicate levels ===== " << std::endl;
   }
 
   out << "%" << std::endl;

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -70,8 +70,6 @@ public:
 
   static bool isGorGEorE(Result r) { return (r == GREATER || r == GREATER_EQ || r == EQUAL); }
 
-  virtual Comparison compareFunctors(unsigned fun1, unsigned fun2) const = 0;
-
   void removeNonMaximal(LiteralList*& lits) const;
 
   static Result fromComparison(Comparison c);
@@ -133,18 +131,20 @@ class PrecedenceOrdering
 {
 public:
   Result compare(Literal* l1, Literal* l2) const override;
-  Comparison compareFunctors(unsigned fun1, unsigned fun2) const override;
   void show(ostream&) const override;
   virtual void showConcrete(ostream&) const = 0;
 
 protected:
   // l1 and l2 are not equalities and have the same predicate
   virtual Result comparePredicates(Literal* l1,Literal* l2) const = 0;
-  
-  PrecedenceOrdering(const DArray<int>& funcPrec, const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM);
+
+  PrecedenceOrdering(const DArray<int>& funcPrec, const DArray<int>& typeConPrec, 
+                     const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM);
   PrecedenceOrdering(Problem& prb, const Options& opt, const DArray<int>& predPrec);
   PrecedenceOrdering(Problem& prb, const Options& opt);
 
+
+  static DArray<int> typeConPrecFromOpts(Problem& prb, const Options& opt);
   static DArray<int> funcPrecFromOpts(Problem& prb, const Options& opt);
   static DArray<int> predPrecFromOpts(Problem& prb, const Options& opt);
   static DArray<int> predLevelsFromOptsAndPrec(Problem& prb, const Options& opt, const DArray<int>& predicatePrecedences);
@@ -165,6 +165,8 @@ protected:
   DArray<int> _predicatePrecedences;
   /** Array of function precedences */
   DArray<int> _functionPrecedences;
+  /** Array of type con precedences */
+  DArray<int> _typeConPrecedences;
 
   bool _reverseLCM;
 };

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -1760,12 +1760,20 @@ bool Theory::isInterpretedFunction(TermList t)
  * Return true iff @b t is an interpreted function interpreted
  * as @b itp
  */
+bool Theory::isInterpretedFunction(unsigned f, Interpretation itp)
+{
+  CALL("Theory::isInterpretedFunction(unsigned,Interpretation)");
+  return isInterpretedFunction(f) && interpretFunction(f)==itp;
+}
+/**
+ * Return true iff @b t is an interpreted function interpreted
+ * as @b itp
+ */
 bool Theory::isInterpretedFunction(Term* t, Interpretation itp)
 {
   CALL("Theory::isInterpretedFunction(Term*,Interpretation)");
 
-  return isInterpretedFunction(t->functor()) &&
-      interpretFunction(t)==itp;
+  return isInterpretedFunction(t->functor(), itp);
 }
 
 /**

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -483,6 +483,7 @@ public:
   bool isInterpretedFunction(unsigned func);
   bool isInterpretedFunction(Term* t);
   bool isInterpretedFunction(TermList t);
+  bool isInterpretedFunction(unsigned func, Interpretation itp);
   bool isInterpretedFunction(Term* t, Interpretation itp);
   bool isInterpretedFunction(TermList t, Interpretation itp);
 

--- a/Lib/DArray.hpp
+++ b/Lib/DArray.hpp
@@ -317,6 +317,21 @@ public:
     }
   }
 
+  template<class It>
+  static DArray fromIterator(It it, size_t count=0) {
+    CALL("DArray::fromIterator");
+
+    DArray out;
+    if (count != 0) {
+      out.initFromIterator(it, count);
+    } else if (it.knowsSize()) {
+      out.initFromIterator(it, it.size());
+    } else {
+      out.initFromIterator(it);
+    }
+    return out;
+  }
+
 
   /**
    * Sort first @b count items using @b Comparator::compare

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2268,7 +2268,7 @@ void Options::init()
     _kboMaxZero = BoolOptionValue("kbo_max_zero","kmz",false);
     _kboMaxZero.setExperimental();
     _kboMaxZero.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
-    _kboMaxZero.description="Modifies any kbo_weight_scheme by setting (for each sort) a maximal (by the precedence) function symbol to have weight 0.";
+    _kboMaxZero.description="Modifies any kbo_weight_scheme by setting the maximal (by the precedence) function symbol to have weight 0.";
     _lookup.insert(&_kboMaxZero);
 
     _kboAdmissabilityCheck = ChoiceOptionValue<KboAdmissibilityCheck>(
@@ -2308,6 +2308,11 @@ void Options::init()
     _functionWeights.setExperimental();
     _functionWeights.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
     _lookup.insert(&_functionWeights);
+
+    _typeConPrecedence = StringOptionValue("function_precendence","fp","");
+    _typeConPrecedence.description = "A name of a file with an explicit user specified precedence on type constructor symbols.";
+    _typeConPrecedence.setExperimental();
+    _lookup.insert(&_typeConPrecedence);
 
     _functionPrecedence = StringOptionValue("function_precendence","fp","");
     _functionPrecedence.description = "A name of a file with an explicit user specified precedence on function symbols.";

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2309,7 +2309,7 @@ void Options::init()
     _functionWeights.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
     _lookup.insert(&_functionWeights);
 
-    _typeConPrecedence = StringOptionValue("function_precendence","fp","");
+    _typeConPrecedence = StringOptionValue("type_con_precendence","tcp","");
     _typeConPrecedence.description = "A name of a file with an explicit user specified precedence on type constructor symbols.";
     _typeConPrecedence.setExperimental();
     _lookup.insert(&_typeConPrecedence);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2215,6 +2215,7 @@ public:
   const vstring& functionWeights() const { return _functionWeights.actualValue; }
   const vstring& predicateWeights() const { return _predicateWeights.actualValue; }
   const vstring& functionPrecedence() const { return _functionPrecedence.actualValue; }
+  const vstring& typeConPrecedence() const { return _typeConPrecedence.actualValue; }
   const vstring& predicatePrecedence() const { return _predicatePrecedence.actualValue; }
   // Return time limit in deciseconds, or 0 if there is no time limit
   int timeLimitInDeciseconds() const { return _timeLimitInDeciseconds.actualValue; }
@@ -2752,6 +2753,7 @@ private:
   ChoiceOptionValue<KboAdmissibilityCheck> _kboAdmissabilityCheck;
   StringOptionValue _functionWeights;
   StringOptionValue _predicateWeights;
+  StringOptionValue _typeConPrecedence;
   StringOptionValue _functionPrecedence;
   StringOptionValue _predicatePrecedence;
 

--- a/UnitTests/tKBO.cpp
+++ b/UnitTests/tKBO.cpp
@@ -36,6 +36,13 @@ DArray<int> predPrec() {
   return out;
 }
 
+DArray<int> typeConPrec(){
+  unsigned num = env.signature->typeCons();
+  DArray<int> out(num);
+  out.initFromIterator(getRangeIterator(0u, num));
+  return out;
+};
+
 DArray<int> predLevels() {
   DArray<int> out(env.signature->predicates());
   out.init(out.size(), 1);
@@ -79,6 +86,7 @@ KBO kbo(unsigned introducedSymbolWeight,
                env.signature->predicates()), 
 #endif
              funcPrec(), 
+             typeConPrec(),
              predPrec(), 
              predLevels(),
              /*revereseLCM*/ false);

--- a/UnitTests/tKBO.cpp
+++ b/UnitTests/tKBO.cpp
@@ -22,27 +22,6 @@
 /////////////////////////////// HELPER FUNCTIONS /////////////////////////////// 
 //////////////////////////////////////////////////////////////////////////////// 
 
-DArray<int> funcPrec() {
-  unsigned num = env.signature->functions();
-  DArray<int> out(num);
-  out.initFromIterator(getRangeIterator(0u, num));
-  return out;
-}
-
-DArray<int> predPrec() {
-  unsigned num = env.signature->predicates();
-  DArray<int> out(num);
-  out.initFromIterator(getRangeIterator(0u, num));
-  return out;
-}
-
-DArray<int> typeConPrec(){
-  unsigned num = env.signature->typeCons();
-  DArray<int> out(num);
-  out.initFromIterator(getRangeIterator(0u, num));
-  return out;
-};
-
 DArray<int> predLevels() {
   DArray<int> out(env.signature->predicates());
   out.init(out.size(), 1);
@@ -85,9 +64,9 @@ KBO kbo(unsigned introducedSymbolWeight,
                preds,
                env.signature->predicates()), 
 #endif
-             funcPrec(), 
-             typeConPrec(),
-             predPrec(), 
+             DArray<int>::fromIterator(getRangeIterator(0, (int) env.signature->functions())),
+             DArray<int>::fromIterator(getRangeIterator(0, (int) env.signature->typeCons())),
+             DArray<int>::fromIterator(getRangeIterator(0, (int) env.signature->predicates())),
              predLevels(),
              /*revereseLCM*/ false);
 }

--- a/UnitTests/tLPO.cpp
+++ b/UnitTests/tLPO.cpp
@@ -28,6 +28,13 @@ DArray<int> lpoPredPrec() {
   return out;
 }
 
+DArray<int> lpoTypeConPrec(){
+  unsigned num = env.signature->typeCons();
+  DArray<int> out(num);
+  out.initFromIterator(getRangeIterator(0u, num));
+  return out;
+};
+
 DArray<int> lpoPredLevels() {
   DArray<int> out(env.signature->predicates());
   out.init(out.size(), 1);
@@ -40,7 +47,7 @@ inline void compareTwoWays(const Ordering& ord, TermSugar t1, TermSugar t2) {
 }
 
 LPO lpo() {
-  return LPO(lpoFuncPrec(), lpoPredPrec(), lpoPredLevels(), false /* reverseLCM */);
+  return LPO(lpoFuncPrec(), lpoTypeConPrec(), lpoPredPrec(), lpoPredLevels(), false /* reverseLCM */);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/UnitTests/tLPO.cpp
+++ b/UnitTests/tLPO.cpp
@@ -14,27 +14,6 @@
 #include "Kernel/Ordering.hpp"
 #include "Kernel/Problem.hpp"
 
-DArray<int> lpoFuncPrec() {
-  unsigned num = env.signature->functions();
-  DArray<int> out(num);
-  out.initFromIterator(getRangeIterator(0u, num));
-  return out;
-}
-
-DArray<int> lpoPredPrec() {
-  unsigned num = env.signature->predicates();
-  DArray<int> out(num);
-  out.initFromIterator(getRangeIterator(0u, num));
-  return out;
-}
-
-DArray<int> lpoTypeConPrec(){
-  unsigned num = env.signature->typeCons();
-  DArray<int> out(num);
-  out.initFromIterator(getRangeIterator(0u, num));
-  return out;
-};
-
 DArray<int> lpoPredLevels() {
   DArray<int> out(env.signature->predicates());
   out.init(out.size(), 1);
@@ -47,7 +26,11 @@ inline void compareTwoWays(const Ordering& ord, TermSugar t1, TermSugar t2) {
 }
 
 LPO lpo() {
-  return LPO(lpoFuncPrec(), lpoTypeConPrec(), lpoPredPrec(), lpoPredLevels(), false /* reverseLCM */);
+  return LPO(
+      DArray<int>::fromIterator(getRangeIterator(0, (int) env.signature->functions())),
+      DArray<int>::fromIterator(getRangeIterator(0, (int) env.signature->typeCons())), 
+      DArray<int>::fromIterator(getRangeIterator(0, (int) env.signature->predicates())),
+      lpoPredLevels(), false /* reverseLCM */);
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
PR achieves the following:

- Setting different symbol precedence schemes affects type constructors as well (previously they always used default scheme)
- There can now only be a single unary function symbol of weight zero (in line with the theory). Exceptions are made for unary minus symbols until new calculus can be merged.
- For the purpose of the term ordering, a function symbol is considered constant or unary based on the number of _term_ arguments it accepts (in line with the theory).