### PR TITLE
Fix sine utils performance

### DIFF
--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -59,7 +59,7 @@ SineSymbolExtractor::SymId SineSymbolExtractor::getSymIdBound()
          max(env.signature->functions()*3, env.signature->typeCons()*3));
 }
 
-void SineSymbolExtractor::addSymIds(Term* term, Stack<SymId>& ids)
+void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId>& ids)
 {
   CALL("SineSymbolExtractor::addSymIds");
 
@@ -94,26 +94,27 @@ void SineSymbolExtractor::addSymIds(Term* term, Stack<SymId>& ids)
       }
     } else {
       //all sorts should be shared
-      ids.push(term->functor() * 3 + 1);
+      ids.insert(term->functor() * 3 + 1);
     }
-    NonVariableIterator nvi(term);
-    while (nvi.hasNext()) {
-      addSymIds(nvi.next().term(), ids);
+
+    for (auto t : concatIters(typeArgIter(term), termArgIter(term))) {
+      if (t.isTerm())
+        addSymIds(t.term(), ids);
     }
   } else {
     if(term->isSort()){
-      ids.push(term->functor() * 3 + 2);
+      ids.insert(term->functor() * 3 + 2);
     } else {
-      ids.push(term->functor() * 3 + 1);
+      ids.insert(term->functor() * 3 + 1);
     }
 
     NonVariableIterator nvi(term);
     while (nvi.hasNext()) {
       Term* t = nvi.next().term();
       if(t->isSort()){
-        ids.push(t->functor() * 3 + 2);
+        ids.insert(t->functor() * 3 + 2);
       } else {
-        ids.push(t->functor() * 3 + 1);
+        ids.insert(t->functor() * 3 + 1);
       }
     }
   }
@@ -124,12 +125,12 @@ void SineSymbolExtractor::addSymIds(Term* term, Stack<SymId>& ids)
  * @since 04/05/2013 Manchester, argument polarity removed
  * @author Andrei Voronkov
  */
-void SineSymbolExtractor::addSymIds(Literal* lit,Stack<SymId>& ids)
+void SineSymbolExtractor::addSymIds(Literal* lit,DHSet<SymId>& ids)
 {
   CALL("SineSymbolExtractor::addSymIds");
 
   SymId predId=lit->functor()*3;
-  ids.push(predId);
+  ids.insert(predId);
 
   if (!lit->shared()) {
     NonVariableIterator nvi(lit);
@@ -141,9 +142,9 @@ void SineSymbolExtractor::addSymIds(Literal* lit,Stack<SymId>& ids)
     while (nvi.hasNext()) {
       Term *t = nvi.next().term();
       if(t->isSort()){
-        ids.push(t->functor() * 3 + 2);
+        ids.insert(t->functor() * 3 + 2);
       } else {
-        ids.push(t->functor() * 3 + 1);
+        ids.insert(t->functor() * 3 + 1);
       }      
     }
   }
@@ -180,7 +181,7 @@ bool SineSymbolExtractor::validSymId(SymId s)
  * @since 04/05/2013 Manchester, argument polarity removed, made non-recursive
  * @author Andrei Voronkov
  */
-void SineSymbolExtractor::extractFormulaSymbols(Formula* f,Stack<SymId>& itms)
+void SineSymbolExtractor::extractFormulaSymbols(Formula* f,DHSet<SymId>& itms)
 {
   CALL("SineSymbolExtractor::extractFormulaSymbols");
   Stack<Formula*> fs;
@@ -238,7 +239,7 @@ SineSymbolExtractor::SymIdIterator SineSymbolExtractor::extractSymIds(Unit* u)
 {
   CALL("SineSymbolExtractor::extractSymIds");
 
-  static Stack<SymId> itms;
+  static DHSet<SymId> itms;
   itms.reset();
 
   if (u->isClause()) {
@@ -252,7 +253,11 @@ SineSymbolExtractor::SymIdIterator SineSymbolExtractor::extractSymIds(Unit* u)
     FormulaUnit* fu=static_cast<FormulaUnit*>(u);
     extractFormulaSymbols(fu->formula(),itms);
   }
-  return pvi( getUniquePersistentIterator(Stack<SymId>::Iterator(itms)) );
+  Stack<SymId> ids(itms.size());
+  DHSet<SymId>::Iterator iter(itms);
+  ids.loadFromIterator(iter);
+  std::sort(ids.begin(), ids.end()); // <- make order deterministic
+  return pvi(ownedArrayishIterator(std::move(ids)));
 }
 
 void SineBase::initGeneralityFunction(UnitList* units)

--- a/Shell/SineUtils.hpp
+++ b/Shell/SineUtils.hpp
@@ -38,9 +38,9 @@ public:
   static void decodeSymId(SymId s, bool& pred, unsigned& functor);
   bool validSymId(SymId s);
 private:
-  void addSymIds(Term* term,Stack<SymId>& ids);
-  void addSymIds(Literal* lit,Stack<SymId>& ids);
-  void extractFormulaSymbols(Formula* f,Stack<SymId>& itms);
+  void addSymIds(Term* term,DHSet<SymId>& ids);
+  void addSymIds(Literal* lit,DHSet<SymId>& ids);
+  void extractFormulaSymbols(Formula* f,DHSet<SymId>& itms);
 };
 
 


### PR DESCRIPTION
Fixes a subtle but massive performance bug in `Shell/SineUtils` for formulas.
The issue is that for "special", i.e. formula terms `void SineSymbolExtractor::addSymIds(Term* term, Stack<SymId>& ids)`, calls itself recursively for every subterm of a term, which results in factorial runtime. 
This PR fixes this behaviour, by only calling it recursively for every immediate subterm, yielding the same result with linear runtime. 

Additionally the symbols are being collected into a `DHSet`, instead of a `Stack` now, in order to save memory. This was changed as the bug first showed up as an out-of-memory bug, which was resolved by this change.


A toy example that shows the performance boost is running `$vampire --input_syntax smtlib2 sine-utils-performance.smt2 -s2a on -t 60 -newcnf on` on this benchmark:
```

(set-info :smt-lib-version 2.6)
(set-logic UFLIA)
(assert 
(let (

  (?v_0 true) 
  (?v_1 true) 
  (?v_2 true) 
  (?v_3 true) 
  (?v_4 true) 
  (?v_5 true) 
  (?v_6 true) 
  (?v_7 true) 
  (?v_8 true) 
  (?v_9 true) 
  (?v_10 true) 
  (?v_11 true) 
  (?v_12 true) 
  (?v_13 true) 
  (?v_14 true) 
  (?v_15 true) 
  (?v_16 true) 
  (?v_17 true) 
  (?v_18 true) 
  (?v_19 true) 
  (?v_20 true) 
  (?v_21 true) 
  (?v_22 true) 
  (?v_23 true) 

  ) true))
(check-sat)
(exit)
```

On master (in debug mode) we get:
```
...
% Time elapsed: 31.170 s
...
```
(Note that adding another let variable in the benchmark ~doubles runtime here.)
On the branch we now get:
```
...
% Time elapsed: 0.010 s
...
```

Before merging we should consider how this interferes with current schedules. I came across this bug, because running vvampire in portfolio gave an an out of memory for one of the strategies in the schedule. This means there were some strategies in there that were never correctly executed. That is they might have exited early due to out of memory, instead of taking their whole runtime slice, which could quite change the performance of the overall schedules i think.