### PR TITLE
Encompassment demodulation check (as an option)

### DIFF
--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -86,7 +86,9 @@ bool ResultSubstitution::isRenamingOn(TermList t, bool result)
       // code trees don't implement general apply, but satisfy the assertion which makes the following OK
       vSubst = applyToBoundResult(v);
     } else {
-      ASSERTION_VIOLATION;
+      ASS(isIdentityOnResultWhenQueryBound());
+      // the above holds, for a change, for the used substitution trees
+      vSubst = applyToBoundQuery(v);
     }
     if (!vSubst.isVar()) {
       return false;

--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -14,6 +14,7 @@
 
 #include "Kernel/RobSubstitution.hpp"
 #include "Kernel/SubstHelper.hpp"
+#include "Kernel/TermIterators.hpp"
 
 #include "ResultSubstitution.hpp"
 
@@ -68,6 +69,35 @@ ResultSubstitutionSP ResultSubstitution::fromSubstitution(RobSubstitution* s, in
   return ResultSubstitutionSP(new RSProxy(s, queryBank, resultBank));
 }
 
+bool ResultSubstitution::isRenamingOn(TermList t, bool result) 
+{
+  CALL("ResultSubstitution::isRenamingOn");
+
+  DHMap<TermList,TermList> renamingInMaking;
+
+  VariableIterator it(t);
+  while(it.hasNext()) {
+    TermList v = it.next();
+    ASS(v.isVar());
+
+    TermList vSubst;
+    if (result) {
+      ASS(isIdentityOnQueryWhenResultBound());
+      // code trees don't implement general apply, but satisfy the assertion which makes the following OK
+      vSubst = applyToBoundResult(v);
+    } else {
+      ASSERTION_VIOLATION;
+    }
+    if (!vSubst.isVar()) {
+      return false;
+    }
+    TermList vStored;
+    if (!renamingInMaking.findOrInsert(v,vStored,vSubst) && vStored != vSubst) {
+      return false;
+    }
+  }
+  return true;
+}
 
 /////////////////////////
 // IdentitySubstitution

--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -69,6 +69,11 @@ ResultSubstitutionSP ResultSubstitution::fromSubstitution(RobSubstitution* s, in
   return ResultSubstitutionSP(new RSProxy(s, queryBank, resultBank));
 }
 
+/**
+ * Test whether this substitution object is a renaming on the variables of @param t
+ * @param result indicates whether we mean the "bank" applied 
+ * to a result term or a query one (cf. applyToQuery/applyToResult)
+ */
 bool ResultSubstitution::isRenamingOn(TermList t, bool result) 
 {
   CALL("ResultSubstitution::isRenamingOn");

--- a/Indexing/ResultSubstitution.hpp
+++ b/Indexing/ResultSubstitution.hpp
@@ -61,12 +61,15 @@ public:
   template<typename T>
   T apply(T t, bool result)
   {
+    CALL("ResultSubstitution::apply")
     if(result) {
       return applyToResult(t);
     } else {
       return applyToQuery(t);
     }
   }
+
+  bool isRenamingOn(TermList t, bool result);
 
   /** if implementation cannot easily give result for this, zero is returned */
   template<typename T>

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -242,7 +242,7 @@ private:
   bool _encompassing;
 
   BackwardDemodulation& _parent;
-  Ordering& _ordering;  
+  Ordering& _ordering;
 };
 
 

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -96,6 +96,7 @@ struct BackwardDemodulation::ResultFn
     _eqLit=(*_cl)[0];
     _eqSort = SortHelper::getEqualityArgumentSort(_eqLit);
     _removed=SmartPtr<ClauseSet>(new ClauseSet());
+    _encompassing = parent.getOptions().demodulationEncompassment();
   }
   /**
    * Return pair of clauses. First clause is being replaced,
@@ -168,32 +169,41 @@ struct BackwardDemodulation::ResultFn
     }
 
     if(_parent.getOptions().demodulationRedundancyCheck() && qr.literal->isEquality() &&
-      (qr.term==*qr.literal->nthArgument(0) || qr.term==*qr.literal->nthArgument(1)) ) {
+      (qr.term==*qr.literal->nthArgument(0) || qr.term==*qr.literal->nthArgument(1)) && 
+      // encompassment has issues only with positive units
+      (!_encompassing || (qr.literal->isPositive() && qr.clause->length() == 1))) {
       TermList other=EqHelper::getOtherEqualitySide(qr.literal, qr.term);
       Ordering::Result tord=_ordering.compare(rhsS, other);
       if(tord!=Ordering::LESS && tord!=Ordering::LESS_EQ) {
-        TermList eqSort = SortHelper::getEqualityArgumentSort(qr.literal);
-        Literal* eqLitS=Literal::createEquality(true, lhsS, rhsS, eqSort);
-        bool isMax=true;
-        Clause::Iterator cit(*qr.clause);
-        while(cit.hasNext()) {
-          Literal* lit2=cit.next();
-          if(qr.literal==lit2) {
-            continue;
+        if (_encompassing) {
+          if (qr.substitution->isRenamingOn(lhs,false /* we talk of a non-result, i.e., a query term */)) {
+            // under _encompassing, we know there are no other literals in qr.clause
+            return BwSimplificationRecord(0);
           }
-          if(_ordering.compare(eqLitS, lit2)==Ordering::LESS) {
-            isMax=false;
-            break;
+        } else {
+          TermList eqSort = SortHelper::getEqualityArgumentSort(qr.literal);
+          Literal* eqLitS=Literal::createEquality(true, lhsS, rhsS, eqSort);
+          bool isMax=true;
+          Clause::Iterator cit(*qr.clause);
+          while(cit.hasNext()) {
+            Literal* lit2=cit.next();
+            if(qr.literal==lit2) {
+              continue;
+            }
+            if(_ordering.compare(eqLitS, lit2)==Ordering::LESS) {
+              isMax=false;
+              break;
+            }
           }
-        }
-        if(isMax) {
-          //	  RSTAT_CTR_INC("bw subsumptions prevented by tlCheck");
-          //The demodulation is this case which doesn't preserve completeness:
-          //s = t     s = t1 \/ C
-          //---------------------
-          //     t = t1 \/ C
-          //where t > t1 and s = t > C
-          return BwSimplificationRecord(0);
+          if(isMax) {
+            //	  RSTAT_CTR_INC("bw subsumptions prevented by tlCheck");
+            //The demodulation is this case which doesn't preserve completeness:
+            //s = t     s = t1 \/ C
+            //---------------------
+            //     t = t1 \/ C
+            //where t > t1 and s = t > C
+            return BwSimplificationRecord(0);
+          }
         }
       }
     }
@@ -229,8 +239,10 @@ private:
   Clause* _cl;
   SmartPtr<ClauseSet> _removed;
 
+  bool _encompassing;
+
   BackwardDemodulation& _parent;
-  Ordering& _ordering;
+  Ordering& _ordering;  
 };
 
 

--- a/Inferences/ForwardDemodulation.cpp
+++ b/Inferences/ForwardDemodulation.cpp
@@ -192,7 +192,7 @@ bool ForwardDemodulationImpl<combinatorySupSupport>::perform(Clause* cl, Clause*
           Ordering::Result tord=ordering.compare(rhsS, other);
           if(tord!=Ordering::LESS && tord!=Ordering::LESS_EQ) {
             if (_encompassing) {
-              // last chance, if the matcher is a renaming
+              // last chance, if the matcher is not a renaming
               if (qr.substitution->isRenamingOn(qr.term,true /* we talk of result term */)) {
                 continue; // under _encompassing, we know there are no other literals in cl
               }

--- a/Inferences/ForwardDemodulation.hpp
+++ b/Inferences/ForwardDemodulation.hpp
@@ -40,6 +40,7 @@ public:
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override = 0;
 protected:
   bool _preorderedOnly;
+  bool _encompassing;
   DemodulationLHSIndex* _index;
 };
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1518,6 +1518,15 @@ void Options::init()
     _demodulationRedundancyCheck.addProblemConstraint(hasEquality());
     _demodulationRedundancyCheck.setRandomChoices({"on","off"});
 
+    _demodulationEncompassment = BoolOptionValue("demodulation_encompassment","de",false);
+    _demodulationEncompassment.description= "Treat demodulations (both forward and backward) as encompassment demodulations (as defined by Duarte and Korovin around 2022)";
+    _lookup.insert(&_demodulationEncompassment);
+    _demodulationEncompassment.tag(OptionTag::INFERENCES);
+    _demodulationEncompassment.onlyUsefulWith(InferencingSaturationAlgorithm());
+    _demodulationEncompassment.onlyUsefulWith(Or(_forwardDemodulation.is(notEqual(Demodulation::OFF)),_backwardDemodulation.is(notEqual(Demodulation::OFF))));
+    _demodulationEncompassment.onlyUsefulWith(_demodulationRedundancyCheck.is(equal(true)));
+    _demodulationEncompassment.addProblemConstraint(hasEquality());
+    _demodulationEncompassment.setRandomChoices({"on","off"});
 
     _extensionalityAllowPosEq = BoolOptionValue( "extensionality_allow_pos_eq","",false);
     _extensionalityAllowPosEq.description="If extensionality resolution equals filter, this dictates"

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1519,7 +1519,7 @@ void Options::init()
     _demodulationRedundancyCheck.setRandomChoices({"on","off"});
 
     _demodulationEncompassment = BoolOptionValue("demodulation_encompassment","de",false);
-    _demodulationEncompassment.description= "Treat demodulations (both forward and backward) as encompassment demodulations (as defined by Duarte and Korovin around 2022)";
+    _demodulationEncompassment.description= "Treat demodulations (both forward and backward) as encompassment demodulations (as defined by Duarte and Korovin in 2022's IJCAR paper)";
     _lookup.insert(&_demodulationEncompassment);
     _demodulationEncompassment.tag(OptionTag::INFERENCES);
     _demodulationEncompassment.onlyUsefulWith(InferencingSaturationAlgorithm());

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2192,6 +2192,7 @@ public:
   //void setArityCheck(bool newVal) { _arityCheck=newVal; }
   Demodulation backwardDemodulation() const { return _backwardDemodulation.actualValue; }
   bool demodulationRedundancyCheck() const { return _demodulationRedundancyCheck.actualValue; }
+  bool demodulationEncompassment() const { return _demodulationEncompassment.actualValue; }
   //void setBackwardDemodulation(Demodulation newVal) { _backwardDemodulation = newVal; }
   Subsumption backwardSubsumption() const { return _backwardSubsumption.actualValue; }
   //void setBackwardSubsumption(Subsumption newVal) { _backwardSubsumption = newVal; }
@@ -2540,6 +2541,7 @@ private:
   ChoiceOptionValue<Condensation> _condensation;
 
   BoolOptionValue _demodulationRedundancyCheck;
+  BoolOptionValue _demodulationEncompassment;
 
   ChoiceOptionValue<EqualityProxy> _equalityProxy;
   BoolOptionValue _useMonoEqualityProxy;


### PR DESCRIPTION
Implements the encompassment demodulation checks according to 

André Duarte, Konstantin Korovin:
[Ground Joinability and Connectedness in the Superposition Calculus.](https://link.springer.com/chapter/10.1007/978-3-031-10769-6_11) IJCAR 2022: 169-187

After some experiments with casc mode (2minutes 8 cores) on the 869 problems from the union of FOF 2020+2021, I got a greedy cover with
FOF_encompassment6348_casc_fwd-de-on.pkl contributes 781 total 781
FOF_encompassment6351_casc_bwd-de-on.pkl contributes 7 total 777
FOF_encompassment6349_casc_both-de-on.pkl contributes 3 total 779
FOF_encompassment6346_casc.pkl contributes 2 total 776
Total 793
So an overall improvement (of a portfolio!) and quite a few new problems solved as well. (Expected to have impact on UEQ as well.)