### PR TITLE
Adding a coefficient/option for tweaking LRS' aggressiveness

### DIFF
--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -107,6 +107,7 @@ long long LRS::estimatedReachableCount()
   // time spent in saturation (preprocessing is excluded)
   long long timeSpent=currTime-_startTime; // (in milliseconds) 
   int opt_timeLimitDeci = _opt.timeLimitInDeciseconds();
+  float correction_coef = _opt.lrsEstimateCorrectionCoef();
   int firstCheck=_opt.lrsFirstTimeCheck(); // (in percent)!
 
   unsigned opt_instruction_limit = 0; // (in mega-instructions)
@@ -144,11 +145,11 @@ long long LRS::estimatedReachableCount()
     // note that result is -1 here already
 
     if(timeLeft > 0) {      
-      result = (processed*timeLeft)/timeSpent;
+      result = correction_coef*(processed*timeLeft)/timeSpent;
     } // otherwise, it's somehow past the deadline, or no timilimit set
     
     if (instrsLeft > 0) {
-      long long res_by_instr = (processed*instrsLeft)/instrsBurned;
+      long long res_by_instr = correction_coef*(processed*instrsLeft)/instrsBurned;
       if (result > 0) {
         result = std::min(result,res_by_instr);
       } else {

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1093,7 +1093,7 @@ void Options::init()
     _simulatedTimeLimit.tag(OptionTag::LRS);
 
     _lrsEstimateCorrectionCoef = FloatOptionValue("lrs_estimate_correction_coef","lecc",1.0);
-    _lrsEstimateCorrectionCoef.description = "Make lrs more (<1.0) or less (>1.0) agressive by multiplying this coef its estimate of how many clauses are still reachable.";
+    _lrsEstimateCorrectionCoef.description = "Make lrs more (<1.0) or less (>1.0) agressive by multiplying by this coef its estimate of how many clauses are still reachable.";
     _lookup.insert(&_lrsEstimateCorrectionCoef);
     _lrsEstimateCorrectionCoef.tag(OptionTag::SATURATION);
     _lrsEstimateCorrectionCoef.addConstraint(greaterThan(0.0f));

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1092,6 +1092,13 @@ void Options::init()
     _lookup.insert(&_simulatedTimeLimit);
     _simulatedTimeLimit.tag(OptionTag::LRS);
 
+    _lrsEstimateCorrectionCoef = FloatOptionValue("lrs_estimate_correction_coef","lecc",1.0);
+    _lrsEstimateCorrectionCoef.description = "Make lrs more (<1.0) or less (>1.0) agressive by multiplying this coef its estimate of how many clauses are still reachable.";
+    _lookup.insert(&_lrsEstimateCorrectionCoef);
+    _lrsEstimateCorrectionCoef.tag(OptionTag::SATURATION);
+    _lrsEstimateCorrectionCoef.addConstraint(greaterThan(0.0f));
+    _lrsEstimateCorrectionCoef.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
+    _lrsEstimateCorrectionCoef.setRandomChoices({"1.0","1.1","1.2","0.9","0.8"});
 
   //*********************** Inferences  ***********************
 

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2205,6 +2205,7 @@ public:
   int lookaheadDelay() const { return _lookaheadDelay.actualValue; }
   int simulatedTimeLimit() const { return _simulatedTimeLimit.actualValue; }
   void setSimulatedTimeLimit(int newVal) { _simulatedTimeLimit.actualValue = newVal; }
+  float lrsEstimateCorrectionCoef() const { return _lrsEstimateCorrectionCoef.actualValue; }
   TermOrdering termOrdering() const { return _termOrdering.actualValue; }
   SymbolPrecedence symbolPrecedence() const { return _symbolPrecedence.actualValue; }
   SymbolPrecedenceBoost symbolPrecedenceBoost() const { return _symbolPrecedenceBoost.actualValue; }
@@ -2722,6 +2723,7 @@ private:
   BoolOptionValue _fixUWA;
   BoolOptionValue _useACeval;
   TimeLimitOptionValue _simulatedTimeLimit;
+  FloatOptionValue _lrsEstimateCorrectionCoef;
   UnsignedOptionValue _sineDepth;
   UnsignedOptionValue _sineGeneralityThreshold;
   UnsignedOptionValue _sineToAgeGeneralityThreshold;


### PR DESCRIPTION
Sometimes LRS throws away clauses and finishes too early. Some other times, maybe interesting problems could be solved by more aggressive discarding? This is a trivial modification of LRS' estimate (multiply it by a float, by default of value 1.0) which allows us to tweak this. With coef -> \infty, LRS -> otter. 

Some greedy cover results (on my now usual 870 FOF 2020+2021 casc problems) with a casc mode (2minutes 8cores):
FOF_master6348_casc.pkl contributes 776 total 776
FOF_6348lecc_casc_lecc1.2.pkl contributes 5 total 776
FOF_6348lecc_casc_lecc0.8.pkl contributes 2 total 776
FOF_6348lecc_casc_lecc0.9.pkl contributes 2 total 774
FOF_6348lecc_casc_lecc1.1.pkl contributes 1 total 776
Total 786
So some potential for strategy building is here...