### PR TITLE
stacktrace without `CALL`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,8 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_ENABLE_EXPORTS ON)
-
 # configure compilers
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
-  add_compile_options(-ggdb)
   add_compile_options(-Wall)
   # we don't use multithreading in (mainline!) Vampire
   add_compile_options(-fno-threadsafe-statics)
@@ -44,6 +41,12 @@ if (NOT BUILD_SHARED_LIBS)
   set(CMAKE_EXE_LINKER_FLAGS -static)
   set(VAMPIRE_BINARY_STATIC _static)
 endif()
+
+# get symbol names in binary for backtraces
+set(CMAKE_ENABLE_EXPORTS ON)
+
+# link to libdl for dladdr() on POSIXy things, used for backtraces
+link_libraries(${CMAKE_DL_LIBS})
 
 # We compile tests only in debug mode, since in release mode assertions are NOPs anyways.
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
@@ -913,10 +916,6 @@ if (COMPILE_TESTS)
   endforeach()
 
 endif() # COMPILE_TESTS
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  link_libraries(${CMAKE_DL_LIBS})
-endif()
 
 #################################################################
 # automated generation of Vampire revision information from git #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,11 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_ENABLE_EXPORTS ON)
+
 # configure compilers
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
+  add_compile_options(-ggdb)
   add_compile_options(-Wall)
   # we don't use multithreading in (mainline!) Vampire
   add_compile_options(-fno-threadsafe-statics)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -911,6 +911,10 @@ if (COMPILE_TESTS)
 
 endif() # COMPILE_TESTS
 
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  link_libraries(${CMAKE_DL_LIBS})
+endif()
+
 #################################################################
 # automated generation of Vampire revision information from git #
 #################################################################

--- a/Debug/Assertion.cpp
+++ b/Debug/Assertion.cpp
@@ -45,12 +45,12 @@ void reportSpiderFail();
 void Assertion::violated(const char* file, int line, const char* cond)
 {
   if (outputAllowed(true)) {
-    cout << "Condition in file " << file << ", line " << line
+    std::cout << "Condition in file " << file << ", line " << line
          << " violated:\n"
          << cond << "\n"
          << "----- stack dump -----\n";
-    Tracer::printStack(cout);
-    cout << "----- end of stack dump -----" << endl;
+    Tracer::printStack(std::cout);
+    std::cout << "----- end of stack dump -----" << std::endl;
   }
   abortAfterViolation();
 } // Assertion::violated
@@ -65,7 +65,7 @@ void Assertion::violatedStrEquality(const char* file, int line, const char* val1
               << val1Str << " == \"" << val1 << "\"\n"
               << val2Str << " == \"" << val2 << "\"\n"
               << "----- stack dump -----\n";
-    Tracer::printStack(cout);
+    Tracer::printStack(std::cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
@@ -78,7 +78,7 @@ void Assertion::checkType(const char* file, int line, const void* ptr, const cha
 
   if (!desc) {
     if (outputAllowed(true)) {
-      cout << "Type condition in file " << file << ", line " << line
+      std::cout << "Type condition in file " << file << ", line " << line
            << " violated:\n"
            << ptrStr << " was not allocated by Lib::Allocator.\n";
     }
@@ -86,7 +86,7 @@ void Assertion::checkType(const char* file, int line, const void* ptr, const cha
   else if (!USE_PRECISE_CLASS_NAMES && strcmp(assumed, desc->cls)) {
     //TODO: the use of precise class names disrupts the check, fix it in the future!
     if (outputAllowed(true)) {
-      cout << "Type condition in file " << file << ", line " << line
+      std::cout << "Type condition in file " << file << ", line " << line
            << " violated:\n"
            << ptrStr << " was allocated as \"" << desc->cls
            << "\" instead of \"" << assumed << "\".\n";
@@ -94,7 +94,7 @@ void Assertion::checkType(const char* file, int line, const void* ptr, const cha
   }
   else if (!desc->allocated) {
     if (outputAllowed(true)) {
-      cout << "Type condition in file " << file << ", line " << line
+      std::cout << "Type condition in file " << file << ", line " << line
            << " violated:\n"
            << ptrStr << " was allocated as \"" << desc->cls
            << "\", but no longer is.\n";
@@ -105,9 +105,9 @@ void Assertion::checkType(const char* file, int line, const void* ptr, const cha
   }
 
   if (outputAllowed(true)) {
-    cout << "----- stack dump -----\n";
-    Tracer::printStack(cout);
-    cout << "----- end of stack dump -----\n";
+    std::cout << "----- stack dump -----\n";
+    Tracer::printStack(std::cout);
+    std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violated
@@ -119,7 +119,7 @@ void Assertion::checkType(const char* file, int line, const void* ptr, const cha
 void Assertion::reportAssertValidException(const char* file, int line, const char* obj)
 {
   if (outputAllowed(true)) {
-    cout << "An exception was thrown by ASSERT_VALID on object " << obj
+    std::cout << "An exception was thrown by ASSERT_VALID on object " << obj
          << " in file " << file << ", line " << line << ".\n";
   }
   abortAfterViolation();

--- a/Debug/Assertion.hpp
+++ b/Debug/Assertion.hpp
@@ -236,13 +236,13 @@ void Debug::Assertion::violated(const char* file, int line, const char* cond,
                                 const T& rep, const char* repStr)
 {
   if (Shell::outputAllowed(true)) {
-    cout << "Condition in file " << file << ", line " << line
+    std::cout << "Condition in file " << file << ", line " << line
          << " violated:\n"
          << cond << "\n"
          << "Value of " << repStr << " is: " << rep
          << "\n----- stack dump -----\n";
-    Tracer::printStack(cout);
-    cout << "----- end of stack dump -----\n";
+    Tracer::printStack(std::cout);
+    std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violated
@@ -252,14 +252,14 @@ void Debug::Assertion::violated(const char* file, int line, const char* cond,
                                 const T& rep, const char* repStr, const U& rep2, const char* repStr2)
 {
   if (Shell::outputAllowed(true)) {
-    cout << "Condition in file " << file << ", line " << line
+    std::cout << "Condition in file " << file << ", line " << line
          << " violated:\n"
          << cond << "\n"
          << "Value of " << repStr << " is: " << rep << "\n"
          << "Value of " << repStr2 << " is: " << rep2
          << "\n----- stack dump -----\n";
-    Tracer::printStack(cout);
-    cout << "----- end of stack dump -----\n";
+    Tracer::printStack(std::cout);
+    std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
 } // Assertion::violated
@@ -274,7 +274,7 @@ void Debug::Assertion::violatedEquality(const char* file, int line, const char* 
               << val1Str << " == " << val1 << "\n"
               << val2Str << " == " << val2 << "\n"
               << "----- stack dump -----\n";
-    Tracer::printStack(cout);
+    Tracer::printStack(std::cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
@@ -290,7 +290,7 @@ void Debug::Assertion::violatedNonequality(const char* file, int line, const cha
               << val1Str << " == " << val1 << "\n"
               << val2Str << " == " << val2 << "\n"
               << "----- stack dump -----\n";
-    Tracer::printStack(cout);
+    Tracer::printStack(std::cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
@@ -322,7 +322,7 @@ void Debug::Assertion::violatedComparison(const char* file, int line, const char
               << val1Str << " == " << val1 << "\n"
               << val2Str << " == " << val2 << "\n"
               << "----- stack dump -----\n";
-    Tracer::printStack(cout);
+    Tracer::printStack(std::cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();
@@ -337,7 +337,7 @@ void Debug::Assertion::violatedMethod(const char* file, int line, const T& obj,
               << file << ", line " << line << " was violated for:\n"
               << objStr << " == " << obj << "\n"
               << "----- stack dump -----\n";
-    Tracer::printStack(cout);
+    Tracer::printStack(std::cout);
     std::cout << "----- end of stack dump -----\n";
   }
   abortAfterViolation();

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -16,6 +16,13 @@
 
 #include <climits>
 #include <iostream>
+#ifdef VDEBUG
+
+#define BOOST_STACKTRACE_USE_ADDR2LINE
+#include <boost/stacktrace.hpp>
+#include "Lib/Allocator.hpp"
+using namespace Lib;
+#endif
 
 #include "Tracer.hpp"
 
@@ -193,6 +200,9 @@ void Tracer::printStack (ostream& str)
  */
 void Tracer::printStackRec(Tracer* current, ostream& str, int& depth)
 {
+  BYPASSING_ALLOCATOR;
+  str << boost::stacktrace::stacktrace();
+  /*
   if (!current) { // beginning of the stack
     return;
   }
@@ -200,6 +210,7 @@ void Tracer::printStackRec(Tracer* current, ostream& str, int& depth)
   spaces(str,depth);
   str << current->_fun << "\n";
   depth ++;
+  */
 } // Tracer::printStack (ostream& str, int& depth)
 
 

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -13,11 +13,6 @@
  * @since 01/05/2002 Manchester
  */
 
-
-#include <climits>
-#include <iostream>
-#if VDEBUG
-
 #ifdef __has_include
 
 #if __has_include(<execinfo.h>)
@@ -37,166 +32,28 @@
 
 #endif
 
-#endif
-
 #include "Tracer.hpp"
 
+// define in version.cpp.in
 extern const char* VERSION_STRING;
 
-#if VDEBUG
-
-// output nothing
-#define CP_FIRST_POINT UINT_MAX
-#define CP_LAST_POINT 0u
-
-// output all
-// #define CP_FIRST_POINT 0u
-// #define CP_LAST_POINT  1481000u
-
- //#define CP_FIRST_POINT UINT_MAX //185539 
- //#define CP_LAST_POINT UINT_MAX 
-
-using namespace std;
-using namespace Debug;
-
-const char* Tracer::_lastControlPoint;
-Tracer* Tracer::_current = 0;
-unsigned Tracer::_depth = 0;
-unsigned Tracer::_passedControlPoints = 0L;
-ControlPointKind Tracer::_lastPointKind = CP_MID;
-bool Tracer::_forced = false;
-
-/** This variable is needed when all changes in the value of an
- *  an address are traced. To make it work one should define
- *  WATCH_ADDRESS in Allocator.cpp to the watched address. When
- *  the allocator discovers that WATCH_ADDRESS gets allocated
- *  it will set canWatch to true. Allocator will also print to
- *  cout all allocations and deallocations relevant to WATCH_ADDRESS.
- *  In order to watch also all changes of the address one should
- *  define WATCH_ADDR in this file. 
- */
-bool Tracer::canWatch = false;
-
-/** To understand how to use the following variable read documentation
- *  to Tracer::canWatch */
-// #define WATCH_ADDR 0x38001a0
-#define WATCH_ADDR 0
-#if WATCH_ADDR
-void* watchAddrLastValue = (void*)0;
-#endif
-
-Tracer::Tracer (const char* fun) 
-  :
-  _fun (fun),
-  _previous (_current)
-{
-//   cout << '+' << fun << '\n';
-  _current = this;
-  controlPoint(_fun,CP_ENTRY);
-  _depth++;
-} // Tracer::Tracer
-
-
-Tracer::~Tracer () 
-{
-//   cout << '-' << _fun << '\n';
-  _current = _previous;
-  _depth--;
-  controlPoint(_fun,CP_EXIT);
-} // Tracer::~Tracer
-
-
-/**
- * Increase the control point counter and remember the description
- * of the last control point. If the control point number is
- * greater than CP_OUTPUT_THRESHOLD, then output the description to
- * cout.
- *
- * @since 12/12/2003 Manchester
- */
-void Tracer::controlPoint (const char* description, ControlPointKind cpk)
-{
-//   AFTER(12339,
-// 	cout << "A: " << *((int*)0x88d84b4) << "\n";);
-//   if (Allocator<10>::_freeList) {
-//     cout << (void*)Allocator<10>::_freeList << " "
-// 	 << (void*)Allocator<10>::_freeList->_next
-// 	 << " (" <<_passedControlPoints << ")\n";
-//   }
-
-  _lastPointKind = cpk;
-
-#if WATCH_ADDR
-  if (canWatch) {
-    void* newVal = *((void**)WATCH_ADDR);
-    if (newVal != watchAddrLastValue) {
-      cout << "W! " << newVal << " (timestamp: "
-	   << _passedControlPoints << ")\n";
-      watchAddrLastValue = newVal;
-      cout << "Stack on " << (cpk == CP_EXIT ? "exiting" : "entering")
-	   << " the last function on the stack:\n";
-      printStack(cout);
-    }
-  }
-#endif
-
-  _passedControlPoints++;
-
-  _lastControlPoint = description;
-  if (_forced ||
-      (_passedControlPoints <= CP_LAST_POINT &&
-       _passedControlPoints >= CP_FIRST_POINT)) {
-    outputLastControlPoint(cout);
-  }
-} // Tracer::controlPoint
-
-
-/**
- * Increase the control point counter and remember the description
- * of the last control point. If the control point number is
- * greater than CP_OUTPUT_THRESHOLD, then output the description to
- * cout.
- *
- * @since 12/12/2003 Manchester
- */
-void Tracer::controlPoint (const char* description)
-{
-  controlPoint (description,CP_MID);
-} // Tracer::controlPoint
-
-
-/**
- * Output the last control point to an ostream.
- * @since 12/12/2003 Manchester
- */
-void Tracer::outputLastControlPoint (ostream& str)
-{
-  spaces(str,_depth);
-  str << (_lastPointKind == CP_ENTRY ? '+' : 
-          _lastPointKind == CP_EXIT ? '-' : ' ')
-      << _lastControlPoint 
-      << " ("
-      << _passedControlPoints 
-      << ")\n";
-} // Tracer::outputLastControlPoint
+// if we have a callstack, the maximum number to actually retrieve
+const unsigned MAX_CALLS = 1024;
 
 /**
  * Print the stack.
  * @since 24/10/2002 Manchester
+ * @since 12/7/2023 using platform-specific calls to get the stack trace
  */
-void Tracer::printStack (ostream& str)
-{
+void Debug::Tracer::printStack(std::ostream& str) {
   str << "Version : " << VERSION_STRING << "\n";
-  str << "Control points passed: " << _passedControlPoints << "\n"
-      << "last control point:\n";
-  outputLastControlPoint(str);
 
 #ifdef HAVE_EXECINFO
-  const unsigned MAX_CALLS = 1024;
   void *call_stack[MAX_CALLS];
   int sz = ::backtrace(call_stack, MAX_CALLS);
   for(int i = 0; i < sz; i++) {
-    spaces(str, i);
+    for(int j = 0; j < i; j++)
+      str << ' ';
     void *call = call_stack[sz - (i + 1)];
 #ifdef HAVE_DLFCN
     Dl_info info;
@@ -222,19 +79,6 @@ void Tracer::printStack (ostream& str)
   }
 #else
   // TODO backtrace support for other platforms
+  str << "no backtrace support for this compiler/platform yet" << std::endl;
 #endif
 } // Tracer::printStack (ostream& str)
-
-
-/**
- * Print n spaces to the stream
- */
-void Tracer::spaces (ostream& str,int n)
-{
-  while (n > 0) {
-    n--;
-    str << ' ';
-  }
-} // Tracer::spaces
-
-#endif // VDEBUG

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -37,8 +37,6 @@
 
 #endif
 
-#include "Lib/Allocator.hpp"
-using namespace Lib;
 #endif
 
 #include "Tracer.hpp"

--- a/Debug/Tracer.hpp
+++ b/Debug/Tracer.hpp
@@ -46,7 +46,6 @@ class Tracer {
   explicit Tracer (const char* fun);
   virtual ~Tracer ();
   static void printStack (ostream&);
-  static void printOnlyStack (ostream&);
   static void controlPoint (const char* name);
   static unsigned passedControlPoints () { return _passedControlPoints; }
   /** start outputting the trace independently of the first and last
@@ -59,7 +58,6 @@ class Tracer {
   const char* _fun;
   Tracer* _previous;
 
-  static void printStackRec (Tracer* current, ostream&, int& depth);
   static void spaces(ostream& str,int number);
 
   /** current trace point */

--- a/Debug/Tracer.hpp
+++ b/Debug/Tracer.hpp
@@ -18,70 +18,16 @@
 
 
 #ifndef __Tracer__
-#  define __Tracer__
-
-#if VDEBUG
+#define __Tracer__
 
 #include <iostream>
 #include <iomanip>
 
-using namespace std;
-
 namespace Debug {
 
-/**
- * What kind of control point it is.
- */
-enum ControlPointKind {
-  /** Entry to a function */
-  CP_ENTRY,
-  /** Exit from a function */
-  CP_EXIT,
-  /** Point inside a function */
-  CP_MID
-}; // enum ControlPointKind
-
-class Tracer {
- public:
-  explicit Tracer (const char* fun);
-  virtual ~Tracer ();
-  static void printStack (ostream&);
-  static void controlPoint (const char* name);
-  static unsigned passedControlPoints () { return _passedControlPoints; }
-  /** start outputting the trace independently of the first and last
-   *  control point setting */
-  static void forceOutput() { _forced = true; }
-  /** stop outputting forced by startOutput */
-  static void stopOutput() { _forced = false; }
-  static bool canWatch;
- private:
-  const char* _fun;
-  Tracer* _previous;
-
-  static void spaces(ostream& str,int number);
-
-  /** current trace point */
-  static Tracer* _current;
-  /** current depth */
-  static unsigned _depth;
-  /** description of the last control point (function name) */
-  static const char* _lastControlPoint;
-  /** total number of passed control points */
-  static unsigned _passedControlPoints;
-  /** kind of the last point */
-  static ControlPointKind _lastPointKind;
-  /** forced by startTrace */
-  static bool _forced;
-  static void controlPoint (const char*, ControlPointKind);
-  static void outputLastControlPoint (ostream& str);
-public:
-  /* prints a message with indent in the of the same size as the current _depth */
-  template<class... A>
-  static void printDbg(const char* file_, int line, const A&... msg);
-  template<class A>
-  static A echoValue(const char* file_, int line, const char* prefix, A value);
+namespace Tracer {
+  void printStack(std::ostream &out);
 };
-  
 
 template<class... As>
 struct _printDbg {
@@ -94,25 +40,13 @@ template<> struct _printDbg<>{
 
 template<class A, class... As> struct _printDbg<A, As...>{
   void operator()(const A& a, const As&... as) {
-    cout << a;
+    std::cout << a;
     _printDbg<As...>{}(as...);
   }
 };
 
-template<class A>
-A Tracer::echoValue(const char* file, int line, const char* prefix, A value) 
+template<class... A> void printDbg(const char* file, int line, const char *fun, const A&... msg)
 {
-  printDbg(file,line, prefix, value);
-  return std::move(value);
-}
-
-template<class... A> void Tracer::printDbg(const char* file, int line, const A&... msg)
-{
-
-  // struct limit_size {
-  //   const char* str;
-  //   unsigned limit;
-  // }
   int width = 60;
   std::cout << "[ debug ] ";
   for (const char* c = file; *c != 0 && width > 0; c++, width--) {
@@ -121,48 +55,30 @@ template<class... A> void Tracer::printDbg(const char* file, int line, const A&.
   for (int i = 0; i < width; i++) {
     std::cout << ' ';
   }
-  std::cout <<  "@" << setw(5) << line << ":";
+  std::cout <<  "@" << std::setw(5) << line << ":";
 
+  // TODO either use backtrace to figure out call depth or don't do this
+  /*
   for (unsigned i = 0; i< _depth; i++) {
     cout << "  ";
   }
-  cout <<_current->_fun << ": ";
-  // cout << std::setw(30) <<_current->_fun << std::setw(0) << ": ";
-  // cout << _lastControlPoint << ": ";
-
+  */
+  std::cout << fun << ": ";
   _printDbg<A...>{}(msg...);
   std::cout << std::endl; 
 }
 
-
 } // namespace Debug
 
+#define CALL(fun)
+#define CALLC(fun, cond)
 
-#  define AUX_CALL_(SEED,Fun) Debug::Tracer _tmp_##SEED##_(Fun);
-#  define AUX_CALL(SEED,Fun) AUX_CALL_(SEED,Fun)
-#  define CALL(Fun) AUX_CALL(__LINE__,Fun)
-#  define DBG(...) { Debug::Tracer::printDbg(__FILE__, __LINE__, __VA_ARGS__); }
+#if VDEBUG
+#  define DBG(...) { Debug::printDbg(__FILE__, __LINE__, __func__, __VA_ARGS__); }
 #  define DBGE(x) DBG(#x, " = ", x)
-#  define ECHO(x) Debug::Tracer::echoValue(__FILE__, __LINE__, #x " = ", x)
-#  define CALLC(Fun,check) if (check){ AUX_CALL(__LINE__,Fun) }
-#  define CONTROL(description) Debug::Tracer::controlPoint(description)
-#  define AFTER(number,command) \
-            if (Debug::Tracer::passedControlPoints() >= number) { command };
-#  define BETWEEN(number1,number2,command) \
-            if (Debug::Tracer::passedControlPoints() >= number1 &&	\
-                Debug::Tracer::passedControlPoints() <= number2)	\
-              { command };
-
 #else // ! VDEBUG
 #  define DBG(...) {}
 #  define DBGE(x) {}
-#  define CALL(Fun) 
-#  define CALLC(Fun,check) 
-#  define CONTROL(description)
-#endif
-
-#ifndef CALL
-#error BLIN
 #endif
 
 #endif // Tracer

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -2630,9 +2630,7 @@ void FiniteModelBuilder::SmtBasedDSAE::reportZ3OutOfMemory()
   if(env.statistics) {
     env.statistics->print(env.out());
   }
-#if VDEBUG
   Debug::Tracer::printStack(env.out());
-#endif
   env.endOutput();
   System::terminateImmediately(1);
 }

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -585,9 +585,7 @@ Allocator::Page* Allocator::allocatePages(size_t size)
       if(env.statistics) {
         env.statistics->print(env.out());
       }
-#if VDEBUG
       Debug::Tracer::printStack(env.out());
-#endif
       env.endOutput();
       System::terminateImmediately(1);
 #else

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -166,15 +166,11 @@ void handleSignal (int sigNum)
 	    env.beginOutput();
 	    env.out() << getpid() << " Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
 	    env.statistics->print(env.out());
-#if VDEBUG
 	    Debug::Tracer::printStack(env.out());
-#endif
 	    env.endOutput();
 	  } else {
 	    cout << getpid() << "Aborted by signal " << signalDescription << "\n";
-#if VDEBUG
 	    Debug::Tracer::printStack(cout);
-#endif
 	  }
 	}
 	System::terminateImmediately(haveSigInt ? VAMP_RESULT_STATUS_SIGINT : VAMP_RESULT_STATUS_OTHER_SIGNAL);

--- a/Makefile
+++ b/Makefile
@@ -571,7 +571,7 @@ LIBVAPI_OBJ := $(addprefix $(CONF_ID)/, $(LIBVAPI_DEP))
 TKV_OBJ := $(addprefix $(CONF_ID)/, $(TKV_DEP))
 
 define COMPILE_CMD
-$(CXX) $(CXXFLAGS) $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB)
+$(CXX) $(CXXFLAGS) -Wl,--export-dynamic $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB) -ldl
 @#$(CXX) -static $(CXXFLAGS) $(Z3LIB) $(filter %.o, $^) -o $@
 @#strip $@
 endef

--- a/Makefile
+++ b/Makefile
@@ -570,8 +570,14 @@ VAPI_OBJ := $(addprefix $(CONF_ID)/, $(VAPI_DEP))
 LIBVAPI_OBJ := $(addprefix $(CONF_ID)/, $(LIBVAPI_DEP))
 TKV_OBJ := $(addprefix $(CONF_ID)/, $(TKV_DEP))
 
+ifeq ($(OS),Darwin)
+EXPORT_DYNAMIC = 
+else
+EXPORT_DYNAMIC = -Wl,--export-dynamic
+endif
+
 define COMPILE_CMD
-$(CXX) $(CXXFLAGS) -Wl,--export-dynamic $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB) -ldl
+$(CXX) $(CXXFLAGS) $(EXPORT_DYNAMIC) $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB) -ldl
 @#$(CXX) -static $(CXXFLAGS) $(Z3LIB) $(filter %.o, $^) -o $@
 @#strip $@
 endef

--- a/SAT/MinisatInterfacingNewSimp.cpp
+++ b/SAT/MinisatInterfacingNewSimp.cpp
@@ -53,9 +53,7 @@ void MinisatInterfacingNewSimp::reportMinisatOutOfMemory() {
   if(env.statistics) {
     env.statistics->print(env.out());
   }
-#if VDEBUG
   Debug::Tracer::printStack(env.out());
-#endif
   env.endOutput();
   System::terminateImmediately(1);
 }

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -403,7 +403,6 @@ void SaturationAlgorithm::onAllProcessed()
  */
 void SaturationAlgorithm::onPassiveAdded(Clause* c)
 {
-  throw;
   if (env.options->showPassive()) {
     env.beginOutput();
     env.out() << "[SA] passive: " << c->toString() << std::endl;

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -403,6 +403,7 @@ void SaturationAlgorithm::onAllProcessed()
  */
 void SaturationAlgorithm::onPassiveAdded(Clause* c)
 {
+  throw;
   if (env.options->showPassive()) {
     env.beginOutput();
     env.out() << "[SA] passive: " << c->toString() << std::endl;


### PR DESCRIPTION
We use manually-inserted `CALL` macros to keep a call stack available in debug builds. This is primarily used to generate backtraces when crashing, but also for some old-school watchpoint stuff that I don't fully understand and suspect isn't used. Backtraces are useful (rather than debugging) when e.g. Vampire crashes on a compute cluster or in a competition, where debugging or even getting a core dump is not so easy.

However, in most cases and on most platforms it's possible to get a callstack without these macros. This PR implements `CALL`-free backtraces for GNU-flavoured things (and MacOS - thanks @quickbeam123!) by (i) inspecting the call stack, (ii) pulling out symbol names and (iii) demangling them according to the C++ ABI. It should be possible to add support for other platforms incrementally.

Pros:
- no need to write or update `CALL` macros
- decrease in binary size, about 2%
- significant increase in debug performance: 20-40% on my machine
- explicit types in backtrace (although this might be considered a disadvantage in some cases)
- get a backtrace in release builds too

Cons:
- more platform-specific code, a small amount of additional complexity
- need to link to `libdl` on GNU (extra library shipped with glibc)
- now displays the real callstack, not an idealised version: optimising transformations may cause some surprises
- no backtraces on unsupported platforms until somebody implements it

Let me know what you think, I've no desire to mess with people's workflows, but the lack of `CALL` and the increase in debug performance are compelling in my view. If people like it I will also remove the `CALL` macros and clean up `Debug::Tracer` a bit.