### PR TITLE
Joe uwa stack of handlers

### DIFF
--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -37,21 +37,13 @@ IndexManager::IndexManager(SaturationAlgorithm* alg) : _alg(alg), _handler()
 {
   CALL("IndexManager::IndexManager");
 
-  static bool const uwa = env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF;
-  static bool const eba = (env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) &&
-                          env.property->higherOrder();
-
   // other handlers can be added here
-  
-  if(uwa || eba){
- 
-   
-    if(uwa){
-      _handler.addHandler(make_unique<UWAMismatchHandler>());
-    }
-    if(eba){
-      _handler.addHandler(make_unique<HOMismatchHandler>());
-    }
+  if(env.options->unificationWithAbstraction() != Options::UnificationWithAbstraction::OFF){
+    _handler.addHandler(make_unique<UWAMismatchHandler>(env.options->unificationWithAbstraction()));
+  }
+  if((env.options->functionExtensionality() == Options::FunctionExtensionality::ABSTRACTION) 
+      && env.property->higherOrder()){
+    _handler.addHandler(make_unique<HOMismatchHandler>());
   }
 }
 

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -124,7 +124,7 @@ Index* IndexManager::create(IndexType t)
                     
   switch(t) {
   case BINARY_RESOLUTION_SUBST_TREE:
-    is=new LiteralSubstitutionTree(&_handler);
+    is=new LiteralSubstitutionTree(mismatchHandler());
     res=new BinaryResolutionIndex(is);
     isGenerating = true;
     break;
@@ -150,12 +150,12 @@ Index* IndexManager::create(IndexType t)
     break;
 
   case SUPERPOSITION_SUBTERM_SUBST_TREE:
-    tis=new TermSubstitutionTree(&_handler);
+    tis=new TermSubstitutionTree(mismatchHandler());
     res=new SuperpositionSubtermIndex(tis, _alg->getOrdering());
     isGenerating = true;
     break;
   case SUPERPOSITION_LHS_SUBST_TREE:
-    tis=new TermSubstitutionTree(&_handler);
+    tis=new TermSubstitutionTree(mismatchHandler());
     res=new SuperpositionLHSIndex(tis, _alg->getOrdering(), _alg->getOptions());
     isGenerating = true;
     break;

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -47,10 +47,10 @@ IndexManager::IndexManager(SaturationAlgorithm* alg) : _alg(alg), _handler()
  
    
     if(uwa){
-      _handler.addHandler(new UWAMismatchHandler());
+      _handler.addHandler(make_unique<UWAMismatchHandler>());
     }
     if(eba){
-      _handler.addHandler(new HOMismatchHandler());
+      _handler.addHandler(make_unique<HOMismatchHandler>());
     }
   }
 }

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -33,7 +33,7 @@
 using namespace Lib;
 using namespace Indexing;
 
-IndexManager::IndexManager(SaturationAlgorithm* alg) : _alg(alg), _handler(0)
+IndexManager::IndexManager(SaturationAlgorithm* alg) : _alg(alg), _handler()
 {
   CALL("IndexManager::IndexManager");
 
@@ -45,25 +45,17 @@ IndexManager::IndexManager(SaturationAlgorithm* alg) : _alg(alg), _handler(0)
   
   if(uwa || eba){
  
-    _handler = new CompositeMismatchHandler();
    
     if(uwa){
-      _handler->addHandler(new UWAMismatchHandler());
+      _handler.addHandler(new UWAMismatchHandler());
     }
     if(eba){
-      _handler->addHandler(new HOMismatchHandler());
+      _handler.addHandler(new HOMismatchHandler());
     }
   }
 }
 
-IndexManager::~IndexManager()
-{
-  CALL("IndexManager::~IndexManager");
-
-  if(_handler){
-    delete _handler;
-  }
-}
+IndexManager::~IndexManager() { }
 
 Index* IndexManager::request(IndexType t)
 {
@@ -140,7 +132,7 @@ Index* IndexManager::create(IndexType t)
                     
   switch(t) {
   case BINARY_RESOLUTION_SUBST_TREE:
-    is=new LiteralSubstitutionTree(_handler);
+    is=new LiteralSubstitutionTree(&_handler);
     res=new BinaryResolutionIndex(is);
     isGenerating = true;
     break;
@@ -166,12 +158,12 @@ Index* IndexManager::create(IndexType t)
     break;
 
   case SUPERPOSITION_SUBTERM_SUBST_TREE:
-    tis=new TermSubstitutionTree(_handler);
+    tis=new TermSubstitutionTree(&_handler);
     res=new SuperpositionSubtermIndex(tis, _alg->getOrdering());
     isGenerating = true;
     break;
   case SUPERPOSITION_LHS_SUBST_TREE:
-    tis=new TermSubstitutionTree(_handler);
+    tis=new TermSubstitutionTree(&_handler);
     res=new SuperpositionLHSIndex(tis, _alg->getOrdering(), _alg->getOptions());
     isGenerating = true;
     break;

--- a/Indexing/IndexManager.hpp
+++ b/Indexing/IndexManager.hpp
@@ -89,7 +89,7 @@ public:
   void release(IndexType t);
   bool contains(IndexType t);
   Index* get(IndexType t);
-  MismatchHandler* mismatchHandler(){ return &_handler; }
+  MismatchHandler* mismatchHandler(){ return _handler.isEmpty() ? nullptr : &_handler; }
 
   void provideIndex(IndexType t, Index* index);
 private:

--- a/Indexing/IndexManager.hpp
+++ b/Indexing/IndexManager.hpp
@@ -89,7 +89,7 @@ public:
   void release(IndexType t);
   bool contains(IndexType t);
   Index* get(IndexType t);
-  MismatchHandler* getHandler(){ return &_handler; }
+  MismatchHandler* mismatchHandler(){ return &_handler; }
 
   void provideIndex(IndexType t, Index* index);
 private:

--- a/Indexing/IndexManager.hpp
+++ b/Indexing/IndexManager.hpp
@@ -89,7 +89,7 @@ public:
   void release(IndexType t);
   bool contains(IndexType t);
   Index* get(IndexType t);
-  MismatchHandler* getHandler(){ return _handler; }
+  MismatchHandler* getHandler(){ return &_handler; }
 
   void provideIndex(IndexType t, Index* index);
 private:
@@ -101,7 +101,7 @@ private:
   SaturationAlgorithm* _alg;
   DHMap<IndexType,Entry> _store;
 
-  CompositeMismatchHandler* _handler;
+  MismatchHandler _handler;
 
   Index* create(IndexType t);
 };

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -88,8 +88,7 @@ void EqualityFactoring::attach(SaturationAlgorithm* salg)
   CALL("EqualityFactoring::attach");
 
   GeneratingInferenceEngine::attach(salg);
-  // TODO rename getHandler to getMismatchHandler ? it's not obv here what kind of handler we mean here
-  _handler = salg->getIndexManager()->getHandler();
+  _handler = salg->getIndexManager()->mismatchHandler();
 }
 
 struct EqualityFactoring::ResultFn

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -88,6 +88,7 @@ void EqualityFactoring::attach(SaturationAlgorithm* salg)
   CALL("EqualityFactoring::attach");
 
   GeneratingInferenceEngine::attach(salg);
+  // TODO rename getHandler to getMismatchHandler ? it's not obv here what kind of handler we mean here
   _handler = salg->getIndexManager()->getHandler();
 }
 

--- a/Inferences/EqualityResolution.cpp
+++ b/Inferences/EqualityResolution.cpp
@@ -64,7 +64,7 @@ void EqualityResolution::attach(SaturationAlgorithm* salg)
   CALL("EqualityResolution::attach");
 
   GeneratingInferenceEngine::attach(salg);
-  _handler = salg->getIndexManager()->getHandler();
+  _handler = salg->getIndexManager()->mismatchHandler();
 }
 
 struct EqualityResolution::ResultFn

--- a/Kernel/MismatchHandler.cpp
+++ b/Kernel/MismatchHandler.cpp
@@ -98,7 +98,7 @@ void MismatchHandler::introduceConstraint(TermList t1,unsigned index1, TermList 
 MismatchHandler::~MismatchHandler(){
   CALL("MismatchHandler::~MismatchHandler");
 
-  MHList::destroyWithDeletion(_inners);
+  for (auto h : _inners) delete h;
 }
 
 bool MismatchHandler::handle(TermList t1, unsigned index1, TermList t2, unsigned index2, 
@@ -127,8 +127,7 @@ bool MismatchHandler::handle(TermList t1, unsigned index1, TermList t2, unsigned
 
 void MismatchHandler::addHandler(AtomicMismatchHandler* hndlr){
   CALL("MismatchHandler::addHandler");
-
-  MHList::push(hndlr,_inners);
+  _inners.push(hndlr);
 }
 
 MaybeBool MismatchHandler::isConstraintTerm(TermList t){
@@ -136,13 +135,11 @@ MaybeBool MismatchHandler::isConstraintTerm(TermList t){
   
   if(t.isVar()){ return false; }
 
-  MHList* hit=_inners;
-  while(hit) {
-    auto res = hit->head()->isConstraintTerm(t);
+  for (auto h : _inners) {
+    auto res = h->isConstraintTerm(t);
     if(!res.isFalse()){
       return res;
     }
-    hit=hit->tail();
   }
   return false; 
 }
@@ -150,13 +147,11 @@ MaybeBool MismatchHandler::isConstraintTerm(TermList t){
 TermList MismatchHandler::transformSubterm(TermList trm){
   CALL("MismatchHandler::transformSubterm");
 
-  MHList* hit=_inners;
-  while(hit) {
-    TermList t = hit->head()->transformSubterm(trm);
+  for (auto h : _inners) {
+    TermList t = h->transformSubterm(trm);
     if(t != trm){
       return t;
     }
-    hit=hit->tail();
   }
   return trm;
 }
@@ -165,13 +160,11 @@ Term* MismatchHandler::get(unsigned var)
 {
   CALL("MismatchHandler::get");
 
-  MHList* hit=_inners;
-  while(hit) {
-    auto res = hit->head()->getTermMap()->tryGet(var);
+  for (auto h : _inners) {
+    auto res = h->getTermMap()->tryGet(var);
     if(res.isSome()){
       return res.unwrap();
     }
-    hit=hit->tail();
   } 
   ASSERTION_VIOLATION;
 }

--- a/Kernel/MismatchHandler.cpp
+++ b/Kernel/MismatchHandler.cpp
@@ -85,7 +85,7 @@ MaybeBool UWAMismatchHandler::isConstraintTerm(TermList t){
 void MismatchHandler::introduceConstraint(TermList t1,unsigned index1, TermList t2,unsigned index2, 
   UnificationConstraintStack& ucs, BacktrackData& bd, bool recording)
 {
-  CALL("MismatchHandler::introduceConstraint");
+  CALL("AtomicMismatchHandler::introduceConstraint");
 
   auto constraint = make_pair(make_pair(t1,index1),make_pair(t2,index2));
   if(recording){
@@ -95,16 +95,16 @@ void MismatchHandler::introduceConstraint(TermList t1,unsigned index1, TermList 
   }
 }
 
-CompositeMismatchHandler::~CompositeMismatchHandler(){
-  CALL("CompositeMismatchHandler::~CompositeMismatchHandler");
+MismatchHandler::~MismatchHandler(){
+  CALL("MismatchHandler::~MismatchHandler");
 
   MHList::destroyWithDeletion(_inners);
 }
 
-bool CompositeMismatchHandler::handle(TermList t1, unsigned index1, TermList t2, unsigned index2, 
+bool MismatchHandler::handle(TermList t1, unsigned index1, TermList t2, unsigned index2, 
   UnificationConstraintStack& ucs,BacktrackData& bd, bool recording)
 {
-  CALL("CompositeMismatchHandler::handle");
+  CALL("MismatchHandler::handle");
 
   // make assumtion that we never create a constraint involving a variable
   // this seems reasonable
@@ -125,14 +125,14 @@ bool CompositeMismatchHandler::handle(TermList t1, unsigned index1, TermList t2,
   return false;
 }
 
-void CompositeMismatchHandler::addHandler(MismatchHandler* hndlr){
-  CALL("CompositeMismatchHandler::addHandler");
+void MismatchHandler::addHandler(AtomicMismatchHandler* hndlr){
+  CALL("MismatchHandler::addHandler");
 
   MHList::push(hndlr,_inners);
 }
 
-MaybeBool CompositeMismatchHandler::isConstraintTerm(TermList t){
-  CALL("CompositeMismatchHandler::isConstraintTerm");
+MaybeBool MismatchHandler::isConstraintTerm(TermList t){
+  CALL("MismatchHandler::isConstraintTerm");
   
   if(t.isVar()){ return false; }
 
@@ -147,8 +147,8 @@ MaybeBool CompositeMismatchHandler::isConstraintTerm(TermList t){
   return false; 
 }
 
-TermList CompositeMismatchHandler::transformSubterm(TermList trm){
-  CALL("CompositeMismatchHandler::transformSubterm");
+TermList MismatchHandler::transformSubterm(TermList trm){
+  CALL("MismatchHandler::transformSubterm");
 
   MHList* hit=_inners;
   while(hit) {
@@ -161,9 +161,9 @@ TermList CompositeMismatchHandler::transformSubterm(TermList trm){
   return trm;
 }
 
-Term* CompositeMismatchHandler::get(unsigned var)
+Term* MismatchHandler::get(unsigned var)
 {
-  CALL("CompositeMismatchHandler::get");
+  CALL("MismatchHandler::get");
 
   MHList* hit=_inners;
   while(hit) {
@@ -190,7 +190,7 @@ bool HOMismatchHandler::isConstraintPair(TermList t1, TermList t2)
 }
 
 MaybeBool HOMismatchHandler::isConstraintTerm(TermList t){
-  CALL("CompositeMismatcHandler::isConstraintTerm");
+  CALL("MismatcHandler::isConstraintTerm");
   
   if(t.isVar()){ return false; }
 

--- a/Kernel/MismatchHandler.cpp
+++ b/Kernel/MismatchHandler.cpp
@@ -33,9 +33,7 @@ bool UWAMismatchHandler::isConstraintPair(TermList t1, TermList t2)
 {
   CALL("UWAMismatchHandler::isConstraintPair");
 
-  static Shell::Options::UnificationWithAbstraction opt = env.options->unificationWithAbstraction();
-
-  switch(opt){
+  switch(_mode){
     case Shell::Options::UnificationWithAbstraction::ONE_INTERP:
       return isConstraintTerm(t1).isTrue() || isConstraintTerm(t2).isTrue();
     case Shell::Options::UnificationWithAbstraction::INTERP_ONLY:{
@@ -64,8 +62,7 @@ MaybeBool UWAMismatchHandler::isConstraintTerm(TermList t){
   
   if(t.isVar()){ return false; }
 
-  static Shell::Options::UnificationWithAbstraction opt = env.options->unificationWithAbstraction();
-  bool onlyInterpreted = opt == Shell::Options::UnificationWithAbstraction::INTERP_ONLY;
+  bool onlyInterpreted = _mode == Shell::Options::UnificationWithAbstraction::INTERP_ONLY;
 
   auto trm = t.term();
   bool isNumeral = Shell::UnificationWithAbstractionConfig::isNumeral(t);

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -25,11 +25,10 @@
 namespace Kernel
 {
 
-class AtomicMismatchHandler : public TermTransformer
+class AtomicMismatchHandler 
 {
 public:
 
-  AtomicMismatchHandler() : TermTransformer(false) {}
 
   // Returns true if <t1, t2> can form a constraint
   // Implementors NEED to override this function with

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -89,6 +89,7 @@ public:
   Term* get(unsigned var);
 
   void addHandler(unique_ptr<AtomicMismatchHandler> hndlr);
+  bool isEmpty() const { return _inners.isEmpty(); }
 
   CLASS_NAME(MismatchHandler);
   USE_ALLOCATOR(MismatchHandler);

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -17,6 +17,7 @@
 #define __MismatchHandler__
 
 #include "Forwards.hpp"
+#include "Shell/Options.hpp"
 #include "Term.hpp"
 #include "Kernel/TermTransformer.hpp"
 #include "Lib/MaybeBool.hpp"
@@ -104,7 +105,7 @@ private:
 class UWAMismatchHandler : public AtomicMismatchHandler
 {
 public:
-  UWAMismatchHandler() {}
+  UWAMismatchHandler(Shell::Options::UnificationWithAbstraction mode) : _mode(mode) {}
   ~UWAMismatchHandler() override {}
 
   bool isConstraintPair(TermList t1, TermList t2) override; 
@@ -115,6 +116,7 @@ public:
   USE_ALLOCATOR(UWAMismatchHandler);
 private:
   bool checkUWA(TermList t1, TermList t2); 
+  Shell::Options::UnificationWithAbstraction const _mode;
 };
 
 class HOMismatchHandler : public AtomicMismatchHandler

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -29,6 +29,7 @@ class AtomicMismatchHandler
 {
 public:
 
+  virtual ~AtomicMismatchHandler();
 
   // Returns true if <t1, t2> can form a constraint
   // Implementors NEED to override this function with
@@ -73,7 +74,6 @@ class MismatchHandler :
 public:
 
   MismatchHandler() : TermTransformer(false) {}
-  ~MismatchHandler();
 
   // Returns true if the mismatch can be handled by some handler
   //
@@ -87,7 +87,7 @@ public:
   MaybeBool isConstraintTerm(TermList t); 
   Term* get(unsigned var);
 
-  void addHandler(AtomicMismatchHandler* hndlr);
+  void addHandler(unique_ptr<AtomicMismatchHandler> hndlr);
 
   CLASS_NAME(MismatchHandler);
   USE_ALLOCATOR(MismatchHandler);
@@ -98,14 +98,14 @@ private:
       TermList t2, unsigned index2, 
       UnificationConstraintStack& ucs, BacktrackData& bd, bool recording);
 
-  typedef List<AtomicMismatchHandler*> MHList;
-  MHList* _inners;
+  Stack<unique_ptr<AtomicMismatchHandler>> _inners;
 };
 
 class UWAMismatchHandler : public AtomicMismatchHandler
 {
 public:
   UWAMismatchHandler() {}
+  ~UWAMismatchHandler() override {}
 
   bool isConstraintPair(TermList t1, TermList t2) override; 
   TermList transformSubterm(TermList trm) override;
@@ -121,6 +121,7 @@ class HOMismatchHandler : public AtomicMismatchHandler
 {
 public:
   HOMismatchHandler() {}
+  ~HOMismatchHandler() override {}
   
   bool isConstraintPair(TermList t1, TermList t2) override;
   TermList transformSubterm(TermList trm) override;

--- a/UnitTests/tUnificationWithAbstraction.cpp
+++ b/UnitTests/tUnificationWithAbstraction.cpp
@@ -43,7 +43,7 @@ Clause* unit(Literal* lit)
 
 TermIndexingStructure* getTermIndex(bool uwa = true)
 {
-  CompositeMismatchHandler* cmh = new CompositeMismatchHandler();
+  auto cmh = new MismatchHandler();
   if(uwa){
     cmh->addHandler(new UWAMismatchHandler());
   } else {
@@ -54,7 +54,7 @@ TermIndexingStructure* getTermIndex(bool uwa = true)
 
 LiteralIndexingStructure* getLiteralIndex()
 {
-  CompositeMismatchHandler* cmh = new CompositeMismatchHandler();
+  auto cmh = new MismatchHandler();
   cmh->addHandler(new UWAMismatchHandler());
   return new LiteralSubstitutionTree(cmh); 
 }
@@ -287,7 +287,7 @@ TEST_FUN(using_robsub)
   DECL_CONST(a, Int) 
   DECL_CONST(b, Int) 
 
-  CompositeMismatchHandler* cmh = new CompositeMismatchHandler();
+  auto cmh = new MismatchHandler();
   cmh->addHandler(new UWAMismatchHandler());  
   RobSubstitution sub(cmh);
 

--- a/UnitTests/tUnificationWithAbstraction.cpp
+++ b/UnitTests/tUnificationWithAbstraction.cpp
@@ -11,6 +11,7 @@
 #include "Lib/Environment.hpp"
 
 #include "Shell/Options.hpp"
+#include "Test/TestUtils.hpp"
 
 #include "Kernel/Unit.hpp"
 #include "Kernel/Clause.hpp"
@@ -58,46 +59,93 @@ LiteralIndexingStructure* getLiteralIndex(Shell::Options::UnificationWithAbstrac
   return new LiteralSubstitutionTree(cmh); 
 }
 
-void reportTermMatches(TermIndexingStructure* index, TermList term, TermList sort)
-{
-  TermQueryResultIterator it= index->getUnificationsUsingSorts(term,sort,true);
-  cout << endl;
-  cout << "Unify with " << term.toString() << endl;
-  while(it.hasNext()){
-    TermQueryResult qr = it.next();
-    cout << qr.term.toString() << " matches with substitution: "<< endl;
-    // cout << qr.substitution->tryGetRobSubstitution()->toString() << endl;
-    cout << "and constraints: "<< endl;
-    qr.substitution->numberOfConstraints();
-    auto constraints = qr.substitution->getConstraints();
-    while(constraints.hasNext()){
-      Literal* constraint = constraints.next();
-      cout << "> " << constraint->toString() << endl;
-    }
-  }
-  cout << endl;
-}
+template<class TermOrLit>
+struct UnificationResultSpec {
+  TermOrLit querySigma;
+  TermOrLit resultSigma;
+  Stack<Literal*> constraints;
 
-void reportMatches(LiteralIndexingStructure* index, Literal* qlit)
-{
-  SLQueryResultIterator it= index->getUnifications(qlit,false,true);
-  cout << endl;
-  cout << "Unify with " << qlit->toString() << endl;
-  while(it.hasNext()){
-    SLQueryResult qr = it.next();
-    cout << qr.clause->toString() << " matches with substitution: "<< endl;
-    // cout << qr.substitution->tryGetRobSubstitution()->toString() << endl;
-    cout << "and constraints: "<< endl;
-    qr.substitution->numberOfConstraints();
-    auto constraints = qr.substitution->getConstraints();
-    while(constraints.hasNext()){
-      Literal* constraint = constraints.next();
-      cout << "> " << constraint->toString() << endl;
-    }
+  friend bool operator==(UnificationResultSpec const& l, UnificationResultSpec const& r)
+  {
+    return Test::TestUtils::eqModAC(l.querySigma, r.querySigma)
+       &&  Test::TestUtils::eqModAC(l.resultSigma, r.resultSigma)
+       &&  Test::TestUtils::permEq(l.constraints, r.constraints,
+             [](auto& l, auto& r) { return Test::TestUtils::eqModAC(l,r); });
   }
-  cout << endl;
-}
 
+  friend std::ostream& operator<<(std::ostream& out, UnificationResultSpec const& self)
+  { 
+    out << "{ querySigma = " << Test::pretty(self.querySigma) << ", resultSigma = " << Test::pretty(self.resultSigma) << ", cons = [ ";
+    for (auto& c : self.constraints) {
+      out << *c << ", ";
+    }
+    return out << "] }";
+  }
+};
+
+using TermUnificationResultSpec    = UnificationResultSpec<TermList>;
+using LiteralUnificationResultSpec = UnificationResultSpec<Literal*>;
+
+
+
+void checkLiteralMatches(LiteralIndexingStructure* index, Literal* lit, Stack<LiteralUnificationResultSpec> expected)
+{
+  Stack<LiteralUnificationResultSpec> is;
+  for (auto qr : iterTraits(index->getUnifications(lit,false,true)) ) {
+    qr.substitution->numberOfConstraints();
+
+    is.push(LiteralUnificationResultSpec {
+        .querySigma = qr.substitution->apply(lit, /* result */ false),
+        .resultSigma = qr.substitution->apply(qr.literal, /* result */ true),
+        .constraints = iterTraits(qr.substitution->getConstraints()).collect<Stack>(),
+    });
+  }
+  if (Test::TestUtils::permEq(is, expected, [](auto& l, auto& r) { return l == r; })) {
+    cout << "[  OK  ] " << *lit << endl;
+  } else {
+    cout << "[ FAIL ] " << *lit << endl;
+
+    cout << "is:" << endl;
+    for (auto& x : is)
+      cout << "         " << x << endl;
+
+    cout << "expected:" << endl;
+    for (auto& x : expected)
+      cout << "         " << x << endl;
+
+    exit(-1);
+  }
+  // cout << endl;
+}
+void checkTermMatches(TermIndexingStructure* index, TermList term, TermList sort, Stack<TermUnificationResultSpec> expected)
+{
+  Stack<TermUnificationResultSpec> is;
+  for (auto qr : iterTraits(index->getUnificationsUsingSorts(term,sort,true)) ) {
+    qr.substitution->numberOfConstraints();
+
+    is.push(TermUnificationResultSpec {
+        .querySigma = qr.substitution->apply(term, /* result */ false),
+        .resultSigma = qr.substitution->apply(qr.term, /* result */ true),
+        .constraints = iterTraits(qr.substitution->getConstraints()).collect<Stack>(),
+    });
+  }
+  if (Test::TestUtils::permEq(is, expected, [](auto& l, auto& r) { return l == r; })) {
+    cout << "[  OK  ] " << term << endl;
+  } else {
+    cout << "[ FAIL ] " << term << endl;
+
+    cout << "is:" << endl;
+    for (auto& x : is)
+      cout << "         " << x << endl;
+
+    cout << "expected:" << endl;
+    for (auto& x : expected)
+      cout << "         " << x << endl;
+
+    exit(-1);
+  }
+  // cout << endl;
+}
 
 TEST_FUN(term_indexing_one_side_interp)
 {
@@ -113,17 +161,108 @@ TEST_FUN(term_indexing_one_side_interp)
   index->insert(num(1) + num(1), p(num(1) + num(1)), unit(p(num(1) + num(1))));
   index->insert(1 + a, p(1 + a), unit(p(a + a)));
   
-  reportTermMatches(index,b + 2, Int);
+  checkTermMatches(index, b + 2, Int,
+      { 
+
+        TermUnificationResultSpec 
+        { .querySigma  = 2 + b,
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != 2 + b, } },
+
+        TermUnificationResultSpec 
+        { .querySigma  = 2 + b,
+          .resultSigma = 1 + num(1),
+          .constraints = { 2 + b != 1 + num(1), } }, 
+
+      });
 
   index->insert(a,p(a),unit(p(a)));
 
-  reportTermMatches(index,b + 2, Int);
-  reportTermMatches(index,x,Int);  
+  checkTermMatches(index,b + 2, Int, {
+
+        TermUnificationResultSpec 
+        { .querySigma  = 2 + b,
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != 2 + b, } },
+
+        TermUnificationResultSpec 
+        { .querySigma  = 2 + b,
+          .resultSigma = 1 + num(1),
+          .constraints = { 2 + b != 1 + num(1), } }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = 2 + b,
+          .resultSigma = a,
+          .constraints = { 2 + b != a, } }, 
+
+      });
+
+
+  checkTermMatches(index, x, Int, {
+
+        TermUnificationResultSpec 
+        { .querySigma  = 1 + a,
+          .resultSigma = 1 + a,
+          .constraints = Stack<Literal*>{} },
+
+        TermUnificationResultSpec 
+        { .querySigma  = 1 + num(1),
+          .resultSigma = 1 + num(1),
+          .constraints = Stack<Literal*>{} }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = a,
+          .resultSigma = a,
+          .constraints = Stack<Literal*>{} }, 
+
+      });
+
 
   index->insert(f(x),p(f(x)),unit(p(f(x))));
 
-  reportTermMatches(index, f(a), Int);
-  reportTermMatches(index, a + 3 ,Int); 
+  checkTermMatches(index, f(a), Int, {
+
+        TermUnificationResultSpec 
+        { .querySigma  = f(a),
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != f(a), } },
+
+        TermUnificationResultSpec 
+        { .querySigma  = f(a),
+          .resultSigma = 1 + num(1),
+          .constraints = { f(a) != 1 + num(1), } }, 
+
+
+        TermUnificationResultSpec 
+        { .querySigma  = f(a),
+          .resultSigma = f(a),
+          .constraints = Stack<Literal*>{} }, 
+
+      });
+
+  checkTermMatches(index, a + 3, Int, {
+
+        TermUnificationResultSpec 
+        { .querySigma  = 3 + a,
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != 3 + a, } },
+
+        TermUnificationResultSpec 
+        { .querySigma  = 3 + a,
+          .resultSigma = 1 + num(1),
+          .constraints = { 3 + a != 1 + num(1), } }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = 3 + a,
+          .resultSigma = a,
+          .constraints = { 3 + a != a, } }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = 3 + a,
+          .resultSigma = f(x),
+          .constraints = { 3 + a != f(x) } }, 
+
+      }); 
 }
 
 TEST_FUN(term_indexing_poly)
@@ -136,11 +275,26 @@ TEST_FUN(term_indexing_poly)
   DECL_PRED(p, {Int})
   DECL_CONST(a, Int) 
   DECL_POLY_CONST(h, 1, alpha)
+  DECL_SORT(A)
 
   index->insert(1 + a, p(1 + a), unit(p(a + a)));
   index->insert(h(Int), p(h(Int)), unit(p(h(Int))));
-  
-  reportTermMatches(index,h(alpha), alpha);
+
+  checkTermMatches(index, h(alpha), alpha, Stack<TermUnificationResultSpec>{
+
+        TermUnificationResultSpec 
+        { .querySigma  = h(Int),
+          .resultSigma = h(Int),
+          .constraints = Stack<Literal*>{  } }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = h(Int),
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != h(Int), } }, 
+
+      });
+
+  checkTermMatches(index, h(A), A, Stack<TermUnificationResultSpec>{ });
 }
 
 TEST_FUN(term_indexing_interp_only)
@@ -157,12 +311,36 @@ TEST_FUN(term_indexing_interp_only)
   index->insert(num(1) + num(1), p(num(1) + num(1)), unit(p(num(1) + num(1))));
   index->insert(1 + a, p(1 + a), unit(p(a + a)));
 
-  reportTermMatches(index,b + 2,Int);
+  checkTermMatches(index,b + 2,Int,{
+
+        TermUnificationResultSpec 
+        { .querySigma  = b + 2,
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != b + 2, } }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = b + 2,
+          .resultSigma = 1 + num(1),
+          .constraints = { 1 + num(1) != b + 2, } }, 
+
+      });
 
   index->insert(a,p(a),unit(p(a)));
 
-  reportTermMatches(index,b + 2,Int);
-  reportTermMatches(index,x,Int);  
+  checkTermMatches(index,b + 2,Int, {
+
+        TermUnificationResultSpec 
+        { .querySigma  = b + 2,
+          .resultSigma = 1 + a,
+          .constraints = { 1 + a != b + 2, } }, 
+
+        TermUnificationResultSpec 
+        { .querySigma  = b + 2,
+          .resultSigma = 1 + num(1),
+          .constraints = { 1 + num(1) != b + 2, } }, 
+
+      });
+
 }
 
 TEST_FUN(literal_indexing)
@@ -180,11 +358,48 @@ TEST_FUN(literal_indexing)
   index->insert(p(1 + a), unit(p(1 + a)));  
 
 
-  reportMatches(index,p(b + 2));
+  checkLiteralMatches(index,p(b + 2),{
+
+      LiteralUnificationResultSpec {
+        .querySigma = p(b + 2),
+        .resultSigma = p(num(1) + 1),
+        .constraints = { b + 2 != num(1) + 1 }, },
+
+      LiteralUnificationResultSpec {
+        .querySigma = p(b + 2),
+        .resultSigma = p(a + 1),
+        .constraints = { b + 2 != a + 1 }, },
+
+      });
 
   index->insert(p(b + 2),unit(p(b + 2)));
+  index->insert(p(2 + b),unit(p(2 + b)));
 
-  reportMatches(index,p(b +2)); 
+  checkLiteralMatches(index,p(b + 2),{
+
+      LiteralUnificationResultSpec {
+        .querySigma = p(b + 2),
+        .resultSigma = p(num(1) + 1),
+        .constraints = { b + 2 != num(1) + 1 }, },
+
+      LiteralUnificationResultSpec {
+        .querySigma = p(b + 2),
+        .resultSigma = p(a + 1),
+        .constraints = { b + 2 != a + 1 }, },
+
+      LiteralUnificationResultSpec {
+        .querySigma = p(b + 2),
+        .resultSigma = p(b + 2),
+        .constraints = Stack<Literal*>{  }, },
+
+      LiteralUnificationResultSpec {
+        .querySigma = p(b + 2),
+        .resultSigma = p(b + 2),
+        .constraints = Stack<Literal*>{ b + 2 != 2 + b }, },
+
+      });
+
+
 }
 
 TEST_FUN(higher_order)
@@ -208,17 +423,26 @@ TEST_FUN(higher_order)
 
   index->insert(ap(f,a), 0, 0);
 
-  reportTermMatches(index,ap(f,b),srt);
+  checkTermMatches(index,ap(f,b),srt, Stack<TermUnificationResultSpec>{
+
+        TermUnificationResultSpec 
+        { .querySigma  = ap(f,b),
+          .resultSigma = ap(f,a),
+          .constraints = { a != b, } }, 
+
+      });
 
   index->insert(ap(g,c), 0, 0);
   index->insert(g, 0, 0);
 
-  reportTermMatches(index,x0,xSrt);
+  // TODO
+  // reportTermMatches(index,x0,xSrt);
 
   index->insert(h(alpha), 0, 0);
 
-  reportTermMatches(index,h(beta),beta);
-  reportTermMatches(index,h(srt),srt);
+  // TODO
+  // reportTermMatches(index,h(beta),beta);
+  // reportTermMatches(index,h(srt),srt);
 }
 
 TEST_FUN(higher_order2)
@@ -237,31 +461,55 @@ TEST_FUN(higher_order2)
 
   index->insert(ap(ap(f,a),b), 0, 0);
 
-  reportTermMatches(index,ap(ap(f,b),a),srt);
+  // TODO
+  // reportTermMatches(index,ap(ap(f,b),a),srt);
 }
 
 static const int NORM_QUERY_BANK=2;
 static const int NORM_RESULT_BANK=3;
 
-void reportRobUnify(TermList a, TermList b, RobSubstitution& sub)
+void checkRobUnify(TermList a, TermList b, RobSubstitution& sub, TermUnificationResultSpec exp)
 {
-  cout << endl;
-  cout << "Unifying " << a.toString() << " with " << b.toString() << endl;
-
   bool result = sub.unify(a,NORM_QUERY_BANK,b,NORM_RESULT_BANK);
-  cout << "Result is " << result << endl;
-  if(result){
-    // cout << "> Substitution is " << endl << sub.toString();
-    cout << "> Constraints are:" << endl;
-    sub.numberOfConstraints();
-    auto constraints = sub.getConstraints();
-    while(constraints.hasNext()){
-      Literal* constraint = constraints.next();
-      cout << "> " << constraint->toString() << endl;
-    }
+  ASS(result)
+  sub.numberOfConstraints();
+  auto is = TermUnificationResultSpec { 
+   .querySigma  = sub.apply(a, NORM_QUERY_BANK), 
+   .resultSigma = sub.apply(b, NORM_RESULT_BANK), 
+   .constraints = iterTraits(sub.getConstraints()).collect<Stack>(),
+  };
+
+  if (is == exp) {
+    cout << "[  OK  ] " << a << " unify " << b << endl;
+  } else {
+    cout << "[ FAIL ] " << a << " unify " << b << endl;
+    cout << "is:       " << is << endl;
+    cout << "expected: " << exp << endl;
+    exit(-1);
   }
-  cout << endl;
 }
+
+
+void checkRobUnifyFail(TermList a, TermList b, RobSubstitution& sub)
+{
+  bool result = sub.unify(a,NORM_QUERY_BANK,b,NORM_RESULT_BANK);
+  if(!result) {
+      cout << "[  OK  ] " << a << " unify " << b << endl;
+  } else {
+    sub.numberOfConstraints();
+    auto is = TermUnificationResultSpec { 
+     .querySigma  = sub.apply(a, NORM_QUERY_BANK), 
+     .resultSigma = sub.apply(b, NORM_RESULT_BANK), 
+     .constraints = iterTraits(sub.getConstraints()).collect<Stack>(),
+    };
+
+    cout << "[ FAIL ] " << a << " unify " << b << endl;
+    cout << "is:       " << is << endl;
+    cout << "expected: nothing" << endl;
+    exit(-1);
+  }
+}
+
 
 TEST_FUN(using_robsub)
 {
@@ -276,14 +524,21 @@ TEST_FUN(using_robsub)
   cmh->addHandler(make_unique<UWAMismatchHandler>(Options::UnificationWithAbstraction::ONE_INTERP));  
   RobSubstitution sub(cmh);
 
-  auto t1 = f(b + 2);
-  auto t2 = f(x + 2);
-  auto t3 = f(a);
-  auto t4 = g(1 + a);
+  checkRobUnify(f(b + 2), f(x + 2), sub, 
+      TermUnificationResultSpec { 
+        .querySigma = f(b + 2),
+        .resultSigma = f(x + 2),
+        .constraints = { x + 2 != b + 2 },
+      });
 
-  reportRobUnify(t1, t2,sub);
   sub.reset();
-  reportRobUnify(t2, t3,sub);
+  checkRobUnify(f(x + 2), f(a), sub, 
+      TermUnificationResultSpec { 
+        .querySigma = f(x + 2),
+        .resultSigma = f(a),
+        .constraints = { x + 2 != a },
+      });
+
   sub.reset();
-  reportRobUnify(t3, t4,sub);
+  checkRobUnifyFail(f(a), g(1 + a), sub);
 }

--- a/UnitTests/tUnificationWithAbstraction.cpp
+++ b/UnitTests/tUnificationWithAbstraction.cpp
@@ -45,9 +45,9 @@ TermIndexingStructure* getTermIndex(bool uwa = true)
 {
   auto cmh = new MismatchHandler();
   if(uwa){
-    cmh->addHandler(new UWAMismatchHandler());
+    cmh->addHandler(make_unique<UWAMismatchHandler>());
   } else {
-    cmh->addHandler(new HOMismatchHandler());
+    cmh->addHandler(make_unique<HOMismatchHandler>());
   }
   return new TermSubstitutionTree(cmh); 
 }
@@ -55,7 +55,7 @@ TermIndexingStructure* getTermIndex(bool uwa = true)
 LiteralIndexingStructure* getLiteralIndex()
 {
   auto cmh = new MismatchHandler();
-  cmh->addHandler(new UWAMismatchHandler());
+  cmh->addHandler(make_unique<UWAMismatchHandler>());
   return new LiteralSubstitutionTree(cmh); 
 }
 
@@ -288,7 +288,7 @@ TEST_FUN(using_robsub)
   DECL_CONST(b, Int) 
 
   auto cmh = new MismatchHandler();
-  cmh->addHandler(new UWAMismatchHandler());  
+  cmh->addHandler(make_unique<UWAMismatchHandler>());  
   RobSubstitution sub(cmh);
 
   auto t1 = f(b + 2);


### PR DESCRIPTION
The biggest change is the change the change in the `MisatchHandler` class hierarchy.
What used to be `CompositieMismatchHandler` is now `MismatchHandler`. No inheritance or subtyping there, because this is the only kind of mismatch handler that is actually being used in client code (i.e. Indexing and Robsubstitution). 

What used to be the abstract class `MisnmatchHandler` is now the abstract class `AtomicMismatchHandler` (maybe we have a better name for this (?), like AbstractionStrategy, ...).
This abstract class is implemeneted by `HOMismatchHandler` and `UWAMismatchHandler`. it is not being interacted with anywhere in the codebase, except for in `MismatchHandler.cpp`.

These changes fix the issue that some function in the old `MismatchHandler would have to throw an exception  before, therefore we get compile-time safety that different handlers cannot be "misused". 