### PR TITLE
remove `__APPLE__` and `__CYGWIN__` logic from `Portability.hpp`

### DIFF
--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -39,7 +39,7 @@
 #endif
 
 #if USE_SYSTEM_ALLOCATION
-# if __APPLE__
+# ifdef __APPLE__
 #  include <malloc/malloc.h>
 # else
 #  include <malloc.h>

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -12,17 +12,6 @@
 #include <climits>
 
 //////////////////////////////////////////////////////
-// Detect compiler
-
-#ifndef __APPLE__
-# define __APPLE__ 0
-#endif
-
-#ifndef __CYGWIN__
-# define __CYGWIN__ 0
-#endif
-
-//////////////////////////////////////////////////////
 // architecture sanity check
 
 static_assert(


### PR DESCRIPTION
`Portability.hpp` defines both `__APPLE__` and `__CYGWIN__` to 1 if defined and 0 if not. This is weird, and only used once in `Lib::Allocator`. Do the more usual `#ifdef` in `Allocator.cpp` and remove this logic from `Portability.hpp`.