### PR TITLE
cleanup around Formula, mostly dead code

### DIFF
--- a/Kernel/Formula.hpp
+++ b/Kernel/Formula.hpp
@@ -18,8 +18,6 @@
 #ifndef __Formula__
 #define __Formula__
 
-#include <utility>
-
 #include "Forwards.hpp"
 
 #include "Lib/Environment.hpp"
@@ -78,15 +76,8 @@ public:
   bool isFreeVariable(unsigned var) const;
   VList* boundVariables () const;
 
-  // miscellaneous
-  bool equals(const Formula*) const;
-  void collectAtoms(Stack<Literal*>& acc);
-  void collectPredicates(Stack<unsigned>& acc);
-  void collectPredicatesWithPolarity(Stack<pair<unsigned,int> >& acc, int polarity=1);
-
   // output
   vstring toString() const;
-  vstring toStringInScopeOf(Connective con) const;
   static vstring toString(Connective con);
   bool parenthesesRequired(Connective outer) const;
   // auxiliary functions
@@ -117,7 +108,6 @@ public:
   CLASS_NAME(Formula);
   USE_ALLOCATOR(Formula);
 protected:
-  static vstring toString(const Formula* f);
 
   /** Create a dummy formula will null content */
   explicit Formula(Connective con)
@@ -389,7 +379,7 @@ class BoolTermFormula
   TermList _ts;
 }; // class BoolTermFormula
 
-// definitions, had to be put out of class
+// out-of-line to break cyclic dependency on subclasses
 
 /** Return the list of variables of a quantified formula */
 inline
@@ -554,8 +544,6 @@ TermList Formula::getBooleanTerm()
   ASS(_connective == BOOL_TERM);
   return static_cast<BoolTermFormula*>(this)->getTerm();
 }
-
-// operators
 
 std::ostream& operator<< (ostream& out, const Formula& f);
 std::ostream& operator<< (ostream& out, const Formula* f);

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -489,28 +489,6 @@ bool Problem::higherOrder() const
   return _higherOrder.value();
 }
 
-
-///////////////////////
-// utility functions
-//
-
-/**
- * Put predicate numbers present in the problem into @c acc
- *
- * The numbers added to acc are not unique.
- *
- */
-void Problem::collectPredicates(Stack<unsigned>& acc) const
-{
-  CALL("Problem::collectPredicates");
-
-  UnitList::Iterator uit(units());
-  while(uit.hasNext()) {
-    Unit* u = uit.next();
-    u->collectPredicates(acc);
-  }
-}
-
 #if VDEBUG
 ///////////////////////
 // debugging

--- a/Kernel/Problem.hpp
+++ b/Kernel/Problem.hpp
@@ -187,12 +187,6 @@ public:
     _mayHaveXEqualsY = false;
   }
 
-
-  //utility functions
-
-  void collectPredicates(Stack<unsigned>& acc) const;
-
-
 #if VDEBUG
   //debugging functions
   void assertValid();

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -158,45 +158,6 @@ Formula* Unit::getFormula()
   }
 }
 
-void Unit::collectAtoms(Stack<Literal*>& acc)
-{
-  CALL("Unit::collectAtoms");
-
-  if(isClause()) {
-    Clause* cl = static_cast<Clause*>(this);
-    Clause::Iterator cit(*cl);
-    while(cit.hasNext()) {
-      Literal* l = cit.next();
-      acc.push(Literal::positiveLiteral(l));
-   }
-  }
-  else {
-    Formula* form = static_cast<FormulaUnit*>(this)->formula();
-    form->collectAtoms(acc);
-  }
-}
-
-/**
- * Add into @c acc numbers of all predicates in the unit.
- * If a predicate occurrs multiple times, it is added once for each occurrence.
- */
-void Unit::collectPredicates(Stack<unsigned>& acc)
-{
-  CALL("Unit::collectPredicates");
-
-  if(isClause()) {
-    Clause* cl = static_cast<Clause*>(this);
-    unsigned clen = cl->length();
-    for(unsigned i=0; i<clen; i++) {
-      acc.push((*cl)[i]->functor());
-    }
-  }
-  else {
-    Formula* form = static_cast<FormulaUnit*>(this)->formula();
-    form->collectPredicates(acc);
-  }
-}
-
 /**
  * Print the inference as a vstring (used in printing units in
  * refutations).

--- a/Kernel/Unit.hpp
+++ b/Kernel/Unit.hpp
@@ -119,8 +119,6 @@ public:
   unsigned getWeight();
 
   Formula* getFormula();
-  void collectAtoms(Stack<Literal*>& acc);
-  void collectPredicates(Stack<unsigned>& acc);
 
   /**
    * Increase the number of references to the unit.


### PR DESCRIPTION
See #157. `Kernel::Formula` has some dead code, ancient commented functions, unused headers, etc. Remove them.