### PR TITLE
Add back ] and end line

### DIFF
--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -404,6 +404,7 @@ protected:
         out << _is->getUnitIdStr(prem);
         first=false;
       }
+      out << "]" << endl;
     }
   }
 


### PR DESCRIPTION
Now there is no ]\n after on non-clause lines in the proof. I tested it with all proof extra options.