### PR TITLE
remove class-level placement new overrides

### DIFF
--- a/Inferences/SubsumptionDemodulationHelper.hpp
+++ b/Inferences/SubsumptionDemodulationHelper.hpp
@@ -221,10 +221,6 @@ class SDClauseMatches
   USE_ALLOCATOR(SDClauseMatches);
 
   public:
-    // required to use std::vector::emplace_back
-    DECLARE_PLACEMENT_NEW;
-
-  public:
     SDClauseMatches(Clause* base, LiteralMiniIndex const& ixAlts);
 
     ~SDClauseMatches();

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -109,10 +109,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 	altBindingPtrs++;
 	altBindingData+=numVars;
 	if(resolvedLit) {
-	  new(altBindingData++) TermList((size_t)0);
+	  ::new (altBindingData++) TermList((size_t)0);
 	} else {
           // add index of the literal in instance clause at the end of the binding sequence
-	  new(altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+	  ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
 	}
       }
       if(MatchingUtils::matchReversedArgs(baseLit, alit)) {
@@ -122,10 +122,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 	altBindingPtrs++;
 	altBindingData+=numVars;
 	if(resolvedLit) {
-	  new(altBindingData++) TermList((size_t)0);
+	  ::new (altBindingData++) TermList((size_t)0);
 	} else {
           // add index of the literal in instance clause at the end of the binding sequence
-	  new(altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+	  ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
 	}
       }
 
@@ -139,10 +139,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       altBindingPtrs++;
       altBindingData+=numVars;
       if(resolvedLit) {
-        new(altBindingData++) TermList((size_t)0);
+        ::new (altBindingData++) TermList((size_t)0);
       } else {
         // add index of the literal in instance clause at the end of the binding sequence
-        new(altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+        ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
       }
     }
   }
@@ -155,7 +155,7 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       *altBindingPtrs=altBindingData;
       altBindingPtrs++;
       altBindingData+=numVars;
-      new(altBindingData++) TermList((size_t)1);
+      ::new (altBindingData++) TermList((size_t)1);
     }
     if(baseLit->isEquality() && MatchingUtils::matchReversedArgs(baseLit, resolvedLit)) {
       ArrayStoringBinder binder(altBindingData, variablePositions);
@@ -163,7 +163,7 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       *altBindingPtrs=altBindingData;
       altBindingPtrs++;
       altBindingData+=numVars;
-      new(altBindingData++) TermList((size_t)1);
+      ::new (altBindingData++) TermList((size_t)1);
     }
 
   }

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -121,7 +121,7 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
         altBindingPtrs++;
         altBindingData+=numVars;
         // add index of the literal in instance clause at the end of the binding sequence
-        new(altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+        ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
       }
       if(MatchingUtils::matchReversedArgs(baseLit, alit)) {
         ArrayStoringBinder binder(altBindingData, variablePositions);
@@ -130,7 +130,7 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
         altBindingPtrs++;
         altBindingData+=numVars;
         // add index of the literal in instance clause at the end of the binding sequence
-        new(altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+        ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
       }
     } else {
       if(numVars) {
@@ -142,7 +142,7 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
       altBindingPtrs++;
       altBindingData+=numVars;
       // add index of the literal in instance clause at the end of the binding sequence
-      new(altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+      ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
     }
   }
 }

--- a/Kernel/Substitution.hpp
+++ b/Kernel/Substitution.hpp
@@ -41,7 +41,6 @@ class Substitution
 public:
   CLASS_NAME(Substitution);
   USE_ALLOCATOR(Substitution);
-  DECLARE_PLACEMENT_NEW;
 
   Substitution() {}
 

--- a/Lib/Allocator.hpp
+++ b/Lib/Allocator.hpp
@@ -388,11 +388,6 @@ void array_delete(T* array, size_t length)
   }
 }
 
-#define DECLARE_PLACEMENT_NEW                                           \
-  void* operator new (size_t, void* buffer) { return buffer; } 		\
-  void operator delete (void*, void*) {}
-
-
 #if VDEBUG
 
 std::ostream& operator<<(std::ostream& out, const Allocator::Descriptor& d);

--- a/Lib/Array.hpp
+++ b/Lib/Array.hpp
@@ -73,7 +73,7 @@ public:
       void* mem = ALLOC_KNOWN(_capacity*sizeof(C),"Array<>");
       _array = static_cast<C*>(mem);
       for(size_t i=0; i<_capacity; i++) {
-        new(&_array[i]) C(o._array[i]);
+        ::new (&_array[i]) C(o._array[i]);
       }
     } else {
       _array = 0;

--- a/Lib/BinaryHeap.hpp
+++ b/Lib/BinaryHeap.hpp
@@ -96,7 +96,7 @@ public:
     CALL("BinaryHeap::insert");
     ensureAvaiablePosition();
     _size++;
-    new(&_data1[_size]) T(obj);
+    ::new (&_data1[_size]) T(obj);
     bubbleUp(_size);
   }
 
@@ -168,7 +168,7 @@ public:
     CALL("BinaryHeap::backtrackableInsert(T,unsigned&)");
     ensureAvaiablePosition();
     _size++;
-    new(&_data1[_size]) T(obj);
+    ::new (&_data1[_size]) T(obj);
     return bubbleUp(_size);
   }
   inline
@@ -204,7 +204,7 @@ public:
     //_lastBubbleIndex is the current index of the formerly last
     //element.
     _size++;
-    new(&_data1[_size]) T(val);
+    ::new (&_data1[_size]) T(val);
     std::swap(_data1[_size], _data1[lastBubbleIndex]);
     //Now at the position _lastBubbleIndex is the smallest element
     //of the heap, so we know that it will bubble up to the first
@@ -346,7 +346,7 @@ private:
       T* otp = oldData+_size;
       T* ntp = _data+_size;
       do {
-	new(--ntp) T(*(--otp));
+	::new (--ntp) T(*(--otp));
 	//because oldCapacity==_size, we destroy all elements of oldData array here
 	otp->~T();
       } while(ntp!=_data);

--- a/Lib/DArray.hpp
+++ b/Lib/DArray.hpp
@@ -79,7 +79,7 @@ public:
     void* mem = ALLOC_KNOWN(sizeof(C)*_capacity,"DArray<>");
     _array = static_cast<C*>(mem);
     for(size_t i=0; i<_size; i++) {
-      new(&_array[i]) C(o[i]);
+      ::new (&_array[i]) C(o[i]);
     }
   }
 
@@ -210,11 +210,11 @@ public:
 
     while(nptr!=firstEmpty) {
       C *oldAddr = optr++, *newAddr = nptr++;
-      new(newAddr) C(std::move(*oldAddr));
+      ::new (newAddr) C(std::move(*oldAddr));
       oldAddr->~C();
     }
     while(nptr!=afterLast) {
-      new(nptr++) C();
+      ::new (nptr++) C();
     }
     _size = s;
 

--- a/Lib/DHMap.hpp
+++ b/Lib/DHMap.hpp
@@ -369,7 +369,7 @@ public:
       e->_info.deleted=0;
       e->_key=key;
       e->_val.~Val();
-      new(&e->_val) Val();
+      ::new (&e->_val) Val();
       _size++;
     }
     pval=&e->_val;

--- a/Lib/Deque.hpp
+++ b/Lib/Deque.hpp
@@ -160,7 +160,7 @@ public:
       expand();
     }
     ASS(_back < _end);
-    new(_back) C(elem);
+    ::new (_back) C(elem);
 
     _back++;
     if(_back==_end) {
@@ -186,7 +186,7 @@ public:
     }
     _front--;
 
-    new(_front) C(elem);
+    ::new (_front) C(elem);
 
     ASS_NEQ(_front, _back);
   }
@@ -469,7 +469,7 @@ protected:
     C* newData = static_cast<C*>(mem);
     C* oldPtr=_front;
     for(size_t i = 0; i<curSize; i++) {
-      new(newData+i) C(*oldPtr);
+      ::new (newData+i) C(*oldPtr);
       oldPtr->~C();
 
       oldPtr++;

--- a/Lib/SkipList.hpp
+++ b/Lib/SkipList.hpp
@@ -192,7 +192,7 @@ public:
       }
     }
     Node* newNode = allocate(nodeHeight);
-    new(&newNode->value) Value();
+    ::new (&newNode->value) Value();
 
 
     unsigned h = _top - 1;

--- a/Lib/Stack.hpp
+++ b/Lib/Stack.hpp
@@ -57,8 +57,6 @@ public:
 
   CLASS_NAME(Stack);
   USE_ALLOCATOR(Stack);
-  DECLARE_PLACEMENT_NEW;
-
 
   /**
    * Create a stack having initialCapacity.

--- a/Lib/VirtualIterator.hpp
+++ b/Lib/VirtualIterator.hpp
@@ -130,8 +130,7 @@ class VirtualIterator {
 public:
   CLASS_NAME(VirtualIterator);
   USE_ALLOCATOR(VirtualIterator);
-  DECLARE_PLACEMENT_NEW;
-  
+
   DECL_ELEMENT_TYPE(T);
 
   /** Return an empty iterator */

--- a/SAT/SATClause.cpp
+++ b/SAT/SATClause.cpp
@@ -74,7 +74,7 @@ SATClause::SATClause(unsigned length)
 
   // call a constructor on the literals
   for (size_t i = 1; i < _length; i++)
-    new (&_literals[i]) SATLiteral();
+    ::new (&_literals[i]) SATLiteral();
 }
 
 /**

--- a/Saturation/ConsequenceFinder.hpp
+++ b/Saturation/ConsequenceFinder.hpp
@@ -21,6 +21,7 @@
 #include "Lib/Array.hpp"
 #include "Lib/Event.hpp"
 #include "Lib/Int.hpp"
+#include "Lib/SkipList.hpp"
 #include "Lib/Stack.hpp"
 
 #include "Kernel/Clause.hpp"


### PR DESCRIPTION
See #157 and comments in #422. It seems that `DECLARE_PLACEMENT_NEW` can go altogether.

However, I did not properly understand placement-new overload resolution: it seems that if there is _any_ class overload of `operator new` (placement or otherwise), then `new (addr) T` resolves to `T::operator new(size_t, void *)`, producing an error if it does not exist.

We never actually override placement-new with anything except the default, and it would be concerning if we did, so in my view we can just replace all instances of `new (addr) T` with `::new (addr) T`. This reduces the amount that my head hurts and also allows us to remove `DECLARE_PLACEMENT_NEW`. I was still concerned that something in `std::` would call `new (addr) T`, but it doesn't seem to be a problem.

By the way, different compilers seem to think differently about the need for forward-declaration. Clang complains about the lack of `SkipList` in `ConsequenceFinder`, so put that back via include.