### PR TITLE
function definition introduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/TautologyDeletionISE.cpp
     Inferences/TermAlgebraReasoning.cpp
     Inferences/URResolution.cpp
+    Inferences/DefinitionIntroduction.cpp
     Inferences/BackwardDemodulation.hpp
     Inferences/BackwardSubsumptionResolution.hpp
     Inferences/BinaryResolution.hpp
@@ -458,6 +459,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/TautologyDeletionISE.hpp
     Inferences/TermAlgebraReasoning.hpp
     Inferences/URResolution.hpp
+    Inferences/DefinitionIntroduction.hpp
     Inferences/TheoryInstAndSimp.hpp
     Inferences/TheoryInstAndSimp.cpp  # this is theory instantiation
     Inferences/ArithmeticSubtermGeneralization.hpp

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -130,7 +130,8 @@ void DefinitionIntroduction::process(Term *t) {
       continue;
 
     entry.term = gen;
-    if(++entry.count > env.options->functionDefinitionIntroduction()) {
+    entry.weight += t->weight();
+    if(entry.weight > env.options->functionDefinitionIntroduction()) {
       introduceDefinitionFor(entry.term);
       std::swap(entries[i], entries.top());
       entries.pop();
@@ -139,7 +140,7 @@ void DefinitionIntroduction::process(Term *t) {
   }
 
   if(i == entries.length())
-    entries.push({t, 1});
+    entries.push({t, t->weight()});
 }
 
 void DefinitionIntroduction::process(Clause *cl) {

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -1,0 +1,158 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file DefinitionIntroduction.cpp
+ */
+
+#include "DefinitionIntroduction.hpp"
+
+#include "Kernel/Clause.hpp"
+#include "Kernel/TermIterators.hpp"
+
+namespace Inferences
+{
+
+Term *DefinitionIntroduction::lgg(Term *left, Term *right) {
+  CALL("DefinitionIntroduction::lgg")
+
+  unsigned fresh = 0;
+  _substitution.reset();
+
+  _function_scratch.push({left->functor(), left->arity(), left->arity()});
+  SubtermIterator left_it(left);
+  SubtermIterator right_it(right);
+  while(left_it.hasNext()) {
+    ALWAYS(right_it.hasNext());
+
+    TermList left_top = left_it.next();
+    TermList right_top = right_it.next();
+    if(left_top.isTerm() && right_top.isTerm() && left_top.term()->functor() == right_top.term()->functor()) {
+      unsigned functor = left_top.term()->functor();
+      unsigned arity = left_top.term()->arity();
+      _function_scratch.push({functor, arity, arity});
+    }
+    else {
+      unsigned mapped;
+      if(!_substitution.find({left_top, right_top}, mapped))
+        _substitution.insert({left_top, right_top}, mapped = fresh++);
+
+      _arg_scratch.push(TermList(mapped, false));
+      left_it.right();
+      right_it.right();
+      _function_scratch.top().remaining--;
+    }
+
+    while(!_function_scratch.top().remaining) {
+      IncompleteFunction record = _function_scratch.pop();
+      Term *term = Term::create(record.functor, record.arity, _arg_scratch.end() - record.arity);
+      _arg_scratch.truncate(_arg_scratch.length() - record.arity);
+      _arg_scratch.push(TermList(term));
+
+      if(_function_scratch.isNonEmpty())
+        _function_scratch.top().remaining--;
+      else
+        break;
+    }
+  }
+
+  ASS_EQ(_arg_scratch.length(), 1);
+  return _arg_scratch.pop().term();
+}
+
+void DefinitionIntroduction::introduceDefinitionFor(Term *t) {
+  CALL("DefinitionIntroduction::introduceDefinitionFor");
+
+  if(!_defined.insert(t))
+    return;
+
+  TermList range_sort = SortHelper::getResultSort(t);
+
+  DHMap<unsigned, TermList> sorts;
+  SortHelper::collectVariableSorts(t, sorts);
+  unsigned arity = sorts.size();
+
+  Stack<TermList> domain_sorts;
+  Stack<TermList> variables;
+  for(unsigned i = 0; i < arity; i++) {
+    domain_sorts.push(TermList(sorts.get(i)));
+    variables.push(TermList(i, false));
+  }
+
+  unsigned functor = env.signature->addFreshFunction(arity, "sF");
+  OperatorType *type = OperatorType::getFunctionType(arity, domain_sorts.begin(), range_sort);
+  env.signature->getFunction(functor)->setType(type);
+
+  Term *def = Term::create(functor, arity, variables.begin());
+  Literal *eq = Literal::createEquality(true, TermList(def), TermList(t), range_sort);
+
+  NonspecificInference0 inference(UnitInputType::AXIOM, InferenceRule::FUNCTION_DEFINITION);
+  Clause *definition = new (1) Clause(1, inference);
+  (*definition)[0] = eq;
+
+  _definitions.push(definition);
+}
+
+void DefinitionIntroduction::process(Term *t) {
+  CALL("DefinitionIntroduction::process(Term *)");
+
+  unsigned functor = t->functor();
+  Stack<Entry> &entries = _entries[functor];
+
+  unsigned i = 0;
+  for(i = 0; i < entries.length(); i++) {
+    Entry &entry = entries[i];
+    Term *gen = lgg(entry.term, t);
+    if(gen->allArgumentsAreVariables() && gen->getDistinctVars() == gen->arity())
+      continue;
+
+    entry.term = gen;
+    if(++entry.count > env.options->functionDefinitionIntroduction()) {
+      introduceDefinitionFor(entry.term);
+      std::swap(entries[i], entries.top());
+      entries.pop();
+      return;
+    }
+  }
+
+  if(i == entries.length())
+    entries.push({t, 1});
+}
+
+void DefinitionIntroduction::process(Clause *cl) {
+  CALL("DefinitionIntroduction::process(Clause *)");
+
+  if(cl->inference().rule() == InferenceRule::FUNCTION_DEFINITION)
+    return;
+
+  while(_entries.length() < env.signature->functions())
+    _entries.push(Stack<Entry>());
+
+  for(unsigned i = 0; i < cl->length(); i++) {
+    NonVariableNonTypeIterator it((*cl)[i]);
+    while(it.hasNext()) {
+      TermList next = it.next();
+      Term *t = next.term();
+      if(t->allArgumentsAreVariables() && t->getDistinctVars() == t->arity())
+        continue;
+
+      process(t);
+    }
+  }
+}
+
+ClauseIterator DefinitionIntroduction::generateClauses(Clause *cl) {
+  CALL("DefinitionIntroduction::generateClauses");
+
+  _definitions.reset();
+  process(cl);
+  return pvi(decltype(_definitions)::Iterator(_definitions));
+}
+
+}

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -165,12 +165,4 @@ void DefinitionIntroduction::process(Clause *cl) {
   }
 }
 
-ClauseIterator DefinitionIntroduction::generateClauses(Clause *cl) {
-  CALL("DefinitionIntroduction::generateClauses");
-
-  _definitions.reset();
-  process(cl);
-  return pvi(decltype(_definitions)::Iterator(_definitions));
-}
-
 }

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -155,8 +155,7 @@ void DefinitionIntroduction::process(Clause *cl) {
   for(unsigned i = 0; i < cl->length(); i++) {
     NonVariableNonTypeIterator it((*cl)[i]);
     while(it.hasNext()) {
-      TermList next = it.next();
-      Term *t = next.term();
+      Term *t = it.next();
       if(t->allArgumentsAreVariables() && t->getDistinctVars() == t->arity())
         continue;
 

--- a/Inferences/DefinitionIntroduction.hpp
+++ b/Inferences/DefinitionIntroduction.hpp
@@ -39,13 +39,6 @@ private:
   DHSet<Term *> _defined;
   Stack<Stack<Entry>> _entries;
   Stack<Clause *> _definitions;
-
-  struct IncompleteFunction {
-    unsigned functor, arity, remaining;
-  };
-  Stack<IncompleteFunction> _function_scratch;
-  Stack<TermList> _arg_scratch;
-  DHMap<std::pair<TermList, TermList>, unsigned> _substitution;
 };
 
 }

--- a/Inferences/DefinitionIntroduction.hpp
+++ b/Inferences/DefinitionIntroduction.hpp
@@ -34,7 +34,7 @@ private:
 
   struct Entry {
     Term *term;
-    unsigned count;
+    unsigned weight;
   };
   DHSet<Term *> _defined;
   Stack<Stack<Entry>> _entries;

--- a/Inferences/DefinitionIntroduction.hpp
+++ b/Inferences/DefinitionIntroduction.hpp
@@ -1,0 +1,53 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file DefinitionIntroduction.hpp
+ */
+
+#ifndef __DefinitionIntroduction__
+#define __DefinitionIntroduction__
+
+#include "InferenceEngine.hpp"
+
+namespace Inferences
+{
+
+class DefinitionIntroduction: public GeneratingInferenceEngine {
+public:
+  CLASS_NAME(DefinitionIntroduction);
+  USE_ALLOCATOR(DefinitionIntroduction);
+
+  ClauseIterator generateClauses(Clause *cl) override;
+
+private:
+  void process(Clause *cl);
+  void process(Term *t);
+  void introduceDefinitionFor(Term *t);
+  Term *lgg(Term *left, Term *right);
+
+  struct Entry {
+    Term *term;
+    unsigned count;
+  };
+  DHSet<Term *> _defined;
+  Stack<Stack<Entry>> _entries;
+  Stack<Clause *> _definitions;
+
+  struct IncompleteFunction {
+    unsigned functor, arity, remaining;
+  };
+  Stack<IncompleteFunction> _function_scratch;
+  Stack<TermList> _arg_scratch;
+  DHMap<std::pair<TermList, TermList>, unsigned> _substitution;
+};
+
+}
+
+#endif

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -517,6 +517,16 @@ public:
   void destroyNonShared();
   Term* apply(Substitution& subst);
 
+  /** True iff all immediate arguments are variables */
+  bool allArgumentsAreVariables() const
+  {
+    for(unsigned i = 0; i < arity(); i++)
+      if(!nthArgument(i)->isVar())
+        return false;
+
+    return true;
+  }
+
   /** True if the term is ground. Only applicable to shared terms */
   bool ground() const
   {

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,7 @@ VINF_OBJ=Inferences/BackwardDemodulation.o\
          Inferences/BinaryResolution.o\
          Inferences/Condensation.o\
          Inferences/DistinctEqualitySimplifier.o\
+         Inferences/DefinitionIntroduction.o\
          Inferences/EqualityFactoring.o\
          Inferences/EqualityResolution.o\
          Inferences/ExtensionalityResolution.o\

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -91,6 +91,7 @@
 #include "Inferences/BoolSimp.hpp"
 #include "Inferences/CasesSimp.hpp"
 #include "Inferences/Cases.hpp"
+#include "Inferences/DefinitionIntroduction.hpp"
 
 #include "Saturation/ExtensionalityClauseContainer.hpp"
 
@@ -1546,6 +1547,9 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
 
   // create generating inference engine
   CompositeGIE* gie=new CompositeGIE();
+
+  if(opt.functionDefinitionIntroduction())
+    gie->addFront(new DefinitionIntroduction);
 
   //TODO here induction is last, is that right?
   if(opt.induction()!=Options::Induction::NONE){

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -465,6 +465,20 @@ void Options::init()
     _functionDefinitionElimination.addProblemConstraint(hasEquality());
     _functionDefinitionElimination.setRandomChoices({"all","none"});
 
+    _functionDefinitionIntroduction = UnsignedOptionValue(
+      "function_definition_introduction",
+      "fdi",
+      0
+    );
+    _functionDefinitionIntroduction.description =
+      "If non-zero, introduces function definitions with generalisation for repeated compound terms in the active set. "
+      "For example, if f(a, g(a)) and f(b, g(b)) occur frequently, we might define d(X) = f(X, g(X)). "
+      "The parameter value 'n' is a threshold: terms that occur more than n times have a definition created.";
+    _lookup.insert(&_functionDefinitionIntroduction);
+    _functionDefinitionIntroduction.tag(OptionTag::INFERENCES);
+    _functionDefinitionIntroduction.addProblemConstraint(hasEquality());
+    _functionDefinitionIntroduction.setRandomChoices({"0", "1", "2", "4", "8", "16", "32", "64"});
+
     _skolemReuse = BoolOptionValue("skolem_reuse", "skr", false);
     _skolemReuse.description =
       "Attempt to reuse Skolem symbols.\n"

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -476,7 +476,6 @@ void Options::init()
       "The parameter value 'n' is a threshold: terms that occur more than n times have a definition created.";
     _lookup.insert(&_functionDefinitionIntroduction);
     _functionDefinitionIntroduction.tag(OptionTag::INFERENCES);
-    _functionDefinitionIntroduction.addProblemConstraint(hasEquality());
     _functionDefinitionIntroduction.setRandomChoices({"0", "1", "2", "4", "8", "16", "32", "64"});
 
     _skolemReuse = BoolOptionValue("skolem_reuse", "skr", false);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2294,6 +2294,7 @@ public:
   bool ignoreConjectureInPreprocessing() const {return _ignoreConjectureInPreprocessing.actualValue;}
 
   FunctionDefinitionElimination functionDefinitionElimination() const { return _functionDefinitionElimination.actualValue; }
+  unsigned functionDefinitionIntroduction() const { return _functionDefinitionIntroduction.actualValue; }
   bool skolemReuse() const { return _skolemReuse.actualValue; }
   bool definitionReuse() const { return _definitionReuse.actualValue; }
   TweeGoalTransformation tweeGoalTransformation() const { return _tweeGoalTransformation.actualValue; }
@@ -2608,6 +2609,7 @@ private:
   BoolOptionValue _forwardSubsumptionDemodulation;
   UnsignedOptionValue _forwardSubsumptionDemodulationMaxMatches;
   ChoiceOptionValue<FunctionDefinitionElimination> _functionDefinitionElimination;
+  UnsignedOptionValue _functionDefinitionIntroduction;
   BoolOptionValue _skolemReuse;
   BoolOptionValue _definitionReuse;
   ChoiceOptionValue<TweeGoalTransformation> _tweeGoalTransformation;


### PR DESCRIPTION
Well, we have function definition _elimination_, why not the opposite? More seriously, we found this was useful in a very specialised application of Vampire. Opening this to see if anyone's interested, not necessarily to be merged.

The general idea is to detect when a term is used frequently and introduce a definition for it.

The code works by looking at terms in clauses as they are activated: if a term has been seen more than a threshold, introduce a definition for it. This includes generalisations: if we see e.g. `f(a, g(a))` and `f(b, g(b))` frequently, we could define `d(X) = f(X, g(X))`. I use a cheap approximate technique to detect when we need a definition, which seems to work well enough. Definitions are added to proof search as a unit equation, as if it were an axiom. Demodulation typically (always?) rewrites the rest of the search space as a result, since the definition is smaller than what it denotes. Since these are just definitions, the technique is sound and complete.

This is not a good idea in general. There is non-zero overhead (although relatively small, at least in the beginning of proof search), but the bigger problem is that the disturbance to proof search is significant, particularly the SAT-based methods which don't tend to like new function symbols appearing. There are however some problems for which this is really beneficial.

I ran 1-second DISCOUNT runs over ~5000 problems in TPTP, with the threshold set to 0 (i.e. off), 1, 2, 4, and 8 occurrences. In hindsight maybe a few more powers of 2 would have been useful. This had no effect on the majority of problems. Of the rest, most were hindered by introducing definitions. However, 60 problems were not solved without definition introduction, but were solved with some threshold. They are:

```
ALG370-1
ARI105=1
ARI535=1
ARI674=1
ARI721=1
ARI726=1
CAT004-1
DAT080=1
GEO112-1
GEO568+1
GEO619+1
GEO632+1
GEO642+1
GRP402-1
GRP498-1
GRP519-1
HWV031-1
ITP012+2
ITP305_1
ITP325_1
KLE010+1
KLE015+1
KLE144+1
KLE150+1
LCL641+1.020
LCL896+1
MGT035-1
NUM569+3
NUM926_1
NUN086+1
PRO009+2
SCT085-1
SET021-6
SET108-7
SET235-6
SET473-6
SET669+3
SET844-1
SEU141+1
SEU147+2
SEU190+1
SWC031+1
SWC058+1
SWC065+1
SWC110+1
SWC355-1
SWC370+1
SWC372-1
SWV053+1
SWV153+1
SWV221+1
SWV394+1
SWV449+1
SWV454+1
SWV473+1
SWV592-1
SWW478_3
SWW619=2
TOP018-1
TOP019-1
```