### PR TITLE
check for body of quantified SMTLIB2 formula

### DIFF
--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1829,6 +1829,9 @@ void SMTLIB2::parseQuantBegin(LExpr* exp)
     }
   }
 
+  if(!lRdr.hasNext())
+    USER_ERROR("Missing body in quantification " + exp->toString());
+
   _scopes.push(lookup);
 
   _todo.push(make_pair(PO_PARSE_APPLICATION,exp)); // will create the actual quantified formula and clear the lookup...


### PR DESCRIPTION
There is currently no check that an SMTLIB quantified formula actually contains a sub-formula. This can be quite difficult to debug. Add this check as I doubt there is a performance concern here.