### PR TITLE
Minisat/utils/System.*: use fpu_control only on glibc

### DIFF
--- a/Minisat/utils/System.cc
+++ b/Minisat/utils/System.cc
@@ -104,7 +104,7 @@ double Minisat::memUsedPeak(bool) {
 
 void Minisat::setX86FPUPrecision()
 {
-#if defined(__linux__) && defined(_FPU_EXTENDED) && defined(_FPU_DOUBLE) && defined(_FPU_GETCW)
+#if defined(__GLIBC__) && defined(_FPU_EXTENDED) && defined(_FPU_DOUBLE) && defined(_FPU_GETCW)
     // Only correct FPU precision on Linux architectures that needs and supports it:
     fpu_control_t oldcw, newcw;
     _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);

--- a/Minisat/utils/System.h
+++ b/Minisat/utils/System.h
@@ -26,7 +26,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_System_h
 #define Minisat_System_h
 
-#if defined(__linux__)
+#if defined(__GLIBC__)
 #include <fpu_control.h>
 #endif
 


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@gentoo.org>