### PR TITLE
Fix show_fool option

### DIFF
--- a/Kernel/OperatorType.cpp
+++ b/Kernel/OperatorType.cpp
@@ -143,16 +143,16 @@ vstring OperatorType::argsToString() const
 {
   CALL("OperatorType::argsToString");
 
-  vstring res = "(";
   unsigned ar = arity();
   ASS(ar);
+  vstring res =  ar > 1 ? "(" : "";  
   for (unsigned i = _typeArgsArity; i < ar; i++) {
     res += arg(i).toString();
     if (i != ar-1) {
       res += " * ";
     }
   }
-  res += ')';
+  res += ar > 1 ? ")" : "";
   return res;
 } // OperatorType::argsToString()
 

--- a/Kernel/OperatorType.hpp
+++ b/Kernel/OperatorType.hpp
@@ -94,6 +94,11 @@ private:
 
   static OperatorType* getTypeFromKey(OperatorKey* key, unsigned taArity);
 
+  static TermList getEmpty() { 
+    static TermList empty(0,false);
+    empty.makeEmpty();
+    return empty;
+  }
   //static const TermList PREDICATE_FLAG;
 
 public:
@@ -107,7 +112,7 @@ public:
     CALL("OperatorType::getPredicateType(unsigned,const unsigned*)");
 
     OperatorKey* key = setupKey(arity,sorts);
-    (*key)[arity] = AtomicSort::boolSort();
+    (*key)[arity] = getEmpty();
     return getTypeFromKey(key,taArity);
   }
 
@@ -115,7 +120,7 @@ public:
     CALL("OperatorType::getPredicateType(std::initializer_list<unsigned>)");
 
     OperatorKey* key = setupKey(sorts);
-    (*key)[sorts.size()] = AtomicSort::boolSort();
+    (*key)[sorts.size()] = getEmpty();
     return getTypeFromKey(key,taArity);
   }
 
@@ -123,7 +128,7 @@ public:
     CALL("OperatorType::getPredicateTypeUniformRange");
 
     OperatorKey* key = setupKeyUniformRange(arity,argsSort);
-    (*key)[arity] = AtomicSort::boolSort();
+    (*key)[arity] = getEmpty();
     return getTypeFromKey(key, taArity);
   }
 
@@ -199,11 +204,11 @@ public:
   //TODO functions below do not hold for higher-order
   //In higher-order we have boolean functions
 
-  bool isPredicateType() const { return (*_key)[arity() - numTypeArguments()] == AtomicSort::boolSort(); };
-  bool isFunctionType() const { return (*_key)[arity() - numTypeArguments()] != AtomicSort::boolSort(); };
+  bool isPredicateType() const { return (*_key)[arity() - numTypeArguments()].isEmpty(); };
+  bool isFunctionType() const { return !(*_key)[arity() - numTypeArguments()].isEmpty(); };
 
   /**
-   * The result sort of function types; or AtomicSort::boolSort() for predicates.
+   * The result sort of function types; or empty for predicates.
    */
   TermList result() const {
     CALL("OperatorType::result");

--- a/Kernel/OperatorType.hpp
+++ b/Kernel/OperatorType.hpp
@@ -94,8 +94,8 @@ private:
 
   static OperatorType* getTypeFromKey(OperatorKey* key, unsigned taArity);
 
-  static TermList getEmpty() { 
-    static TermList empty(0,false);
+  static inline TermList getEmpty() { 
+    TermList empty;
     empty.makeEmpty();
     return empty;
   }

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -637,7 +637,12 @@ vstring Term::headToString() const
     if(isLiteral()) {
       name = static_cast<const Literal *>(this)->predicateName();
     } else if (isSort()) {
-      name = static_cast<const AtomicSort *>(this)->typeConName();
+      const AtomicSort* asSort = static_cast<const AtomicSort *>(this);
+      if(env.options->showFOOL() && asSort->isBoolSort()){
+        name = "$bool";
+      } else {
+        name = asSort->typeConName();
+      }
     } else {
       name = functionName();
     }

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -610,42 +610,22 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, 
   //out << "tff(" << (function ? "func" : "pred") << "_def_" << symNumber << ", type, "
   //    << sym->name() << ": ";
 
+  vstring symName = sym->name();
+  if(typeCon && env.signature->isBoolCon(symNumber)){
+    ASS(env.options->showFOOL());
+    symName = "$bool";
+  }
+
   //don't output type of app. It is an internal Vampire thing
   if(!(function && env.signature->isAppFun(symNumber))){
     out << (env.property->higherOrder() ? "thf(" : "tff(")
         << (function ? "func" : (typeCon ?  "type" : "pred")) 
         << "_def_" << symNumber << ", type, "
-        << sym->name() << ": ";
+        << symName << ": ";
     out << type->toString();
     out << ")." << endl;
   }
   //out << ")." << endl;
 }
-
-/**
- * Output to @b out all sort declarations for the current signature.
- * Built-in sorts and structures sorts will not be output.
- * @author Evgeny Kotelnikov
- * @since 04/09/2015 Gothneburg
- */
-/*void UIHelper::outputSortDeclarations(ostream& out)
-{
-  CALL("UIHelper::outputSortDeclarations");
-
-  if(env.statistics->higherOrder){
-    return;
-  }
-
-  unsigned sorts = env.sorts->count();
-  for (unsigned sort = 1; sort < sorts; ++sort) {
-    if (sort < Sorts::FIRST_USER_SORT && ((sort != 1) || !env.options->showFOOL())) {
-      continue;
-    }
-    if (SortHelper::isStructuredSort(sort)) {
-      continue;
-    }
-    out << "tff(type_def_" << sort << ", type, " << env.sorts->sortName(sort) << ": $tType)." << endl;
-  }
-}*/ // UIHelper::outputSortDeclarations
 
 } // namespace Shell

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -59,8 +59,6 @@ public:
   static void outputSymbolDeclarations(ostream& out);
   static void outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, bool typecon, unsigned symNumber);
 
-  static void outputSortDeclarations(ostream& out);//TODO modify all places that call function
-
   /**
    * A hacky global flag distinguishing the parent and the child in portfolio modes.
    * Currently affects how things are reported during timeout (see Timer.cpp)


### PR DESCRIPTION
This PR should fix the `show_fool` option that had been broken by earlier higher-order work. Terms of Boolean sort are now shown as being of sort `$bool` if `show_fool` is on. Along the way, the following improvements have been made:

- Distinction between predicate and function types has been improved
- Commented out code from UIHelper has been removed
- Types for unary functions and predicates no longer add unnecessary brackets around the single argument type when printing