### PR TITLE
added option --ignore_unrecognized_logic

### DIFF
--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -214,8 +214,8 @@ class NotImplementedException
 
 #define VAMPIRE_EXCEPTION \
   throw Lib::Exception(__FILE__,__LINE__)
-#define USER_ERROR(msg) \
-  throw Lib::UserErrorException(msg)
+#define USER_ERROR(...) \
+  throw Lib::UserErrorException(__VA_ARGS__)
 #define INVALID_OPERATION(msg) \
   throw Lib::InvalidOperationException(msg)
 #define SYSTEM_FAIL(msg,err) \

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -501,7 +501,11 @@ void SMTLIB2::readLogic(const vstring& logicStr)
   case SMT_UFBV:
     USER_ERROR("unsupported logic "+logicStr);
   default:
-    USER_ERROR("unrecognized logic "+logicStr);
+    if (env.options->ignoreUnrecognizedLogic()) {
+      break;
+    } else {
+      USER_ERROR("unrecognized logic ", logicStr, " ( use `--ignore_unrecognized_logic on` if you want vampire to try proof search anyways)");
+    }
   }
 
 }

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -523,6 +523,11 @@ void Options::init()
     _lookup.insert(&_theoryFlattening);
     _theoryFlattening.tag(OptionTag::PREPROCESSING);
 
+    _ignoreUnrecognizedLogic = BoolOptionValue("ignore_unrecognized_logic","iul",false);
+    _ignoreUnrecognizedLogic.description = "Try proof search anyways, if vampire would throw an \"unrecognized logic\" error otherwise.";
+    _lookup.insert(&_ignoreUnrecognizedLogic);
+    _ignoreUnrecognizedLogic.tag(OptionTag::INPUT);
+
     _sineDepth = UnsignedOptionValue("sine_depth","sd",0);
     _sineDepth.description=
     "Limit number of iterations of the transitive closure algorithm that selects formulas based on SInE's D-relation (see SInE description). 0 means no limit, 1 is a maximal limit (least selected axioms), 2 allows two iterations, etc...";

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2336,6 +2336,7 @@ public:
 
   Instantiation instantiation() const { return _instantiation.actualValue; }
   bool theoryFlattening() const { return _theoryFlattening.actualValue; }
+  bool ignoreUnrecognizedLogic() const { return _ignoreUnrecognizedLogic.actualValue; }
 
   Induction induction() const { return _induction.actualValue; }
   StructuralInductionKind structInduction() const { return _structInduction.actualValue; }
@@ -2805,6 +2806,7 @@ private:
   StringOptionValue _thanks;
   ChoiceOptionValue<TheoryAxiomLevel> _theoryAxioms;
   BoolOptionValue _theoryFlattening;
+  BoolOptionValue _ignoreUnrecognizedLogic;
 
   /** Time limit in deciseconds */
   TimeLimitOptionValue _timeLimitInDeciseconds;


### PR DESCRIPTION
I added an option that lets us attempt proof search even though we do not recognize a logic in an SMTLIB file.
Currently vampire just throws an error in that case. 
Motivation is that i for example got some benchmarks from `QF_UFDTNIA` and wanted to see what my branch does for them without adding all the code to properly support that logic.
I ran into issues like that quite often before and always just renamed the logic in all the smt files to something vampire knows. I think this is a nicer solution, and will also be nice for users who don't know vampire.
When vampire dies now because of an unrecognized logic it will also give the hint to use the option `--ignore_unrecoginized_logic on` to try proof serach anyways.