### PR TITLE
cleanup TermSharing

### DIFF
--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -39,15 +39,7 @@ typedef ApplicativeHelper AH;
  * @since 29/12/2007 Manchester
  */
 TermSharing::TermSharing()
-  : _totalTerms(0),
-    _totalSorts(0),
-    // _groundTerms(0), //MS: unused
-    _totalLiterals(0),
-    // _groundLiterals(0), //MS: unused
-    _literalInsertions(0),
-    _sortInsertions(0),
-    _termInsertions(0),
-    _poly(1),
+  : _poly(true),
     _wellSortednessCheckingDisabled(false)
 {
   CALL("TermSharing::TermSharing");
@@ -111,9 +103,8 @@ Term* TermSharing::insert(Term* t)
     }
   }
 
-  _termInsertions++;
   Term* s = _terms.insert(t);
-   if (s == t) {
+  if (s == t) {
     unsigned weight = 1;
     unsigned vars = 0;
     bool hasInterpretedConstants=t->arity()==0 &&
@@ -191,7 +182,7 @@ Term* TermSharing::insert(Term* t)
       }
     }
     t->markShared();
-    t->setId(_totalTerms);
+    t->setId(_terms.size());
     t->setNumVarOccs(vars);
     t->setWeight(weight);
     t->setHasTermVar(hasTermVar);
@@ -200,9 +191,8 @@ Term* TermSharing::insert(Term* t)
       color = static_cast<Color>(color | fcolor);
       t->setColor(color);
     }
-      
+
     t->setInterpretedConstantsPresence(hasInterpretedConstants);
-    _totalTerms++;
 
     //poly function works for mono as well, but is slow
     //it is fine to use for debug
@@ -228,7 +218,6 @@ AtomicSort* TermSharing::insert(AtomicSort* sort)
 
   TIME_TRACE("sort sharing");
 
-  _sortInsertions++;
   AtomicSort* s = _sorts.insert(sort);
   if (s == sort) {
     if(sort->isArraySort()){
@@ -254,11 +243,9 @@ AtomicSort* TermSharing::insert(AtomicSort* sort)
       }
     }
     sort->markShared();
-    sort->setId(_totalSorts);
+    sort->setId(_sorts.size());
     sort->setNumVarOccs(vars);
     sort->setWeight(weight);
-      
-    _totalSorts++;
 
     ASS_REP(SortHelper::allTopLevelArgsAreSorts(sort), sort->toString());
     if (!SortHelper::allTopLevelArgsAreSorts(sort)){
@@ -301,7 +288,6 @@ Literal* TermSharing::insert(Literal* t)
     }
   }
 
-  _literalInsertions++;
   Literal* s = _literals.insert(t);
   if (s == t) {
     unsigned weight = 1;
@@ -335,7 +321,7 @@ Literal* TermSharing::insert(Literal* t)
       }
     }
     t->markShared();
-    t->setId(_totalLiterals);
+    t->setId(_literals.size());
     t->setNumVarOccs(vars);
     t->setWeight(weight);
     if (env.colorUsed) {
@@ -344,7 +330,6 @@ Literal* TermSharing::insert(Literal* t)
       t->setColor(color);
     }
     t->setInterpretedConstantsPresence(hasInterpretedConstants);
-    _totalLiterals++;
 
     ASS_REP(_wellSortednessCheckingDisabled || SortHelper::areImmediateSortsValidPoly(t), t->toString());
     if (!_poly && !SortHelper::areImmediateSortsValidMono(t) && !_wellSortednessCheckingDisabled){
@@ -385,11 +370,10 @@ Literal* TermSharing::insertVariableEquality(Literal* t, TermList sort)
   t->markTwoVarEquality();
   t->setTwoVarEqSort(sort);
 
-  _literalInsertions++;
   Literal* s = _literals.insert(t);
   if (s == t) {
     t->markShared();
-    t->setId(_totalLiterals);
+    t->setId(_literals.size());
     // 3 since we have two variables and the equality symbol itself.
     // Additionally, we need sort.weight() in the polymorphic case since
     // the sort may contain variables and Vampire assumes the invariant
@@ -405,49 +389,12 @@ Literal* TermSharing::insertVariableEquality(Literal* t, TermList sort)
       t->setColor(COLOR_TRANSPARENT);
     }
     t->setInterpretedConstantsPresence(false);
-    _totalLiterals++;
   }
   else {
     t->destroy();
   }
   return s;
 } // TermSharing::insertVariableEquality
-
-/**
- * Insert a new term and all its unshared subterms
- * in the index, and return the result.
- */
-Term* TermSharing::insertRecurrently(Term* t)
-{
-  CALL("TermSharing::insert");
-
-  TIME_TRACE(TimeTrace::TERM_SHARING);
-
-  TermList tRef;
-  tRef.setTerm(t);
-
-  TermList* ts=&tRef;
-  static Stack<TermList*> stack(4);
-  static Stack<TermList*> insertingStack(8);
-  for(;;) {
-    if(ts->isTerm() && !ts->term()->shared()) {
-      stack.push(ts->term()->args());
-      insertingStack.push(ts);
-    }
-    if(stack.isEmpty()) {
-      break;
-    }
-    ts=stack.pop();
-    if(!ts->next()->isEmpty()) {
-      stack.push(ts->next());
-    }
-  }
-  while(!insertingStack.isEmpty()) {
-    ts=insertingStack.pop();
-    ts->setTerm(insert(ts->term()));
-  }
-  return tRef.term();
-}
 
 /**
  * If the sharing structure contains a literal opposite to @b l, return it.
@@ -536,7 +483,8 @@ bool TermSharing::equals(const Term* s,const Term* t)
 /**
  * True if the two literals are equal (or equal except polarity if @c opposite is true)
  */
-bool TermSharing::equals(const Literal* l1, const Literal* l2, bool opposite)
+template<bool opposite>
+bool TermSharing::equals(const Literal* l1, const Literal* l2)
 {
   CALL("TermSharing::equals(Literal*,Literal*)");
 
@@ -549,8 +497,5 @@ bool TermSharing::equals(const Literal* l1, const Literal* l2, bool opposite)
     return false;
   }
 
-  return equals(static_cast<const Term*>(l1),
-		static_cast<const Term*>(l2));
+  return equals(static_cast<const Term*>(l1), static_cast<const Term*>(l2));
 }
-
-

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -36,8 +36,8 @@ public:
   TermSharing();
   ~TermSharing();
 
+  // TODO we should probably inline the common path where a term already exists
   Term* insert(Term*);
-  Term* insertRecurrently(Term*);
 
   AtomicSort* insert(AtomicSort*);
 
@@ -56,7 +56,8 @@ public:
   { return t->hash(); }
   static bool equals(const Term* t1,const Term* t2);
 
-  static bool equals(const Literal* l1, const Literal* l2, bool opposite=false);
+  template<bool opposite = false>
+  static bool equals(const Literal* l1, const Literal* l2);
 
   DHSet<TermList>* getArraySorts(){
     return &_arraySorts;
@@ -67,13 +68,13 @@ public:
     Literal* l;
   };
   inline static unsigned hash(const OpLitWrapper& w)
-  { return w.l->hash(true); }
+  { return w.l->hash<true>(); }
   static bool equals(const Literal* l1,const OpLitWrapper& w) {
-    return equals(l1, w.l, true);
+    return equals<true>(l1, w.l);
   }
 
-  friend class WellSortednessCheckingLocalDisabler;
-
+  // stuff for disabling a well-sortedness check
+  // still used, but only in BlockedClauseElimination: can we eliminate that occurrence?
   class WellSortednessCheckingLocalDisabler {
     TermSharing* _tsInstance;
     bool _valueToRestore;
@@ -103,22 +104,6 @@ private:
    * Can be deleted once array axioms are made truly poltmorphic
    */  
   DHSet<TermList> _arraySorts;
-  /** Number of terms stored */
-  unsigned _totalTerms;
-  /** Number of sorts stored */
-  unsigned _totalSorts;
-  /** Number of ground terms stored */
-  // unsigned _groundTerms; // MS: unused
-  /** Number of literals stored */
-  unsigned _totalLiterals;
-  /** Number of ground literals stored */
-  // unsigned _groundLiterals; // MS: unused
-  /** Number of literal insertions */
-  unsigned _literalInsertions;
-  /** number of sort insertions */
-  unsigned _sortInsertions;
-  /** Number of term insertions */
-  unsigned _termInsertions;
 
   bool _poly;
   bool _wellSortednessCheckingDisabled;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -941,7 +941,8 @@ public:
    * Return the hash function of the top-level of a literal.
    * @since 30/03/2008 Flight Murcia-Manchester
    */
-  unsigned hash(bool flip = false) const
+  template<bool flip = false>
+  unsigned hash() const
   {
     CALL("Literal::hash");
     bool positive = (flip ^ isPositive());


### PR DESCRIPTION
Let's have an easy one to get the ball rolling again. See #157. Cleanup `Indexing::TermSharing` a bit:
- remove `insertRecurrently`, unused
- remove unused variables that were probably statistics at some point (`totalTerms` and friends)
- `_totalTerms`  I believe to be in one-to-one correspondence with `_terms.size()`, and they are only used for setting the ID of inserted terms (resp. literals, sorts). Remove them and use the container size instead.
- some Boolean parameters are only ever used with a constant argument: `template<>` them instead - in theory this is a performance win, in practice it's more semantic
- add some TODOs that will take more time