### PR TITLE
distinct objects always have sort `$i` in TPTP

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -2953,6 +2953,10 @@ void TPTP::term()
       switch (tok.tag) {
         case T_STRING:
           number = env.signature->addStringConstant(tok.content);
+          // "distinct_object"s are _always_ of sort $i, even in typed contexts
+          env.signature->getFunction(number)->setType(
+            OperatorType::getConstantsType(AtomicSort::defaultSort())
+          );
           break;
         case T_INT:
           number = addIntegerConstant(tok.content,_overflow,_isFof);


### PR DESCRIPTION
Consider
```
fof(test, conjecture, "foo" != "bar").
```

Current master complains that we didn't set a type for "foo" (or "bar"). According to https://tptp.org/TPTP/TR/TPTPTR.shtml#FormulaeSection we should set this to `$i` regardless of the type context, and this is confirmed if you look at e.g. `SYN000^2`. Fix this.