### PR TITLE
Fixing symbol recording bug

### DIFF
--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -135,6 +135,8 @@ enum Color {
   COLOR_INVALID = 3u
 };
 
+enum SymbolType{FUNC, PRED, TYPE_CON};
+
 };
 
 namespace Indexing

--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -135,7 +135,7 @@ enum Color {
   COLOR_INVALID = 3u
 };
 
-enum SymbolType{FUNC, PRED, TYPE_CON};
+enum class SymbolType{FUNC, PRED, TYPE_CON};
 
 };
 

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -95,13 +95,13 @@ void InferenceStore::recordSplittingNameLiteral(Unit* us, Literal* lit)
 /**
  * Record the introduction of a new symbol
  */
-void InferenceStore::recordIntroducedSymbol(Unit* u, bool func, unsigned number)
+void InferenceStore::recordIntroducedSymbol(Unit* u, SymbolType st, unsigned number)
 {
   CALL("InferenceStore::recordIntroducedSymbol");
 
   SymbolStack* pStack;
   _introducedSymbols.getValuePtr(u->number(),pStack);
-  pStack->push(SymbolId(func,number));
+  pStack->push(SymbolId(st,number));
 }
 
 /**
@@ -876,7 +876,7 @@ protected:
     defStr=getQuantifiedStr(nameVars, defStr);
     List<unsigned>::destroy(nameVars);
 
-    SymbolId nameSymbol = SymbolId(false,nameLit->functor());
+    SymbolId nameSymbol = SymbolId(PRED,nameLit->functor());
     vostringstream originStm;
     originStm << "introduced(" << tptpRuleName(rule)
 	      << ",[" << getNewSymbols("naming",getSingletonIterator(nameSymbol))

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -688,14 +688,15 @@ protected:
     vostringstream symsStr;
     while(symIt.hasNext()) {
       SymbolId sym = symIt.next();
-      if (sym.first) {
-	symsStr << env.signature->functionName(sym.second);
-      }
-      else {
-	symsStr << env.signature->predicateName(sym.second);
+      if (sym.first == SymbolType::FUNC ) {
+        symsStr << env.signature->functionName(sym.second);
+      } else if (sym.first == SymbolType::PRED){
+        symsStr << env.signature->predicateName(sym.second);
+      } else {
+        symsStr << env.signature->typeConName(sym.second);       
       }
       if (symIt.hasNext()) {
-	symsStr << ',';
+        symsStr << ',';
       }
     }
     return getNewSymbols(origin, symsStr.str());
@@ -876,7 +877,7 @@ protected:
     defStr=getQuantifiedStr(nameVars, defStr);
     List<unsigned>::destroy(nameVars);
 
-    SymbolId nameSymbol = SymbolId(PRED,nameLit->functor());
+    SymbolId nameSymbol = SymbolId(SymbolType::PRED,nameLit->functor());
     vostringstream originStm;
     originStm << "introduced(" << tptpRuleName(rule)
 	      << ",[" << getNewSymbols("naming",getSingletonIterator(nameSymbol))

--- a/Kernel/InferenceStore.hpp
+++ b/Kernel/InferenceStore.hpp
@@ -73,7 +73,7 @@ public:
   };
 
   void recordSplittingNameLiteral(Unit* us, Literal* lit);
-  void recordIntroducedSymbol(Unit* u, bool func, unsigned number);
+  void recordIntroducedSymbol(Unit* u, SymbolType st, unsigned number);  
   void recordIntroducedSplitName(Unit* u, vstring name);
 
   void outputUnsatCore(ostream& out, Unit* refutation);
@@ -101,7 +101,7 @@ private:
 
 
   /** first is true for function symbols, second is symbol number */
-  typedef pair<bool,unsigned> SymbolId;
+  typedef pair<SymbolType,unsigned> SymbolId;  
   typedef Stack<SymbolId> SymbolStack;
   DHMap<unsigned,SymbolStack> _introducedSymbols;
   DHMap<unsigned,vstring> _introducedSplitNames;

--- a/Kernel/InferenceStore.hpp
+++ b/Kernel/InferenceStore.hpp
@@ -100,7 +100,7 @@ private:
   DHMap<Unit*, Literal*> _splittingNameLiterals;
 
 
-  /** first is true for function symbols, second is symbol number */
+  /** first records the type of the symbol (PRED,FUNC or TYPE_CON), second is symbol number */
   typedef pair<SymbolType,unsigned> SymbolId;  
   typedef Stack<SymbolId> SymbolStack;
   DHMap<unsigned,SymbolStack> _introducedSymbols;

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -479,20 +479,14 @@ Ordering::Result PrecedenceOrdering::compareTypeConPrecedences(unsigned tyc1, un
     tyc2 >= size ? (int)(reverse ? -tyc2 : tyc2) : _typeConPrecedences[tyc2] ));
 }
 
-enum SymbolType {
-  FUNCTION,
-  PREDICATE,
-  TYPE_CON
-};
-
 struct SymbolComparator {
   SymbolType _symType;
   SymbolComparator(SymbolType symType) : _symType(symType) {}
 
   Signature::Symbol* getSymbol(unsigned s) {
-    if(_symType == SymbolType::FUNCTION){
+    if(_symType == FUNC){
       return env.signature->getFunction(s);
-    } else if (_symType == SymbolType::PREDICATE){
+    } else if (_symType == PRED){
       return env.signature->getPredicate(s);      
     } else {
       return env.signature->getTypeCon(s);            
@@ -787,7 +781,7 @@ DArray<int> PrecedenceOrdering::typeConPrecFromOpts(Problem& prb, const Options&
         precedence_file.close();
       }
     } else {
-      sortAuxBySymbolPrecedence(aux,opt,SymbolType::TYPE_CON);
+      sortAuxBySymbolPrecedence(aux,opt,TYPE_CON);
     }
   }
 
@@ -817,7 +811,7 @@ DArray<int> PrecedenceOrdering::funcPrecFromOpts(Problem& prb, const Options& op
         precedence_file.close();
       }
     } else {
-      sortAuxBySymbolPrecedence(aux,opt,SymbolType::FUNCTION);
+      sortAuxBySymbolPrecedence(aux,opt,FUNC);
     }
   }
 
@@ -845,7 +839,7 @@ DArray<int> PrecedenceOrdering::predPrecFromOpts(Problem& prb, const Options& op
       precedence_file.close();
     }
   } else {
-    sortAuxBySymbolPrecedence(aux,opt,SymbolType::PREDICATE);
+    sortAuxBySymbolPrecedence(aux,opt,PRED);
   }
 
   DArray<int> predicatePrecedences(nPredicates);

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -484,9 +484,9 @@ struct SymbolComparator {
   SymbolComparator(SymbolType symType) : _symType(symType) {}
 
   Signature::Symbol* getSymbol(unsigned s) {
-    if(_symType == FUNC){
+    if(_symType == SymbolType::FUNC){
       return env.signature->getFunction(s);
-    } else if (_symType == PRED){
+    } else if (_symType == SymbolType::PRED){
       return env.signature->getPredicate(s);      
     } else {
       return env.signature->getTypeCon(s);            
@@ -781,7 +781,7 @@ DArray<int> PrecedenceOrdering::typeConPrecFromOpts(Problem& prb, const Options&
         precedence_file.close();
       }
     } else {
-      sortAuxBySymbolPrecedence(aux,opt,TYPE_CON);
+      sortAuxBySymbolPrecedence(aux,opt,SymbolType::TYPE_CON);
     }
   }
 
@@ -811,7 +811,7 @@ DArray<int> PrecedenceOrdering::funcPrecFromOpts(Problem& prb, const Options& op
         precedence_file.close();
       }
     } else {
-      sortAuxBySymbolPrecedence(aux,opt,FUNC);
+      sortAuxBySymbolPrecedence(aux,opt,SymbolType::FUNC);
     }
   }
 
@@ -839,7 +839,7 @@ DArray<int> PrecedenceOrdering::predPrecFromOpts(Problem& prb, const Options& op
       precedence_file.close();
     }
   } else {
-    sortAuxBySymbolPrecedence(aux,opt,PRED);
+    sortAuxBySymbolPrecedence(aux,opt,SymbolType::PRED);
   }
 
   DArray<int> predicatePrecedences(nPredicates);

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -338,7 +338,7 @@ unsigned EqualityProxy::getProxyPredicate()
 
   _defUnit = new FormulaUnit(quantDefForm,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::EQUALITY_PROXY_AXIOM1));
 
-  InferenceStore::instance()->recordIntroducedSymbol(_defUnit, false, newPred);
+  InferenceStore::instance()->recordIntroducedSymbol(_defUnit, PRED, newPred);
   _proxyPredicate = newPred;
   _addedPred = true;
   return newPred;

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -338,7 +338,7 @@ unsigned EqualityProxy::getProxyPredicate()
 
   _defUnit = new FormulaUnit(quantDefForm,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::EQUALITY_PROXY_AXIOM1));
 
-  InferenceStore::instance()->recordIntroducedSymbol(_defUnit, PRED, newPred);
+  InferenceStore::instance()->recordIntroducedSymbol(_defUnit, SymbolType::PRED, newPred);
   _proxyPredicate = newPred;
   _addedPred = true;
   return newPred;

--- a/Shell/EqualityProxyMono.cpp
+++ b/Shell/EqualityProxyMono.cpp
@@ -369,7 +369,7 @@ unsigned EqualityProxyMono::getProxyPredicate(TermList sort)
   FormulaUnit* defUnit = new FormulaUnit(quantDefForm,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::EQUALITY_PROXY_AXIOM1));
 
   s_proxyPremises.insert(sort, defUnit);
-  InferenceStore::instance()->recordIntroducedSymbol(defUnit, PRED, newPred);
+  InferenceStore::instance()->recordIntroducedSymbol(defUnit, SymbolType::PRED, newPred);
   return newPred;
 }
 

--- a/Shell/EqualityProxyMono.cpp
+++ b/Shell/EqualityProxyMono.cpp
@@ -369,7 +369,7 @@ unsigned EqualityProxyMono::getProxyPredicate(TermList sort)
   FormulaUnit* defUnit = new FormulaUnit(quantDefForm,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::EQUALITY_PROXY_AXIOM1));
 
   s_proxyPremises.insert(sort, defUnit);
-  InferenceStore::instance()->recordIntroducedSymbol(defUnit, false, newPred);
+  InferenceStore::instance()->recordIntroducedSymbol(defUnit, PRED, newPred);
   return newPred;
 }
 

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -203,9 +203,9 @@ Literal* InequalitySplitting::splitLiteral(Literal* lit, UnitInputType inpType, 
   _predDefs.push(defCl);
 
   if(_appify){
-    InferenceStore::instance()->recordIntroducedSymbol(defCl,FUNC,fun);
+    InferenceStore::instance()->recordIntroducedSymbol(defCl,SymbolType::FUNC,fun);
   } else {
-    InferenceStore::instance()->recordIntroducedSymbol(defCl,PRED,fun);
+    InferenceStore::instance()->recordIntroducedSymbol(defCl,SymbolType::PRED,fun);
   }
 
   premise=defCl;

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -202,7 +202,11 @@ Literal* InequalitySplitting::splitLiteral(Literal* lit, UnitInputType inpType, 
   (*defCl)[0]=makeNameLiteral(fun, t, false, vars);
   _predDefs.push(defCl);
 
-  InferenceStore::instance()->recordIntroducedSymbol(defCl,false,fun);
+  if(_appify){
+    InferenceStore::instance()->recordIntroducedSymbol(defCl,FUNC,fun);
+  } else {
+    InferenceStore::instance()->recordIntroducedSymbol(defCl,PRED,fun);
+  }
 
   premise=defCl;
 

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1263,7 +1263,7 @@ Formula* Naming::introduceDefinition(Formula* f, bool iff) {
   }
   Unit* definition = new FormulaUnit(def, NonspecificInference0(UnitInputType::AXIOM,InferenceRule::PREDICATE_DEFINITION));
 
-  InferenceStore::instance()->recordIntroducedSymbol(definition, PRED,
+  InferenceStore::instance()->recordIntroducedSymbol(definition, SymbolType::PRED,
       atom->functor());
 
   UnitList::push(definition, _defs);

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1263,7 +1263,7 @@ Formula* Naming::introduceDefinition(Formula* f, bool iff) {
   }
   Unit* definition = new FormulaUnit(def, NonspecificInference0(UnitInputType::AXIOM,InferenceRule::PREDICATE_DEFINITION));
 
-  InferenceStore::instance()->recordIntroducedSymbol(definition, false,
+  InferenceStore::instance()->recordIntroducedSymbol(definition, PRED,
       atom->functor());
 
   UnitList::push(definition, _defs);

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -104,9 +104,9 @@ FormulaUnit* Skolem::skolemiseImpl (FormulaUnit* unit, bool appify)
     auto symPair = _introducedSkolemSyms.pop();
 
     if(symPair.first){
-      InferenceStore::instance()->recordIntroducedSymbol(res,TYPE_CON,symPair.second);
+      InferenceStore::instance()->recordIntroducedSymbol(res,SymbolType::TYPE_CON,symPair.second);
     } else {
-      InferenceStore::instance()->recordIntroducedSymbol(res,FUNC,symPair.second);
+      InferenceStore::instance()->recordIntroducedSymbol(res,SymbolType::FUNC,symPair.second);
     }
 
     if(unit->derivedFromGoal()){

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -101,10 +101,20 @@ FormulaUnit* Skolem::skolemiseImpl (FormulaUnit* unit, bool appify)
 
   ASS(_introducedSkolemSyms.isNonEmpty());
   while(_introducedSkolemSyms.isNonEmpty()) {
-    unsigned fn = _introducedSkolemSyms.pop();
-    InferenceStore::instance()->recordIntroducedSymbol(res,true,fn);
+    auto symPair = _introducedSkolemSyms.pop();
+
+    if(symPair.first){
+      InferenceStore::instance()->recordIntroducedSymbol(res,TYPE_CON,symPair.second);
+    } else {
+      InferenceStore::instance()->recordIntroducedSymbol(res,FUNC,symPair.second);
+    }
+
     if(unit->derivedFromGoal()){
-      env.signature->getFunction(fn)->markInGoal();
+      if(symPair.first){
+        env.signature->getTypeCon(symPair.second)->markInGoal();
+      } else {
+        env.signature->getFunction(symPair.second)->markInGoal();
+      }
     }
   }
 
@@ -528,7 +538,7 @@ Formula* Skolem::skolemise (Formula* f)
           skolemTerm = ApplicativeHelper::createAppTerm(
             SortHelper::getResultSort(head.term()), head, termVars).term();      
         }
-        _introducedSkolemSyms.push(sym);
+        _introducedSkolemSyms.push(make_pair(skolemisingTypeVar, sym));
 
         if(!successfully_reused) {
           env.statistics->skolemFunctions++;
@@ -561,7 +571,7 @@ Formula* Skolem::skolemise (Formula* f)
         }
 
 #if VDEBUG
-        ASS(first_pass || sym == last_sym+1);
+        ASS(!name_reuse || first_pass || sym == last_sym+1);
         last_sym = sym;
 #endif
         // in case we are reusing and there is more than one f->vars() in the block

--- a/Shell/Skolem.hpp
+++ b/Shell/Skolem.hpp
@@ -107,8 +107,8 @@ private:
   DHMap<unsigned,TermList> _varSorts;
 
   // for some heuristic evaluations after we are done
-  Stack<unsigned> _introducedSkolemSyms;
-
+  Stack<pair<bool, unsigned>> _introducedSkolemSyms;
+  
   FormulaUnit* _beingSkolemised;
 
   // to create one big inference after we are done

--- a/Shell/TPTPPrinter.hpp
+++ b/Shell/TPTPPrinter.hpp
@@ -34,8 +34,6 @@ class TPTPPrinter {
 public:
   TPTPPrinter(ostream* tgtStream=0);
 
-  enum SymbolType{FUNC, PRED, TYPE_CON};
-
   void print(Unit* u);
   void printAsClaim(vstring name, Unit* u);
   void printWithRole(vstring name, vstring role, Unit* u, bool includeSplitLevels = true);


### PR DESCRIPTION
PR fixes a bug whereby new symbols are recorded as either function or predicate (even if it is a type constructor). There is already a fix for this on the `ahmed-new-hol` branch, but that branch does not look like it will be merged soon. In the mean time, the bug is affecting Konstantin as he attempts to use Vampire as a preprocessor for polymorphic problems.