### PR TITLE
fixes from `clang-tidy`

### DIFF
--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1673,7 +1673,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
 #endif
     //TODO consider adding clauses directly to SAT solver in new interface?
     // pass clauses and assumption to SAT Solver
-    SATSolver::Status satResult;
+    SATSolver::Status satResult = SATSolver::UNKNOWN;
     {
       if (_opt.randomTraversals()) {
         TIME_TRACE(TimeTrace::SHUFFLING);
@@ -1683,7 +1683,6 @@ MainLoopResult FiniteModelBuilder::runImpl()
 
       _solver->addClausesIter(pvi(SATClauseStack::ConstIterator(_clausesToBeAdded)));
 
-      satResult = SATSolver::UNKNOWN;
       env.statistics->phase = Statistics::FMB_SOLVING;
 
       static SATLiteralStack assumptions(_distinctSortSizes.size());

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -1172,6 +1172,7 @@ bool InterpretedLiteralEvaluator::balance(Literal* lit,Literal*& resLit,Stack<Li
     
     // find which arg of t2 is the non_constant bit, this is what we are unwrapping 
     TermList to_unwrap;
+    to_unwrap.makeEmpty();
     while(args->isNonEmpty()){
       if(!theory->isInterpretedNumber(*args)){
         if(!to_unwrap.isEmpty()){

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -361,8 +361,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
     
         unsigned position = 0;
         for (TermList* ts = term->args(); ts->isNonEmpty(); ts = ts->next()) {
-          CollectTask newTask;
-          newTask.fncTag = COLLECT_TERMLIST;
+          CollectTask newTask(COLLECT_TERMLIST);
           newTask.ts = *ts;
           newTask.contextSort = getArgSort(term, position++);
           todo.push(newTask);
@@ -376,17 +375,10 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
         if (ts.isTerm()) {
           Term* term = ts.term();
 
-          CollectTask newTask;
+          CollectTask newTask(term->isSpecial() ? COLLECT_SPECIALTERM : COLLECT_TERM);
           newTask.t = term;
           newTask.contextSort = task.contextSort;
-
-          if (term->isSpecial()) {
-            newTask.fncTag = COLLECT_SPECIALTERM;
-            todo.push(newTask);
-          } else {
-            newTask.fncTag = COLLECT_TERM;
-            todo.push(newTask);
-          }
+          todo.push(newTask);
         } else if (ts.isOrdinaryVar()) {
           unsigned var = ts.var();
           if (!ignoreBound || !bound.get(var)) {
@@ -407,9 +399,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
 
         switch (term->functor()) {
           case Term::SF_ITE: {
-            CollectTask newTask;
-
-            newTask.fncTag = COLLECT_TERMLIST;
+            CollectTask newTask(COLLECT_TERMLIST);
             newTask.contextSort = sd->getSort();
 
             newTask.ts = *term->nthArgument(0);
@@ -449,9 +439,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
               }
             }
 
-            CollectTask newTask;
-
-            newTask.fncTag = COLLECT_TERMLIST;
+            CollectTask newTask(COLLECT_TERMLIST);
             newTask.contextSort = sd->getSort();
 
             newTask.ts = *term->nthArgument(0);
@@ -488,8 +476,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
               }
             }
 
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_TERMLIST;
+            CollectTask newTask(COLLECT_TERMLIST);
             newTask.contextSort = sd->getSort();
             newTask.ts = *term->nthArgument(0);
             todo.push(newTask);
@@ -502,30 +489,25 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
           }
 
           case Term::SF_FORMULA: {
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_FORMULA;
+            CollectTask newTask(COLLECT_FORMULA);
             newTask.f = sd->getFormula();
             todo.push(newTask);
           } break;
           case Term::SF_LAMBDA: {
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_TERMLIST;
+            CollectTask newTask(COLLECT_TERMLIST);
             newTask.contextSort = sd->getLambdaExpSort();
             newTask.ts = sd->getLambdaExp();
-            todo.push(newTask);              
+            todo.push(newTask);
           } break;
 
           case Term::SF_TUPLE: {
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_TERM;
+            CollectTask newTask(COLLECT_TERM);
             newTask.t = sd->getTupleTerm();
             todo.push(newTask);
           } break;
 
           case Term::SF_MATCH: {
-            CollectTask newTask;
-
-            newTask.fncTag = COLLECT_TERMLIST;
+            CollectTask newTask(COLLECT_TERMLIST);
             auto matchedSort = term->getSpecialData()->getMatchedSort();
 
             // there are two sorts here, one is the sort
@@ -560,14 +542,12 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
           case LITERAL: {
             Literal* lit = f->literal();
             if(lit->isTwoVarEquality()){
-              CollectTask newTask;
-              newTask.fncTag = COLLECT_TERMLIST;
+              CollectTask newTask(COLLECT_TERMLIST);
               newTask.ts = lit->twoVarEqSort();
               newTask.contextSort = AtomicSort::superSort();
               todo.push(newTask);
             }
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_TERM;
+            CollectTask newTask(COLLECT_TERM);
             newTask.t = lit;
 
             todo.push(newTask);
@@ -585,12 +565,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
             } else {
               ASS(ts.isTerm());
 
-              CollectTask newTask;
-              if(ts.term()->isSpecial()){
-                newTask.fncTag = COLLECT_SPECIALTERM;
-              } else {
-                newTask.fncTag = COLLECT_TERM;
-              }
+              CollectTask newTask(ts.term()->isSpecial() ? COLLECT_SPECIALTERM : COLLECT_TERM);
               newTask.t = ts.term();
               newTask.contextSort = AtomicSort::boolSort();
 
@@ -602,20 +577,17 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
           case EXISTS:
           case FORALL: {
             if (ignoreBound) {
-              CollectTask unbindTask;
-              unbindTask.fncTag = UNBIND;
+              CollectTask unbindTask(UNBIND);
               unbindTask.vars = f->vars();
               todo.push(unbindTask);
             }
 
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_FORMULA;
+            CollectTask newTask(COLLECT_FORMULA);
             newTask.f = f->qarg();
             todo.push(newTask);
 
             if (ignoreBound) {
-              CollectTask bindTask;
-              bindTask.fncTag = BIND;
+              CollectTask bindTask(BIND);
               bindTask.vars = f->vars();
               todo.push(bindTask);
             }
@@ -626,8 +598,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
           case OR: {
             FormulaList::Iterator argIt(f->args());
             while (argIt.hasNext()) {
-              CollectTask newTask;
-              newTask.fncTag = COLLECT_FORMULA;
+              CollectTask newTask(COLLECT_FORMULA);
               newTask.f = argIt.next();
               todo.push(newTask);
             }
@@ -637,21 +608,18 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
           case IMP:
           case IFF:
           case XOR: {
-            CollectTask leftTask;
-            leftTask.fncTag = COLLECT_FORMULA;
+            CollectTask leftTask(COLLECT_FORMULA);
             leftTask.f = f->left();
             todo.push(leftTask);
 
-            CollectTask rightTask;
-            rightTask.fncTag = COLLECT_FORMULA;
+            CollectTask rightTask(COLLECT_FORMULA);
             rightTask.f = f->right();
             todo.push(rightTask);
             break;
           }
 
           case NOT: {
-            CollectTask newTask;
-            newTask.fncTag = COLLECT_FORMULA;
+            CollectTask newTask(COLLECT_FORMULA);
             newTask.f = f->uarg();
             todo.push(newTask);
             break;
@@ -691,12 +659,7 @@ void SortHelper::collectVariableSorts(Term* term, DHMap<unsigned,TermList>& map)
 {
   CALL("SortHelper::collectVariableSorts(Term*,...)");
 
-  CollectTask t;
-  if (term->isSpecial()) {
-    t.fncTag = COLLECT_SPECIALTERM;
-  } else {
-    t.fncTag = COLLECT_TERM;
-  }
+  CollectTask t(term->isSpecial() ? COLLECT_SPECIALTERM : COLLECT_TERM);
   t.t = term;
 
   collectVariableSortsIter(t,map);
@@ -711,8 +674,7 @@ void SortHelper::collectVariableSorts(Formula* f, DHMap<unsigned,TermList>& map,
 {
   CALL("SortHelper::collectVariableSorts(Formula*,...)");
 
-  CollectTask task;
-  task.fncTag = COLLECT_FORMULA;
+  CollectTask task(COLLECT_FORMULA);
   task.f = f;
 
   collectVariableSortsIter(task,map,ignoreBound);
@@ -730,8 +692,7 @@ void SortHelper::collectVariableSorts(Unit* u, DHMap<unsigned,TermList>& map)
   if (!u->isClause()) {
     FormulaUnit* fu = static_cast<FormulaUnit*>(u);
 
-    CollectTask task;
-    task.fncTag = COLLECT_FORMULA;
+    CollectTask task(COLLECT_FORMULA);
     task.f = fu->formula();
 
     collectVariableSortsIter(task,map);
@@ -744,8 +705,7 @@ void SortHelper::collectVariableSorts(Unit* u, DHMap<unsigned,TermList>& map)
   while (cit.hasNext()) {
     Literal* l = cit.next();
 
-    CollectTask task;
-    task.fncTag = COLLECT_TERM;
+    CollectTask task(COLLECT_TERM);
     task.t = l;
 
     collectVariableSortsIter(task,map);

--- a/Kernel/SortHelper.hpp
+++ b/Kernel/SortHelper.hpp
@@ -37,7 +37,7 @@ private:
   };
 
   struct CollectTask {
-    CollectTask() {}
+    CollectTask(CollectWhat what) : fncTag(what) {}
     CollectWhat fncTag;
     union {
       TermList ts;


### PR DESCRIPTION
Small fixes from the `clang-tidy` tool. Experiencing diminishing returns now, but it's nice to have a clean report. Comments inline to explain the changes.