### PR TITLE
Special Functor Type-Safety

### DIFF
--- a/Kernel/Formula.hpp
+++ b/Kernel/Formula.hpp
@@ -350,8 +350,8 @@ class BoolTermFormula
     Term* term = ts.term();
     if (term->isSpecial()) {
       Term::SpecialTermData *sd = term->getSpecialData();
-      switch (sd->getType()) {
-        case Term::SF_FORMULA:
+      switch (sd->specialFunctor()) {
+        case Term::SpecialFunctor::FORMULA:
           return sd->getFormula();
         default:
           return new BoolTermFormula(ts);

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -125,6 +125,8 @@ TermList FormulaTransformer::apply(TermList ts) {
       case Term::SpecialFunctor::TUPLE:
         return TermList(Term::createTuple(apply(TermList(sd->getTupleTerm())).term()));
 
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         for (unsigned i = 0; i < term->arity(); i++) {

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -98,34 +98,34 @@ TermList FormulaTransformer::apply(TermList ts) {
 
   if (term->isSpecial()) {
     Term::SpecialTermData *sd = ts.term()->getSpecialData();
-    switch (sd->getType()) {
-      case Term::SF_ITE:
+    switch (sd->specialFunctor()) {
+      case Term::SpecialFunctor::ITE:
         return TermList(Term::createITE(apply(sd->getCondition()),
                                         apply(*term->nthArgument(0)),
                                         apply(*term->nthArgument(1)),
                                         sd->getSort()));
 
-      case Term::SF_FORMULA:
+      case Term::SpecialFunctor::FORMULA:
         return TermList(Term::createFormula(apply(sd->getFormula())));
 
-      case Term::SF_LET:
+      case Term::SpecialFunctor::LET:
         return TermList(Term::createLet(sd->getFunctor(),
                                         sd->getVariables(),
                                         apply(sd->getBinding()),
                                         apply(*term->nthArgument(0)),
                                         sd->getSort()));
 
-      case Term::SF_LET_TUPLE:
+      case Term::SpecialFunctor::LET_TUPLE:
         return TermList(Term::createTupleLet(sd->getFunctor(),
                                              sd->getTupleSymbols(),
                                              apply(sd->getBinding()),
                                              apply(*term->nthArgument(0)),
                                              sd->getSort()));
 
-      case Term::SF_TUPLE:
+      case Term::SpecialFunctor::TUPLE:
         return TermList(Term::createTuple(apply(TermList(sd->getTupleTerm())).term()));
 
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         for (unsigned i = 0; i < term->arity(); i++) {
           terms[i] = apply(*term->nthArgument(i));
@@ -133,9 +133,8 @@ TermList FormulaTransformer::apply(TermList ts) {
         return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
       }
 
-      default:
-        ASSERTION_VIOLATION_REP(ts.toString());
     }
+    ASSERTION_VIOLATION_REP(ts.toString());
   }
 
   if (term->shared()) {

--- a/Kernel/FormulaVarIterator.cpp
+++ b/Kernel/FormulaVarIterator.cpp
@@ -161,20 +161,20 @@ bool FormulaVarIterator::hasNext()
 
         if (t->isSpecial()) {
           const Term::SpecialTermData* sd = t->getSpecialData();
-          switch (t->functor()) {
-            case Term::SF_ITE:
+          switch (t->specialFunctor()) {
+            case Term::SpecialFunctor::ITE:
               _instructions.push(FVI_FORMULA);
               _formulas.push(sd->getCondition());
               _instructions.push(FVI_TERM_LIST);
               _termLists.push(sd->getSort());
               break;
 
-            case Term::SF_FORMULA:
+            case Term::SpecialFunctor::FORMULA:
               _instructions.push(FVI_FORMULA);
               _formulas.push(sd->getFormula());
               break;
 
-            case Term::SF_LET: {
+            case Term::SpecialFunctor::LET: {
               _instructions.push(FVI_UNBIND);
 
               _instructions.push(FVI_TERM_LIST);
@@ -188,7 +188,7 @@ bool FormulaVarIterator::hasNext()
               break;
             }
 
-            case Term::SF_LET_TUPLE: {
+            case Term::SpecialFunctor::LET_TUPLE: {
               _instructions.push(FVI_TERM_LIST);
               _termLists.push(sd->getBinding());
               _instructions.push(FVI_TERM_LIST);
@@ -196,7 +196,7 @@ bool FormulaVarIterator::hasNext()
               break;
             }
 
-            case Term::SF_TUPLE: {
+            case Term::SpecialFunctor::TUPLE: {
               Term* tt = sd->getTupleTerm();
               Term::Iterator tts(tt);
               while (tts.hasNext()) {
@@ -206,7 +206,7 @@ bool FormulaVarIterator::hasNext()
               break;
             }
       
-            case Term::SF_LAMBDA:{
+            case Term::SpecialFunctor::LAMBDA:{
               _instructions.push(FVI_UNBIND);
               SList* sorts = sd->getLambdaVarSorts();
               while(sorts){
@@ -223,7 +223,7 @@ bool FormulaVarIterator::hasNext()
               break;
             }
 
-            case Term::SF_MATCH: {
+            case Term::SpecialFunctor::MATCH: {
               for (unsigned int i = 0; i < t->arity(); i++) {
                 _instructions.push(FVI_TERM_LIST);
                 _termLists.push(*t->nthArgument(i));
@@ -235,10 +235,6 @@ bool FormulaVarIterator::hasNext()
               break;
             }
 
-#if VDEBUG
-            default:
-              ASSERTION_VIOLATION;
-#endif
           }
         }
 

--- a/Kernel/SubformulaIterator.cpp
+++ b/Kernel/SubformulaIterator.cpp
@@ -161,15 +161,15 @@ bool SubformulaIterator::hasNext ()
           break;
         }
 
-        switch (term->functor()) {
-          case Term::SF_ITE: {
+        switch (term->specialFunctor()) {
+          case Term::SpecialFunctor::ITE: {
             _current = term->getSpecialData()->getCondition();
             _currentPolarity = polarity;
             delete _reserve;
             _reserve = rest;
             return true;
           }
-          case Term::SF_LET: {
+          case Term::SpecialFunctor::LET: {
             delete _reserve;
             TermList binding = term->getSpecialData()->getBinding();
             if (!binding.isTerm()) {
@@ -180,7 +180,7 @@ bool SubformulaIterator::hasNext ()
             }
             break;
           }
-          case Term::SF_LET_TUPLE: {
+          case Term::SpecialFunctor::LET_TUPLE: {
             delete _reserve;
             TermList binding = term->getSpecialData()->getBinding();
             if (!binding.isTerm()) {
@@ -191,14 +191,14 @@ bool SubformulaIterator::hasNext ()
             }
             break;
           }
-          case Term::SF_FORMULA: {
+          case Term::SpecialFunctor::FORMULA: {
             _current = term->getSpecialData()->getFormula();
             _currentPolarity = polarity;
             delete _reserve;
             _reserve = rest;
             return true;
           }
-          case Term::SF_LAMBDA: {
+          case Term::SpecialFunctor::LAMBDA: {
             delete _reserve;
             TermList lambdaExp = term->getSpecialData()->getLambdaExp();
             if (!lambdaExp.isTerm()) {
@@ -209,22 +209,18 @@ bool SubformulaIterator::hasNext ()
             }
             break;
           }
-          case Term::SF_TUPLE: {
+          case Term::SpecialFunctor::TUPLE: {
             delete _reserve;
             Term* tupleTerm = term->getSpecialData()->getTupleTerm();
             // TODO: should be 1 instead of polarity?
             _reserve = new Element(tupleTerm, polarity, rest);
             break;
           }
-          case Term::SF_MATCH: {
+          case Term::SpecialFunctor::MATCH: {
             delete _reserve;
             _reserve = rest;
             break;
           }
-#if VDEBUG
-          default:
-            ASSERTION_VIOLATION;
-#endif
         }
         break;
       }

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -285,15 +285,15 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
 
   if(trm->isSpecial()) {
     Term::SpecialTermData* sd = trm->getSpecialData();
-    switch(trm->functor()) {
-    case Term::SF_ITE:
+    switch(trm->specialFunctor()) {
+    case Term::SpecialFunctor::ITE:
       return Term::createITE(
     applyImpl<ProcessSpecVars>(sd->getCondition(), applicator, noSharing),
     applyImpl<ProcessSpecVars>(*trm->nthArgument(0), applicator, noSharing),
     applyImpl<ProcessSpecVars>(*trm->nthArgument(1), applicator, noSharing),
     applyImpl<ProcessSpecVars>(sd->getSort(), applicator, noSharing)
     );
-    case Term::SF_LET:
+    case Term::SpecialFunctor::LET:
       return Term::createLet(
     sd->getFunctor(),
     sd->getVariables(),
@@ -301,11 +301,11 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
     applyImpl<ProcessSpecVars>(*trm->nthArgument(0), applicator, noSharing),
     sd->getSort()
     );
-    case Term::SF_FORMULA:
+    case Term::SpecialFunctor::FORMULA:
       return Term::createFormula(
       applyImpl<ProcessSpecVars>(sd->getFormula(), applicator, noSharing)
       );
-    case Term::SF_LET_TUPLE:
+    case Term::SpecialFunctor::LET_TUPLE:
       return Term::createTupleLet(
         sd->getFunctor(),
         sd->getTupleSymbols(),
@@ -313,9 +313,9 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
         applyImpl<ProcessSpecVars>(*trm->nthArgument(0), applicator, noSharing),
         sd->getSort()
         );
-    case Term::SF_TUPLE:
+    case Term::SpecialFunctor::TUPLE:
       return Term::createTuple(applyImpl<ProcessSpecVars>(sd->getTupleTerm(), applicator, noSharing));
-    case Term::SF_MATCH: {
+    case Term::SpecialFunctor::MATCH: {
       DArray<TermList> terms(trm->arity());
       for (unsigned i = 0; i < trm->arity(); i++) {
         terms[i] = applyImpl<ProcessSpecVars>(*trm->nthArgument(i), applicator, noSharing);

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -315,6 +315,9 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
         );
     case Term::SpecialFunctor::TUPLE:
       return Term::createTuple(applyImpl<ProcessSpecVars>(sd->getTupleTerm(), applicator, noSharing));
+    case Term::SpecialFunctor::LAMBDA:
+      // TODO in principle this should not be so difficult to handle
+      ASSERTION_VIOLATION;
     case Term::SpecialFunctor::MATCH: {
       DArray<TermList> terms(trm->arity());
       for (unsigned i = 0; i < trm->arity(); i++) {

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -271,14 +271,26 @@ class Term
 {
 public:
   //special functor values
-  static const unsigned SF_ITE = 0xFFFFFFFF;
-  static const unsigned SF_LET = 0xFFFFFFFE;
-  static const unsigned SF_FORMULA = 0xFFFFFFFD;
-  static const unsigned SF_TUPLE = 0xFFFFFFFC;
-  static const unsigned SF_LET_TUPLE = 0xFFFFFFFB;
-  static const unsigned SF_LAMBDA = 0xFFFFFFFA;
-  static const unsigned SF_MATCH = 0xFFFFFFF9;
-  static const unsigned SPECIAL_FUNCTOR_LOWER_BOUND = 0xFFFFFFF9;
+  enum class SpecialFunctor {
+    ITE,
+    LET,
+    FORMULA,
+    TUPLE,
+    LET_TUPLE,
+    LAMBDA,
+    MATCH, // <- keep this one the last, or modify SPECIAL_FUNCTOR_LAST accordingly
+  };
+  static constexpr SpecialFunctor SPECIAL_FUNCTOR_LAST = SpecialFunctor::MATCH;
+
+  static constexpr unsigned SPECIAL_FUNCTOR_LOWER_BOUND  = 0xFFFFFFFF - unsigned(SPECIAL_FUNCTOR_LAST);
+  static SpecialFunctor toSpecialFunctor(unsigned f) {
+    ASS_GE(f, SPECIAL_FUNCTOR_LOWER_BOUND);
+    unsigned result = std::numeric_limits<unsigned>::max() - unsigned(f);
+    ASS_LE(result, unsigned(SPECIAL_FUNCTOR_LAST))
+    return SpecialFunctor(result);
+  }
+  static unsigned toNormalFunctor(SpecialFunctor f) 
+  { return std::numeric_limits<unsigned>::max() - unsigned(f); }
 
   class SpecialTermData
   {
@@ -322,43 +334,41 @@ public:
     /** Return pointer to the term to which this object is attached */
     const Term* getTerm() const { return reinterpret_cast<const Term*>(this+1); }
   public:
-    unsigned getType() const {
-      unsigned res = getTerm()->functor();
-      ASS_GE(res,SPECIAL_FUNCTOR_LOWER_BOUND);
-      return res;
-    }
-    Formula* getCondition() const { ASS_EQ(getType(), SF_ITE); return _iteData.condition; }
+    SpecialFunctor specialFunctor() const
+    { return getTerm()->specialFunctor(); }
+
+    Formula* getCondition() const { ASS_EQ(specialFunctor(), SpecialFunctor::ITE); return _iteData.condition; }
     unsigned getFunctor() const {
-      ASS_REP(getType() == SF_LET || getType() == SF_LET_TUPLE, getType());
-      return getType() == SF_LET ? _letData.functor : _letTupleData.functor;
+      ASS_REP(specialFunctor() == SpecialFunctor::LET || specialFunctor() == SpecialFunctor::LET_TUPLE, specialFunctor());
+      return specialFunctor() == SpecialFunctor::LET ? _letData.functor : _letTupleData.functor;
     }
-    VList* getLambdaVars() const { ASS_EQ(getType(), SF_LAMBDA); return _lambdaData._vars; }
-    SList* getLambdaVarSorts() const { ASS_EQ(getType(), SF_LAMBDA); return _lambdaData._sorts; }
-    TermList getLambdaExp() const { ASS_EQ(getType(), SF_LAMBDA); return _lambdaData.lambdaExp; }
-    VList* getVariables() const { ASS_EQ(getType(), SF_LET); return _letData.variables; }
+    VList* getLambdaVars() const { ASS_EQ(specialFunctor(), SpecialFunctor::LAMBDA); return _lambdaData._vars; }
+    SList* getLambdaVarSorts() const { ASS_EQ(specialFunctor(), SpecialFunctor::LAMBDA); return _lambdaData._sorts; }
+    TermList getLambdaExp() const { ASS_EQ(specialFunctor(), SpecialFunctor::LAMBDA); return _lambdaData.lambdaExp; }
+    VList* getVariables() const { ASS_EQ(specialFunctor(), SpecialFunctor::LET); return _letData.variables; }
     VList* getTupleSymbols() const { return _letTupleData.symbols; }
     TermList getBinding() const {
-      ASS_REP(getType() == SF_LET || getType() == SF_LET_TUPLE, getType());
-      return TermList(getType() == SF_LET ? _letData.binding : _letTupleData.binding);
+      ASS_REP(specialFunctor() == SpecialFunctor::LET || specialFunctor() == SpecialFunctor::LET_TUPLE, specialFunctor());
+      return TermList(specialFunctor() == SpecialFunctor::LET ? _letData.binding : _letTupleData.binding);
     }
-    TermList getLambdaExpSort() const { ASS_EQ(getType(), SF_LAMBDA); return _lambdaData.expSort; }
+    TermList getLambdaExpSort() const { ASS_EQ(specialFunctor(), SpecialFunctor::LAMBDA); return _lambdaData.expSort; }
     TermList getSort() const {
-      switch (getType()) {
-        case SF_ITE:
+      switch (specialFunctor()) {
+        case SpecialFunctor::ITE:
           return _iteData.sort;
-        case SF_LET:
+        case SpecialFunctor::LET:
           return _letData.sort;
-        case SF_LET_TUPLE:
+        case SpecialFunctor::LET_TUPLE:
           return _letTupleData.sort;
-        case SF_LAMBDA:
+        case SpecialFunctor::LAMBDA:
           return _lambdaData.sort;
-        case SF_MATCH:
+        case SpecialFunctor::MATCH:
           return _matchData.sort;
         default:
-          ASSERTION_VIOLATION_REP(getType());
+          ASSERTION_VIOLATION_REP(specialFunctor());
       }
     }
-    Formula* getFormula() const { ASS_EQ(getType(), SF_FORMULA); return _formulaData.formula; }
+    Formula* getFormula() const { ASS_EQ(specialFunctor(), SpecialFunctor::FORMULA); return _formulaData.formula; }
     Term* getTupleTerm() const { return _tupleData.term; }
     TermList getMatchedSort() const { return _matchData.matchedSort; }
   };
@@ -401,6 +411,9 @@ public:
   /** Function or predicate symbol of a term */
   const unsigned functor() const { return _functor; }
 
+
+  SpecialFunctor specialFunctor() const 
+  { return toSpecialFunctor(functor()); }
   vstring toString(bool topLevel = true) const;
   static vstring variableToString(unsigned var);
   static vstring variableToString(TermList var);
@@ -726,14 +739,15 @@ public:
   void setInterpretedConstantsPresence(bool value) { _hasInterpretedConstants=value; }
 
   /** Return true if term is either an if-then-else or a let...in expression */
-  bool isSpecial() const { return functor()>=SPECIAL_FUNCTOR_LOWER_BOUND; }
-  bool isITE() const { return functor() == SF_ITE; }
-  bool isLet() const { return functor() == SF_LET; }
-  bool isTupleLet() const { return functor() == SF_LET_TUPLE; }
-  bool isTuple() const { return functor() == SF_TUPLE; }
-  bool isFormula() const { return functor() == SF_FORMULA; }
-  bool isLambda() const { return functor() == SF_LAMBDA; }
-  bool isMatch() const { return functor() == SF_MATCH; }
+  bool isSpecial() const { return functor() >= SPECIAL_FUNCTOR_LOWER_BOUND; }
+
+  bool isITE()      const { return functor() == toNormalFunctor(SpecialFunctor::ITE); }
+  bool isLet()      const { return functor() == toNormalFunctor(SpecialFunctor::LET); }
+  bool isTupleLet() const { return functor() == toNormalFunctor(SpecialFunctor::LET_TUPLE); }
+  bool isTuple()    const { return functor() == toNormalFunctor(SpecialFunctor::TUPLE); }
+  bool isFormula()  const { return functor() == toNormalFunctor(SpecialFunctor::FORMULA); }
+  bool isLambda()   const { return functor() == toNormalFunctor(SpecialFunctor::LAMBDA); }
+  bool isMatch()    const { return functor() == toNormalFunctor(SpecialFunctor::MATCH); }
   bool isBoolean() const;
   bool isSuper() const; 
   
@@ -1057,6 +1071,8 @@ std::ostream& operator<< (ostream& out, TermList tl );
 std::ostream& operator<< (ostream& out, const Term& tl );
 std::ostream& operator<< (ostream& out, const Literal& tl );
 
-};
+std::ostream& operator<<(std::ostream& out, Term::SpecialFunctor const& self);
+
+} // namespace Kernel
 
 #endif

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -282,7 +282,7 @@ public:
   };
   static constexpr SpecialFunctor SPECIAL_FUNCTOR_LAST = SpecialFunctor::MATCH;
 
-  static constexpr unsigned SPECIAL_FUNCTOR_LOWER_BOUND  = 0xFFFFFFFF - unsigned(SPECIAL_FUNCTOR_LAST);
+  static constexpr unsigned SPECIAL_FUNCTOR_LOWER_BOUND  =  std::numeric_limits<unsigned>::max() - unsigned(SPECIAL_FUNCTOR_LAST);
   static SpecialFunctor toSpecialFunctor(unsigned f) {
     ASS_GE(f, SPECIAL_FUNCTOR_LOWER_BOUND);
     unsigned result = std::numeric_limits<unsigned>::max() - unsigned(f);

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -148,8 +148,8 @@ Term* TermTransformer::transformSpecial(Term* term)
   ASS(term->isSpecial());
 
   Term::SpecialTermData* sd = term->getSpecialData();
-  switch (sd->getType()) {
-    case Term::SF_ITE: {
+  switch (sd->specialFunctor()) {
+    case Term::SpecialFunctor::ITE: {
       Formula* condition = transform(sd->getCondition());
       TermList thenBranch = transform(*term->nthArgument(0));
       TermList elseBranch = transform(*term->nthArgument(1));
@@ -163,7 +163,7 @@ Term* TermTransformer::transformSpecial(Term* term)
       }
     }
 
-    case Term::SF_FORMULA: {
+    case Term::SpecialFunctor::FORMULA: {
       Formula* formula = transform(sd->getFormula());
 
       if (formula == sd->getFormula()) {
@@ -173,7 +173,7 @@ Term* TermTransformer::transformSpecial(Term* term)
       }
     }
 
-    case Term::SF_LET: {
+    case Term::SpecialFunctor::LET: {
       TermList binding = transform(sd->getBinding());
       TermList body = transform(*term->nthArgument(0));
 
@@ -184,7 +184,7 @@ Term* TermTransformer::transformSpecial(Term* term)
       }
     }
 
-    case Term::SF_LET_TUPLE: {
+    case Term::SpecialFunctor::LET_TUPLE: {
       TermList binding = transform(sd->getBinding());
       TermList body = transform(*term->nthArgument(0));
 
@@ -196,7 +196,7 @@ Term* TermTransformer::transformSpecial(Term* term)
       break;
     }
 
-    case Term::SF_TUPLE: {
+    case Term::SpecialFunctor::TUPLE: {
       Term* tupleTerm = transform(sd->getTupleTerm());
 
       if (tupleTerm == sd->getTupleTerm()) {
@@ -206,7 +206,7 @@ Term* TermTransformer::transformSpecial(Term* term)
       }
     }
 
-    case Term::SF_MATCH: {
+    case Term::SpecialFunctor::MATCH: {
       DArray<TermList> terms(term->arity());
       bool unchanged = true;
       for (unsigned i = 0; i < term->arity(); i++) {

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -206,6 +206,8 @@ Term* TermTransformer::transformSpecial(Term* term)
       }
     }
 
+    case Term::SpecialFunctor::LAMBDA:
+      NOT_IMPLEMENTED;
     case Term::SpecialFunctor::MATCH: {
       DArray<TermList> terms(term->arity());
       bool unchanged = true;
@@ -221,8 +223,7 @@ Term* TermTransformer::transformSpecial(Term* term)
     }
 
   }
-  ASSERTION_VIOLATION_REP(term->toString()); 
-  return nullptr;
+  ASSERTION_VIOLATION_REP(term->toString());
 }
 
 TermList TermTransformer::transform(TermList ts)

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -503,8 +503,8 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
     Term::SpecialTermData* sd = term->getSpecialData();
 
-    switch (term->functor()) {
-      case Term::SF_ITE: {
+    switch (term->specialFunctor()) {
+      case Term::SpecialFunctor::ITE: {
         /**
          * Having a term of the form $ite(f, s, t) and the list Y1, ..., Ym, 
          * X1, ..., Xn of its free type and term variables (it is the union of 
@@ -584,7 +584,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         break;
       }
 
-      case Term::SF_LET: {
+      case Term::SpecialFunctor::LET: {
         /**
          * Having a term of the form $let(f(B1,...Bj,Y1, ..., Yk) := s, t), where f is a
          * function or predicate symbol and the list A1,...,Am,X1, ..., Xn of free 
@@ -711,7 +711,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         break;
       }
 
-      case Term::SF_FORMULA: {
+      case Term::SpecialFunctor::FORMULA: {
         if (context == FORMULA_CONTEXT) {
           formulaResult = process(sd->getFormula());
           break;
@@ -767,7 +767,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         }
         break;
       }
-      case Term::SF_LAMBDA: {
+      case Term::SpecialFunctor::LAMBDA: {
         // Lambda terms are translated to FOL using SKIBC combinators which are extensively described in
         // the literature.
         LambdaElimination le = LambdaElimination();
@@ -775,7 +775,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         break;
       }
 
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         /**
          * Having a term of the form $match(v, p1, b1, ..., pm, bm) and the list
          * X1, ..., Xn of its free variables (it is the union of free variables
@@ -843,8 +843,6 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         break;
       }
 
-      default:
-        ASSERTION_VIOLATION;
     }
 
     if (env.options->showPreprocessing()) {

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -710,7 +710,9 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
         break;
       }
-
+      case Term::SpecialFunctor::TUPLE:
+      case Term::SpecialFunctor::LET_TUPLE:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::FORMULA: {
         if (context == FORMULA_CONTEXT) {
           formulaResult = process(sd->getFormula());

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -324,6 +324,8 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -255,8 +255,8 @@ TermList Flattening::flatten (TermList ts)
 
  if (term->isSpecial()) {
     Term::SpecialTermData* sd = term->getSpecialData();
-    switch (sd->getType()) {
-      case Term::SF_FORMULA: {
+    switch (sd->specialFunctor()) {
+      case Term::SpecialFunctor::FORMULA: {
         Formula* f = sd->getFormula();
         Formula* flattenedF = flatten(f);
         if (f == flattenedF) {
@@ -266,7 +266,7 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
-      case Term::SF_ITE: {
+      case Term::SpecialFunctor::ITE: {
         TermList thenBranch = *term->nthArgument(0);
         TermList elseBranch = *term->nthArgument(1);
         Formula* condition  = sd->getCondition();
@@ -284,7 +284,7 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
-      case Term::SF_LET: {
+      case Term::SpecialFunctor::LET: {
         TermList binding = sd->getBinding();
         TermList body = *term->nthArgument(0);
 
@@ -298,7 +298,7 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
-      case Term::SF_LET_TUPLE: {
+      case Term::SpecialFunctor::LET_TUPLE: {
         TermList binding = sd->getBinding();
         TermList body = *term->nthArgument(0);
 
@@ -312,7 +312,7 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
-      case Term::SF_TUPLE: {
+      case Term::SpecialFunctor::TUPLE: {
         TermList tupleTerm = TermList(sd->getTupleTerm());
         TermList flattenedTupleTerm = flatten(tupleTerm);
 
@@ -324,7 +324,7 @@ TermList Flattening::flatten (TermList ts)
         }
       }
 
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;
         for (unsigned i = 0; i < term->arity(); i++) {
@@ -337,9 +337,6 @@ TermList Flattening::flatten (TermList ts)
         }
         return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
       }
-
-      default:
-        ASSERTION_VIOLATION;
     }
   }
 

--- a/Shell/LambdaElimination.cpp
+++ b/Shell/LambdaElimination.cpp
@@ -248,11 +248,11 @@ TermList LambdaElimination::elimLambda(TermList term)
 
   Term* t = term.term();
   if(t->isSpecial()){   
-    switch(t->functor()){
-      case Term::SF_FORMULA: 
+    switch(t->specialFunctor()){
+      case Term::SpecialFunctor::FORMULA: 
         return elimLambda(t->getSpecialData()->getFormula());
 
-      case Term::SF_LAMBDA:{
+      case Term::SpecialFunctor::LAMBDA:{
         Stack<int> vars;
         TermStack sorts;
         Term::SpecialTermData* sd = t->getSpecialData();

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -337,6 +337,8 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -255,8 +255,8 @@ TermList NNF::ennf(TermList ts, bool polarity)
 
   if (term->isSpecial()) {
     Term::SpecialTermData* sd = term->getSpecialData();
-    switch (sd->getType()) {
-      case Term::SF_FORMULA: {
+    switch (sd->specialFunctor()) {
+      case Term::SpecialFunctor::FORMULA: {
         Formula* f = sd->getFormula();
         Formula* ennfF = ennf(f, polarity);
         switch (ennfF->connective()) {
@@ -275,7 +275,7 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
-      case Term::SF_ITE: {
+      case Term::SpecialFunctor::ITE: {
         TermList thenBranch = *term->nthArgument(0);
         TermList elseBranch = *term->nthArgument(1);
         Formula* condition  = sd->getCondition();
@@ -294,7 +294,7 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
-      case Term::SF_LET: {
+      case Term::SpecialFunctor::LET: {
         TermList binding = sd->getBinding();
         TermList body = *term->nthArgument(0);
 
@@ -309,7 +309,7 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
-      case Term::SF_LET_TUPLE: {
+      case Term::SpecialFunctor::LET_TUPLE: {
         TermList binding = sd->getBinding();
         TermList body = *term->nthArgument(0);
 
@@ -324,7 +324,7 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
-      case Term::SF_TUPLE: {
+      case Term::SpecialFunctor::TUPLE: {
         TermList tupleTerm = TermList(sd->getTupleTerm());
         TermList ennfTupleTerm = ennf(tupleTerm, true);
 
@@ -337,7 +337,7 @@ TermList NNF::ennf(TermList ts, bool polarity)
         break;
       }
 
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;
         for (unsigned i = 0; i < term->arity(); i++) {
@@ -351,9 +351,8 @@ TermList NNF::ennf(TermList ts, bool polarity)
         return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
       }
 
-      default:
-        ASSERTION_VIOLATION;
     }
+    ASSERTION_VIOLATION;
   }
 
   bool changed = false;

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -367,7 +367,8 @@ TermList NewCNF::findITEs(TermList ts, Stack<unsigned> &variables, Stack<Formula
       return findITEs(tupleTerm, variables, conditions, thenBranches,
                       elseBranches, matchVariables, matchConditions, matchBranches);
     }
-
+    case Term::SpecialFunctor::LAMBDA:
+      NOT_IMPLEMENTED;
     case Term::SpecialFunctor::MATCH: {
       sort = sd->getSort();
       auto matched = *term->nthArgument(0);
@@ -1191,7 +1192,8 @@ void NewCNF::processBoolterm(TermList ts, Occurrences &occurrences)
     case Term::SpecialFunctor::FORMULA:
       process(sd->getFormula(), occurrences);
       break;
-
+    case Term::SpecialFunctor::TUPLE:
+      NOT_IMPLEMENTED;
     case Term::SpecialFunctor::ITE: {
       Formula* condition = sd->getCondition();
 
@@ -1205,7 +1207,8 @@ void NewCNF::processBoolterm(TermList ts, Occurrences &occurrences)
     case Term::SpecialFunctor::LET_TUPLE:
       processLet(sd, *term->nthArgument(0), occurrences);
       break;
-
+    case Term::SpecialFunctor::LAMBDA:
+      NOT_IMPLEMENTED;
     case Term::SpecialFunctor::MATCH: {
       processMatch(sd, term, occurrences);
       break;

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -450,8 +450,7 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
   }
 
   if (t1->isSpecial() && t2->isSpecial()) {
-    comp = compare ((int)t1->functor(),
-                    (int)t2->functor());
+    comp = compare (unsigned(t1->specialFunctor()), unsigned(t2->specialFunctor()));
     if (comp != EQUAL) {
       return comp;
     }

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -450,25 +450,25 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
   }
 
   if (t1->isSpecial() && t2->isSpecial()) {
-    comp = compare ((int)t1->getSpecialData()->getType(),
-                    (int)t2->getSpecialData()->getType());
+    comp = compare ((int)t1->functor(),
+                    (int)t2->functor());
     if (comp != EQUAL) {
       return comp;
     }
 
     // same kind of special terms
-    switch (t1->getSpecialData()->getType()) {
-      case Term::SF_FORMULA:
+    switch (t1->specialFunctor()) {
+      case Term::SpecialFunctor::FORMULA:
         return compare(t1->getSpecialData()->getFormula(), t2->getSpecialData()->getFormula());
 
-      case Term::SF_ITE:
+      case Term::SpecialFunctor::ITE:
         comp = compare(t1->getSpecialData()->getCondition(), t2->getSpecialData()->getCondition());
         if (comp != EQUAL) {
           return comp;
         }
         break; // compare arguments "then" and "else" as usual below
 
-      case Term::SF_LET: {
+      case Term::SpecialFunctor::LET: {
         comp = compare((int) VList::length(t1->getSpecialData()->getVariables()),
                        (int) VList::length(t2->getSpecialData()->getVariables()));
         if (comp != EQUAL) {
@@ -483,7 +483,7 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
         break; // compare body of the let as usual below (although 1) what about sorts, 2) what about doing the modulo the bound name?)
       }
 
-      case Term::SF_LET_TUPLE: {
+      case Term::SpecialFunctor::LET_TUPLE: {
         comp = compare((int) VList::length(t1->getSpecialData()->getTupleSymbols()),
                        (int) VList::length(t2->getSpecialData()->getTupleSymbols()));
         if (comp != EQUAL) {
@@ -498,7 +498,7 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
         break; // compare body of the tuple below
       }
 
-      case Term::SF_TUPLE: {
+      case Term::SpecialFunctor::TUPLE: {
         comp = compare(t1->getSpecialData()->getTupleTerm(), t2->getSpecialData()->getTupleTerm());
         if (comp != EQUAL) {
           return comp;
@@ -506,7 +506,7 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
         break; // compare body of the tuple below
       }
 
-      case Term::SF_LAMBDA: {
+      case Term::SpecialFunctor::LAMBDA: {
         comp = compare((int) VList::length(t1->getSpecialData()->getLambdaVars()),
                        (int) VList::length(t2->getSpecialData()->getLambdaVars()));
         if (comp != EQUAL) {
@@ -518,12 +518,10 @@ Comparison Normalisation::compare(Term* t1, Term* t2)
         return comp;     
       }
 
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         break; // comparison by arity and pairwise by arguments is done below
       }
 
-      default:
-        ASSERTION_VIOLATION;
     }
   }
 

--- a/Shell/Normalisation.hpp
+++ b/Shell/Normalisation.hpp
@@ -62,6 +62,10 @@ private:
              : LESS;
   }
 
+  inline static
+  Comparison compare (unsigned i1, unsigned i2)
+  { return i1 > i2 ? GREATER : i1 == i2 ? EQUAL : LESS; }
+
   /**
    * Return the result of comparison of two booleans b1 and b2.
    * @since 30/04/2005 Manchester

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -899,6 +899,13 @@ void PredicateDefinition::count (TermList ts,int add, Unit* unit)
         count(TermList(sd->getTupleTerm()), add, unit);
         break;
 
+      case Term::SpecialFunctor::LAMBDA:
+        // TODO we don't break existing fall-through behaviour for now,
+        // but we should handle this case
+        // something like
+        // count() the lambda body
+        // count() the lambda sorts?
+        break;
       case Term::SpecialFunctor::MATCH:
         break; // args are handled later
 

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -881,29 +881,27 @@ void PredicateDefinition::count (TermList ts,int add, Unit* unit)
 
   if (term->isSpecial()) {
     Term::SpecialTermData* sd = term->getSpecialData();
-    switch (sd->getType()) {
-      case Term::SF_FORMULA:
+    switch (sd->specialFunctor()) {
+      case Term::SpecialFunctor::FORMULA:
         count(sd->getFormula(), 0, add, unit);
         break;
 
-      case Term::SF_ITE:
+      case Term::SpecialFunctor::ITE:
         count(sd->getCondition(), 0, add, unit);
         break;
 
-      case Term::SF_LET:
-      case Term::SF_LET_TUPLE:
+      case Term::SpecialFunctor::LET:
+      case Term::SpecialFunctor::LET_TUPLE:
         count(sd->getBinding(), add, unit);
         break;
 
-      case Term::SF_TUPLE:
+      case Term::SpecialFunctor::TUPLE:
         count(TermList(sd->getTupleTerm()), add, unit);
         break;
 
-      case Term::SF_MATCH:
+      case Term::SpecialFunctor::MATCH:
         break; // args are handled later
 
-      default:
-        ASSERTION_VIOLATION;
     }
   }
 

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -900,12 +900,7 @@ void PredicateDefinition::count (TermList ts,int add, Unit* unit)
         break;
 
       case Term::SpecialFunctor::LAMBDA:
-        // TODO we don't break existing fall-through behaviour for now,
-        // but we should handle this case
-        // something like
-        // count() the lambda body
-        // count() the lambda sorts?
-        break;
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH:
         break; // args are handled later
 

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -663,6 +663,12 @@ void Property::scan(TermList ts,bool unit,bool goal)
         addProp(PR_HAS_ITE);
         break;
 
+      case Term::SpecialFunctor::TUPLE:
+        // TODO something like
+        // _hasFOOL = true
+        // addProp(PR_HAS_TUPLE)
+        // for now, do nothing
+        break;
       case Term::SpecialFunctor::LET:
       case Term::SpecialFunctor::LET_TUPLE:
         _hasFOOL = true;

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -657,31 +657,29 @@ void Property::scan(TermList ts,bool unit,bool goal)
   Term* t = ts.term();
 
   if (t->isSpecial()) {
-    switch(t->functor()) {
-      case Term::SF_ITE:
+    switch(t->specialFunctor()) {
+      case Term::SpecialFunctor::ITE:
         _hasFOOL = true;
         addProp(PR_HAS_ITE);
         break;
 
-      case Term::SF_LET:
-      case Term::SF_LET_TUPLE:
+      case Term::SpecialFunctor::LET:
+      case Term::SpecialFunctor::LET_TUPLE:
         _hasFOOL = true;
         addProp(PR_HAS_LET_IN);
         break;
-      case Term::SF_FORMULA:
+      case Term::SpecialFunctor::FORMULA:
         _hasFOOL = true;
         break;
 
-      case Term::SF_MATCH:
+      case Term::SpecialFunctor::MATCH:
         _hasFOOL = true;
         break;
 
-      case Term::SF_LAMBDA:
+      case Term::SpecialFunctor::LAMBDA:
         _hasLambda = true;
         break;
 
-      default:
-        break;
     }
   } else {
     if(t->isSort()){

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -139,8 +139,8 @@ Term* Rectify::rectifySpecialTerm(Term* t)
   CALL("Rectify::rectifySpecialTerm");
 
   Term::SpecialTermData* sd = t->getSpecialData();
-  switch(t->functor()) {
-  case Term::SF_ITE:
+  switch(t->specialFunctor()) {
+  case Term::SpecialFunctor::ITE:
   {
     ASS_EQ(t->arity(),2);
     Formula* c = rectify(sd->getCondition());
@@ -152,7 +152,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createITE(c, th, el, sort);
   }
-  case Term::SF_LET:
+  case Term::SpecialFunctor::LET:
   {
     ASS_EQ(t->arity(),1);
 
@@ -179,7 +179,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createLet(sd->getFunctor(), variables, binding, contents, sort);
   }
-  case Term::SF_LET_TUPLE:
+  case Term::SpecialFunctor::LET_TUPLE:
   {
     ASS_EQ(t->arity(),1);
 
@@ -192,7 +192,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createTupleLet(sd->getFunctor(), sd->getTupleSymbols(), binding, contents, sort);
   } 
-  case Term::SF_FORMULA:
+  case Term::SpecialFunctor::FORMULA:
   {
     ASS_EQ(t->arity(),0);
     Formula* orig = rectify(sd->getFormula());
@@ -201,7 +201,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createFormula(orig);
   }
-  case Term::SF_LAMBDA:
+  case Term::SpecialFunctor::LAMBDA:
   {
     ASS_EQ(t->arity(),0);
     bindVars(sd->getLambdaVars());
@@ -235,7 +235,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createLambda(lambdaTerm, vs, rectifiedSorts, lambdaTermS);   
   }
-  case Term::SF_TUPLE:
+  case Term::SpecialFunctor::TUPLE:
   {
     ASS_EQ(t->arity(),0);
     Term* rectifiedTupleTerm = rectify(sd->getTupleTerm());
@@ -244,7 +244,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createTuple(rectifiedTupleTerm);
   }
-  case Term::SF_MATCH: {
+  case Term::SpecialFunctor::MATCH: {
     DArray<TermList> terms(t->arity());
     bool unchanged = true;
     for (unsigned i = 0; i < t->arity(); i++) {
@@ -259,8 +259,6 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     }
     return Term::createMatch(sort, matchedSort, t->arity(), terms.begin());
   }
-  default:
-    ASSERTION_VIOLATION;
   }
   ASSERTION_VIOLATION;
 }

--- a/Shell/Shuffling.cpp
+++ b/Shell/Shuffling.cpp
@@ -267,33 +267,32 @@ void Shuffling::shuffleIter(Shufflable sh) {
         if (!t->shared()) {
           if (t->isSpecial()) {
             Term::SpecialTermData* sd = t->getSpecialData();
-            switch (sd->getType()) {
-              case Term::SF_ITE:
+            switch (sd->specialFunctor()) {
+              case Term::SpecialFunctor::ITE:
                 todo.push(Shufflable(sd->getCondition()));
                 todo.push(Shufflable(*t->nthArgument(0)));
                 tl = *t->nthArgument(1);
                 goto tl_updated;
                 break; // I know, unreachable;
 
-              case Term::SF_FORMULA:
+              case Term::SpecialFunctor::FORMULA:
                 todo.push(Shufflable(sd->getFormula()));
                 break;
 
-              case Term::SF_LET:
-              case Term::SF_LET_TUPLE:
+              case Term::SpecialFunctor::LET:
+              case Term::SpecialFunctor::LET_TUPLE:
                 todo.push(Shufflable(sd->getBinding()));
                 tl = *t->nthArgument(0);
                 goto tl_updated;
                 break; // I know, unreachable;
 
-              case Term::SF_TUPLE:
+              case Term::SpecialFunctor::TUPLE:
                 tl = TermList(sd->getTupleTerm());
                 goto tl_updated;
                 break; // I know, unreachable;
 
-              default:
-                ASSERTION_VIOLATION_REP(tl.toString());
             }
+            ASSERTION_VIOLATION_REP(tl.toString());
           } else {
             Term::Iterator it(t);
             while (it.hasNext()) {

--- a/Shell/Shuffling.cpp
+++ b/Shell/Shuffling.cpp
@@ -291,6 +291,18 @@ void Shuffling::shuffleIter(Shufflable sh) {
                 goto tl_updated;
                 break; // I know, unreachable;
 
+              case Term::SpecialFunctor::LAMBDA:
+                tl = sd->getLambdaExp();
+                goto tl_updated;
+                break; // I know, unreachable;
+
+              case Term::SpecialFunctor::MATCH:
+                // treat as non-special (and don't shuffle the MATCH specifics)
+                Term::Iterator it(t);
+                while (it.hasNext()) {
+                  todo.push(Shufflable(it.next()));
+                }
+                break;
             }
             ASSERTION_VIOLATION_REP(tl.toString());
           } else {

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -450,6 +450,8 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         ASS_REP(simplifiedTupleTerm.isTerm(), simplifiedTupleTerm.toString());
         return TermList(Term::createTuple(simplifiedTupleTerm.term()));
       }
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -339,8 +339,8 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
 
   if (term->isSpecial()) {
     Term::SpecialTermData* sd = term->getSpecialData();
-    switch (sd->getType()) {
-      case Term::SF_FORMULA: {
+    switch (sd->specialFunctor()) {
+      case Term::SpecialFunctor::FORMULA: {
         Formula* simplifiedFormula = simplify(sd->getFormula());
         switch (simplifiedFormula->connective()) {
           case TRUE: {
@@ -357,7 +357,7 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
           }
         }
       }
-      case Term::SF_ITE: {
+      case Term::SpecialFunctor::ITE: {
         Formula* condition  = simplify(sd->getCondition());
 
         #define BRANCH unsigned
@@ -419,7 +419,7 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         TermList sort = sd->getSort();
         return TermList(Term::createITE(condition, branches[THEN], branches[ELSE], sort));
       }
-      case Term::SF_LET: {
+      case Term::SpecialFunctor::LET: {
         unsigned functor = sd->getFunctor();
         VList* variables = sd->getVariables();
         TermList binding = simplify(sd->getBinding());
@@ -430,7 +430,7 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         TermList sort = sd->getSort();
         return TermList(Term::createLet(functor, variables, binding, body, sort));
       }
-      case Term::SF_LET_TUPLE: {
+      case Term::SpecialFunctor::LET_TUPLE: {
         unsigned functor = sd->getFunctor();
         VList* symbols = sd->getTupleSymbols();
         TermList binding = simplify(sd->getBinding());
@@ -441,7 +441,7 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         TermList sort = sd->getSort();
         return TermList(Term::createLet(functor, symbols, binding, body, sort));
       }
-      case Term::SF_TUPLE: {
+      case Term::SpecialFunctor::TUPLE: {
         TermList tupleTerm = TermList(sd->getTupleTerm());
         TermList simplifiedTupleTerm = simplify(tupleTerm);
         if (tupleTerm == simplifiedTupleTerm) {
@@ -450,7 +450,7 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         ASS_REP(simplifiedTupleTerm.isTerm(), simplifiedTupleTerm.toString());
         return TermList(Term::createTuple(simplifiedTupleTerm.term()));
       }
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;
         for (unsigned i = 0; i < term->arity(); i++) {
@@ -463,9 +463,8 @@ TermList SimplifyFalseTrue::simplify(TermList ts)
         }
         return TermList(Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin()));
       }
-      default:
-        ASSERTION_VIOLATION_REP(term->toString());
     }
+    ASSERTION_VIOLATION_REP(term->toString());
   }
 
   bool simplified = false;

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -86,11 +86,7 @@ void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId>& ids)
           break;
         }
         case Term::SpecialFunctor::LAMBDA:
-          // TODO we don't break existing fall-through behaviour for now,
-          // but we should handle this case:
-          // recursively addSymIds() for the lambda body
-          // recursively addSymIds() for the lambda sorts?
-          break;
+          NOT_IMPLEMENTED;
         case Term::SpecialFunctor::MATCH: {
           // args are handled below
           break;

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -66,31 +66,29 @@ void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId>& ids)
   if (!term->shared()) {
     if (term->isSpecial()) {
       Term::SpecialTermData *sd = term->getSpecialData();
-      switch (sd->getType()) {
-        case Term::SF_FORMULA:
+      switch (sd->specialFunctor()) {
+        case Term::SpecialFunctor::FORMULA:
           extractFormulaSymbols(sd->getFormula(), ids);
               break;
-        case Term::SF_ITE:
+        case Term::SpecialFunctor::ITE:
           extractFormulaSymbols(sd->getCondition(), ids);
               break;
-        case Term::SF_LET:
-        case Term::SF_LET_TUPLE: {
+        case Term::SpecialFunctor::LET:
+        case Term::SpecialFunctor::LET_TUPLE: {
           TermList binding = sd->getBinding();
           if (binding.isTerm()) {
             addSymIds(binding.term(), ids);
           }
           break;
         }
-        case Term::SF_TUPLE: {
+        case Term::SpecialFunctor::TUPLE: {
           addSymIds(sd->getTupleTerm(), ids);
           break;
         }
-        case Term::SF_MATCH: {
+        case Term::SpecialFunctor::MATCH: {
           // args are handled below
           break;
         }
-        default:
-          ASSERTION_VIOLATION;
       }
     } else {
       //all sorts should be shared

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -85,6 +85,12 @@ void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId>& ids)
           addSymIds(sd->getTupleTerm(), ids);
           break;
         }
+        case Term::SpecialFunctor::LAMBDA:
+          // TODO we don't break existing fall-through behaviour for now,
+          // but we should handle this case:
+          // recursively addSymIds() for the lambda body
+          // recursively addSymIds() for the lambda sorts?
+          break;
         case Term::SpecialFunctor::MATCH: {
           // args are handled below
           break;

--- a/Shell/SubexpressionIterator.cpp
+++ b/Shell/SubexpressionIterator.cpp
@@ -152,9 +152,9 @@ namespace Shell {
 			       _subexpressions.push(Expression(sd->getLambdaExp(), polarity));
 			       break;
 
-            /*case Term::SpecialFunctor::TUPLE:
+            case Term::SpecialFunctor::TUPLE:
               _subexpressions.push(Expression(sd->getTupleTerm()));
-              break; */
+              break;
 
             case Term::SpecialFunctor::MATCH: {
               for (unsigned i = 0; i < term->arity(); i++) {

--- a/Shell/SubexpressionIterator.cpp
+++ b/Shell/SubexpressionIterator.cpp
@@ -117,8 +117,8 @@ namespace Shell {
 
         if (term->isSpecial()) {
           Term::SpecialTermData* sd = term->getSpecialData();
-          switch (sd->getType()) {
-            case Term::SF_FORMULA:
+          switch (sd->specialFunctor()) {
+            case Term::SpecialFunctor::FORMULA:
               /**
                * Note that here we propagate the polarity of the boolean term to its
                * underlying formula
@@ -126,7 +126,7 @@ namespace Shell {
               _subexpressions.push(Expression(sd->getFormula(), polarity));
               break;
 
-            case Term::SF_ITE: 
+            case Term::SpecialFunctor::ITE: 
               /**
                * Regardless of the polarity of the whole if-then-else expression,
                * the polarity of the condition is always 0. This is because you
@@ -137,8 +137,8 @@ namespace Shell {
               _subexpressions.push(Expression(*term->nthArgument(1), polarity));
               break;
 
-            case Term::SF_LET:
-            case Term::SF_LET_TUPLE: 
+            case Term::SpecialFunctor::LET:
+            case Term::SpecialFunctor::LET_TUPLE: 
               /**
                * The polarity of the body of let-bindings is 0.
                * An expression "$let(f := A, ...)", where A is a formula,
@@ -148,25 +148,21 @@ namespace Shell {
               _subexpressions.push(Expression(*term->nthArgument(0), polarity));
               break;
 
-            case Term::SF_LAMBDA:
+            case Term::SpecialFunctor::LAMBDA:
 			       _subexpressions.push(Expression(sd->getLambdaExp(), polarity));
 			       break;
 
-            /*case Term::SF_TUPLE:
+            /*case Term::SpecialFunctor::TUPLE:
               _subexpressions.push(Expression(sd->getTupleTerm()));
               break; */
 
-            case Term::SF_MATCH: {
+            case Term::SpecialFunctor::MATCH: {
               for (unsigned i = 0; i < term->arity(); i++) {
                 _subexpressions.push(Expression(*term->nthArgument(i), polarity));
               }
               break;
             }
 
-#if VDEBUG
-            default:
-              ASSERTION_VIOLATION_REP(term->toString());
-#endif
           }
         } else {
           Term::Iterator args(term);

--- a/Shell/SymCounter.cpp
+++ b/Shell/SymCounter.cpp
@@ -234,33 +234,33 @@ void SymCounter::count(Term* term, int polarity, int add)
   if (!term->shared()) {
     if (term->isSpecial()) {
       Term::SpecialTermData *sd = term->getSpecialData();
-      switch (sd->getType()) {
-        case Term::SF_FORMULA:
+      switch (sd->specialFunctor()) {
+        case Term::SpecialFunctor::FORMULA:
           count(sd->getFormula(), polarity, add);
               break;
-        case Term::SF_ITE:
+        case Term::SpecialFunctor::ITE:
           count(sd->getCondition(), 0, add);
               break;
-        case Term::SF_LET:
-        case Term::SF_LET_TUPLE: {
+        case Term::SpecialFunctor::LET:
+        case Term::SpecialFunctor::LET_TUPLE: {
           TermList binding = sd->getBinding();
           if (binding.isTerm()) {
             count(binding.term(), 1, add);
           }
           break;
         }
-        case Term::SF_TUPLE: {
+        case Term::SpecialFunctor::TUPLE: {
           count(sd->getTupleTerm(), 0, add);
           break;
         }
-        case Term::SF_LAMBDA: {
+        case Term::SpecialFunctor::LAMBDA: {
           TermList lambdaExp = sd->getLambdaExp();
           if(lambdaExp.isTerm()){
             count(lambdaExp.term(), polarity, add);
           }
           break;
         }
-        case Term::SF_MATCH: {
+        case Term::SpecialFunctor::MATCH: {
           for (unsigned i = 0; i < term->arity(); i++) {
             TermList t = *term->nthArgument(i);
             if (t.isTerm()) {
@@ -269,8 +269,6 @@ void SymCounter::count(Term* term, int polarity, int add)
           }
           break;
         }
-        default:
-          ASSERTION_VIOLATION;
       }
     } else {
       //There should never be a non-shared sort

--- a/Shell/SymbolDefinitionInlining.cpp
+++ b/Shell/SymbolDefinitionInlining.cpp
@@ -138,6 +138,8 @@ TermList SymbolDefinitionInlining::process(TermList ts) {
         return TermList(Term::createTuple(t));
       }
 
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         bool unchanged = true;
@@ -398,6 +400,8 @@ void SymbolDefinitionInlining::collectBoundVariables(Term* t) {
         collectBoundVariables(sd->getTupleTerm());
         break;
       }
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         // args are handled below
         break;

--- a/Shell/SymbolOccurrenceReplacement.cpp
+++ b/Shell/SymbolOccurrenceReplacement.cpp
@@ -51,6 +51,8 @@ Term* SymbolOccurrenceReplacement::process(Term* term) {
       case Term::SpecialFunctor::TUPLE:
         return Term::createTuple(process(TermList(sd->getTupleTerm())).term());
 
+      case Term::SpecialFunctor::LAMBDA:
+        NOT_IMPLEMENTED;
       case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         for (unsigned i = 0; i < term->arity(); i++) {

--- a/Shell/SymbolOccurrenceReplacement.cpp
+++ b/Shell/SymbolOccurrenceReplacement.cpp
@@ -23,11 +23,11 @@ Term* SymbolOccurrenceReplacement::process(Term* term) {
 
   if (term->isSpecial()) {
     Term::SpecialTermData* sd = term->getSpecialData();
-    switch (term->functor()) {
-      case Term::SF_ITE:
+    switch (term->specialFunctor()) {
+      case Term::SpecialFunctor::ITE:
         return Term::createITE(process(sd->getCondition()), process(*term->nthArgument(0)), process(*term->nthArgument(1)), sd->getSort());
 
-        case Term::SF_LET:
+      case Term::SpecialFunctor::LET:
           if (_isPredicate == (sd->getBinding().isTerm() && sd->getBinding().term()->isBoolean())) {
             // function symbols, defined inside $let are expected to be
             // disjoint and fresh symbols are expected to be fresh
@@ -36,10 +36,10 @@ Term* SymbolOccurrenceReplacement::process(Term* term) {
           }
           return Term::createLet(sd->getFunctor(), sd->getVariables(), process(sd->getBinding()), process(*term->nthArgument(0)), sd->getSort());
 
-        case Term::SF_FORMULA:
+      case Term::SpecialFunctor::FORMULA:
           return Term::createFormula(process(sd->getFormula()));
 
-      case Term::SF_LET_TUPLE:
+      case Term::SpecialFunctor::LET_TUPLE:
         if (_isPredicate == (sd->getBinding().isTerm() && sd->getBinding().term()->isBoolean())) {
           // function symbols, defined inside $let are expected to be
           // disjoint and fresh symbols are expected to be fresh
@@ -48,22 +48,18 @@ Term* SymbolOccurrenceReplacement::process(Term* term) {
         }
         return Term::createTupleLet(sd->getFunctor(), sd->getTupleSymbols(), process(sd->getBinding()), process(*term->nthArgument(0)), sd->getSort());
 
-      case Term::SF_TUPLE:
+      case Term::SpecialFunctor::TUPLE:
         return Term::createTuple(process(TermList(sd->getTupleTerm())).term());
 
-      case Term::SF_MATCH: {
+      case Term::SpecialFunctor::MATCH: {
         DArray<TermList> terms(term->arity());
         for (unsigned i = 0; i < term->arity(); i++) {
           terms[i] = process(*term->nthArgument(i));
         }
         return Term::createMatch(sd->getSort(), sd->getMatchedSort(), term->arity(), terms.begin());
       }
-
-#if VDEBUG
-        default:
-          ASSERTION_VIOLATION;
-#endif
     }
+    ASSERTION_VIOLATION;
   }
 
   bool renaming = !_isPredicate && (term->functor() == _symbol);


### PR DESCRIPTION
I made the special functor constants in `Term` an enum class. 
This has the advantage that in all switch statements where were we don't handle a variant we get a compile-time warning (instead of a runtime crash).

The reason i did this is because i ran into the following crash:

```
vampire --mode vampire --input_syntax tptp TPTP-v8.0.0/Problems/SET/SET017^1.p --decode lrs+10_1:1_sos=on:ss=included:st=1.2:urr=on:si=on:rawr=on:rtra=on_0

Condition in file /Users/jo/projects/vampire/master/Shell/Shuffling.cpp, line 295 violated:
false
Value of tl.toString() is: (^[X0 : $i, X3 : $i] : ((X0 = X3)))
----- stack dump -----
Version : Vampire 4.7 (commit 6d32a82dc on 2023-06-29 16:19:30 +0100)
Control points passed: 113907
last control point:
         -TermList::toString (113907)
main
 vampireMode()
  doProving()
   getPreprocessedProblem
    Preprocess::preprocess
     Shuffling::shuffle (Problem&)
      Shuffling::shuffle (UnitList*&)
       Shuffling::shuffle (Unit*
        Shuffling::shuffleIter
----- end of stack dump -----
```

Which is caused by the variant `Term::SpecialFunctor::LAMBDA` (former `Term::SF_LAMBDA`) not being handled in [this](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/Shuffling.cpp#L270-L294) switch statement. 

I guess the either @ibnyusuf or @quickbeam123 should easily be able to fix this.

But refactoring to enums also showed a lot of other spots where some variants are not being handled. Maybe we can fix them together in this branch as it's a lot of places in the code base i never touched. 

In particular the other switch-cases are:
- `LET_TUPLE`
  - [x] [Shell/FOOLElimination.cpp line 506](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/FOOLElimination.cpp#L506)

- `TUPLE`
  - [x] [Shell/FOOLElimination.cpp line 506](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/FOOLElimination.cpp#L506)
  - [x] [Shell/NewCNF.cpp line 190](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/NewCNF.cpp#L1190)
  - [x] [Shell/Property.cpp line 660](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/Property.cpp#L660)
  - [x] [Shell/SubexpressionIterator.cpp line 120](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/SubexpressionIterator.cpp#L120)

- `MATCH`:
  - [x] [Shell/Shuffling.cpp line 270](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/Shuffling.cpp#L270)

- `LAMBDA`:
  - [x] [Shell/SymbolDefinitionInlining.cpp line 378](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/SymbolDefinitionInlining.cpp#L378)
  - [x] [Shell/SymbolDefinitionInlining.cp line 76](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/SymbolDefinitionInlining.cpp#L76)
  - [x] [Shell/SymbolOccurrenceReplacement.cp line 26](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/SymbolOccurrenceReplacement.cpp#L26)
  - [x] [Kernel/FormulaTransformer.cpp line 101](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Kernel/FormulaTransformer.cpp#L101)
  - [x] [Kernel/SubstHelper.hpp line 288](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Kernel/SubstHelper.hpp#L288)
  - [x] [Shell/Flattening.cpp line 258](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/Flattening.cpp#L258)
  - [x] [Kernel/TermTransformer.cpp line 151](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Kernel/TermTransformer.cpp#L151)
  - [x] [Shell/NNF.cpp line 258](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/NNF.cpp#L258)
  - [x] [Shell/NewCNF.cpp# line 190](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/NewCNF.cpp#L1190)
  - [x] [Shell/NewCNF.cpp line 340](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/NewCNF.cpp#L340)
  - [x] [Shell/PredicateDefinition.cpp line 884](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/PredicateDefinition.cpp#L884)
  - [x] [Shell/Shuffling.cpp line 270](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/Shuffling.cpp#L270)
  - [x] [Shell/SimplifyFalseTrue.cpp line 342](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/SimplifyFalseTrue.cpp#L342)
  - [x] [Shell/SineUtils.cp line 69](https://github.com/vprover/vampire/blob/6d32a82dc2a003268785a73424efca941666ebf7/Shell/SineUtils.cpp#L69)
