### PR TITLE
Fixes UWA polymorphism compability

### DIFF
--- a/Kernel/MismatchHandler.cpp
+++ b/Kernel/MismatchHandler.cpp
@@ -46,6 +46,7 @@ bool UWAMismatchHandler::checkUWA(TermList t1, TermList t2)
   CALL("UWAMismatchHandler::checkUWA");
 
     if(!(t1.isTerm() && t2.isTerm())) return false;
+    if(t1.term()->isSort() || t2.term()->isSort()) return false;
 
     bool t1Interp = Shell::UnificationWithAbstractionConfig::isInterpreted(t1.term());
     bool t2Interp = Shell::UnificationWithAbstractionConfig::isInterpreted(t2.term());


### PR DESCRIPTION
Fixes the issue that UWA sometimes tries to introduce constraints between sorts, which is not allowed, and results in assertion violations.

An example is the following run:
```
./vampire TPTP-v8.0.0/Problems/LCL/LCL831_5.p --decode lrs+1011_1:1_fd=preordered:fsd=on:sos=on:thsq=on:thsqc=64:thsqd=32:uwa=ground:si=on:rawr=on:rtra=on_100
```