### PR TITLE
Fixing equality weight computation

### DIFF
--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -294,6 +294,11 @@ Literal* TermSharing::insert(Literal* t)
     unsigned vars = 0;
     Color color = COLOR_TRANSPARENT;
     bool hasInterpretedConstants=false;
+
+    if(t->isEquality()){
+      weight += SortHelper::getEqualityArgumentSort(s).weight() - 1;
+    }
+
     for (TermList* tt = t->args(); ! tt->isEmpty(); tt = tt->next()) {
       if (tt->isVar()) {
         ASS(tt->isOrdinaryVar());
@@ -305,11 +310,6 @@ Literal* TermSharing::insert(Literal* t)
         Term* r = tt->term();
         vars += r->numVarOccs();
         weight += r->weight();
-
-        if(t->isEquality()){
-          TermList sort = SortHelper::getResultSort(r);
-          weight += sort.weight() - 1;
-        }
 
         if (env.colorUsed) {
           ASS(color == COLOR_TRANSPARENT || r->color() == COLOR_TRANSPARENT || color == r->color());


### PR DESCRIPTION
Fixes the following bug: 
In term sharing we compute the weight of the literal. For equalities this includes (since introducing polymorphism) that we add the weight of the equality sort (minus 1) to the literal. In our current implementation we double-add this weight for terms with two non-variable terms. This was confirmed to be a bug and not expected behaviour by @ibnyusuf . 
This mini-PR fixes this.