### PR TITLE
Proposition/question: more efficient use of unbound variables in RobSubstitution

### DIFF
--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -167,8 +167,13 @@ RobSubstitution::TermSpec RobSubstitution::deref(VarSpec v) const
     bool found=_bank.find(v,binding);
     if(!found) {
       binding.index=UNBOUND_INDEX;
+      unsigned nuaVal = _nextUnboundAvailable;
       binding.term.makeVar(_nextUnboundAvailable++);
-      const_cast<RobSubstitution&>(*this).bind(v,binding);
+      RobSubstitution* self = const_cast<RobSubstitution*>(this);
+      self->bind(v,binding);
+      if(self->bdIsRecording()) {
+        self->bdAdd(new NextUnboundVariableBacktrackObject(self, nuaVal));
+      }
       return binding;
     } else if(binding.index==UNBOUND_INDEX || binding.term.isTerm()
               || binding.term.isVSpecialVar()) {

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -259,6 +259,19 @@ private:
   friend std::ostream& operator<<(std::ostream& out, RobSubstitution const& self)
   { return out << self._bank; }
 
+  class NextUnboundVariableBacktrackObject
+  : public BacktrackObject
+  {
+  public:
+    NextUnboundVariableBacktrackObject(RobSubstitution* subst, unsigned v) : _subst(subst), _v(v) {}
+    void backtrack() { _subst->_nextUnboundAvailable = _v; }
+    CLASS_NAME(RobSubstitution::NextUnboundVariableBacktrackObject);
+    USE_ALLOCATOR(NextUnboundVariableBacktrackObject);
+  private:
+    RobSubstitution* _subst;
+    unsigned _v;
+  };
+
   class BindingBacktrackObject
   : public BacktrackObject
   {


### PR DESCRIPTION
Due to the current wasteful use of variables in unifications via `_nextUnboundAvailable` in `RobSubstitution`, there is an unnecessary amount of variants for most of the terms during proof search. This places a huge burden on term sharing, for example.

My proposition is to backtrack the `_nextUnboundAvailable` value whenever we can, which can be done very easily. Initial tests suggests that this is beneficial, running `-sa discount -t 10` across TPTP resulted in 35 more solved problems (no lost problems) with the overall runtime going down from 138000 to 137000 seconds and the overall memory from 3430000 to 2250000 (!) MB. Of course, more elaborate tests would be needed. 

If the current behaviour is intentional for some reason, please let me know, there is the chance that I'm oblivious to something more subtle here. Is any code relying on what exact variables are there? Or if the backtracking itself is wasteful, I'm open to suggestions how else to do it.