### PR TITLE
Reset nextUnbound

### DIFF
--- a/Indexing/SubstitutionTree.cpp
+++ b/Indexing/SubstitutionTree.cpp
@@ -664,6 +664,11 @@ SubstitutionTree::QueryResult SubstitutionTree::UnificationsIterator::next()
     _subst->bdRecord(_clientBacktrackData);
     _clientBDRecording=true;
 
+    // Reset nextUnbound before we start applying substitutions
+    // so that we rename variables from 0 instead of from some large number.
+    // This improves sharing of terms and hence memory usage and performance
+    _subst->resetNextUnboundAvailable();
+
     _subst->denormalize(normalizer,NORM_RESULT_BANK,RESULT_BANK);
 
     return QueryResult(ld, ResultSubstitution::fromSubstitution( &*_subst, QUERY_BANK, RESULT_BANK),

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -168,13 +168,8 @@ RobSubstitution::TermSpec RobSubstitution::deref(VarSpec v) const
     bool found=_bank.find(v,binding);
     if(!found) {
       binding.index=UNBOUND_INDEX;
-      unsigned nuaVal = _nextUnboundAvailable;
       binding.term.makeVar(_nextUnboundAvailable++);
-      RobSubstitution* self = const_cast<RobSubstitution*>(this);
-      self->bind(v,binding);
-      if(self->bdIsRecording()) {
-        self->bdAdd(new NextUnboundVariableBacktrackObject(self, nuaVal));
-      }
+      const_cast<RobSubstitution&>(*this).bind(v,binding);
       return binding;
     } else if(binding.index==UNBOUND_INDEX || binding.term.isTerm()
               || binding.term.isVSpecialVar()) {

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -64,6 +64,11 @@ public:
     _nextUnboundAvailable=0;
   }
 
+  void resetNextUnboundAvailable()
+  {
+    _nextUnboundAvailable = 0;
+  }
+
   void setMap(FuncSubtermMap* fmap){
     _funcSubtermMap = fmap;
   }
@@ -258,19 +263,6 @@ private:
 
   friend std::ostream& operator<<(std::ostream& out, RobSubstitution const& self)
   { return out << self._bank; }
-
-  class NextUnboundVariableBacktrackObject
-  : public BacktrackObject
-  {
-  public:
-    NextUnboundVariableBacktrackObject(RobSubstitution* subst, unsigned v) : _subst(subst), _v(v) {}
-    void backtrack() { _subst->_nextUnboundAvailable = _v; }
-    CLASS_NAME(RobSubstitution::NextUnboundVariableBacktrackObject);
-    USE_ALLOCATOR(NextUnboundVariableBacktrackObject);
-  private:
-    RobSubstitution* _subst;
-    unsigned _v;
-  };
 
   class BindingBacktrackObject
   : public BacktrackObject


### PR DESCRIPTION
As discussed on Zulip, here is an alternative implementation that solves the `nextUnboundAvailable` issue without allocating any backtrack objects.