### PR TITLE
distinct group expansion option

### DIFF
--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -121,7 +121,7 @@ void Signature::Symbol::destroyTypeConSymbol()
  * A constant can be added into one particular distinct group
  * at most once
  *
- * We also record the symbol in the group's members, under certain conditions
+ * We also record the symbol in the group's members
  */
 void Signature::Symbol::addToDistinctGroup(unsigned group,unsigned this_number)
 {
@@ -129,17 +129,10 @@ void Signature::Symbol::addToDistinctGroup(unsigned group,unsigned this_number)
   ASS(!List<unsigned>::member(group, _distinctGroups))
 
   List<unsigned>::push(group, _distinctGroups);
-
   env.signature->_distinctGroupsAddedTo=true;
 
   Signature::DistinctGroupMembers members = env.signature->_distinctGroupMembers[group];
-  if(members->size() <= DistinctGroupExpansion::EXPAND_UP_TO_SIZE
-                       || env.options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING){
-    // we add one more than EXPAND_UP_TO_SIZE to signal to DistinctGroupExpansion::apply not to expand
-    // ... instead DistinctEqualitySimplifier will take over
-    members->push(this_number);
-  }
-
+  members->push(this_number);
 } // addToDistinctGroup
 
 /**

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -3149,7 +3149,7 @@ Formula* TPTP::createPredicateApplication(vstring name, unsigned arity)
         if(t.isVar() || t.term()->arity()!=0){ USER_ERROR("$distinct can only be used with constants");}
         distincts.push(t.term()->functor());
       }
-      Formula* distinct_formula = DistinctGroupExpansion().expand(distincts);
+      Formula* distinct_formula = DistinctGroupExpansion(0 /* zero means "always expand"*/).expand(distincts);
       return distinct_formula;
     }else{
       // Otherwise record them as being in a distinct group

--- a/Shell/DistinctGroupExpansion.cpp
+++ b/Shell/DistinctGroupExpansion.cpp
@@ -59,16 +59,15 @@ bool DistinctGroupExpansion::apply(UnitList*& units)
 
   Stack<Signature::DistinctGroupMembers>& group_members = env.signature->distinctGroupMembers();
 
-  // If this is updated then make sure you update the check in
-  // Kernel::Signature::Symol::addToDistinctGroup as well
-  bool expandEverything = env.options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING;
+  bool expandEverything = (_expandUpToSize == 0) ||
+     env.options->saturationAlgorithm()==Options::SaturationAlgorithm::FINITE_MODEL_BUILDING;
 
   bool someLeft = false;
 
   for(unsigned i=0;i<group_members.size();i++){
     Signature::DistinctGroupMembers members = group_members[i];
     if(members->size() > 0) {
-      if( members->size()>1 && (members->size() <= EXPAND_UP_TO_SIZE || expandEverything)) {
+      if( members->size()>1 && (expandEverything || members->size() <= _expandUpToSize)) {
         added=true;
         Formula* expansion = expand(*members);
         if(env.options->showPreprocessing()){
@@ -79,7 +78,9 @@ bool DistinctGroupExpansion::apply(UnitList*& units)
           new FormulaUnit(expansion,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::DISTINCTNESS_AXIOM)),
           units);
       }
-      else someLeft=true;
+      else {
+        someLeft=true;
+      }
     }
   } 
 

--- a/Shell/DistinctGroupExpansion.hpp
+++ b/Shell/DistinctGroupExpansion.hpp
@@ -26,14 +26,13 @@ using namespace Kernel;
  */
 class DistinctGroupExpansion {
 public:
-  static const unsigned EXPAND_UP_TO_SIZE = 140;
-
-  DistinctGroupExpansion(){}
+  DistinctGroupExpansion(unsigned expandUpToSize) : _expandUpToSize(expandUpToSize) {}
 
   void apply(Problem& prb);
   bool apply(UnitList*& units);
   Formula* expand(Stack<unsigned>& constants);
-
+private:
+  unsigned _expandUpToSize;
 };
 
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -515,6 +515,13 @@ void Options::init()
     _blockedClauseElimination.addProblemConstraint(notWithCat(Property::UEQ));
     _blockedClauseElimination.setRandomChoices({"on","off"});
 
+    _distinctGroupExpansionLimit = UnsignedOptionValue("distinct_group_expansion_limit","dgel",140);
+    _distinctGroupExpansionLimit.description = "If a distinct group (defined, e.g., via TPTP's $distinct)"
+         " is not larger than this limit, it will be expanded during preprocessing into quadratically many disequalities."
+         " (0 means `always expand`)";
+    _lookup.insert(&_distinctGroupExpansionLimit);
+    _distinctGroupExpansionLimit.tag(OptionTag::PREPROCESSING);
+
     _theoryAxioms = ChoiceOptionValue<TheoryAxiomLevel>("theory_axioms","tha",TheoryAxiomLevel::ON,{"on","off","some"});
     _theoryAxioms.description="Include theory axioms for detected interpreted symbols";
     _lookup.insert(&_theoryAxioms);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2161,6 +2161,7 @@ public:
 
   bool unusedPredicateDefinitionRemoval() const { return _unusedPredicateDefinitionRemoval.actualValue; }
   bool blockedClauseElimination() const { return _blockedClauseElimination.actualValue; }
+  unsigned distinctGroupExpansionLimit() const { return _distinctGroupExpansionLimit.actualValue; }
   void setUnusedPredicateDefinitionRemoval(bool newVal) { _unusedPredicateDefinitionRemoval.actualValue = newVal; }
   SatSolver satSolver() const { return _satSolver.actualValue; }
   //void setSatSolver(SatSolver newVal) { _satSolver = newVal; }
@@ -2775,6 +2776,7 @@ private:
   ChoiceOptionValue<URResolution> _unitResultingResolution;
   BoolOptionValue _unusedPredicateDefinitionRemoval;
   BoolOptionValue _blockedClauseElimination;
+  UnsignedOptionValue _distinctGroupExpansionLimit;
 
   OptionChoiceValues _tagNames;
 

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -155,7 +155,7 @@ void Preprocess::preprocess(Problem& prb)
   }
 
   if(env.options->choiceAxiom()){
-    LambdaElimination::addChoiceAxiom(prb);    
+    LambdaElimination::addChoiceAxiom(prb);
   }
 
   prb.getProperty();
@@ -167,7 +167,7 @@ void Preprocess::preprocess(Problem& prb)
   if ((prb.hasLogicalProxy() || prb.hasBoolVar()) && env.options->addProxyAxioms()){
     LambdaElimination::addProxyAxioms(prb);
   }
-  
+
   if (prb.hasInterpretedOperations() || env.signature->hasTermAlgebras()){
     // Some axioms needed to be normalized, so we call InterpretedNormalizer twice
     InterpretedNormalizer().apply(prb);
@@ -178,7 +178,7 @@ void Preprocess::preprocess(Problem& prb)
   if(env.signature->hasDistinctGroups()){
     if(env.options->showPreprocessing())
       env.out() << "distinct group expansion" << std::endl;
-    DistinctGroupExpansion().apply(prb);
+    DistinctGroupExpansion(_options.distinctGroupExpansionLimit()).apply(prb);
   }
 
   if (_options.sineToAge() || _options.useSineLevelSplitQueues() || (_options.sineToPredLevels() != Options::PredicateSineLevels::OFF)) {


### PR DESCRIPTION
We have a limit defining how large a distinct group (parsed via TPTP's $distinct) must be not to get expanded into quadratically many disequalities. Now this limit can be specified by the user via an option. In particular, the limit can be disabled leading to "always expand" behaviour. (This feature has been requested by some of our users.)

A bit of tidying along the way.