### PR TITLE
remove dollar signs from inference names, not allowed in TSTP output

### DIFF
--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -597,11 +597,11 @@ vstring Kernel::ruleName(InferenceRule rule)
   case InferenceRule::FOOL_ELIMINATION:
     return "fool elimination";
   case InferenceRule::FOOL_ITE_ELIMINATION:
-    return "fool $ite elimination";
+    return "fool ite elimination";
   case InferenceRule::FOOL_LET_ELIMINATION:
-    return "fool $let elimination";
+    return "fool let elimination";
   case InferenceRule::FOOL_MATCH_ELIMINATION:
-    return "fool $match elimination";
+    return "fool match elimination";
   case InferenceRule::FOOL_PARAMODULATION:
     return "fool paramodulation";
 //  case CHOICE_AXIOM:


### PR DESCRIPTION
Who says there's no dollars in inference? I do.

These strings get used for TSTP output - but this eventually breaks downstream users (i.e. Geoff) because `$` is not allowed in TPTP identifiers unquoted.

> Yep, there's a syntax error in the Vampire proof ...
> 
> ```
> tff(f715,plain,(
>   ! [X0 : $int] : (infix_lseq(0,X0) => (iG1(X0) <=> abs(X0) = X0))),
>   inference(fool_$ite_elimination,[],[f714])).
> ```
> 
> ... `fool_$ite_elimination` contains a $ that is not allowed, unless the
> whole thing is ''ed ...
> 
> ```
> tff(f715,plain,(
>   ! [X0 : $int] : (infix_lseq(0,X0) => (iG1(X0) <=> abs(X0) = X0))),
>   inference('fool_$ite_elimination',[],[f714])).
> ```

Fix this by removing the dollars. I don't think many people rely on the exact inference names so this seems like the option with least potential for breakage, and it's still obvious what the inferences do.