### PR TITLE
FOOL proofs TPTP compliant

### DIFF
--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -15,6 +15,7 @@
 
 #include "Kernel/Clause.hpp"
 #include "Kernel/TermIterators.hpp"
+#include "Kernel/InferenceStore.hpp"
 
 namespace Inferences
 {
@@ -109,6 +110,8 @@ void DefinitionIntroduction::introduceDefinitionFor(Term *t) {
   NonspecificInference0 inference(UnitInputType::AXIOM, InferenceRule::FUNCTION_DEFINITION);
   Clause *definition = new (1) Clause(1, inference);
   (*definition)[0] = eq;
+
+  InferenceStore::instance()->recordIntroducedSymbol(definition,SymbolType::FUNC,functor);
 
   _definitions.push(definition);
 }

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -599,7 +599,9 @@ vstring Kernel::ruleName(InferenceRule rule)
   case InferenceRule::FOOL_ITE_DEFINITION:
     return "fool ite definition";
   case InferenceRule::FOOL_LET_DEFINITION:
-    return "fool let elimination";
+    return "fool let definition";
+  case InferenceRule::FOOL_FORMULA_DEFINITION:
+    return "fool formula definition";
   case InferenceRule::FOOL_MATCH_ELIMINATION:
     return "fool match elimination";
   case InferenceRule::FOOL_PARAMODULATION:

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -598,7 +598,7 @@ vstring Kernel::ruleName(InferenceRule rule)
     return "fool elimination";
   case InferenceRule::FOOL_ITE_DEFINITION:
     return "fool ite definition";
-  case InferenceRule::FOOL_LET_ELIMINATION:
+  case InferenceRule::FOOL_LET_DEFINITION:
     return "fool let elimination";
   case InferenceRule::FOOL_MATCH_ELIMINATION:
     return "fool match elimination";

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -602,8 +602,8 @@ vstring Kernel::ruleName(InferenceRule rule)
     return "fool let definition";
   case InferenceRule::FOOL_FORMULA_DEFINITION:
     return "fool formula definition";
-  case InferenceRule::FOOL_MATCH_ELIMINATION:
-    return "fool match elimination";
+  case InferenceRule::FOOL_MATCH_DEFINITION:
+    return "fool match definition";
   case InferenceRule::FOOL_PARAMODULATION:
     return "fool paramodulation";
 //  case CHOICE_AXIOM:

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -596,8 +596,8 @@ vstring Kernel::ruleName(InferenceRule rule)
     return "flattening";
   case InferenceRule::FOOL_ELIMINATION:
     return "fool elimination";
-  case InferenceRule::FOOL_ITE_ELIMINATION:
-    return "fool ite elimination";
+  case InferenceRule::FOOL_ITE_DEFINITION:
+    return "fool ite definition";
   case InferenceRule::FOOL_LET_ELIMINATION:
     return "fool let elimination";
   case InferenceRule::FOOL_MATCH_ELIMINATION:

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -390,8 +390,10 @@ enum class InferenceRule : unsigned char {
   FOOL_ELIMINATION,
   /** Definition of $ite expressions */
   FOOL_ITE_DEFINITION,
-  /** Elimination of $let expressions */
+  /** Definition of $let expressions */
   FOOL_LET_DEFINITION,
+  /** Definition of formulas used as terms */
+  FOOL_FORMULA_DEFINITION,
   /** Elimination of $match expressions */
   FOOL_MATCH_ELIMINATION,
   /** result of general splitting */

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -391,7 +391,7 @@ enum class InferenceRule : unsigned char {
   /** Definition of $ite expressions */
   FOOL_ITE_DEFINITION,
   /** Elimination of $let expressions */
-  FOOL_LET_ELIMINATION,
+  FOOL_LET_DEFINITION,
   /** Elimination of $match expressions */
   FOOL_MATCH_ELIMINATION,
   /** result of general splitting */

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -388,8 +388,8 @@ enum class InferenceRule : unsigned char {
   BOOLEAN_TERM_ENCODING,
   /** Elimination of FOOL expressions that makes a formula not syntactically first-order */
   FOOL_ELIMINATION,
-  /** Elimination of $ite expressions */
-  FOOL_ITE_ELIMINATION,
+  /** Definition of $ite expressions */
+  FOOL_ITE_DEFINITION,
   /** Elimination of $let expressions */
   FOOL_LET_ELIMINATION,
   /** Elimination of $match expressions */

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -394,8 +394,8 @@ enum class InferenceRule : unsigned char {
   FOOL_LET_DEFINITION,
   /** Definition of formulas used as terms */
   FOOL_FORMULA_DEFINITION,
-  /** Elimination of $match expressions */
-  FOOL_MATCH_ELIMINATION,
+  /** Definition for $match expressions */
+  FOOL_MATCH_DEFINITION,
   /** result of general splitting */
   GENERAL_SPLITTING,
   /** component introduced by general splitting */

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -714,7 +714,8 @@ protected:
       vstring newSymbolInfo;
       if (hasNewSymbols(us)) {
         vstring newSymbOrigin;
-        if (rule == InferenceRule::FUNCTION_DEFINITION || rule == InferenceRule::FOOL_ITE_DEFINITION || rule == InferenceRule::FOOL_LET_DEFINITION) {
+        if (rule == InferenceRule::FUNCTION_DEFINITION ||
+          rule == InferenceRule::FOOL_ITE_DEFINITION || rule == InferenceRule::FOOL_LET_DEFINITION || rule == InferenceRule::FOOL_FORMULA_DEFINITION) {
           newSymbOrigin = "definition";
         } else {
           newSymbOrigin = "naming";

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -713,7 +713,13 @@ protected:
     else if (!parents.hasNext()) {
       vstring newSymbolInfo;
       if (hasNewSymbols(us)) {
-	      newSymbolInfo = getNewSymbols("naming",us);
+        vstring newSymbOrigin;
+        if (rule == InferenceRule::FUNCTION_DEFINITION) {
+          newSymbOrigin = "definition";
+        } else {
+          newSymbOrigin = "naming";
+        }
+	      newSymbolInfo = getNewSymbols(newSymbOrigin,us);
       }
       inferenceStr="introduced("+tptpRuleName(rule)+",["+newSymbolInfo+"])";
     }

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -652,7 +652,7 @@ protected:
       } else if (sym.first == SymbolType::PRED){
         symsStr << env.signature->predicateName(sym.second);
       } else {
-        symsStr << env.signature->typeConName(sym.second);       
+        symsStr << env.signature->typeConName(sym.second);
       }
       if (symIt.hasNext()) {
         symsStr << ',';
@@ -689,7 +689,6 @@ protected:
     default: ;
     }
 
-
     //get vstring representing the formula
 
     vstring formulaStr=getFormulaString(us);
@@ -700,21 +699,21 @@ protected:
     if (rule==InferenceRule::INPUT) {
       vstring fileName;
       if (env.options->inputFile()=="") {
-	fileName="unknown";
+	      fileName="unknown";
       }
       else {
-	fileName="'"+env.options->inputFile()+"'";
+	      fileName="'"+env.options->inputFile()+"'";
       }
       vstring axiomName;
       if (!outputAxiomNames || !Parse::TPTP::findAxiomName(us, axiomName)) {
-	axiomName="unknown";
+	      axiomName="unknown";
       }
       inferenceStr="file("+fileName+","+quoteAxiomName(axiomName)+")";
     }
     else if (!parents.hasNext()) {
       vstring newSymbolInfo;
       if (hasNewSymbols(us)) {
-	newSymbolInfo = getNewSymbols("naming",us);
+	      newSymbolInfo = getNewSymbols("naming",us);
       }
       inferenceStr="introduced("+tptpRuleName(rule)+",["+newSymbolInfo+"])";
     }
@@ -722,7 +721,7 @@ protected:
       ASS(parents.hasNext());
       vstring statusStr;
       if (rule==InferenceRule::SKOLEMIZE) {
-	statusStr="status(esa),"+getNewSymbols("skolem",us);
+	      statusStr="status(esa),"+getNewSymbols("skolem",us);
       }
 
       inferenceStr="inference("+tptpRuleName(rule);
@@ -754,7 +753,7 @@ protected:
     vstring inferenceStr="inference("+tptpRuleName(rule)+",[],[";
 
     //here we rely on the fact that the base premise is always put as the first premise in
-    //GeneralSplitting::apply 
+    //GeneralSplitting::apply
 
     ALWAYS(parents.hasNext());
     Unit* base=parents.next();
@@ -784,7 +783,7 @@ protected:
     vstring defId=tptpDefId(us);
 
     out<<getFofString(tptpUnitId(us), getFormulaString(us),
-	"inference("+tptpRuleName(InferenceRule::CLAUSIFY)+",[],["+defId+"])", InferenceRule::CLAUSIFY)<<endl;
+	    "inference("+tptpRuleName(InferenceRule::CLAUSIFY)+",[],["+defId+"])", InferenceRule::CLAUSIFY)<<endl;
 
 
     List<unsigned>* nameVars=0;
@@ -803,14 +802,14 @@ protected:
     while(lits.hasNext()) {
       Literal* lit=lits.next();
       if (lit==nameLit) {
-	continue;
+	      continue;
       }
       if (first) {
-	first=false;
+	      first=false;
       }
       else {
-	multiple=true;
-	compStr+=" | ";
+	      multiple=true;
+	      compStr+=" | ";
       }
       compStr+=lit->toString();
 
@@ -855,7 +854,7 @@ protected:
     vstring defStr=getQuantifiedStr(cl)+" <=> ~"+splitPred;
 
     out<<getFofString(tptpUnitId(us), getFormulaString(us),
-  "inference("+tptpRuleName(InferenceRule::CLAUSIFY)+",[],["+defId+"])", InferenceRule::CLAUSIFY)<<endl;
+      "inference("+tptpRuleName(InferenceRule::CLAUSIFY)+",[],["+defId+"])", InferenceRule::CLAUSIFY)<<endl;
 
     vstringstream originStm;
     originStm << "introduced(" << tptpRuleName(rule)
@@ -872,7 +871,7 @@ struct InferenceStore::ProofCheckPrinter
 {
   CLASS_NAME(InferenceStore::ProofCheckPrinter);
   USE_ALLOCATOR(InferenceStore::ProofCheckPrinter);
-  
+
   ProofCheckPrinter(ostream& out, InferenceStore* is)
   : ProofPrinter(out, is) {}
 
@@ -881,7 +880,7 @@ protected:
   {
     InferenceRule rule;
     UnitIterator parents=_is->getParents(cs, rule);
- 
+
     //outputSymbolDeclarations also deals with sorts for now
     //UIHelper::outputSortDeclarations(out);
     UIHelper::outputSymbolDeclarations(out);

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -714,7 +714,7 @@ protected:
       vstring newSymbolInfo;
       if (hasNewSymbols(us)) {
         vstring newSymbOrigin;
-        if (rule == InferenceRule::FUNCTION_DEFINITION || rule == InferenceRule::FOOL_ITE_DEFINITION) {
+        if (rule == InferenceRule::FUNCTION_DEFINITION || rule == InferenceRule::FOOL_ITE_DEFINITION || rule == InferenceRule::FOOL_LET_DEFINITION) {
           newSymbOrigin = "definition";
         } else {
           newSymbOrigin = "naming";
@@ -934,7 +934,7 @@ protected:
     case InferenceRule::AVATAR_REFUTATION:
     case InferenceRule::AVATAR_SPLIT_CLAUSE:
     case InferenceRule::AVATAR_CONTRADICTION_CLAUSE:
-    case InferenceRule::FOOL_LET_ELIMINATION:
+    case InferenceRule::FOOL_LET_DEFINITION:
     case InferenceRule::FOOL_ITE_DEFINITION:
     case InferenceRule::FOOL_ELIMINATION:
     case InferenceRule::BOOLEAN_TERM_ENCODING:

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -715,7 +715,8 @@ protected:
       if (hasNewSymbols(us)) {
         vstring newSymbOrigin;
         if (rule == InferenceRule::FUNCTION_DEFINITION ||
-          rule == InferenceRule::FOOL_ITE_DEFINITION || rule == InferenceRule::FOOL_LET_DEFINITION || rule == InferenceRule::FOOL_FORMULA_DEFINITION) {
+          rule == InferenceRule::FOOL_ITE_DEFINITION || rule == InferenceRule::FOOL_LET_DEFINITION ||
+          rule == InferenceRule::FOOL_FORMULA_DEFINITION || rule == InferenceRule::FOOL_MATCH_DEFINITION) {
           newSymbOrigin = "definition";
         } else {
           newSymbOrigin = "naming";

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -714,7 +714,7 @@ protected:
       vstring newSymbolInfo;
       if (hasNewSymbols(us)) {
         vstring newSymbOrigin;
-        if (rule == InferenceRule::FUNCTION_DEFINITION) {
+        if (rule == InferenceRule::FUNCTION_DEFINITION || rule == InferenceRule::FOOL_ITE_DEFINITION) {
           newSymbOrigin = "definition";
         } else {
           newSymbOrigin = "naming";
@@ -935,7 +935,7 @@ protected:
     case InferenceRule::AVATAR_SPLIT_CLAUSE:
     case InferenceRule::AVATAR_CONTRADICTION_CLAUSE:
     case InferenceRule::FOOL_LET_ELIMINATION:
-    case InferenceRule::FOOL_ITE_ELIMINATION:
+    case InferenceRule::FOOL_ITE_DEFINITION:
     case InferenceRule::FOOL_ELIMINATION:
     case InferenceRule::BOOLEAN_TERM_ENCODING:
     case InferenceRule::CHOICE_AXIOM:

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -824,7 +824,9 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
             //TODO do we know the sorts of freeVars?
             impl = new QuantifiedFormula(FORALL, freeVars, 0, impl);
           }
-          addDefinition(new FormulaUnit(impl, NonspecificInference1(InferenceRule::FOOL_MATCH_ELIMINATION, _unit)));
+          FormulaUnit* defUnit = new FormulaUnit(impl,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::FOOL_MATCH_DEFINITION));
+          addDefinition(defUnit);
+          InferenceStore::instance()->recordIntroducedSymbol(defUnit,context == FORMULA_CONTEXT ? SymbolType::PRED : SymbolType::FUNC, freshSymbol);
         }
 
         if (context == FORMULA_CONTEXT) {

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -111,7 +111,7 @@ void FOOLElimination::apply(UnitList*& units) {
       for (unsigned i = 0; i < clause->length(); i++) {
         // we do not allow special terms in clauses so we check that all clause literals
         // are shared (special terms can not be shared)
-        if(!(*clause)[i]->shared()){ 
+        if(!(*clause)[i]->shared()){
           USER_ERROR("Input clauses (cnf) cannot use $ite, $let or $o terms. Error in "+clause->literalsOnlyToString());
         }
       }
@@ -136,7 +136,7 @@ FormulaUnit* FOOLElimination::apply(FormulaUnit* unit) {
   }
 
   FormulaUnit* rectifiedUnit = Rectify::rectify(unit);
-  
+
   Formula* formula = rectifiedUnit->formula();
 
   _unit = rectifiedUnit;
@@ -424,7 +424,7 @@ Formula* FOOLElimination::processAsFormula(TermList terms) {
 void FOOLElimination::process(Term* term, Context context, TermList& termResult, Formula*& formulaResult) {
   // collect free variables of the term and their sorts
   // WARNING, this list is leaked in all cases. Sometimes,
-  // it becomes the quantified variables of a formula, 
+  // it becomes the quantified variables of a formula,
   // and leaks with the formula. In other situations, it leaks
   // form this function.
   VList* freeVars = term->freeVariables();
@@ -432,7 +432,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
   TermStack termVars;
   TermStack typeVars;
   TermStack allVars;
-  
+
   /**
    * Note that we collected free variables before processing subterms. That
    * assumes that process() preserves free variables. This assumption relies
@@ -489,8 +489,8 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
     switch (term->specialFunctor()) {
       case Term::SpecialFunctor::ITE: {
         /**
-         * Having a term of the form $ite(f, s, t) and the list Y1, ..., Ym, 
-         * X1, ..., Xn of its free type and term variables (it is the union of 
+         * Having a term of the form $ite(f, s, t) and the list Y1, ..., Ym,
+         * X1, ..., Xn of its free type and term variables (it is the union of
          * free variables of f, s and t) we will do the following:
          *  1) Create a fresh function symbol g of arity m + n that spans over sorts
          *     of X1, ..., Xn and the return sort of the term
@@ -499,7 +499,6 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
          *     * ![X1, ..., Xn]: (~f => g(Y1,...,Ym,X1, ..., Xn) = t)
          *  3) Replace the term with g(Y1,...,Ym,X1, ..., Xn)
          */
-        
 
         Formula* condition = process(sd->getCondition());
 
@@ -517,7 +516,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
           resultSort = SortHelper::getResultSort(thenBranch, _varSorts);
           ASS_EQ(resultSort, SortHelper::getResultSort(elseBranch, _varSorts));
         }
- 
+
         collectSorts(freeVars, typeVars, termVars, allVars, termVarSorts);
         SortHelper::normaliseSort(typeVars, resultSort);
         // create a fresh symbol g
@@ -528,7 +527,6 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         Formula* freshPredicateApplication = nullptr;
         buildApplication(freshSymbol, context, allVars, freshFunctionApplication, freshPredicateApplication);
 
-        
         // build g(Y1, ..., Ym,X1, ..., Xn) == s
         Formula* thenEq = buildEq(context, freshPredicateApplication, thenBranchFormula,
                                            freshFunctionApplication, thenBranch, resultSort);
@@ -570,17 +568,17 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
       case Term::SpecialFunctor::LET: {
         /**
          * Having a term of the form $let(f(B1,...Bj,Y1, ..., Yk) := s, t), where f is a
-         * function or predicate symbol and the list A1,...,Am,X1, ..., Xn of free 
+         * function or predicate symbol and the list A1,...,Am,X1, ..., Xn of free
          * variables of the binding of f (it is the set of free variables of s minus
          * A1,...Am,Y1, ..., Yk) we will do the following:
          *  1) Create a fresh function or predicate symbol g (depending on which
          *     one is f) of arity m + j + n + k that spans over sorts of
          *     X1, ..., Xn, Y1, ..., Yk
          *  2) If f is a predicate symbol, add the following definition:
-         *       ![X1, ..., Xn, Y1, ..., Yk]: 
+         *       ![X1, ..., Xn, Y1, ..., Yk]:
          *        g(A1,...Am, B1,...Bj,X1, ..., Xn, Y1, ..., Yk) <=> s
          *     Otherwise, add
-         *       ![X1, ..., Xn, Y1, ..., Yk]: 
+         *       ![X1, ..., Xn, Y1, ..., Yk]:
          *        g(A1,...Am, B1,...Bj,X1, ..., Xn, Y1, ..., Yk) = s
          *  3) Build a term t' by replacing all of its subterms of the form
          *     f(s1, ..., sj,t1, ..., tk) by
@@ -618,10 +616,10 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
         // take the defined function symbol and its result sort
         unsigned symbol = sd->getFunctor();
-        TermList bindingSort = SortHelper::getResultSort(binding, _varSorts); 
+        TermList bindingSort = SortHelper::getResultSort(binding, _varSorts);
 
         SortHelper::normaliseSort(typeVars, bindingSort);
-  
+
         /**
          * Here we can take a simple shortcut. If the there are no free variables,
          * f and g would have the same type, but g would have an ugly generated name.
@@ -629,7 +627,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
          * reuse f and leave the t term as it is.
          */
         bool renameSymbol = VList::isNonEmpty(bodyFreeVars);
-        
+
         /**
          * If the symbol is not marked as introduced then this means it was used
          * in the input after introduction, therefore it should be renamed here
@@ -650,7 +648,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         Formula* freshPredicateApplication = nullptr;
         buildApplication(freshSymbol, bindingContext, allVars, freshFunctionApplication, freshPredicateApplication);
 
-        Term* freshApplication = bindingContext == FORMULA_CONTEXT ? freshPredicateApplication->literal() : 
+        Term* freshApplication = bindingContext == FORMULA_CONTEXT ? freshPredicateApplication->literal() :
                                                                      freshFunctionApplication.term();
 
         // build g(A1, ..., Am, B1, ..., Bj,X1, ..., Xn, Y1, ..., Yk) == s
@@ -668,7 +666,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
         TermList contents = *term->nthArgument(0); // deliberately unprocessed here
 
-        // replace occurrences of f(s1, ..., sj,t1, ..., tk) by 
+        // replace occurrences of f(s1, ..., sj,t1, ..., tk) by
         // g(A1, ..., Am, s1, ..., sj,X1, ..., Xn, t1, ..., tk)
         if (renameSymbol) {
           if (env.options->showPreprocessing()) {
@@ -677,7 +675,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
             env.endOutput();
           }
 
-          SymbolOccurrenceReplacement replacement(bindingContext == FORMULA_CONTEXT, 
+          SymbolOccurrenceReplacement replacement(bindingContext == FORMULA_CONTEXT,
               freshApplication, symbol, argumentVars);
 
           contents = replacement.process(contents);
@@ -929,13 +927,13 @@ void FOOLElimination::buildApplication(unsigned symbol, Context context, TermSta
  * Creates a stack of sorts for the given variables, using the sorting context
  * of the current formula.
  */
-void FOOLElimination::collectSorts(VList* vars, TermStack& typeVars, 
+void FOOLElimination::collectSorts(VList* vars, TermStack& typeVars,
                                    TermStack& termVars, TermStack& allVars, TermStack& termVarSorts)
 {
   VList::Iterator fvi(vars);
   while (fvi.hasNext()) {
     unsigned var = fvi.next();
-    ASS_REP(_varSorts.find(var), var);    
+    ASS_REP(_varSorts.find(var), var);
     TermList sort = _varSorts.get(var, AtomicSort::defaultSort());
     if(sort == AtomicSort::superSort()){
       //variable is a type var

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -665,17 +665,20 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         }
 
         // add the introduced definition
-        addDefinition(new FormulaUnit(freshSymbolDefinition,
-            NonspecificInference1(InferenceRule::FOOL_LET_ELIMINATION, _unit)));
+        FormulaUnit* defUnit = new FormulaUnit(freshSymbolDefinition,
+            NonspecificInference0(UnitInputType::AXIOM,InferenceRule::FOOL_LET_DEFINITION));
+        addDefinition(defUnit);
 
         TermList contents = *term->nthArgument(0); // deliberately unprocessed here
 
         // replace occurrences of f(s1, ..., sj,t1, ..., tk) by
         // g(A1, ..., Am, s1, ..., sj,X1, ..., Xn, t1, ..., tk)
         if (renameSymbol) {
+          InferenceStore::instance()->recordIntroducedSymbol(defUnit,bindingContext == FORMULA_CONTEXT ? SymbolType::PRED : SymbolType::FUNC, freshSymbol);
+
           if (env.options->showPreprocessing()) {
             env.beginOutput();
-            env.out() << "[PP] FOOL replace in:  " << contents.toString() << endl;
+            env.out() << "[PP] FOOL replace in: " << contents.toString() << endl;
             env.endOutput();
           }
 

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -747,8 +747,11 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
           }
 
           // add the introduced definition
-          addDefinition(new FormulaUnit(freshSymbolDefinition,
-            NonspecificInference1(InferenceRule::FOOL_ELIMINATION, _unit)));
+          FormulaUnit* defUnit = new FormulaUnit(freshSymbolDefinition,
+            NonspecificInference0(UnitInputType::AXIOM,InferenceRule::FOOL_FORMULA_DEFINITION));
+          addDefinition(defUnit);
+
+          InferenceStore::instance()->recordIntroducedSymbol(defUnit,SymbolType::FUNC, freshSymbol);
 
           termResult = freshSymbolApplication;
         } else {

--- a/Shell/FOOLElimination.hpp
+++ b/Shell/FOOLElimination.hpp
@@ -46,6 +46,9 @@ private:
 
   /** A list of definitions, produced during preprocessing */
   UnitList* _defs;
+  /** A list of definitions (a sublist of the above, but not sharing memory),
+   * relevant to the currently processed unit. To become part of its premises. */
+  UnitList* _currentDefs;
   bool _higherOrder;
   bool _polymorphic;
 

--- a/Shell/FOOLElimination.hpp
+++ b/Shell/FOOLElimination.hpp
@@ -48,7 +48,7 @@ private:
   UnitList* _defs;
   bool _higherOrder;
   bool _polymorphic;
- 
+
   /** Add a new definitions to _defs */
   void addDefinition(FormulaUnit* unit);
 

--- a/Shell/TweeGoalTransformation.cpp
+++ b/Shell/TweeGoalTransformation.cpp
@@ -34,6 +34,7 @@
 #include "Kernel/TermIterators.hpp"
 #include "Kernel/TermTransformer.hpp"
 #include "Kernel/Renaming.hpp"
+#include "Kernel/InferenceStore.hpp"
 
 #include "TweeGoalTransformation.hpp"
 
@@ -147,6 +148,8 @@ class Definizator : public BottomUpTermTransformer {
           Inference inference(NonspecificInference0(UnitInputType::AXIOM,InferenceRule::FUNCTION_DEFINITION));
           newDef = new (1) Clause(1, inference);
           newDef->literals()[0] = equation;
+
+          InferenceStore::instance()->recordIntroducedSymbol(newDef,SymbolType::FUNC,newSym);
         } else {
           // linear term, don't replace (and remember it in cache)
           symAndDef.first = 0;


### PR DESCRIPTION
Following the last email from Geoff this PR tries to make sure that
* definitions introduced during FoolElimination are called as such,
* they are not proof-wise dependent on the unit they are getting introduced for, but
* the unit the elimination outputs is proof-wise dependent on them.
* They are jointly called FOOL_XXX_DEFINITION (not ELIMINATION).
* They inform InferenceStore about the new symbol introduction (which makes the TPTP proof report that further to the user).
* The last aspect is added also to the TweeGoalTransformation code and to FunctionDefinitionIntroduction.

I also updated the MATCH elimination code in FoolElimination although that's probably never going to be (immediately) relevant to TPTP users.