### PR TITLE
Implement assert-claim in smtlib2 (a vampiric extension of the format)

### DIFF
--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -445,6 +445,13 @@ private:
   /**
    * Unofficial command
    *
+   * Treated analogously to the TPTP CLAIM formula role (see the TPTP parser on that).
+   */
+  void readAssertClaim(LExpr* body);
+
+  /**
+   * Unofficial command
+   *
    * Behaves like conjecture declaration in TPTP
    */
   void readAssertNot(LExpr* body);

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -837,6 +837,9 @@ public:
   static unsigned addRealConstant(const vstring&, Set<vstring>& overflow, bool defaultSort);
   static unsigned addUninterpretedConstant(const vstring& name, Set<vstring>& overflow, bool& added);
 
+  // also here, simply made public static to share the code with another use site
+  static Unit* processClaimFormula(Unit* unit, Formula* f, const vstring& nm);
+
   /**
    * Used to store the contents of the 'source' of an input formula
    * This is based on the 'file' and 'inference' record description in


### PR DESCRIPTION
mimicking the TPTP `claim` role (actually, also a vampire-custom extension, I believe) and sharing a bit of the code

The benefit of claims is that they are lemmas that can be used, but need to be proven as well. Suggesting a good lemma can often be crucial for finding proofs quickly.