### PR TITLE
do not axiomatise congruence for introduced symbols

### DIFF
--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -820,14 +820,19 @@ unsigned Signature::addPredicate (const vstring& name,
  */
 unsigned Signature::addNamePredicate(unsigned arity)
 {
-  return addFreshPredicate(arity,"sP");
+  unsigned index = addFreshPredicate(arity,"sP");
+  getPredicate(index)->markNamesFormula();
+  return index;
 } // addNamePredicate
 
 
 unsigned Signature::addNameFunction(unsigned arity)
 {
-  return addFreshFunction(arity,"sP");
-} // addNamePredicate
+  unsigned index = addFreshFunction(arity,"sP");
+  getFunction(index)->markNamesFormula();
+  return index;
+} // addNameFunction
+
 /**
  * Add fresh function of a given arity and with a given prefix. If suffix is non-zero,
  * the function name will be prefixI, where I is an integer, otherwise it will be

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -58,6 +58,7 @@ Signature::Symbol::Symbol(const vstring& nm, unsigned arity, bool interpreted, b
     _inUnit(0),
     _inductionSkolem(0),
     _skolem(0),
+    _namesFormula(0),
     _tuple(0),
     _prox(NOT_PROXY),
     _comb(NOT_COMB)

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -151,6 +151,8 @@ class Signature
     unsigned _inductionSkolem : 1;
     /** if skolem function in general **/
     unsigned _skolem : 1;
+    /** if introduced for naming a subformula */
+    unsigned _namesFormula : 1;
     /** if tuple sort */
     unsigned _tuple : 1;
     /** proxy type */
@@ -256,6 +258,9 @@ class Signature
 
     inline void markSkolem(){ _skolem = 1;}
     inline bool skolem(){ return _skolem; }
+
+    inline void markNamesFormula() { _namesFormula = 1; }
+    inline bool namesFormula() { return _namesFormula; }
 
     inline void markTuple(){ _tuple = 1; }
     inline bool tupleSort(){ return _tuple; }

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -196,6 +196,9 @@ void EqualityProxy::addCongruenceAxioms(UnitList*& units)
   unsigned funs = env.signature->functions();
   for (unsigned i=0; i<funs; i++) {
     Signature::Symbol* fnSym = env.signature->getFunction(i);
+    // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
+    if(fnSym->skolem())
+      continue;
     unsigned arity = fnSym->arity();
     OperatorType* fnType = fnSym->fnType();
     if (arity == 0) {
@@ -214,8 +217,11 @@ void EqualityProxy::addCongruenceAxioms(UnitList*& units)
   unsigned preds = env.signature->predicates();
   for (unsigned i = 1; i < preds; i++) {
     Signature::Symbol* predSym = env.signature->getPredicate(i);
+    // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
+    if(predSym->namesFormula() || predSym->equalityProxy() || predSym->answerPredicate())
+      continue;
     unsigned arity = predSym->arity();
-    if (predSym->equalityProxy() || predSym->answerPredicate() || predSym->arity() == 0) {
+    if (arity == 0) {
       continue;
     }
     getArgumentEqualityLiterals(arity, lits, vars1, vars2, predSym->predType());

--- a/Shell/EqualityProxyMono.cpp
+++ b/Shell/EqualityProxyMono.cpp
@@ -202,6 +202,9 @@ void EqualityProxyMono::addCongruenceAxioms(UnitList*& units)
   unsigned funs = env.signature->functions();
   for (unsigned i=0; i<funs; i++) {
     Signature::Symbol* fnSym = env.signature->getFunction(i);
+    // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
+    if(fnSym->skolem())
+      continue;
     unsigned arity = fnSym->arity();
     if (arity == 0) {
       continue;
@@ -219,8 +222,11 @@ void EqualityProxyMono::addCongruenceAxioms(UnitList*& units)
   unsigned preds = env.signature->predicates();
   for (unsigned i = 1; i < preds; i++) {
     Signature::Symbol* predSym = env.signature->getPredicate(i);
+    // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
+    if(predSym->namesFormula() || predSym->equalityProxy() || predSym->answerPredicate())
+      continue;
     unsigned arity = predSym->arity();
-    if (predSym->equalityProxy() || predSym->answerPredicate() || predSym->arity() == 0) {
+    if (arity == 0) {
       continue;
     }
     if (!getArgumentEqualityLiterals(arity, lits, vars1, vars2, predSym->predType(), true)) {


### PR DESCRIPTION
Equality proxy with `-ep RSTC` adds congruence axioms for functions and predicates in the signature, with the exception of answer literals and the equality proxy predicate itself.

As far as I can tell it could skip introduced symbols altogether, because one could imagine performing the equality-proxy transformation before clausification.