### PR TITLE
Splitter::_compNames unecessary

### DIFF
--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -1137,7 +1137,7 @@ bool Splitter::doSplitting(Clause* cl)
  *
  * @param size number of literals in component
  * @param lits literals of component
- * @param comp the existing propositional name (SplitLevel) for this component - to be filled 
+ * @param comp the existing propositional name (SplitLevel) for this component - to be filled
  * @param compCl the existing clause for this component - to be filled
  * @return True if the component already exists
  *
@@ -1146,7 +1146,7 @@ bool Splitter::doSplitting(Clause* cl)
 bool Splitter::tryGetExistingComponentName(unsigned size, Literal* const * lits, SplitLevel& comp, Clause*& compCl)
 {
   ClauseIterator existingComponents;
-  { 
+  {
     TIME_TRACE("splitting component index usage");
     existingComponents = _componentIdx->retrieveVariants(lits, size);
   }
@@ -1156,7 +1156,7 @@ bool Splitter::tryGetExistingComponentName(unsigned size, Literal* const * lits,
   }
   compCl = existingComponents.next();
   ASS(!existingComponents.hasNext());
-  comp = _compNames.get(compCl);
+  comp = compCl->splits()->sval();
   return true;
 }
 
@@ -1166,7 +1166,6 @@ bool Splitter::tryGetExistingComponentName(unsigned size, Literal* const * lits,
  * - Create a SplitRecord for the component
  * - Record the name in the splits of the clause
  * - Insert the clause into _componentIdx for variant checking later
- * - Insert the clause with the name into _compNames for lookup later
  *
  * @param name The propositional name for the component to add
  * @param size The number of literals in the component to add
@@ -1256,7 +1255,6 @@ Clause* Splitter::buildAndInsertComponentClause(SplitLevel name, unsigned size, 
     TIME_TRACE("splitting component index maintenance");
     _componentIdx->insert(compCl);
   }
-  _compNames.insert(compCl, name);
 
   return compCl;
 }

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -145,7 +145,7 @@ private:
  *
  * SplitRecord - records the split information for the clause component
  *
- * Let's call the SplitLevel associated with a comp its name = _compNames.get(comp)
+ * Let's call the SplitLevel associated with a comp its "name"
  * A corresponding SplitRecord is added to _db[name] 
  *
  * children - Clauses that rely on name (of comp), should be thrown away "on backtracking"
@@ -275,7 +275,6 @@ private:
    * the _db record of this level is non-null.
    */
   Stack<SplitRecord*> _db;
-  DHMap<Clause*,SplitLevel> _compNames;
 
   /**
    * Definitions of ground components C and ~C are shared and placed at the slot of C.


### PR DESCRIPTION
`Splitter::_compNames` is used to map component clauses to their component name: but this is already kept as a singleton set of splits in the clause itself. I claim this is useless and remove it. Nothing seems to break obviously.