### PR TITLE
prevent readFromEncodedOptions from silently setting normalize to true

### DIFF
--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3443,7 +3443,6 @@ void Options::readOptionsString(vstring optionsString,bool assign)
  */
 void Options::readFromEncodedOptions (vstring testId)
 {
-  _normalize.actualValue = true;
   _testId.actualValue = testId;
 
   vstring ma(testId,0,3); // the first 3 characters


### PR DESCRIPTION
As @ibnyusuf noticed at some point, the function `Options::readFromEncodedOptions` silently sets _normalize to true. 

This means any vampire run using --decode will use normalize unless turned off explicitly again later.

This might have been a precaution against forgetting normalize for casc mode, but casc mode already does  
``env.options->setNormalize(true);``
in `vampire.cpp` which has the additional benefit that it applies normalization in the master process once (and not in every child).