### PR TITLE
IsRenaming fix

### DIFF
--- a/Indexing/ResultSubstitution.cpp
+++ b/Indexing/ResultSubstitution.cpp
@@ -72,12 +72,16 @@ ResultSubstitutionSP ResultSubstitution::fromSubstitution(RobSubstitution* s, in
  */
 bool ResultSubstitution::isRenamingOn(TermList t, bool result) 
 {
-  DHMap<TermList,TermList> renamingInMaking;
+  DHSet<TermList> renamingDomain;
+  DHSet<TermList> renamingRange;
 
   VariableIterator it(t);
   while(it.hasNext()) {
     TermList v = it.next();
     ASS(v.isVar());
+    if (!renamingDomain.insert(v)) {
+      continue;
+    }
 
     TermList vSubst;
     if (result) {
@@ -92,8 +96,7 @@ bool ResultSubstitution::isRenamingOn(TermList t, bool result)
     if (!vSubst.isVar()) {
       return false;
     }
-    TermList vStored;
-    if (!renamingInMaking.findOrInsert(v,vStored,vSubst) && vStored != vSubst) {
+    if (!renamingRange.insert(vSubst)) {
       return false;
     }
   }


### PR DESCRIPTION
Until now, the `ResultSubstitution::isRenaming` function only checked if same variables are mapped to same variables in the renaming (which is always true), but not that the mapped variables are only used once.

Fortunately, this function is rarely ever called even when encompassment demodulation is on and the error did not result in incompleteness, only some demodulations not performed.

As a side note, how would people feel about enabling encompassment demodulation as default and getting rid of the messy original demodulation redundancy checks?  