### PR TITLE
Fix hidden overloaded virtual function warning in AnswerExtractor

### DIFF
--- a/Inferences/ArrayTheoryISE.hpp
+++ b/Inferences/ArrayTheoryISE.hpp
@@ -37,7 +37,7 @@ public:
   ~ArrayTermTransformer();
   Literal* rewriteNegEqByExtensionality(Literal* l);
 protected:
-  TermList transformSubterm(TermList trm);
+  TermList transformSubterm(TermList trm) override;
 };
 
 class ArrayTheoryISE

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -226,9 +226,17 @@ Term* TermTransformer::transformSpecial(Term* term)
 
 TermList TermTransformer::transform(TermList ts)
 {
-  if (ts.isVar()) {
-    return transformSubterm(ts);
+  // first let's try transforming ts directly
+  TermList transformed = transformSubterm(ts);
+  if (transformed != ts) {
+    // we did transform, so we are done
+    return transformed;
+  } else if (ts.isVar()) {
+    // we didn't transform, but it's a var (no way to recurse)
+    return ts;
   } else {
+    // try transform subterms
+    ASS(ts.isTerm());
     return TermList(transform(ts.term()));
   }
 }

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -72,7 +72,7 @@ Term* TermTransformer::transform(Term* term)
       if(orig->isSort()){
         //For most applications we probably dont want to transform sorts.
         //However, we don't enforce that here, inheriting classes can decide
-        //for themselves        
+        //for themselves
         newTrm=AtomicSort::create(static_cast<AtomicSort*>(orig), argLst);
       } else {
         newTrm=Term::create(orig,argLst);
@@ -229,12 +229,7 @@ TermList TermTransformer::transform(TermList ts)
   if (ts.isVar()) {
     return transformSubterm(ts);
   } else {
-    Term* transformed = transform(ts.term());
-    if (transformed != ts.term()) {
-      return TermList(transformed);
-    } else {
-      return ts;
-    }
+    return TermList(transform(ts.term()));
   }
 }
 

--- a/Kernel/TermTransformer.hpp
+++ b/Kernel/TermTransformer.hpp
@@ -46,8 +46,8 @@ public:
 protected:
   virtual TermList transformSubterm(TermList trm) = 0;
   Term* transformSpecial(Term* specialTerm);
-  virtual TermList transform(TermList ts);
   virtual Formula* transform(Formula* f);
+  TermList transform(TermList ts);
 };
 
 /**

--- a/Kernel/TermTransformer.hpp
+++ b/Kernel/TermTransformer.hpp
@@ -24,17 +24,19 @@ namespace Kernel {
 /**
  * Class to allow for easy transformations of subterms in shared literals.
  *
- * The inheriting class implemets function transform(TermList)
- * and then the function transform(Literal*) uses it to transform subterms
- * of the given literal.
+ * The inheriting class implements function transformSubterm(TermList)
+ * and then the functions transform(Literal*)/transform(Term*) use it to transform subterms
+ * of the given literal/term.
  *
- * The literal and subterms returned by the transform(TermList) function have
+ * The literal and subterms returned by the transformSubterm(TermList) function have
  * to be shared.
  *
  * This class can be used to transform sort arguments as well by suitably
- * implementing the transform(TermList) function
- * 
+ * implementing the transformSubterm(TermList) function
+ *
  * TermTransformer goes top down but does no recurse into the replaced term
+ *
+ * Note that if called via transform(Term* term) the given term itself will not get transformed, only possibly its proper subterms
  */
 class TermTransformer {
 public:

--- a/Shell/AnswerExtractor.cpp
+++ b/Shell/AnswerExtractor.cpp
@@ -781,15 +781,6 @@ TermList SynthesisManager::ConjectureSkolemReplacement::transformTermList(TermLi
   return transform(tl);
 }
 
-TermList SynthesisManager::ConjectureSkolemReplacement::transform(TermList tl) {
-  TermList transformed = transformSubterm(tl);
-  if (transformed != tl) {
-    return transformed;
-  } else {
-    return TermTransformer::transform(tl);
-  }
-}
-
 TermList SynthesisManager::ConjectureSkolemReplacement::transformSubterm(TermList trm) {
   if (trm.isTerm()) {
     auto it = _skolemToVar.find(trm.term());

--- a/Shell/AnswerExtractor.hpp
+++ b/Shell/AnswerExtractor.hpp
@@ -107,14 +107,14 @@ public:
 private:
   class ConjectureSkolemReplacement : public TermTransformer {
    public:
+    using TermTransformer::transform;
     ConjectureSkolemReplacement() : _skolemToVar() {}
     void bindSkolemToVar(Term* t, unsigned v);
     TermList transformTermList(TermList tl, TermList sort);
-    virtual Literal* transform(Literal* lit) { return TermTransformer::transform(lit); }
     void addCondPair(unsigned fn, unsigned pred) { _condFnToPred.insert(fn, pred); }
    protected:
-    virtual TermList transformSubterm(TermList trm);
-    virtual TermList transform(TermList ts);
+    TermList transformSubterm(TermList trm) override;
+    TermList transform(TermList ts) override;
    private:
     vmap<Term*, unsigned> _skolemToVar;
     // Map from functions to predicates they represent in answer literal conditions

--- a/Shell/AnswerExtractor.hpp
+++ b/Shell/AnswerExtractor.hpp
@@ -107,14 +107,12 @@ public:
 private:
   class ConjectureSkolemReplacement : public TermTransformer {
    public:
-    using TermTransformer::transform;
     ConjectureSkolemReplacement() : _skolemToVar() {}
     void bindSkolemToVar(Term* t, unsigned v);
     TermList transformTermList(TermList tl, TermList sort);
     void addCondPair(unsigned fn, unsigned pred) { _condFnToPred.insert(fn, pred); }
    protected:
     TermList transformSubterm(TermList trm) override;
-    TermList transform(TermList ts) override;
    private:
     vmap<Term*, unsigned> _skolemToVar;
     // Map from functions to predicates they represent in answer literal conditions


### PR DESCRIPTION
Just renaming a function that apparently hides a virtual one, according to my clang. Also, I removed the `virtual` keyword since the function called is not virtual either, but I'm okay with leaving it if it is needed.