### PR TITLE
Make encompassment demodulation the default demodulation mode

### DIFF
--- a/Inferences/ForwardDemodulation.hpp
+++ b/Inferences/ForwardDemodulation.hpp
@@ -41,7 +41,6 @@ public:
 protected:
   bool _preorderedOnly;
   bool _redundancyCheck;
-  bool _encompassing;
   DemodulationLHSIndex* _index;
 };
 

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -299,12 +299,6 @@ public:
     GOAL_PLUS,                // above plus skolem terms introduced in induction inferences
   };
 
-  enum class DemodulationRedunancyCheck : unsigned int {
-    OFF,
-    ENCOMPASS,
-    ON
-  };
-
   enum class TheoryAxiomLevel : unsigned int {
     ON,  // all of them
     OFF, // none of them
@@ -2222,7 +2216,7 @@ public:
   bool arityCheck() const { return _arityCheck.actualValue; }
   //void setArityCheck(bool newVal) { _arityCheck=newVal; }
   Demodulation backwardDemodulation() const { return _backwardDemodulation.actualValue; }
-  DemodulationRedunancyCheck demodulationRedundancyCheck() const { return _demodulationRedundancyCheck.actualValue; }
+  bool demodulationRedundancyCheck() const { return _demodulationRedundancyCheck.actualValue; }
   //void setBackwardDemodulation(Demodulation newVal) { _backwardDemodulation = newVal; }
   Subsumption backwardSubsumption() const { return _backwardSubsumption.actualValue; }
   //void setBackwardSubsumption(Subsumption newVal) { _backwardSubsumption = newVal; }
@@ -2577,7 +2571,7 @@ private:
   BoolOptionValue _colorUnblocking;
   ChoiceOptionValue<Condensation> _condensation;
 
-  ChoiceOptionValue<DemodulationRedunancyCheck> _demodulationRedundancyCheck;
+  BoolOptionValue _demodulationRedundancyCheck;
 
   ChoiceOptionValue<EqualityProxy> _equalityProxy;
   BoolOptionValue _useMonoEqualityProxy;


### PR DESCRIPTION
As discussed, I'm opening this PR to move forward with encompassment demodulation and remove the old, more expensive and harder to maintain standard check.

My initial measurements show the following over the entirety of TPTP, with 10s timeout (uniques in parentheses):
- Discount: old 10865 (93), encompassment 10977 (205)
- Otter: old 10583 (114), encompassment 10794 (325)