### PR TITLE
turn off run-time type information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
   add_compile_options(-Wall)
   # we don't use multithreading in (mainline!) Vampire
   add_compile_options(-fno-threadsafe-statics)
+  # ...or RTTI
+  add_compile_options(-fno-rtti)
   # enable standards-compliant standard library with sized operator delete
   add_compile_options(-fsized-deallocation)
 endif()

--- a/Indexing/RequestedIndex.hpp
+++ b/Indexing/RequestedIndex.hpp
@@ -58,8 +58,7 @@ class RequestedIndex final
       ASS(!_indexManager);
       _indexManager = indexManager;
       _type = type;
-      _index = dynamic_cast<Index*>(_indexManager->request(type));
-      ASS(_index != nullptr);  // if this fails, the wrong index type was requested
+      _index = static_cast<Index*>(_indexManager->request(type));
     }
 
     // NOTE: release() might be called multiple times (manually and by destructor)

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ endif
 ################################################################
 
 CXX = g++
-CXXFLAGS = $(XFLAGS) -Wall -fno-threadsafe-statics -std=c++14  $(INCLUDES) # -Wno-unknown-warning-option for clang
+CXXFLAGS = $(XFLAGS) -Wall -fno-threadsafe-statics -fno-rtti -std=c++14  $(INCLUDES) # -Wno-unknown-warning-option for clang
 
 CC = gcc 
 CCFLAGS = -Wall -O3 -DNDBLSCR -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLPICOSAT 


### PR DESCRIPTION
We currently compile in support for [run-time type information](https://en.wikipedia.org/wiki/Run-time_type_information), but we don't use it - except as a runtime type-safety check in `Indexing::RequestedIndex<T>`, which is relatively lightly-used.

Therefore: turn off RTTI in the build system, profit from smaller binaries.