### PR TITLE
do not include congruence axioms for unused symbols

### DIFF
--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -197,7 +197,7 @@ void EqualityProxy::addCongruenceAxioms(UnitList*& units)
   for (unsigned i=0; i<funs; i++) {
     Signature::Symbol* fnSym = env.signature->getFunction(i);
     // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
-    if(fnSym->skolem())
+    if(!fnSym->usageCnt() || fnSym->skolem())
       continue;
     unsigned arity = fnSym->arity();
     OperatorType* fnType = fnSym->fnType();
@@ -218,7 +218,7 @@ void EqualityProxy::addCongruenceAxioms(UnitList*& units)
   for (unsigned i = 1; i < preds; i++) {
     Signature::Symbol* predSym = env.signature->getPredicate(i);
     // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
-    if(predSym->namesFormula() || predSym->equalityProxy() || predSym->answerPredicate())
+    if(!predSym->usageCnt() || predSym->namesFormula() || predSym->equalityProxy() || predSym->answerPredicate())
       continue;
     unsigned arity = predSym->arity();
     if (arity == 0) {

--- a/Shell/EqualityProxyMono.cpp
+++ b/Shell/EqualityProxyMono.cpp
@@ -203,7 +203,7 @@ void EqualityProxyMono::addCongruenceAxioms(UnitList*& units)
   for (unsigned i=0; i<funs; i++) {
     Signature::Symbol* fnSym = env.signature->getFunction(i);
     // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
-    if(fnSym->skolem())
+    if(!fnSym->usageCnt() || fnSym->skolem())
       continue;
     unsigned arity = fnSym->arity();
     if (arity == 0) {
@@ -223,7 +223,7 @@ void EqualityProxyMono::addCongruenceAxioms(UnitList*& units)
   for (unsigned i = 1; i < preds; i++) {
     Signature::Symbol* predSym = env.signature->getPredicate(i);
     // can axiomatise equality _before_ preprocessing, so skip (some) introduced symbols
-    if(predSym->namesFormula() || predSym->equalityProxy() || predSym->answerPredicate())
+    if(!predSym->usageCnt() || predSym->namesFormula() || predSym->equalityProxy() || predSym->answerPredicate())
       continue;
     unsigned arity = predSym->arity();
     if (arity == 0) {

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -393,14 +393,13 @@ void Preprocess::preprocess(Problem& prb)
      twee.apply(prb,(env.options->tweeGoalTransformation() == Options::TweeGoalTransformation::GROUND));
    }
 
-   // refresh symbol usage counts, can skip unused symbols for equality proxy
-   prb.getProperty();
-
    if (!prb.isHigherOrder() && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
      env.statistics->phase=Statistics::EQUALITY_PROXY;
      if (env.options->showPreprocessing())
        env.out() << "equality proxy" << std::endl;
 
+     // refresh symbol usage counts, can skip unused symbols for equality proxy
+     prb.getProperty();
      if(_options.useMonoEqualityProxy() && !prb.hasPolymorphicSym()){
        EqualityProxyMono proxy(_options.equalityProxy());
        proxy.apply(prb);

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -393,6 +393,9 @@ void Preprocess::preprocess(Problem& prb)
      twee.apply(prb,(env.options->tweeGoalTransformation() == Options::TweeGoalTransformation::GROUND));
    }
 
+   // refresh symbol usage counts, can skip unused symbols for equality proxy
+   prb.getProperty();
+
    if (!prb.isHigherOrder() && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
      env.statistics->phase=Statistics::EQUALITY_PROXY;
      if (env.options->showPreprocessing())


### PR DESCRIPTION
Fixes #501 if correct.

I believe that if we make sure we refresh the property object, we can rely on `sym->usageCnt()` to detect unused symbols and avoid generating congruence axioms for them.

Not sure if the refresh is actually needed, seems to work without it - but better safe than sorry.