### PR TITLE
use addr2line(1) for stacktraces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,11 @@
 ################################################################
 # general configuration
 ################################################################
-cmake_minimum_required (VERSION 3.12.0)
+cmake_minimum_required (VERSION 3.14.0)
 project(Vampire)
+
+include(CheckIPOSupported)
+include(CheckPIESupported)
 
 # require the compiler to use C++14
 set(CMAKE_CXX_STANDARD 14)
@@ -53,10 +56,11 @@ else()
   SET(COMPILE_TESTS OFF)
 endif()
 
+# options for inter-procedural optimisation, which you might know as "LTO"
 option(IPO "If supported, build with link-time optimisation." OFF)
 option(DEBUG_IPO "Print information about why IPO isn't supported" OFF)
+
 # check whether IPO is available
-include(CheckIPOSupported)
 check_ipo_supported(RESULT IPO_SUPPORTED OUTPUT IPO_ERROR)
 if (IPO_SUPPORTED)
   message(STATUS "IPO supported")
@@ -71,7 +75,7 @@ endif()
 
 ################################################################
 # define all vampire sources,
-# generate the main target and 
+# generate the main target and
 # link it against the libraries
 # NOTE: we add the header files here such that they are considered
 #       to be a part of the project and therefore are displayed
@@ -111,7 +115,7 @@ source_group(minisat_source_files FILES ${VAMPIRE_MINISAT_SOURCES})
 set(VAMPIRE_DEBUG_SOURCES
     Debug/Assertion.cpp
     Debug/RuntimeStatistics.cpp
-    Debug/Tracer.cpp    
+    Debug/Tracer.cpp
     Debug/Assertion.hpp
     Debug/RuntimeStatistics.hpp
     Debug/Tracer.hpp
@@ -241,7 +245,7 @@ set(VAMPIRE_KERNEL_SOURCES
     Kernel/SortHelper.cpp
     Kernel/OperatorType.cpp
     Kernel/SpassLiteralSelector.cpp
-    Kernel/RndLiteralSelector.cpp    
+    Kernel/RndLiteralSelector.cpp
     Kernel/SubformulaIterator.cpp
     Kernel/Substitution.cpp
     Kernel/Term.cpp
@@ -288,7 +292,7 @@ set(VAMPIRE_KERNEL_SOURCES
     Kernel/SortHelper.hpp
     Kernel/OperatorType.hpp
     Kernel/SpassLiteralSelector.hpp
-    Kernel/RndLiteralSelector.hpp    
+    Kernel/RndLiteralSelector.hpp
     Kernel/SubformulaIterator.hpp
     Kernel/SubstHelper.hpp
     Kernel/Substitution.hpp
@@ -545,7 +549,7 @@ set(VAMPIRE_SHELL_SOURCES
     Shell/DistinctGroupExpansion.cpp
     Shell/EqResWithDeletion.cpp
     Shell/EqualityProxy.cpp
-    Shell/EqualityProxyMono.cpp    
+    Shell/EqualityProxyMono.cpp
     Shell/Flattening.cpp
     Shell/FunctionDefinition.cpp
     Shell/GeneralSplitting.cpp
@@ -667,7 +671,7 @@ set(
     FMB/DefinitionIntroduction.hpp
     FMB/FiniteModel.hpp
     FMB/FiniteModelBuilder.hpp
-    FMB/FiniteModelMultiSorted.hpp    
+    FMB/FiniteModelMultiSorted.hpp
     FMB/FunctionRelationshipInference.hpp
     FMB/ModelCheck.hpp
     FMB/Monotonicity.hpp
@@ -749,7 +753,7 @@ source_group(unit_tests_z3 FILES ${UNIT_TESTS_Z3})
 
 
 # also include forwards.hpp?
-set(VAMPIRE_SOURCES 
+set(VAMPIRE_SOURCES
     ${VAMPIRE_DEBUG_SOURCES}
     ${VAMPIRE_LIB_SOURCES}
     ${VAMPIRE_LIB_SYS_SOURCES}
@@ -799,11 +803,6 @@ add_compile_definitions(VTIME_PROFILING=0)
 
 if (CYGWIN)
  add_compile_definitions(_BSD_SOURCE)
-endif()
-
-# configure warning flags
-if(CMAKE_CXX_COMPILER_ID STREQUAL GNU OR CMAKE_CXX_COMPILER_ID MATCHES Clang$)
-  add_compile_options(-Wall)
 endif()
 
 ################################################################
@@ -863,25 +862,25 @@ endif()
 # build objects
 ################################################################
 add_library(obj OBJECT ${VAMPIRE_SOURCES})
-if (COMPILE_TESTS) 
+if (COMPILE_TESTS)
   add_library(test_obj OBJECT ${VAMPIRE_TESTING_SOURCES})
 endif()
 
 ################################################################
-# UNIT TESTING 
+# UNIT TESTING
 ################################################################
 
 set(UNIT_TEST_OBJ   )
 set(UNIT_TEST_CASES )
-if (COMPILE_TESTS) 
+if (COMPILE_TESTS)
   include(CTest)
   foreach(test_file ${UNIT_TESTS})
     get_filename_component(test_name ${test_file} NAME_WE)
     string(REGEX REPLACE "^t" "" test_name ${test_name})
 
-    # compiling the test case object 
+    # compiling the test case object
     add_library(${test_name}_obj OBJECT ${test_file})
-    target_compile_definitions(${test_name}_obj PUBLIC 
+    target_compile_definitions(${test_name}_obj PUBLIC
       UNIT_ID_STR=\"${test_name}\"
       UNIT_ID=${test_name}
       )
@@ -977,8 +976,18 @@ set_target_properties(vampire PROPERTIES
   )
 configure_file(version.cpp.in version.cpp)
 
+# enable IPO
 if(CMAKE_BUILD_TYPE STREQUAL Release AND IPO)
   message(STATUS "compiling Vampire with IPO: this might take a while")
   set_property(TARGET obj PROPERTY INTERPROCEDURAL_OPTIMIZATION true)
   set_property(TARGET vampire PROPERTY INTERPROCEDURAL_OPTIMIZATION true)
+endif()
+
+# do not generate position-independent code:
+# 1. it has some overhead
+# 2. it's used for ASLR, which isn't a huge concern for us and messes with our backtrace support
+check_pie_supported()
+# FIXME this guard should not be necessary but is currently because of how we do static linking above
+if(BUILD_SHARED_LIBS)
+  set_property(TARGET vampire PROPERTY POSITION_INDEPENDENT_CODE false)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,6 @@ if (NOT BUILD_SHARED_LIBS)
   set(VAMPIRE_BINARY_STATIC _static)
 endif()
 
-# get symbol names in binary for backtraces
-set(CMAKE_ENABLE_EXPORTS ON)
-
-# link to libdl for dladdr() on POSIXy things, used for backtraces
-link_libraries(${CMAKE_DL_LIBS})
-
 # We compile tests only in debug mode, since in release mode assertions are NOPs anyways.
 if(CMAKE_BUILD_TYPE STREQUAL Debug)
   SET(COMPILE_TESTS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -986,7 +986,12 @@ endif()
 # do not generate position-independent code:
 # 1. it has some overhead
 # 2. it's used for ASLR, which isn't a huge concern for us and messes with our backtrace support
-check_pie_supported()
+check_pie_supported(OUTPUT_VARIABLE PIE_ERROR LANGUAGES CXX)
+if(NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
+  message(STATUS "PIE not supported, stack traces may be broken")
+  message(STATUS "${PIE_ERROR}")
+endif()
+
 # FIXME this guard should not be necessary but is currently because of how we do static linking above
 if(BUILD_SHARED_LIBS)
   set_property(TARGET vampire PROPERTY POSITION_INDEPENDENT_CODE false)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -988,7 +988,7 @@ endif()
 # 2. it's used for ASLR, which isn't a huge concern for us and messes with our backtrace support
 check_pie_supported(OUTPUT_VARIABLE PIE_ERROR LANGUAGES CXX)
 if(NOT CMAKE_CXX_LINK_PIE_SUPPORTED)
-  message(STATUS "PIE not supported, stack traces may be broken")
+  message(STATUS "disabling position-independent code not supported, stack traces may be broken")
   message(STATUS "${PIE_ERROR}")
 endif()
 

--- a/Debug/Tracer.hpp
+++ b/Debug/Tracer.hpp
@@ -26,6 +26,7 @@
 namespace Debug {
 
 namespace Tracer {
+  // print the current stack
   void printStack(std::ostream &out);
 };
 

--- a/Lib/System.hpp
+++ b/Lib/System.hpp
@@ -59,6 +59,7 @@ public:
    * it can be later used to determine the executable directory
    */
   static void registerArgv0(const char* argv0) { s_argv0 = argv0; }
+  static const char *getArgv0() { return s_argv0; }
 
   /**
    * Return number of CPU cores

--- a/Makefile
+++ b/Makefile
@@ -544,14 +544,8 @@ VUTIL_OBJ := $(addprefix $(CONF_ID)/, $(VUTIL_DEP))
 VSAT_OBJ := $(addprefix $(CONF_ID)/, $(VSAT_DEP))
 TKV_OBJ := $(addprefix $(CONF_ID)/, $(TKV_DEP))
 
-ifeq ($(OS),Darwin)
-EXPORT_DYNAMIC = 
-else
-EXPORT_DYNAMIC = -Wl,--export-dynamic
-endif
-
 define COMPILE_CMD
-$(CXX) $(CXXFLAGS) $(EXPORT_DYNAMIC) $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB) -ldl
+$(CXX) $(CXXFLAGS) $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB)
 @#$(CXX) -static $(CXXFLAGS) $(Z3LIB) $(filter %.o, $^) -o $@
 @#strip $@
 endef

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,13 @@
 #   VZ3              - compile with Z3
 
 COMPILE_ONLY = -fno-pie
+
+OS = $(shell uname)
+ifeq ($(OS),Darwin)
 LINK_ONLY = -Wl,-no_pie
+else
+LINK_ONLY = -no-pie
+endif
 
 DBG_FLAGS = -g -DVTIME_PROFILING=0 -DVDEBUG=1 -DCHECK_LEAKS=0 # debugging for spider
 # DELETEMEin2017: the bug with gcc-6.2 and problems in ClauseQueue could be also fixed by adding -fno-tree-ch

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@
 #   CHECK_LEAKS      - test for memory leaks (debugging mode only)
 #   VZ3              - compile with Z3
 
+COMPILE_ONLY = -fno-pie
+LINK_ONLY = -Wl,-no_pie
+
 DBG_FLAGS = -g -DVTIME_PROFILING=0 -DVDEBUG=1 -DCHECK_LEAKS=0 # debugging for spider
 # DELETEMEin2017: the bug with gcc-6.2 and problems in ClauseQueue could be also fixed by adding -fno-tree-ch
 REL_FLAGS = -O6 -DVTIME_PROFILING=0 -DVDEBUG=0 # no debugging
@@ -525,15 +528,15 @@ obj/%X: | obj
 
 $(CONF_ID)/%.o : %.cpp | $(CONF_ID)
 	mkdir -p `dirname $@`
-	$(CXX) $(CXXFLAGS) -c -o $@ $*.cpp -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -MMD -MF $(CONF_ID)/$*.d
+	$(CXX) $(CXXFLAGS) $(COMPILE_ONLY) -c -o $@ $*.cpp -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -MMD -MF $(CONF_ID)/$*.d
 
 %.o : %.c 
 $(CONF_ID)/%.o : %.c | $(CONF_ID)
-	$(CC) $(CCFLAGS) -c -o $@ $*.c -MMD -MF $(CONF_ID)/$*.d
+	$(CC) $(CCFLAGS) $(COMPILE_ONLY) -c -o $@ $*.c -MMD -MF $(CONF_ID)/$*.d
 
 %.o : %.cc
 $(CONF_ID)/%.o : %.cc | $(CONF_ID)
-	$(CXX) $(CXXFLAGS) -c -o $@ $*.cc $(MINISAT_FLAGS) -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -MMD -MF $(CONF_ID)/$*.d
+	$(CXX) $(CXXFLAGS) $(COMPILE_ONLY) -c -o $@ $*.cc $(MINISAT_FLAGS) -D __STDC_LIMIT_MACROS -D __STDC_FORMAT_MACROS -MMD -MF $(CONF_ID)/$*.d
 
 ################################################################
 # targets for executables
@@ -545,7 +548,7 @@ VSAT_OBJ := $(addprefix $(CONF_ID)/, $(VSAT_DEP))
 TKV_OBJ := $(addprefix $(CONF_ID)/, $(TKV_DEP))
 
 define COMPILE_CMD
-$(CXX) $(CXXFLAGS) $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB)
+$(CXX) $(CXXFLAGS) $(LINK_ONLY) $(filter -l%, $+) $(filter %.o, $^) -o $@_$(BRANCH)_$(COM_CNT) $(Z3LIB)
 @#$(CXX) -static $(CXXFLAGS) $(Z3LIB) $(filter %.o, $^) -o $@
 @#strip $@
 endef


### PR DESCRIPTION
Something to chew on over the weekend. @hzzv brought to my attention that the stack trace mechanism could be better: it doesn't include file/line information where available, and it's kinda flaky with static builds for some reason I don't fully understand.

The current solution calls a system function to obtain a backtrace in the form of an array of pointers, then jumps through system hoops to map them to symbols. Instead, I propose that we shell out to `addr2line(1)`, which is very often installed on POSIXy machines. If we have it, great. If not, we're crashing anyway so we don't lose much, and we print out the addresses so that we can figure it out offline. This also rids us of a library dependency and some build magic. What do you think?