### PR TITLE
remove USE_ALLOCATOR where it very likely makes no difference

### DIFF
--- a/DP/ShortConflictMetaDP.hpp
+++ b/DP/ShortConflictMetaDP.hpp
@@ -34,8 +34,6 @@ using namespace SAT;
 
 class ShortConflictMetaDP : public DecisionProcedure {
 public:
-  USE_ALLOCATOR(ShortConflictMetaDP);
-
   /**
    * Create object using @c inner decision procedure. Object takes ownership of the @c inner object.
    */

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -48,8 +48,6 @@ using namespace Kernel;
 class SimpleCongruenceClosure : public DecisionProcedure
 {
 public:
-  USE_ALLOCATOR(SimpleCongruenceClosure);
-
   SimpleCongruenceClosure(Ordering* ord);
 
   virtual void addLiterals(LiteralIterator lits, bool onlyEqualites) override;

--- a/Debug/TimeProfiling.hpp
+++ b/Debug/TimeProfiling.hpp
@@ -195,8 +195,6 @@ class TimeTraceOrdering : public Kernel::Ordering
   const char* _nameTerm;
   Ord _ord;
 public:
-  USE_ALLOCATOR(TimeTraceOrdering);
-
   TimeTraceOrdering(const char* nameLit, const char* nameTerm, Ord ord)
   : _nameLit(nameLit)
   , _nameTerm(nameTerm)

--- a/FMB/FiniteModel.hpp
+++ b/FMB/FiniteModel.hpp
@@ -35,8 +35,6 @@ using namespace Kernel;
  *
  */
 class FiniteModel {
- USE_ALLOCATOR(FiniteModel);
-
 public:
 
  const unsigned _size;

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -57,8 +57,6 @@ using namespace SAT;
 
 class FiniteModelBuilder : public MainLoop {
 public:
-  USE_ALLOCATOR(FiniteModelBuilder);    
-  
   FiniteModelBuilder(Problem& prb, const Options& opt);
   ~FiniteModelBuilder();
 
@@ -251,8 +249,6 @@ private:
 
   class HackyDSAE : public DSAEnumerator {
     struct Constraint_Generator {
-      USE_ALLOCATOR(FiniteModelBuilder::HackyDSAE::Constraint_Generator);
-
       Constraint_Generator_Vals _vals;
       unsigned _weight;
 
@@ -287,8 +283,6 @@ private:
     bool checkConstriant(DArray<unsigned>& newSortSizes, Constraint_Generator_Vals& constraint);
 
   public:
-    USE_ALLOCATOR(FiniteModelBuilder::HackyDSAE);
-
     HackyDSAE(bool keepOldGenerators) : _maxWeightSoFar(0), _keepOldGenerators(keepOldGenerators) {}
 
     bool init(unsigned _startSize, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>& dsc, Stack<std::pair<unsigned,unsigned>>& sdsc) override {
@@ -314,9 +308,6 @@ private:
     unsigned loadSizesFromSmt(DArray<unsigned>& szs);
     void reportZ3OutOfMemory();
   public:
-    // the following is not sufficient, since z3::solver and z3::context allocate internally
-    USE_ALLOCATOR(FiniteModelBuilder::SmtBasedDSAE);
-
     SmtBasedDSAE() : _smtSolver(_context) {}
 
     bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>&, Stack<std::pair<unsigned,unsigned>>&) override;

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -35,8 +35,6 @@ using namespace Kernel;
  *
  */
 class FiniteModelMultiSorted {
- USE_ALLOCATOR(FiniteModelMultiSorted);
-
  DHMap<unsigned,unsigned> _sizes;
 
 public:

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -40,9 +40,6 @@ namespace FMB {
   using namespace Lib;
 
 class Monotonicity{
-
-  USE_ALLOCATOR(Monotonicity);
-
 public:
   // Assumes clauses are flattened
   Monotonicity(ClauseList* clauses, unsigned srt);

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -32,8 +32,6 @@ using namespace Shell;
 using namespace Lib;
 
 struct SortedSignature{
-    USE_ALLOCATOR(SortedSignature);
-
     unsigned sorts;
     DArray<Stack<unsigned>> sortedConstants;
     DArray<Stack<unsigned>> sortedFunctions;
@@ -77,8 +75,6 @@ struct SortedSignature{
 
 class SortInference {
 public:
-  USE_ALLOCATOR(SortInference);    
-  
   SortInference(ClauseList* clauses,
                 DArray<unsigned> del_f,
                 DArray<unsigned> del_p,

--- a/Indexing/AcyclicityIndex.hpp
+++ b/Indexing/AcyclicityIndex.hpp
@@ -66,8 +66,6 @@ public:
   void remove(Kernel::Literal *lit, Kernel::Clause *c);
 
   CycleQueryResultsIterator queryCycles(Kernel::Literal *lit, Kernel::Clause *c);
-             
-  USE_ALLOCATOR(AcyclicityIndex);
 protected:
   void handleClause(Kernel::Clause* c, bool adding);
 private:

--- a/Indexing/ClauseVariantIndex.hpp
+++ b/Indexing/ClauseVariantIndex.hpp
@@ -52,8 +52,6 @@ protected:
 class SubstitutionTreeClauseVariantIndex : public ClauseVariantIndex
 {
 public:
-  USE_ALLOCATOR(SubstitutionTreeClauseVariantIndex);
-
   SubstitutionTreeClauseVariantIndex() : _emptyClauses(0) {}
   virtual ~SubstitutionTreeClauseVariantIndex() override;
 
@@ -76,8 +74,6 @@ private:
 class HashingClauseVariantIndex : public ClauseVariantIndex
 {
 public:
-  USE_ALLOCATOR(HashingClauseVariantIndex);
-
   virtual ~HashingClauseVariantIndex() override;
 
   virtual void insert(Clause* cl) override;

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -40,8 +40,6 @@ using namespace Lib;
 class CodeTreeTIS : public TermIndexingStructure
 {
 public:
-  USE_ALLOCATOR(CodeTreeTIS);
-
   void insert(TypedTermList t, Literal* lit, Clause* cls);
   void remove(TypedTermList t, Literal* lit, Clause* cls);
 
@@ -78,8 +76,6 @@ class CodeTreeSubsumptionIndex
 : public ClauseSubsumptionIndex
 {
 public:
-  USE_ALLOCATOR(CodeTreeSubsumptionIndex);
-
   ClauseSResResultIterator getSubsumingOrSResolvingClauses(Clause* c, bool subsumptionResolution);
 protected:
   //overrides Index::handleClause

--- a/Indexing/GroundingIndex.hpp
+++ b/Indexing/GroundingIndex.hpp
@@ -31,8 +31,6 @@ using namespace Shell;
 
 class GroundingIndex : public Index {
 public:
-  USE_ALLOCATOR(GroundingIndex);
-
   GroundingIndex(const Options& opt);
 
   SATSolverWithAssumptions& getSolver() { return *_solver; }

--- a/Indexing/Index.hpp
+++ b/Indexing/Index.hpp
@@ -129,8 +129,6 @@ typedef VirtualIterator<FormulaQueryResult> FormulaQueryResultIterator;
 class Index
 {
 public:
-  USE_ALLOCATOR(Index);
-
   virtual ~Index();
 
   void attachContainer(ClauseContainer* cc);
@@ -157,8 +155,6 @@ class ClauseSubsumptionIndex
 : public Index
 {
 public:
-  USE_ALLOCATOR(ClauseSubsumptionIndex);
-
   virtual ClauseSResResultIterator getSubsumingOrSResolvingClauses(Clause* c, 
     bool subsumptionResolution)
   { NOT_IMPLEMENTED; };

--- a/Indexing/IndexManager.hpp
+++ b/Indexing/IndexManager.hpp
@@ -72,8 +72,6 @@ enum IndexType {
 class IndexManager
 {
 public:
-  USE_ALLOCATOR(IndexManager);
-
   /** alg can be zero, then it must be set by setSaturationAlgorithm */
   explicit IndexManager(SaturationAlgorithm* alg) : _alg(alg) {}
   void setSaturationAlgorithm(SaturationAlgorithm* alg) 

--- a/Indexing/LiteralIndex.hpp
+++ b/Indexing/LiteralIndex.hpp
@@ -27,8 +27,6 @@ class LiteralIndex
 : public Index
 {
 public:
-  USE_ALLOCATOR(LiteralIndex);
-
   virtual ~LiteralIndex();
 
   SLQueryResultIterator getAll();
@@ -60,8 +58,6 @@ class BinaryResolutionIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(BinaryResolutionIndex);
-
   BinaryResolutionIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
@@ -72,8 +68,6 @@ class BackwardSubsumptionIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(BackwardSubsumptionIndex);
-
   BackwardSubsumptionIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
@@ -84,8 +78,6 @@ class FwSubsSimplifyingLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(FwSubsSimplifyingLiteralIndex);
-
   FwSubsSimplifyingLiteralIndex(LiteralIndexingStructure* is)
     : LiteralIndex(is)
   { }
@@ -98,8 +90,6 @@ class FSDLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(FSDLiteralIndex);
-
   FSDLiteralIndex(LiteralIndexingStructure* is)
     : LiteralIndex(is)
   { }
@@ -112,8 +102,6 @@ class UnitClauseLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(UnitClauseLiteralIndex);
-
   UnitClauseLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
@@ -124,8 +112,6 @@ class UnitClauseWithALLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(UnitClauseWithALLiteralIndex);
-
   UnitClauseWithALLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
 protected:
@@ -136,8 +122,6 @@ class NonUnitClauseLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(NonUnitClauseLiteralIndex);
-
   NonUnitClauseLiteralIndex(LiteralIndexingStructure* is, bool selectedOnly=false)
   : LiteralIndex(is), _selectedOnly(selectedOnly) {};
 protected:
@@ -150,8 +134,6 @@ class NonUnitClauseWithALLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(NonUnitClauseWithALLiteralIndex);
-
   NonUnitClauseWithALLiteralIndex(LiteralIndexingStructure* is, bool selectedOnly=false)
   : LiteralIndex(is), _selectedOnly(selectedOnly) {};
 protected:
@@ -164,8 +146,6 @@ class RewriteRuleIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(RewriteRuleIndex);
-
   RewriteRuleIndex(LiteralIndexingStructure* is, Ordering& ordering);
   ~RewriteRuleIndex();
 
@@ -188,8 +168,6 @@ class DismatchingLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(DismatchingLiteralIndex);
-
   DismatchingLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {};
   void handleClause(Clause* c, bool adding);
@@ -200,8 +178,6 @@ class UnitIntegerComparisonLiteralIndex
 : public LiteralIndex
 {
 public:
-  USE_ALLOCATOR(UnitIntegerComparisonLiteralIndex);
-
   UnitIntegerComparisonLiteralIndex(LiteralIndexingStructure* is)
   : LiteralIndex(is) {}
 

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -36,8 +36,6 @@ class LiteralSubstitutionTree
   using Leaf = SubstitutionTree::Leaf;
 
 public:
-  USE_ALLOCATOR(LiteralSubstitutionTree);
-
   LiteralSubstitutionTree(bool useC=false);
 
   void insert(Literal* lit, Clause* cls) override { handleLiteral(lit, cls, /* insert */ true); }

--- a/Indexing/RequestedIndex.hpp
+++ b/Indexing/RequestedIndex.hpp
@@ -23,8 +23,6 @@ template <typename Index>
 class RequestedIndex final
 {
   public:
-    USE_ALLOCATOR(RequestedIndex);
-
     RequestedIndex()
     { }
 

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -119,7 +119,6 @@ class SubstitutionTree
 public:
   static constexpr int QRS_QUERY_BANK = 0;
   static constexpr int QRS_RESULT_BANK = 1;
-  USE_ALLOCATOR(SubstitutionTree);
 
   SubstitutionTree(bool useC, bool rfSubs);
 

--- a/Indexing/TermIndex.hpp
+++ b/Indexing/TermIndex.hpp
@@ -28,8 +28,6 @@ class TermIndex
 : public Index
 {
 public:
-  USE_ALLOCATOR(TermIndex);
-
   virtual ~TermIndex();
 
   TermQueryResultIterator getUnifications(TypedTermList t, bool retrieveSubstitutions = true, bool withConstraints = false);
@@ -46,8 +44,6 @@ class SuperpositionSubtermIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(SuperpositionSubtermIndex);
-
   SuperpositionSubtermIndex(TermIndexingStructure* is, Ordering& ord)
   : TermIndex(is), _ord(ord) {};
 protected:
@@ -60,8 +56,6 @@ class SuperpositionLHSIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(SuperpositionLHSIndex);
-
   SuperpositionLHSIndex(TermSubstitutionTree* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord), _opt(opt), _tree(is) {};
 protected:
@@ -92,8 +86,6 @@ class DemodulationSubtermIndexImpl
 : public DemodulationSubtermIndex
 {
 public:
-  USE_ALLOCATOR(DemodulationSubtermIndexImpl);
-
   DemodulationSubtermIndexImpl(TermIndexingStructure* is)
   : DemodulationSubtermIndex(is) {};
 protected:
@@ -107,8 +99,6 @@ class DemodulationLHSIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(DemodulationLHSIndex);
-
   DemodulationLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord), _opt(opt) {};
 protected:
@@ -125,8 +115,6 @@ class InductionTermIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(InductionTermIndex);
-
   InductionTermIndex(TermIndexingStructure* is)
   : TermIndex(is) {}
 
@@ -141,8 +129,6 @@ class StructInductionTermIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(StructInductionTermIndex);
-
   StructInductionTermIndex(TermIndexingStructure* is)
   : TermIndex(is) {}
 
@@ -158,8 +144,6 @@ class PrimitiveInstantiationIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(PrimitiveInstantiationIndex);
-
   PrimitiveInstantiationIndex(TermIndexingStructure* is) : TermIndex(is)
   {
     populateIndex();
@@ -172,8 +156,6 @@ class SubVarSupSubtermIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(SubVarSupSubtermIndex);
-
   SubVarSupSubtermIndex(TermIndexingStructure* is, Ordering& ord)
   : TermIndex(is), _ord(ord) {};
 protected:
@@ -186,8 +168,6 @@ class SubVarSupLHSIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(SubVarSupLHSIndex);
-
   SubVarSupLHSIndex(TermIndexingStructure* is, Ordering& ord, const Options& opt)
   : TermIndex(is), _ord(ord) {};
 protected:
@@ -203,8 +183,6 @@ class NarrowingIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(NarrowingIndex);
-
   NarrowingIndex(TermIndexingStructure* is) : TermIndex(is)
   {
     populateIndex();
@@ -218,8 +196,6 @@ class SkolemisingFormulaIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(SkolemisingFormulaIndex);
-
   SkolemisingFormulaIndex(TermIndexingStructure* is) : TermIndex(is)
   {}
   void insertFormula(TermList formula, TermList skolem);
@@ -229,8 +205,6 @@ public:
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(HeuristicInstantiationIndex);
-
   HeuristicInstantiationIndex(TermIndexingStructure* is) : TermIndex(is)
   {}
 protected:
@@ -244,8 +218,6 @@ class RenamingFormulaIndex
 : public TermIndex
 {
 public:
-  USE_ALLOCATOR(RenamingFormulaIndex);
-
   RenamingFormulaIndex(TermIndexingStructure* is) : TermIndex(is)
   {}
   void insertFormula(TermList formula, TermList name, Literal* lit, Clause* cls);

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -30,8 +30,6 @@ namespace Indexing {
 class TermSharing
 {
 public:
-  USE_ALLOCATOR(TermSharing);
-
   TermSharing();
   ~TermSharing();
 

--- a/Indexing/TermSubstitutionTree.hpp
+++ b/Indexing/TermSubstitutionTree.hpp
@@ -39,8 +39,6 @@ class TermSubstitutionTree
 : public TermIndexingStructure, SubstitutionTree
 {
 public:
-  USE_ALLOCATOR(TermSubstitutionTree);
-  
   /* 
    * The extra flag is a higher-order concern. it is set to true when 
    * we require the term query result to include two terms, the result term

--- a/Inferences/ArgCong.hpp
+++ b/Inferences/ArgCong.hpp
@@ -31,8 +31,6 @@ class ArgCong
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(ArgCong);
-
   ClauseIterator generateClauses(Clause* premise);
 private:
   struct ResultFn;

--- a/Inferences/ArithmeticSubtermGeneralization.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization.hpp
@@ -23,8 +23,6 @@ class NumeralMultiplicationGeneralization
 : public SimplifyingGeneratingInference1
 {
 public:
-  USE_ALLOCATOR(NumeralMultiplicationGeneralization);
-
   virtual ~NumeralMultiplicationGeneralization();
 
   SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
@@ -35,8 +33,6 @@ class VariableMultiplicationGeneralization
 : public SimplifyingGeneratingInference1
 {
 public:
-  USE_ALLOCATOR(VariableMultiplicationGeneralization);
-
   virtual ~VariableMultiplicationGeneralization();
 
   SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
@@ -47,8 +43,6 @@ class VariablePowerGeneralization
 : public SimplifyingGeneratingInference1
 {
 public:
-  USE_ALLOCATOR(VariablePowerGeneralization);
-
   virtual ~VariablePowerGeneralization();
 
   SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
@@ -59,8 +53,6 @@ class AdditionGeneralization
 : public SimplifyingGeneratingInference1
 {
 public:
-  USE_ALLOCATOR(AdditionGeneralization);
-
   virtual ~AdditionGeneralization();
 
   SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);

--- a/Inferences/BackwardDemodulation.hpp
+++ b/Inferences/BackwardDemodulation.hpp
@@ -30,8 +30,6 @@ class BackwardDemodulation
 : public BackwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(BackwardDemodulation);
-
   void attach(SaturationAlgorithm* salg);
   void detach();
 

--- a/Inferences/BackwardSubsumptionDemodulation.hpp
+++ b/Inferences/BackwardSubsumptionDemodulation.hpp
@@ -49,8 +49,6 @@ class BackwardSubsumptionDemodulation
   : public BackwardSimplificationEngine
 {
   public:
-    USE_ALLOCATOR(BackwardSubsumptionDemodulation);
-
     BackwardSubsumptionDemodulation();
 
     void attach(SaturationAlgorithm* salg) override;

--- a/Inferences/BackwardSubsumptionResolution.hpp
+++ b/Inferences/BackwardSubsumptionResolution.hpp
@@ -28,8 +28,6 @@ class BackwardSubsumptionResolution
 : public BackwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(BackwardSubsumptionResolution);
-
   BackwardSubsumptionResolution(bool byUnitsOnly) : _byUnitsOnly(byUnitsOnly) {}
 
   void attach(SaturationAlgorithm* salg);

--- a/Inferences/BinaryResolution.hpp
+++ b/Inferences/BinaryResolution.hpp
@@ -33,8 +33,6 @@ class BinaryResolution
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(BinaryResolution);
-
   BinaryResolution() 
     : _index(0),
     _unificationWithAbstraction(false)

--- a/Inferences/BoolEqToDiseq.hpp
+++ b/Inferences/BoolEqToDiseq.hpp
@@ -24,8 +24,6 @@ namespace Inferences {
 class BoolEqToDiseq : public GeneratingInferenceEngine
 {
   public:
-    USE_ALLOCATOR(BoolEqToDiseq);
-
     ClauseIterator generateClauses(Clause* premise);
 
 };

--- a/Inferences/BoolSimp.hpp
+++ b/Inferences/BoolSimp.hpp
@@ -24,7 +24,6 @@ namespace Inferences {
 class BoolSimp : public ImmediateSimplificationEngine
 {
   public:
-    USE_ALLOCATOR(BoolSimp);
     Clause* simplify(Clause* premise);
 
   private:

--- a/Inferences/CNFOnTheFly.hpp
+++ b/Inferences/CNFOnTheFly.hpp
@@ -34,9 +34,6 @@ class IFFXORRewriterISE
   : public ImmediateSimplificationEngine
 {
 public:
-
-  USE_ALLOCATOR(IFFXORRewriterISE);
-
   Clause* simplify(Clause* c);
 };
 
@@ -44,9 +41,6 @@ class EagerClausificationISE
   : public ImmediateSimplificationEngine
 {
 public:
-
-  USE_ALLOCATOR(EagerClausificationISE);
-
   ClauseIterator simplifyMany(Clause* c);
   Clause* simplify(Clause* c){ NOT_IMPLEMENTED; }
 
@@ -56,8 +50,6 @@ class LazyClausification
   : public SimplificationEngine
 {
 public:
-  USE_ALLOCATOR(LazyClausification);
-
   LazyClausification(){
     _formulaIndex = 0;
   }
@@ -75,9 +67,6 @@ class LazyClausificationGIE
   : public GeneratingInferenceEngine
 {
 public:
-
-  USE_ALLOCATOR(LazyClausificationGIE);
-
   LazyClausificationGIE(){
     _formulaIndex = 0;
   }
@@ -95,8 +84,6 @@ private:
   : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(NotProxyISE);
-  
   Kernel::Clause* simplify(Kernel::Clause* c);
 };
 
@@ -106,8 +93,6 @@ class EqualsProxyISE
 {
 
 public:
-  USE_ALLOCATOR(EqualsProxyISE);
-  
   Kernel::Clause* simplify(Kernel::Clause* c);        
 };
 
@@ -117,8 +102,6 @@ class OrImpAndProxyISE
 {
 
 public:
-  USE_ALLOCATOR(OrImpAndProxyISE);
-  
   Kernel::Clause* simplify(Kernel::Clause* c);
 };
 
@@ -128,8 +111,6 @@ class PiSigmaProxyISE
 {
   
 public:
-  USE_ALLOCATOR(PiSigmaProxyISE);
-  
   Kernel::Clause* simplify(Kernel::Clause* c);     
 };
 
@@ -137,7 +118,6 @@ public:
 class ProxyISE 
   : public ImmediateSimplificationEngine {
   public:
-    USE_ALLOCATOR(ProxyISE);
     ClauseIterator simplifyMany(Clause* c);
     Clause* simplify(Clause* c){ NOT_IMPLEMENTED; }
 };*/

--- a/Inferences/Cancellation.hpp
+++ b/Inferences/Cancellation.hpp
@@ -20,8 +20,6 @@ class Cancellation
 : public SimplifyingGeneratingLiteralSimplification
 {
 public:
-  USE_ALLOCATOR(Cancellation);
-
   Cancellation(Ordering& ordering);
   virtual ~Cancellation();
 

--- a/Inferences/Cases.hpp
+++ b/Inferences/Cases.hpp
@@ -23,8 +23,6 @@ namespace Inferences {
 
 class Cases : public GeneratingInferenceEngine {
   public:
-    USE_ALLOCATOR(Cases);
-    
     Clause* performParamodulation(Clause* cl, Literal* lit, TermList t);
     ClauseIterator generateClauses(Clause* premise);
     struct RewriteableSubtermsFn;

--- a/Inferences/CasesSimp.hpp
+++ b/Inferences/CasesSimp.hpp
@@ -23,8 +23,6 @@ namespace Inferences {
 
 class CasesSimp : public ImmediateSimplificationEngine {
   public:
-    USE_ALLOCATOR(CasesSimp);
-
     ClauseIterator simplifyMany(Clause* premise);
     Clause* simplify(Clause* premise){ NOT_IMPLEMENTED; }
 

--- a/Inferences/Choice.hpp
+++ b/Inferences/Choice.hpp
@@ -24,8 +24,6 @@ namespace Inferences {
 class Choice : public GeneratingInferenceEngine
 {
   public:
-    USE_ALLOCATOR(Choice);
-
     ClauseIterator generateClauses(Clause* premise);
 
   private:

--- a/Inferences/CombinatorDemodISE.hpp
+++ b/Inferences/CombinatorDemodISE.hpp
@@ -25,8 +25,6 @@ class CombinatorDemodISE
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(CombinatorDemodISE);
-
   CombinatorDemodISE(){}
   Clause* simplify(Clause* cl);
 private:

--- a/Inferences/CombinatorNormalisationISE.hpp
+++ b/Inferences/CombinatorNormalisationISE.hpp
@@ -40,8 +40,6 @@ class CombinatorNormalisationISE
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(CombinatorNormalisationISE);
-
   CombinatorNormalisationISE(){}
   Clause* simplify(Clause* cl);
 private:

--- a/Inferences/Condensation.hpp
+++ b/Inferences/Condensation.hpp
@@ -34,8 +34,6 @@ class Condensation
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(Condensation);
-
   Clause* simplify(Clause* cl);
 };
 

--- a/Inferences/DefinitionIntroduction.hpp
+++ b/Inferences/DefinitionIntroduction.hpp
@@ -23,8 +23,6 @@ namespace Inferences
 
 class DefinitionIntroduction: public GeneratingInferenceEngine, public Index {
 public:
-  USE_ALLOCATOR(DefinitionIntroduction);
-
   void attach(SaturationAlgorithm *salg) override {
     GeneratingInferenceEngine::attach(salg);
     attachContainer(salg->getPassiveClauseContainer());

--- a/Inferences/DistinctEqualitySimplifier.hpp
+++ b/Inferences/DistinctEqualitySimplifier.hpp
@@ -24,8 +24,6 @@ class DistinctEqualitySimplifier
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(DistinctEqualitySimplifier);
-
   Clause* simplify(Clause* cl);
   static bool mustBeDistinct(TermList t1, TermList t2);
   static bool mustBeDistinct(TermList t1, TermList t2, unsigned& grp);

--- a/Inferences/ElimLeibniz.hpp
+++ b/Inferences/ElimLeibniz.hpp
@@ -25,8 +25,6 @@ namespace Inferences {
 class ElimLeibniz : public GeneratingInferenceEngine
 {
   public:
-    USE_ALLOCATOR(ElimLeibniz);
-
     ClauseIterator generateClauses(Clause* premise);
 
   private:

--- a/Inferences/EqualityFactoring.hpp
+++ b/Inferences/EqualityFactoring.hpp
@@ -31,8 +31,6 @@ class EqualityFactoring
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(EqualityFactoring);
-
   ClauseIterator generateClauses(Clause* premise);
 private:
   struct IsPositiveEqualityFn;

--- a/Inferences/EqualityResolution.hpp
+++ b/Inferences/EqualityResolution.hpp
@@ -31,8 +31,6 @@ class EqualityResolution
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(EqualityResolution);
-
   ClauseIterator generateClauses(Clause* premise);
   static Clause* tryResolveEquality(Clause* cl, Literal* toResolve);
 private:

--- a/Inferences/EquationalTautologyRemoval.hpp
+++ b/Inferences/EquationalTautologyRemoval.hpp
@@ -26,8 +26,6 @@ class EquationalTautologyRemoval
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(EquationalTautologyRemoval);
-
   EquationalTautologyRemoval() : _cc(nullptr) {}
 
   Clause* simplify(Clause* cl) override;

--- a/Inferences/ExtensionalityResolution.hpp
+++ b/Inferences/ExtensionalityResolution.hpp
@@ -40,8 +40,6 @@ class ExtensionalityResolution
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(ExtensionalityResolution);
-
   ExtensionalityResolution() {}
   
   ClauseIterator generateClauses(Clause* premise);

--- a/Inferences/FOOLParamodulation.hpp
+++ b/Inferences/FOOLParamodulation.hpp
@@ -23,7 +23,6 @@ namespace Inferences {
 
 class FOOLParamodulation : public GeneratingInferenceEngine {
   public:
-    USE_ALLOCATOR(FOOLParamodulation);
     ClauseIterator generateClauses(Clause* premise);
 };
 

--- a/Inferences/Factoring.hpp
+++ b/Inferences/Factoring.hpp
@@ -30,8 +30,6 @@ class Factoring
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(Factoring);
-
   ClauseIterator generateClauses(Clause* premise);
 private:
   class UnificationsOnPositiveFn;

--- a/Inferences/FastCondensation.hpp
+++ b/Inferences/FastCondensation.hpp
@@ -43,8 +43,6 @@ class FastCondensation
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(FastCondensation);
-
   Clause* simplify(Clause* cl);
 private:
   struct CondensationBinder;

--- a/Inferences/ForwardDemodulation.hpp
+++ b/Inferences/ForwardDemodulation.hpp
@@ -32,8 +32,6 @@ class ForwardDemodulation
 : public ForwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(ForwardDemodulation);
-
   void attach(SaturationAlgorithm* salg) override;
   void detach() override;
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override = 0;
@@ -49,8 +47,6 @@ class ForwardDemodulationImpl
 : public ForwardDemodulation
 {
 public:
-  USE_ALLOCATOR(ForwardDemodulationImpl);
-
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
 private:
 };

--- a/Inferences/ForwardLiteralRewriting.hpp
+++ b/Inferences/ForwardLiteralRewriting.hpp
@@ -31,8 +31,6 @@ class ForwardLiteralRewriting
 : public ForwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(ForwardLiteralRewriting);
-
   void attach(SaturationAlgorithm* salg) override;
   void detach() override;
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;

--- a/Inferences/ForwardSubsumptionAndResolution.hpp
+++ b/Inferences/ForwardSubsumptionAndResolution.hpp
@@ -30,8 +30,6 @@ class ForwardSubsumptionAndResolution
 : public ForwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(ForwardSubsumptionAndResolution);
-
   ForwardSubsumptionAndResolution(bool subsumptionResolution=true)
   : _subsumptionResolution(subsumptionResolution) {}
 

--- a/Inferences/ForwardSubsumptionDemodulation.hpp
+++ b/Inferences/ForwardSubsumptionDemodulation.hpp
@@ -48,8 +48,6 @@ class ForwardSubsumptionDemodulation
   : public ForwardSimplificationEngine
 {
   public:
-    USE_ALLOCATOR(ForwardSubsumptionDemodulation);
-
     ForwardSubsumptionDemodulation(bool doSubsumption)
       : _doSubsumption(doSubsumption)
     { }

--- a/Inferences/GaussianVariableElimination.hpp
+++ b/Inferences/GaussianVariableElimination.hpp
@@ -18,8 +18,6 @@ class GaussianVariableElimination
   : public SimplifyingGeneratingInference1 
 {
 public:
-  USE_ALLOCATOR(GaussianVariableElimination);
-
   SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) override;
 private:
   SimplifyingGeneratingInference1::Result rewrite(Clause &cl, TermList find, TermList replace,

--- a/Inferences/GlobalSubsumption.hpp
+++ b/Inferences/GlobalSubsumption.hpp
@@ -35,8 +35,6 @@ class GlobalSubsumption
 : public ForwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(GlobalSubsumption);
-
   GlobalSubsumption(const Options& opts) : _index(0),
       _uprOnly(opts.globalSubsumptionSatSolverPower()==Options::GlobalSubsumptionSatSolverPower::PROPAGATION_ONLY),
       _explicitMinim(opts.globalSubsumptionExplicitMinim()!=Options::GlobalSubsumptionExplicitMinim::OFF),

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -162,8 +162,6 @@ class Induction
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(Induction);
-
   void attach(SaturationAlgorithm* salg) override;
   void detach() override;
 

--- a/Inferences/InductionHelper.hpp
+++ b/Inferences/InductionHelper.hpp
@@ -31,8 +31,6 @@ using namespace Kernel;
 
 class InductionHelper {
 public:
-  USE_ALLOCATOR(InductionHelper);
-
   InductionHelper(LiteralIndex* comparisonIndex, TermIndex* inductionTermIndex)
       : _comparisonIndex(comparisonIndex), _inductionTermIndex(inductionTermIndex) {}
 

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -52,8 +52,6 @@ using namespace Shell;
 class InferenceEngine
 {
 public:
-  USE_ALLOCATOR(InferenceEngine);
-
   InferenceEngine() : _salg(0) {}
   virtual ~InferenceEngine()
   {
@@ -310,8 +308,6 @@ class DummyGIE
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(DummyGIE);
-
   ClauseIterator generateClauses(Clause* premise)
   {
     return ClauseIterator::getEmpty();
@@ -323,8 +319,6 @@ class DummyFSE
 : public ForwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(DummyFSE);
-
   void perform(Clause* cl, bool& keep, ClauseIterator& toAdd, ClauseIterator& premises)
   {
     keep=true;
@@ -337,8 +331,6 @@ class DummyBSE
 : public BackwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(DummyBSE);
-
   void perform(Clause* premise, BwSimplificationRecordIterator& simplifications)
   {
     simplifications=BwSimplificationRecordIterator::getEmpty();
@@ -350,8 +342,6 @@ class CompositeISE
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(CompositeISE);
-
   CompositeISE() : _inners(0), _innersMany(0) {}
   virtual ~CompositeISE();
   void addFront(ImmediateSimplificationEngine* fse);
@@ -385,8 +375,6 @@ class CompositeGIE
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(CompositeGIE);
-
   CompositeGIE() : _inners(0) {}
   virtual ~CompositeGIE();
   void addFront(GeneratingInferenceEngine* fse);
@@ -403,8 +391,6 @@ class CompositeSGI
 : public SimplifyingGeneratingInference
 {
 public:
-  USE_ALLOCATOR(CompositeSGI);
-
   CompositeSGI() : _simplifiers(), _generators() {}
   virtual ~CompositeSGI();
   void push(SimplifyingGeneratingInference*);
@@ -422,8 +408,6 @@ class ChoiceDefinitionISE
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(ChoiceDefinitionISE);
-
   Clause* simplify(Clause* cl);
 
   bool isPositive(Literal* lit);
@@ -436,8 +420,6 @@ class DuplicateLiteralRemovalISE
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(DuplicateLiteralRemovalISE);
-
   Clause* simplify(Clause* cl);
 };
 
@@ -445,8 +427,6 @@ class TautologyDeletionISE2
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(TautologyDeletionISE2);
-
   Clause* simplify(Clause* cl);
 };
 

--- a/Inferences/Injectivity.hpp
+++ b/Inferences/Injectivity.hpp
@@ -23,7 +23,6 @@ namespace Inferences {
 
 class Injectivity : public GeneratingInferenceEngine {
   public:
-    USE_ALLOCATOR(Injectivity);
     ClauseIterator generateClauses(Clause* premise);
 
   private:

--- a/Inferences/InnerRewriting.hpp
+++ b/Inferences/InnerRewriting.hpp
@@ -30,8 +30,6 @@ class InnerRewriting
 : public ForwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(InnerRewriting);
-  
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
 };
 

--- a/Inferences/Instantiation.hpp
+++ b/Inferences/Instantiation.hpp
@@ -33,8 +33,6 @@ class Instantiation
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(Instantiation);
-
   Instantiation() {}
 
   //void init();

--- a/Inferences/InterpretedEvaluation.hpp
+++ b/Inferences/InterpretedEvaluation.hpp
@@ -31,8 +31,6 @@ class InterpretedEvaluation
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(InterpretedEvaluation);
-
   InterpretedEvaluation(bool doNormalize, Ordering& ordering);
   virtual ~InterpretedEvaluation();
 

--- a/Inferences/InvalidAnswerLiteralRemoval.hpp
+++ b/Inferences/InvalidAnswerLiteralRemoval.hpp
@@ -28,8 +28,6 @@ class InvalidAnswerLiteralRemoval
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(InvalidAnswerLiteralRemoval);
-
   Clause* simplify(Clause* cl) override;
 };
 

--- a/Inferences/LfpRule.hpp
+++ b/Inferences/LfpRule.hpp
@@ -21,8 +21,6 @@ class LfpRule
 {
   Rule _inner;
 public:
-  USE_ALLOCATOR(LfpRule);
- 
   LfpRule(Rule rule);
   LfpRule();
   SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) override;

--- a/Inferences/Narrow.hpp
+++ b/Inferences/Narrow.hpp
@@ -31,8 +31,6 @@ class Narrow
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(Narrow);
-
   ClauseIterator generateClauses(Clause* premise);
 
   void attach(SaturationAlgorithm* salg);

--- a/Inferences/NegativeExt.hpp
+++ b/Inferences/NegativeExt.hpp
@@ -31,8 +31,6 @@ class NegativeExt
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(NegativeExt);
-
   ClauseIterator generateClauses(Clause* premise);
 private:
   struct ResultFn;

--- a/Inferences/PolynomialEvaluation.hpp
+++ b/Inferences/PolynomialEvaluation.hpp
@@ -30,8 +30,6 @@ class PolynomialEvaluation
 : public SimplifyingGeneratingLiteralSimplification
 {
 public:
-  USE_ALLOCATOR(PolynomialEvaluation);
-
   PolynomialEvaluation(Ordering& ordering);
   virtual ~PolynomialEvaluation();
 

--- a/Inferences/PrimitiveInstantiation.hpp
+++ b/Inferences/PrimitiveInstantiation.hpp
@@ -31,8 +31,6 @@ class PrimitiveInstantiation
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(PrimitiveInstantiation);
-
   void attach(SaturationAlgorithm* salg);
   void detach();
 

--- a/Inferences/PushUnaryMinus.hpp
+++ b/Inferences/PushUnaryMinus.hpp
@@ -27,8 +27,6 @@ class PushUnaryMinus
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(PushUnaryMinus);
-
   virtual ~PushUnaryMinus();
 
   Clause* simplify(Clause* cl);

--- a/Inferences/RenamingOnTheFly.hpp
+++ b/Inferences/RenamingOnTheFly.hpp
@@ -31,8 +31,6 @@ class RenamingOnTheFly
   : public SimplificationEngine
 {
 public:
-  USE_ALLOCATOR(RenamingOnTheFly);
-
   ClauseIterator perform(Clause* c);
 
   void attach(SaturationAlgorithm* salg) override;

--- a/Inferences/SLQueryBackwardSubsumption.hpp
+++ b/Inferences/SLQueryBackwardSubsumption.hpp
@@ -26,8 +26,6 @@ class SLQueryBackwardSubsumption
 : public BackwardSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(SLQueryBackwardSubsumption);
-
   SLQueryBackwardSubsumption(bool byUnitsOnly) : _byUnitsOnly(byUnitsOnly), _index(0) {}
 
   /**

--- a/Inferences/SubVarSup.hpp
+++ b/Inferences/SubVarSup.hpp
@@ -31,8 +31,6 @@ class SubVarSup
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(SubVarSup);
-
   void attach(SaturationAlgorithm* salg);
   void detach();
 

--- a/Inferences/Superposition.hpp
+++ b/Inferences/Superposition.hpp
@@ -31,8 +31,6 @@ class Superposition
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(Superposition);
-
   void attach(SaturationAlgorithm* salg);
   void detach();
 

--- a/Inferences/TautologyDeletionISE.hpp
+++ b/Inferences/TautologyDeletionISE.hpp
@@ -25,8 +25,6 @@ class TautologyDeletionISE
 : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(TautologyDeletionISE);
-
   TautologyDeletionISE(bool deleteEqTautologies=true) : _deleteEqTautologies(deleteEqTautologies) {}
   Clause* simplify(Clause* cl);
 private:

--- a/Inferences/TermAlgebraReasoning.hpp
+++ b/Inferences/TermAlgebraReasoning.hpp
@@ -50,8 +50,6 @@ class DistinctnessISE
 {
 
 public:
-  USE_ALLOCATOR(DistinctnessISE);
-  
   Kernel::Clause* simplify(Kernel::Clause* c);
 };
 
@@ -69,8 +67,6 @@ public:
 class InjectivityGIE
   : public GeneratingInferenceEngine {
 public:
-  USE_ALLOCATOR(InjectivityGIE);
-  
   Kernel::ClauseIterator generateClauses(Kernel::Clause* c);
 
 private:
@@ -91,8 +87,6 @@ class InjectivityISE
   : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(InjectivityISE);
-  
   Kernel::Clause* simplify(Kernel::Clause* c);
 };
 
@@ -100,8 +94,6 @@ class NegativeInjectivityISE
   : public ImmediateSimplificationEngine
 {
 public:
-  USE_ALLOCATOR(NegativeInjectivityISE);
-
   Kernel::Clause* simplify(Kernel::Clause* c);
 
 private:
@@ -111,8 +103,6 @@ private:
 class AcyclicityGIE
   : public GeneratingInferenceEngine {
 public:
-  USE_ALLOCATOR(AcyclicityGIE);
-
   void attach(Saturation::SaturationAlgorithm* salg);
   void detach();
   Kernel::ClauseIterator generateClauses(Kernel::Clause *c);
@@ -126,8 +116,6 @@ private:
 class AcyclicityGIE1
   : public GeneratingInferenceEngine {
 public:
-  USE_ALLOCATOR(AcyclicityGIE1);
-  
   Kernel::ClauseIterator generateClauses(Kernel::Clause* c);
 
 private:

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -48,8 +48,6 @@ class TheoryInstAndSimp
 {
 public:
   using SortId = SAT::Z3Interfacing::SortId;
-  USE_ALLOCATOR(TheoryInstAndSimp);
-
   ~TheoryInstAndSimp();
   TheoryInstAndSimp() : TheoryInstAndSimp(*env.options) {}
 

--- a/Inferences/URResolution.hpp
+++ b/Inferences/URResolution.hpp
@@ -30,8 +30,6 @@ class URResolution
 : public GeneratingInferenceEngine
 {
 public:
-  USE_ALLOCATOR(URResolution);
-
   URResolution();
   URResolution(bool selectedOnly, UnitClauseLiteralIndex* unitIndex,
       NonUnitClauseLiteralIndex* nonUnitIndex);

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -54,8 +54,6 @@ class BestLiteralSelector
     : public LiteralSelector
       {
       public:
-  USE_ALLOCATOR(BestLiteralSelector);
-
   BestLiteralSelector(const Ordering& ordering, const Options& options) : LiteralSelector(ordering, options)
   {
     _comp.attachSelector(this);
@@ -115,8 +113,6 @@ class CompleteBestLiteralSelector
     : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(CompleteBestLiteralSelector);
-
   CompleteBestLiteralSelector(const Ordering& ordering, const Options& options) : LiteralSelector(ordering, options)
   {
     _comp.attachSelector(this);

--- a/Kernel/ELiteralSelector.hpp
+++ b/Kernel/ELiteralSelector.hpp
@@ -32,8 +32,6 @@ class ELiteralSelector
 : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(ELiteralSelector);
-
   enum Values {
     // NoSelection, -- not implemented, this would be the same as spass's OFF
     SelectNegativeLiterals = 0,

--- a/Kernel/Grounder.hpp
+++ b/Kernel/Grounder.hpp
@@ -30,8 +30,6 @@ using namespace SAT;
 
 class Grounder {
 public:
-  USE_ALLOCATOR(Grounder);
-  
   Grounder(SATSolver* satSolver) : _satSolver(satSolver) {}
   virtual ~Grounder() {}
 
@@ -69,8 +67,6 @@ class GlobalSubsumptionGrounder : public Grounder {
 
   bool _doNormalization;
 public:
-  USE_ALLOCATOR(GlobalSubsumptionGrounder);
-
   GlobalSubsumptionGrounder(SATSolver* satSolver, bool doNormalization=true) 
           : Grounder(satSolver), _doNormalization(doNormalization) {}
 protected:
@@ -79,8 +75,6 @@ protected:
 
 class IGGrounder : public Grounder {
 public:
-  USE_ALLOCATOR(IGGrounder);
-
   IGGrounder(SATSolver* satSolver);
 private:
   TermList _tgtTerm;

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -246,8 +246,6 @@ struct UnitNumberComparator
 
 struct InferenceStore::ProofPrinter
 {
-  USE_ALLOCATOR(InferenceStore::ProofPrinter);
-  
   ProofPrinter(ostream& out, InferenceStore* is)
   : _is(is), out(out)
   {
@@ -426,8 +424,6 @@ protected:
 struct InferenceStore::ProofPropertyPrinter
 : public InferenceStore::ProofPrinter
 {
-  USE_ALLOCATOR(InferenceStore::ProofPropertyPrinter);
-
   ProofPropertyPrinter(ostream& out, InferenceStore* is) : ProofPrinter(out,is)
   {
     max_theory_clause_depth = 0;
@@ -511,8 +507,6 @@ protected:
 struct InferenceStore::TPTPProofPrinter
 : public InferenceStore::ProofPrinter
 {
-  USE_ALLOCATOR(InferenceStore::TPTPProofPrinter);
-  
   TPTPProofPrinter(ostream& out, InferenceStore* is)
   : ProofPrinter(out, is) {
     splitPrefix = Saturation::Splitter::splPrefix; 
@@ -874,8 +868,6 @@ protected:
 struct InferenceStore::ProofCheckPrinter
 : public InferenceStore::ProofPrinter
 {
-  USE_ALLOCATOR(InferenceStore::ProofCheckPrinter);
-
   ProofCheckPrinter(ostream& out, InferenceStore* is)
   : ProofPrinter(out, is) {}
 

--- a/Kernel/InferenceStore.hpp
+++ b/Kernel/InferenceStore.hpp
@@ -38,8 +38,6 @@ using namespace Lib;
 class InferenceStore
 {
 public:
-  USE_ALLOCATOR(InferenceStore);
-  
   static InferenceStore* instance();
 
   typedef List<int> IntList;

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -67,8 +67,6 @@ private:
 class InterpretedLiteralEvaluator::Evaluator
 {
 public:
-  USE_ALLOCATOR(InterpretedLiteralEvaluator::Evaluator);
-  
   virtual ~Evaluator() {}
 
   virtual bool canEvaluateFunc(unsigned func) { return false; }
@@ -130,8 +128,6 @@ template<class AbelianGroup>
    : public Evaluator
 {
 public:
-  USE_ALLOCATOR(InterpretedLiteralEvaluator::ACFunEvaluator<AbelianGroup>);
-
   using ConstantType = typename AbelianGroup::ConstantType;
 
   ACFunEvaluator() : _fun(env.signature->getInterpretingSymbol(AbelianGroup::interpreation)) { }

--- a/Kernel/InterpretedLiteralEvaluator.hpp
+++ b/Kernel/InterpretedLiteralEvaluator.hpp
@@ -31,8 +31,6 @@ class InterpretedLiteralEvaluator
   :  private BottomUpTermTransformer 
 {
 public:
-  USE_ALLOCATOR(InterpretedLiteralEvaluator);
-  
   InterpretedLiteralEvaluator(bool doNormalize = true);
   ~InterpretedLiteralEvaluator();
 

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -57,8 +57,6 @@ public:
     _varDiffs.reset();
   }
 
-  USE_ALLOCATOR(State);
-
   void traverse(Term* t1, Term* t2);
   void traverse(TermList tl,int coefficient);
   Result result(Term* t1, Term* t2);

--- a/Kernel/KBO.hpp
+++ b/Kernel/KBO.hpp
@@ -127,8 +127,6 @@ class KBO
 : public PrecedenceOrdering
 {
 public:
-  USE_ALLOCATOR(KBO);
-
   KBO(Problem& prb, const Options& opt);
   KBO(
       // KBO params

--- a/Kernel/KBOForEPR.hpp
+++ b/Kernel/KBOForEPR.hpp
@@ -31,8 +31,6 @@ class KBOForEPR
 : public PrecedenceOrdering
 {
 public:
-  USE_ALLOCATOR(KBOForEPR);
-
   KBOForEPR(Problem& prb, const Options& opt);
 
   using PrecedenceOrdering::compare;

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -33,8 +33,6 @@ class LPO
 : public PrecedenceOrdering
 {
 public:
-  USE_ALLOCATOR(LPO);
-
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}

--- a/Kernel/LiteralSelector.hpp
+++ b/Kernel/LiteralSelector.hpp
@@ -36,8 +36,6 @@ using namespace Shell;
 class LiteralSelector
 {
 public:
-  USE_ALLOCATOR(LiteralSelector);
-
   LiteralSelector(const Ordering& ordering, const Options& options)
   : _ord(ordering), _opt(options), _reversePolarity(false)
   {
@@ -122,8 +120,6 @@ class TotalLiteralSelector
 : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(TotalLiteralSelector);
-
   TotalLiteralSelector(const Ordering& ordering, const Options& options)
   : LiteralSelector(ordering, options) {}
 

--- a/Kernel/LookaheadLiteralSelector.hpp
+++ b/Kernel/LookaheadLiteralSelector.hpp
@@ -25,8 +25,6 @@ class LookaheadLiteralSelector
 : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(LookaheadLiteralSelector);
-
   LookaheadLiteralSelector(bool completeSelection, const Ordering& ordering, const Options& options)
   : LiteralSelector(ordering, options), _completeSelection(completeSelection)
   {

--- a/Kernel/MainLoop.hpp
+++ b/Kernel/MainLoop.hpp
@@ -53,9 +53,7 @@ struct MainLoopResult
 
 
 class MainLoop {
-public:  
-  USE_ALLOCATOR(MainLoop);
-
+public:
   MainLoop(Problem& prb, const Options& opt) : _prb(prb), _opt(opt) {}
   virtual ~MainLoop() {}
 

--- a/Kernel/MaximalLiteralSelector.hpp
+++ b/Kernel/MaximalLiteralSelector.hpp
@@ -34,8 +34,6 @@ class MaximalLiteralSelector
 : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(MaximalLiteralSelector);
-
   MaximalLiteralSelector(const Ordering& ordering, const Options& options) : LiteralSelector(ordering, options) {}
 
   bool isBGComplete() const override { return true; }

--- a/Kernel/MismatchHandler.hpp
+++ b/Kernel/MismatchHandler.hpp
@@ -35,8 +35,6 @@ public:
   UWAMismatchHandler(Stack<UnificationConstraint>& c) : constraints(c) /*, specialVar(0)*/ {}
   virtual bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2);
 
-  USE_ALLOCATOR(UWAMismatchHandler);
-
 private:
   bool checkUWA(TermList t1, TermList t2); 
   virtual bool introduceConstraint(TermList t1,unsigned index1, TermList t2, unsigned index2);
@@ -51,8 +49,6 @@ public:
   HOMismatchHandler(UnificationConstraintStack& c) : constraints(c) {}
   
   virtual bool handle(RobSubstitution* sub, TermList t1, unsigned index1, TermList t2, unsigned index2);
-
-  USE_ALLOCATOR(HOMismatchHandler);
 
 private:
 

--- a/Kernel/OperatorType.hpp
+++ b/Kernel/OperatorType.hpp
@@ -55,8 +55,6 @@ namespace Kernel {
 class OperatorType
 {
 public:
-  USE_ALLOCATOR(OperatorType);
-
   class TypeHash {
   public:
     static bool equals(OperatorType* t1, OperatorType* t2)

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -39,8 +39,6 @@ using namespace Shell;
 class Ordering
 {
 public:
-  USE_ALLOCATOR(Ordering);
-
   /**
    * Represents the results of ordering comparisons
    *

--- a/Kernel/Ordering_Equality.cpp
+++ b/Kernel/Ordering_Equality.cpp
@@ -24,8 +24,6 @@ namespace Kernel
 class Ordering::EqCmp
 {
 public:
-  USE_ALLOCATOR(EqCmp);
-
   EqCmp(Ordering* ordering) : _ordering(ordering)
   {
 #if VDEBUG

--- a/Kernel/Problem.hpp
+++ b/Kernel/Problem.hpp
@@ -49,9 +49,6 @@ private:
   Problem(const Problem&); //private and undefined copy constructor
   Problem& operator=(const Problem&); //private and undefined assignment operator
 public:
-
-  USE_ALLOCATOR(Problem);
-
   explicit Problem(UnitList* units=0);
   explicit Problem(ClauseIterator clauses, bool copy);
   ~Problem();

--- a/Kernel/Renaming.hpp
+++ b/Kernel/Renaming.hpp
@@ -33,8 +33,6 @@ using namespace Lib;
 
 class Renaming {
 public:
-  USE_ALLOCATOR(Renaming);
-
   Renaming() :
     _nextVar(0), _identity(true) {
   }

--- a/Kernel/RndLiteralSelector.hpp
+++ b/Kernel/RndLiteralSelector.hpp
@@ -32,8 +32,6 @@ class RndLiteralSelector
 : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(RndLiteralSelector);
-
   RndLiteralSelector(const Ordering& ordering, const Options& options, bool complete) :
     LiteralSelector(ordering, options), _complete(complete) {}
 

--- a/Kernel/SKIKBO.cpp
+++ b/Kernel/SKIKBO.cpp
@@ -58,8 +58,6 @@ public:
     _varDiffs.reset();
   }
 
-  USE_ALLOCATOR(State);
-
   void traverse(ArgsIt_ptr aai1, ArgsIt_ptr aai2);
   void traverse(ArgsIt_ptr aai, int coefficient);
   Result result(ArgsIt_ptr aai1, ArgsIt_ptr aai2);

--- a/Kernel/SKIKBO.hpp
+++ b/Kernel/SKIKBO.hpp
@@ -40,8 +40,6 @@ class SKIKBO
 : public PrecedenceOrdering
 {
 public:
-  USE_ALLOCATOR(SKIKBO);
-
   SKIKBO(Problem& prb, const Options& opt, bool basic_hol = false);
   SKIKBO(
         // KBO params

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -315,8 +315,6 @@ class Signature
     OperatorType* fnType() const;
     OperatorType* predType() const;
     OperatorType* typeConType() const;
-
-    USE_ALLOCATOR(Symbol);
   }; // class Symbol
 
   class InterpretedSymbol
@@ -333,8 +331,6 @@ class Signature
     : Symbol(nm, Theory::getArity(interp), true), _interp(interp)
     {
     }
-
-    USE_ALLOCATOR(InterpretedSymbol);
 
     /** Return the interpreted function that corresponds to this symbol */
     inline Interpretation getInterpretation() const { ASS_REP(interpreted(), _name); return _interp; }
@@ -354,7 +350,6 @@ class Signature
     {
       setType(OperatorType::getConstantsType(AtomicSort::intSort()));
     }
-    USE_ALLOCATOR(IntegerSymbol);
   };
 
   class RationalSymbol
@@ -371,7 +366,6 @@ class Signature
     {
       setType(OperatorType::getConstantsType(AtomicSort::rationalSort()));
     }
-    USE_ALLOCATOR(RationalSymbol);
   };
 
   class RealSymbol
@@ -388,7 +382,6 @@ class Signature
     {
       setType(OperatorType::getConstantsType(AtomicSort::realSort()));
     }
-    USE_ALLOCATOR(RealSymbol);
   }; 
 
   //////////////////////////////////////
@@ -574,8 +567,6 @@ class Signature
 
   Signature();
   ~Signature();
-
-  USE_ALLOCATOR(Signature);
 
   bool functionExists(const vstring& name,unsigned arity) const;
   bool predicateExists(const vstring& name,unsigned arity) const;

--- a/Kernel/SpassLiteralSelector.hpp
+++ b/Kernel/SpassLiteralSelector.hpp
@@ -32,8 +32,6 @@ class SpassLiteralSelector
 : public LiteralSelector
 {
 public:
-  USE_ALLOCATOR(SpassLiteralSelector);
-
   enum Values {
     OFF = 0,
     IFSEVERALMAXIMAL = 1,

--- a/Lib/Coproduct.hpp
+++ b/Lib/Coproduct.hpp
@@ -75,7 +75,6 @@ namespace CoproductImpl {
    * data VariadicUnion (a::as) = union {a, Coproduct as}
    */
   template <class A, class... As> union VariadicUnion<A, As...> {
-    // USE_ALLOCATOR(VariadicUnion)
     using Ts = TL::List<A,As...>;
 
     A _head;

--- a/Lib/Event.hpp
+++ b/Lib/Event.hpp
@@ -67,8 +67,6 @@ public:
   ~SubscriptionObject();
   void unsubscribe();
   bool belongsTo(BaseEvent& evt);
-
-  USE_ALLOCATOR(SubscriptionObject);
 private:
   BaseEvent* event;
   BaseEvent::HandlerStruct* hs;
@@ -110,7 +108,6 @@ protected:
     {
       (pObj->*pMethod)();
     }
-    USE_ALLOCATOR(MethodSpecificHandlerStruct);
   };
 
   template<class Cls>
@@ -159,8 +156,6 @@ protected:
     {
       (pObj->*pMethod)(t);
     }
-
-    USE_ALLOCATOR(MethodSpecificHandlerStruct);
   };
 
   template<class Cls>
@@ -212,8 +207,6 @@ protected:
     {
       (pObj->*pMethod)(t1, t2);
     }
-
-    USE_ALLOCATOR(MethodSpecificHandlerStruct);
   };
 
   template<class Cls>

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -36,8 +36,6 @@ class Timer
   ~Timer() { deinitializeTimer(); }
  
 public:
-  USE_ALLOCATOR(Timer);
-
   static Timer* instance();
   
   /** stop the timer and reset the clock */

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -355,7 +355,6 @@ private:
    */
   class Type {
   public:
-    USE_ALLOCATOR(Type);
     explicit Type(TypeTag tag) : _tag(tag) {}
     /** return the kind of this sort */
     TypeTag tag() const {return _tag;}
@@ -369,7 +368,6 @@ private:
     : public Type
   {
   public:
-    USE_ALLOCATOR(AtomicType);
     explicit AtomicType(TermList sort)
       : Type(TT_ATOMIC), _sort(sort)
     {}
@@ -385,7 +383,6 @@ private:
     : public Type
   {
   public:
-    USE_ALLOCATOR(ArrowType);
     ArrowType(Type* lhs,Type* rhs)
       : Type(TT_ARROW), _lhs(lhs), _rhs(rhs)
     {}
@@ -408,7 +405,6 @@ private:
     : public Type
   {
   public:
-    USE_ALLOCATOR(ProductType);
     ProductType(Type* lhs,Type* rhs)
       : Type(TT_PRODUCT), _lhs(lhs), _rhs(rhs)
     {}
@@ -429,7 +425,6 @@ private:
     : public Type
   {
   public:
-    USE_ALLOCATOR(QuantifiedType);
     QuantifiedType(Type* t, VList* vars)
       : Type(TT_QUANTIFIED), _type(t), _vars(vars)
     {}

--- a/SAT/BufferedSolver.hpp
+++ b/SAT/BufferedSolver.hpp
@@ -35,8 +35,6 @@ using namespace Lib;
 
 class BufferedSolver : public SATSolver {
 public:
-  USE_ALLOCATOR(BufferedSolver);
-
   BufferedSolver(SATSolver* inner);
 
   virtual SATClause* getRefutation() override { return _inner->getRefutation(); }

--- a/SAT/FallbackSolverWrapper.hpp
+++ b/SAT/FallbackSolverWrapper.hpp
@@ -37,8 +37,6 @@ using namespace Lib;
 
 class FallbackSolverWrapper : public SATSolver {
 public:
-  USE_ALLOCATOR(FallbackSolverWrapper);
-
   FallbackSolverWrapper(SATSolver* inner,SATSolver* fallback);
 
   virtual SATClause* getRefutation() override { 

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -36,8 +36,6 @@ using namespace Lib;
 
 class MinimizingSolver : public SATSolver {
 public:
-  USE_ALLOCATOR(MinimizingSolver);
-
   MinimizingSolver(SATSolver* inner);
 
   virtual SATClause* getRefutation() override { return _inner->getRefutation(); }

--- a/SAT/MinisatInterfacing.hpp
+++ b/SAT/MinisatInterfacing.hpp
@@ -25,8 +25,6 @@ namespace SAT{
 class MinisatInterfacing : public PrimitiveProofRecordingSATSolver
 {
 public: 
-  USE_ALLOCATOR(MinisatInterfacing);
-  
 	MinisatInterfacing(const Shell::Options& opts, bool generateProofs=false);
 
   /**

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -30,8 +30,6 @@ namespace SAT{
 class MinisatInterfacingNewSimp : public SATSolverWithAssumptions
 {
 public:
-  USE_ALLOCATOR(MinisatInterfacingNewSimp);
-  
   static const unsigned VAR_MAX;
 
 	MinisatInterfacingNewSimp(const Shell::Options& opts, bool generateProofs=false);

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -56,8 +56,6 @@ namespace SAT{
 class Z3Interfacing : public PrimitiveProofRecordingSATSolver
 {
 public:
-  USE_ALLOCATOR(Z3Interfacing);
-
   Z3Interfacing(const Shell::Options& opts, SAT2FO& s2f, bool unsatCoresForAssumptions, vstring const& exportSmtlib);
   Z3Interfacing(SAT2FO& s2f, bool showZ3, bool unsatCoresForAssumptions, vstring const& exportSmtlib);
   ~Z3Interfacing();

--- a/SAT/Z3MainLoop.hpp
+++ b/SAT/Z3MainLoop.hpp
@@ -38,8 +38,6 @@ using namespace Lib;
 class Z3MainLoop : public MainLoop 
 {
 public:
-  USE_ALLOCATOR(Z3MainLoop);  
-  
   Z3MainLoop(Problem& prb, const Options& opt);
   ~Z3MainLoop(){};
 

--- a/Saturation/AWPassiveClauseContainer.hpp
+++ b/Saturation/AWPassiveClauseContainer.hpp
@@ -65,8 +65,6 @@ class AWPassiveClauseContainer
 : public PassiveClauseContainer
 {
 public:
-  USE_ALLOCATOR(AWPassiveClauseContainer);
-
   AWPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name);
   ~AWPassiveClauseContainer();
   void add(Clause* cl) override;

--- a/Saturation/ClauseContainer.hpp
+++ b/Saturation/ClauseContainer.hpp
@@ -38,8 +38,6 @@ using namespace Shell;
 class ClauseContainer
 {
 public:
-  USE_ALLOCATOR(ClauseContainer);
-
   virtual ~ClauseContainer() {}
   ClauseEvent addedEvent;
   /**
@@ -65,8 +63,6 @@ class RandomAccessClauseContainer
 : public ClauseContainer
 {
 public:
-  USE_ALLOCATOR(RandomAccessClauseContainer);
-
   virtual void attach(SaturationAlgorithm* salg);
   virtual void detach();
 
@@ -86,8 +82,6 @@ private:
 
 class PlainClauseContainer : public ClauseContainer {
 public:
-  USE_ALLOCATOR(PlainClauseContainer);
-
   void add(Clause* c) override
   {
     addedEvent.fire(c);
@@ -99,8 +93,6 @@ class UnprocessedClauseContainer
 : public ClauseContainer
 {
 public:
-  USE_ALLOCATOR(UnprocessedClauseContainer);
-
   virtual ~UnprocessedClauseContainer();
   UnprocessedClauseContainer() : _data(64) {}
   void add(Clause* c) override;
@@ -117,8 +109,6 @@ class PassiveClauseContainer
 : public RandomAccessClauseContainer
 {
 public:
-  USE_ALLOCATOR(PassiveClauseContainer);
-
   PassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name = "") : _isOutermost(isOutermost), _opt(opt), _name(name) {}
   virtual ~PassiveClauseContainer(){};
 
@@ -177,8 +167,6 @@ class ActiveClauseContainer
 : public RandomAccessClauseContainer
 {
 public:
-  USE_ALLOCATOR(ActiveClauseContainer);
-
   ActiveClauseContainer(const Shell::Options& opt) {}
 
   void add(Clause* c) override;

--- a/Saturation/ConsequenceFinder.hpp
+++ b/Saturation/ConsequenceFinder.hpp
@@ -39,8 +39,6 @@ using namespace Inferences;
  */
 class ConsequenceFinder {
 public:
-  USE_ALLOCATOR(ConsequenceFinder);
-  
   ~ConsequenceFinder();
 
   void init(SaturationAlgorithm* sa);

--- a/Saturation/Discount.hpp
+++ b/Saturation/Discount.hpp
@@ -28,8 +28,6 @@ class Discount
 : public SaturationAlgorithm
 {
 public:
-  USE_ALLOCATOR(Discount);
-
   Discount(Problem& prb, const Options& opt)
     : SaturationAlgorithm(prb, opt) {}
 

--- a/Saturation/ExtensionalityClauseContainer.hpp
+++ b/Saturation/ExtensionalityClauseContainer.hpp
@@ -49,8 +49,6 @@ typedef DHMap<TermList, ExtensionalityClauseList*> ClausesBySort;
 class ExtensionalityClauseContainer
 {
 public:
-  USE_ALLOCATOR(ExtensionalityClauseContainer);
-
   ExtensionalityClauseContainer(const Options& opt)
   : _size(0),
     _maxLen(opt.extensionalityMaxLength()),

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -30,8 +30,6 @@ class LRS
 : public Otter
 {
 public:
-  USE_ALLOCATOR(LRS);
-
   LRS(Problem& prb, const Options& opt)
   : Otter(prb, opt), _limitsEverActive(false) {}
 

--- a/Saturation/LabelFinder.hpp
+++ b/Saturation/LabelFinder.hpp
@@ -32,8 +32,6 @@ using namespace Inferences;
 
 class LabelFinder {
 public:
-  USE_ALLOCATOR(LabelFinder);
-  
   ~LabelFinder();
 
   void onNewPropositionalClause(Clause* cl);

--- a/Saturation/ManCSPassiveClauseContainer.cpp
+++ b/Saturation/ManCSPassiveClauseContainer.cpp
@@ -21,23 +21,6 @@ namespace Saturation
 using namespace Lib;
 using namespace Kernel;
 
-/*
- * this class wraps the iterator of std::vector into IteratorCore required by Vampire.
- */
-class VectorIteratorWrapper : public IteratorCore<Clause*>
-{
-public:
-  USE_ALLOCATOR(VectorIteratorWrapper);
-  
-  explicit VectorIteratorWrapper(const std::vector<Clause*>& v) : curr(v.begin()), end(v.end()) {}
-  bool hasNext() { return curr != end; };
-  Clause* next() { auto cl = *curr; curr = std::next(curr); return cl;};
-
-private:
-  std::vector<Clause*>::const_iterator curr;
-  const std::vector<Clause*>::const_iterator end;
-};
-
 void ManCSPassiveClauseContainer::add(Clause* cl)
 {
   clauses.push_back(cl);

--- a/Saturation/ManCSPassiveClauseContainer.hpp
+++ b/Saturation/ManCSPassiveClauseContainer.hpp
@@ -31,8 +31,6 @@ using namespace Kernel;
 class ManCSPassiveClauseContainer : public PassiveClauseContainer
 {
 public:
-  USE_ALLOCATOR(ManCSPassiveClauseContainer);
-
   ManCSPassiveClauseContainer(bool isOutermost, const Shell::Options& opt) : PassiveClauseContainer(isOutermost, opt) {}
   virtual ~ManCSPassiveClauseContainer(){}
   

--- a/Saturation/Otter.hpp
+++ b/Saturation/Otter.hpp
@@ -28,8 +28,6 @@ class Otter
 : public SaturationAlgorithm
 {
 public:
-  USE_ALLOCATOR(Otter);
-
   Otter(Problem& prb, const Options& opt);
 
   ClauseContainer* getSimplifyingClauseContainer() override;

--- a/Saturation/PredicateSplitPassiveClauseContainer.hpp
+++ b/Saturation/PredicateSplitPassiveClauseContainer.hpp
@@ -23,8 +23,6 @@ class PredicateSplitPassiveClauseContainer
 : public PassiveClauseContainer
 {
 public:
-  USE_ALLOCATOR(PredicateSplitPassiveClauseContainer);
-
   PredicateSplitPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, vstring name, Lib::vvector<std::unique_ptr<PassiveClauseContainer>> queues, Lib::vvector<float> cutoffs, Lib::vvector<int> ratios, bool layeredArrangement);
   virtual ~PredicateSplitPassiveClauseContainer();
 

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -57,8 +57,6 @@ class Splitter;
 class SaturationAlgorithm : public MainLoop
 {
 public:
-  USE_ALLOCATOR(SaturationAlgorithm);
-
   static SaturationAlgorithm* createFromOptions(Problem& prb, const Options& opt, IndexManager* indexMgr=0);
 
   SaturationAlgorithm(Problem& prb, const Options& opt);

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -172,8 +172,6 @@ private:
   };
   
 public:
-  USE_ALLOCATOR(Splitter);
-
   Splitter();
   ~Splitter();
 

--- a/Saturation/SymElOutput.hpp
+++ b/Saturation/SymElOutput.hpp
@@ -33,8 +33,6 @@ using namespace Shell;
  */
 class SymElOutput {
 public:
-  USE_ALLOCATOR(SymElOutput);
-  
   SymElOutput();
 
   void init(SaturationAlgorithm* sa);

--- a/Shell/EqualityProxy.hpp
+++ b/Shell/EqualityProxy.hpp
@@ -56,8 +56,6 @@ using namespace Kernel;
 class EqualityProxy
 {
 public:
-  USE_ALLOCATOR(EqualityProxy);
-
   EqualityProxy(Options::EqualityProxy opt);
 
   void apply(Problem& prb);

--- a/Shell/EqualityProxyMono.hpp
+++ b/Shell/EqualityProxyMono.hpp
@@ -55,8 +55,6 @@ using namespace Kernel;
 class EqualityProxyMono
 {
 public:
-  USE_ALLOCATOR(EqualityProxyMono);
-
   EqualityProxyMono(Options::EqualityProxy opt);
 
   void apply(Problem& prb);

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -117,8 +117,6 @@ struct FunctionDefinition::Def
       DEALLOC_KNOWN(argOccurs, lhs->arity()*sizeof(bool), "FunctionDefinition::Def::argOccurs");
     }
   }
-
-  USE_ALLOCATOR(Def);
 }; // class FunctionDefintion::Def
 
 

--- a/Shell/GoalGuessing.hpp
+++ b/Shell/GoalGuessing.hpp
@@ -25,8 +25,6 @@ using namespace Kernel;
 class GoalGuessing
 {
 public:
-  USE_ALLOCATOR(GoalGuessing);
-
   void apply(Problem& prb);
 private:
   bool apply(UnitList*& units);

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -50,8 +50,6 @@ public:
 class InterpretedNormalizer::RoundingFunctionTranslator : public FunctionTranslator
 {
 public:
-  USE_ALLOCATOR(InterpretedNormalizer::RoundingFunctionTranslator);
-  
   RoundingFunctionTranslator(Interpretation origf, Interpretation newf, Interpretation roundf)
   {
     _origFun = env.signature->getInterpretingSymbol(origf);
@@ -87,8 +85,6 @@ private:
 class InterpretedNormalizer::SuccessorTranslator : public FunctionTranslator
 {
 public:
-  USE_ALLOCATOR(InterpretedNormalizer::SuccessorTranslator);
-  
   SuccessorTranslator()
   {
     _succFun = env.signature->getInterpretingSymbol(Theory::INT_SUCCESSOR);
@@ -120,8 +116,6 @@ private:
 class InterpretedNormalizer::BinaryMinusTranslator : public FunctionTranslator
 {
 public:
-  USE_ALLOCATOR(InterpretedNormalizer::BinaryMinusTranslator);
-  
   BinaryMinusTranslator(Interpretation bMinus, Interpretation plus, Interpretation uMinus)
   {
     _bMinusFun = env.signature->getInterpretingSymbol(bMinus);
@@ -155,8 +149,6 @@ private:
 class InterpretedNormalizer::IneqTranslator
 {
 public:
-  USE_ALLOCATOR(InterpretedNormalizer::IneqTranslator);
-  
   IneqTranslator(Interpretation src, Interpretation tgt, bool swapArguments, bool reversePolarity)
    : _swapArguments(swapArguments), _reversePolarity(reversePolarity)
   {
@@ -194,8 +186,6 @@ private:
 class InterpretedNormalizer::NLiteralTransformer : public TermTransformer
 {
 public:
-  USE_ALLOCATOR(InterpretedNormalizer::NLiteralTransformer);
-  
   NLiteralTransformer()
   : _ineqTransls(env.signature->predicates()),
     _fnTransfs(env.signature->functions())

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -179,8 +179,6 @@ public:
     void setInputFile(const vstring& newVal){ _inputFile.set(newVal); }
     vstring includeFileName (const vstring& relativeName);
 
-    USE_ALLOCATOR(Options);
-    
     // standard ways of creating options
     void set(const vstring& name, const vstring& value); // implicitly the long version used here
     void set(const char* name, const char* value, bool longOpt);
@@ -842,9 +840,6 @@ private:
      * @author Giles
      */
     struct AbstractOptionValue {
-
-        USE_ALLOCATOR(AbstractOptionValue);
-
         AbstractOptionValue(){}
         AbstractOptionValue(vstring l,vstring s) :
         longName(l), shortName(s), experimental(false), is_set(false),_should_copy(true), _tag(OptionTag::LAST_TAG), supress_problemconstraints(false) {}
@@ -974,9 +969,6 @@ private:
      */
     template<typename T>
     struct OptionValue : public AbstractOptionValue {
-        
-        USE_ALLOCATOR(OptionValue);
-        
         // We need to include an empty constructor as all the OptionValue objects need to be initialized
         // with something when the Options object is created. They should then all be reconstructed
         // This is annoying but preferable to the alternative in my opinion
@@ -1074,9 +1066,6 @@ private:
      */
     template<typename T >
     struct ChoiceOptionValue : public OptionValue<T> {
-        
-        USE_ALLOCATOR(ChoiceOptionValue);
-        
         ChoiceOptionValue(){}
         ChoiceOptionValue(vstring l, vstring s,T def,OptionChoiceValues c) :
         OptionValue<T>(l,s,def), choices(c) {}
@@ -1206,9 +1195,6 @@ vstring getStringOfValue(float value) const{ return Lib::Int::toString(value); }
 * @author Giles
 */
 struct RatioOptionValue : public OptionValue<int> {
-
-USE_ALLOCATOR(RatioOptionValue);
-
 RatioOptionValue(){}
 RatioOptionValue(vstring l, vstring s, int def, int other, char sp=':') :
 OptionValue(l,s,def), sep(sp), defaultOtherValue(other), otherValue(other) {};
@@ -1251,9 +1237,6 @@ virtual vstring getStringOfActual() const override {
 * @author Giles
 */
 struct NonGoalWeightOptionValue : public OptionValue<float>{
-
-USE_ALLOCATOR(NonGoalWeightOptionValue);
-
 NonGoalWeightOptionValue(){}
 NonGoalWeightOptionValue(vstring l, vstring s, float def) :
 OptionValue(l,s,def), numerator(1), denominator(1) {};
@@ -1392,7 +1375,6 @@ virtual vstring getStringOfValue(int value) const{ return Lib::Int::toString(val
 
 template<typename T>
 struct OptionValueConstraint{
-USE_ALLOCATOR(OptionValueConstraint);
 OptionValueConstraint() : _hard(false) {}
 
 virtual ~OptionValueConstraint() {} // virtual methods present -> there should be virtual destructor
@@ -1418,8 +1400,6 @@ bool _hard;
 
     template<typename T>
     struct WrappedConstraint : AbstractWrappedConstraint {
-        USE_ALLOCATOR(WrappedConstraint);
-        
         WrappedConstraint(const OptionValue<T>& v, OptionValueConstraintUP<T> c) : value(v), con(std::move(c)) {}
         
         bool check() override {
@@ -1434,7 +1414,6 @@ bool _hard;
     };
     
     struct WrappedConstraintOrWrapper : public AbstractWrappedConstraint {
-        USE_ALLOCATOR(WrappedConstraintOrWrapper);
         WrappedConstraintOrWrapper(AbstractWrappedConstraintUP l, AbstractWrappedConstraintUP r) : left(std::move(l)),right(std::move(r)) {}
         bool check() override {
             return left->check() || right->check();
@@ -1446,7 +1425,6 @@ bool _hard;
     };
 
     struct WrappedConstraintAndWrapper : public AbstractWrappedConstraint {
-        USE_ALLOCATOR(WrappedConstraintAndWrapper);
         WrappedConstraintAndWrapper(AbstractWrappedConstraintUP l, AbstractWrappedConstraintUP r) : left(std::move(l)),right(std::move(r)) {}
         bool check() override {
             return left->check() && right->check();
@@ -1459,7 +1437,6 @@ bool _hard;
 
     template<typename T>
     struct OptionValueConstraintOrWrapper : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(OptionValueConstraintOrWrapper);
         OptionValueConstraintOrWrapper(OptionValueConstraintUP<T> l, OptionValueConstraintUP<T> r) : left(std::move(l)),right(std::move(r)) {}
         bool check(const OptionValue<T>& value){
             return left->check(value) || right->check(value);
@@ -1472,7 +1449,6 @@ bool _hard;
 
     template<typename T>
     struct OptionValueConstraintAndWrapper : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(OptionValueConstraintAndWrapper);
         OptionValueConstraintAndWrapper(OptionValueConstraintUP<T> l, OptionValueConstraintUP<T> r) : left(std::move(l)),right(std::move(r)) {}
         bool check(const OptionValue<T>& value){
             return left->check(value) && right->check(value);
@@ -1485,8 +1461,6 @@ bool _hard;
 
     template<typename T>
     struct UnWrappedConstraint : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(UnWrappedConstraint);
-        
         UnWrappedConstraint(AbstractWrappedConstraintUP c) : con(std::move(c)) {}
         
         bool check(const OptionValue<T>&){ return con->check(); }
@@ -1549,7 +1523,6 @@ bool _hard;
 
     template<typename T>
     struct Equal : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(Equal);
         Equal(T gv) : _goodvalue(gv) {}
         bool check(const OptionValue<T>& value){
             return value.actualValue == _goodvalue;
@@ -1566,7 +1539,6 @@ bool _hard;
     
     template<typename T>
     struct NotEqual : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(NotEqual);
         NotEqual(T bv) : _badvalue(bv) {}
         bool check(const OptionValue<T>& value){
             return value.actualValue != _badvalue;
@@ -1583,7 +1555,6 @@ bool _hard;
     // optionally we can allow it be equal to that value also
     template<typename T>
     struct LessThan : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(LessThan);
         LessThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
         bool check(const OptionValue<T>& value){
             return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
@@ -1609,7 +1580,6 @@ bool _hard;
     // optionally we can allow it be equal to that value also
     template<typename T>
     struct GreaterThan : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(GreaterThan);
         GreaterThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
         bool check(const OptionValue<T>& value){
             return (value.actualValue > _goodvalue || (_orequal && value.actualValue==_goodvalue));
@@ -1636,7 +1606,6 @@ bool _hard;
     // optionally we can allow it be equal to that value also
     template<typename T>
     struct SmallerThan : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(SmallerThan);
         SmallerThan(T gv,bool eq=false) : _goodvalue(gv), _orequal(eq) {}
         bool check(const OptionValue<T>& value){
             return (value.actualValue < _goodvalue || (_orequal && value.actualValue==_goodvalue));
@@ -1668,8 +1637,6 @@ bool _hard;
     
     template<typename T>
     struct IfThenConstraint : public OptionValueConstraint<T>{
-        USE_ALLOCATOR(IfThenConstraint);
-        
         IfThenConstraint(OptionValueConstraintUP<T> ic, OptionValueConstraintUP<T> c) :
         if_con(std::move(ic)), then_con(std::move(c)) {}
         
@@ -1688,7 +1655,6 @@ bool _hard;
     
     template<typename T>
     struct IfConstraint {
-        USE_ALLOCATOR(IfConstraint);
         IfConstraint(OptionValueConstraintUP<T> c) :if_con(std::move(c)) {}
 
         OptionValueConstraintUP<T> then(OptionValueConstraintUP<T> c){
@@ -1763,7 +1729,6 @@ bool _hard;
     }
 
     struct isLookAheadSelectionConstraint : public OptionValueConstraint<int>{
-        USE_ALLOCATOR(isLookAheadSelectionConstraint);
         isLookAheadSelectionConstraint() {}
         bool check(const OptionValue<int>& value){
             return value.actualValue == 11 || value.actualValue == 1011 || value.actualValue == -11 || value.actualValue == -1011;
@@ -1785,16 +1750,12 @@ bool _hard;
      */
     
     struct OptionProblemConstraint{
-      USE_ALLOCATOR(OptionProblemConstraint);
-
       virtual bool check(Property* p) = 0;
       virtual vstring msg() = 0;
       virtual ~OptionProblemConstraint() {};
     };
     
     struct CategoryCondition : OptionProblemConstraint{
-      USE_ALLOCATOR(CategoryCondition);
-
       CategoryCondition(Property::Category c,bool h) : cat(c), has(h) {}
       bool check(Property*p){
           ASS(p);
@@ -1810,8 +1771,6 @@ bool _hard;
     };
 
     struct UsesEquality : OptionProblemConstraint{
-      USE_ALLOCATOR(UsesEquality);
-
       bool check(Property*p){
         ASS(p)
         return (p->equalityAtoms() != 0) ||
@@ -1822,8 +1781,6 @@ bool _hard;
     };
 
     struct HasHigherOrder : OptionProblemConstraint{
-      USE_ALLOCATOR(HasHigherOrder);
-
       bool check(Property*p){
         ASS(p)
         return (p->higherOrder());
@@ -1832,8 +1789,6 @@ bool _hard;
     };
 
     struct OnlyFirstOrder : OptionProblemConstraint{
-      USE_ALLOCATOR(OnlyFirstOrder);
-
       bool check(Property*p){
         ASS(p)
         return (!p->higherOrder());
@@ -1842,8 +1797,6 @@ bool _hard;
     };
 
     struct MayHaveNonUnits : OptionProblemConstraint{
-      USE_ALLOCATOR(MayHaveNonUnits);
-
       bool check(Property*p){
         return (p->formulas() > 0) // let's not try to guess what kind of clauses these will give rise to
           || (p->clauses() > p->unitClauses());
@@ -1852,8 +1805,6 @@ bool _hard;
     };
 
     struct NotJustEquality : OptionProblemConstraint{
-      USE_ALLOCATOR(NotJustEquality);
-
       bool check(Property*p){
         return (p->category()!=Property::PEQ || p->category()!=Property::UEQ);
       }
@@ -1861,8 +1812,6 @@ bool _hard;
     };
 
     struct AtomConstraint : OptionProblemConstraint{
-      USE_ALLOCATOR(AtomConstraint);
-
       AtomConstraint(int a,bool g) : atoms(a),greater(g) {}
       int atoms;
       bool greater;
@@ -1878,8 +1827,6 @@ bool _hard;
     };
 
     struct HasTheories : OptionProblemConstraint {
-      USE_ALLOCATOR(HasTheories);
-
       static bool actualCheck(Property*p);
 
       bool check(Property*p);
@@ -1887,8 +1834,6 @@ bool _hard;
     };
 
     struct HasFormulas : OptionProblemConstraint {
-      USE_ALLOCATOR(HasFormulas);
-
       bool check(Property*p) {
         return p->hasFormulas();
       }
@@ -1896,8 +1841,6 @@ bool _hard;
     };
 
     struct HasGoal : OptionProblemConstraint {
-      USE_ALLOCATOR(HasGoal);
-
       bool check(Property*p){
         return p->hasGoal();
       }
@@ -1933,8 +1876,6 @@ bool _hard;
     // set of options will not be randomized and some will be randomized first
 
     struct OptionHasValue : OptionProblemConstraint{
-      USE_ALLOCATOR(OptionHasValue);
-
       OptionHasValue(vstring ov,vstring v) : option_value(ov),value(v) {}
       bool check(Property*p);
       vstring msg(){ return option_value+" has value "+value; } 
@@ -1943,8 +1884,6 @@ bool _hard;
     };
 
     struct ManyOptionProblemConstraints : OptionProblemConstraint {
-      USE_ALLOCATOR(ManyOptionProblemConstraints);
-
       ManyOptionProblemConstraints(bool a) : is_and(a) {}
 
       bool check(Property*p){

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -152,8 +152,6 @@ public:
   static const uint64_t PR_HAS_CDT_CONSTRUCTORS = 2199023255552ul; // 2^41
 
  public:
-  USE_ALLOCATOR(Property);
-
   // constructor, operators new and delete
   explicit Property();
   static Property* scan(UnitList*);

--- a/Shell/Statistics.hpp
+++ b/Shell/Statistics.hpp
@@ -43,8 +43,6 @@ using namespace Kernel;
 class Statistics
 {
 public:
-  USE_ALLOCATOR(Statistics);
-
   Statistics();
 
   void print(std::ostream& out);

--- a/Shell/SubexpressionIterator.hpp
+++ b/Shell/SubexpressionIterator.hpp
@@ -28,7 +28,6 @@ namespace Shell {
 
   class SubexpressionIterator {
     public:
-      USE_ALLOCATOR(SubexpressionIterator);
       /**
        * SubexpressionIterator::Expression represents an expression, which is
        * either a term or a formula. Terms are stored as objects of TermList,

--- a/Shell/TermAlgebra.hpp
+++ b/Shell/TermAlgebra.hpp
@@ -25,8 +25,6 @@ using Kernel::TermList;
 namespace Shell {
   class TermAlgebraConstructor {
   public:
-    USE_ALLOCATOR(TermAlgebraConstructor);
-
     /* A term algebra constructor, described by its name, range,
        arity, and for each argument: the name of its destructor and
        its sort*/
@@ -87,9 +85,6 @@ namespace Shell {
 
   class TermAlgebra {
   public:
-    USE_ALLOCATOR(TermAlgebra);
-
-
     /* An algebra described by its name, sort, number of constructors,
        the constructors themselves (whose range must be the algebra
        sort), and their cyclicity. If allowsCyclicTerms is false, and


### PR DESCRIPTION
In #499 we got rid of quite a few of the old allocator macros. However, it's not possible to remove any more without possibly affecting performance significantly.

This PR removes only those `USE_ALLOCATOR` instances where in my opinion it's unlikely to make a difference. This could be because:
1. The code is unused.
2. The object is only likely to be created a small number of times: inference engines, decision procedures, SAT solvers, main loops, indices, and the like.
3. The object is used a moderate number of times, but mostly during parsing: symbols, types.
4. The object is never heap-allocated.

This removes roughly two-thirds of the  `USE_ALLOCATOR` instances, which allows us to focus on the trickier ones. In my view this could go in without performance testing, but of course I don't object if you think it needs it.