### PR TITLE
do not consider {inequality,general} splitting as naming a formula

### DIFF
--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -429,7 +429,9 @@ class Signature
   unsigned addSkolemTypeCon(unsigned arity,const char* suffix = 0);
   unsigned addFreshPredicate(unsigned arity, const char* prefix, const char* suffix = 0);
   unsigned addSkolemPredicate(unsigned arity,const char* suffix = 0);
+  // add a predicate naming a sub-formula - if you are not sure, use `addFreshPredicate`
   unsigned addNamePredicate(unsigned arity);
+  // same as `addNamePredicate`, but produces a function of Boolean sort
   unsigned addNameFunction(unsigned arity);
   void addEquality();
   unsigned getApp();

--- a/Shell/GeneralSplitting.cpp
+++ b/Shell/GeneralSplitting.cpp
@@ -227,7 +227,7 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
   }
 
 
-  unsigned namingPred=env.signature->addNamePredicate(minDeg);
+  unsigned namingPred=env.signature->addFreshPredicate(minDeg, "sQ", "gsp");
   OperatorType* npredType = OperatorType::getPredicateType(minDeg, argSorts.begin());
   env.signature->getPredicate(namingPred)->setType(npredType);
 

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -157,11 +157,11 @@ Literal* InequalitySplitting::splitLiteral(Literal* lit, UnitInputType inpType, 
   unsigned fun;
   OperatorType* type;
   if(!_appify){
-    fun=env.signature->addNamePredicate(vars.size() + 1);
+    fun=env.signature->addFreshPredicate(vars.size() + 1, "sQ", "ins");
     type = OperatorType::getPredicateType({srt}, vars.size());
   } else {
     srt = AtomicSort::arrowSort(srt, AtomicSort::boolSort());
-    fun=env.signature->addNameFunction(vars.size());
+    fun=env.signature->addFreshFunction(vars.size(), "sQ", "ins");
     type = OperatorType::getConstantsType(srt, vars.size());
   }
 


### PR DESCRIPTION
Should fix #509 - the problem was that I over-eagerly removed stuff from congruence axioms with `ep=RSTC`. Mea culpa etc, I have eaten my humble pie twice now.

This one is quite subtle. The argument for skipping introduced symbols goes that you could do equality proxy completely before clausification, on the input problem - so you don't need to include introduced names because they aren't in the original problem. *However* we don't actually do equality proxy before clausification, and inequality splitting happens before equality proxy, changing the "input problem" in such a way that we need to include its definition predicates. I'm not sure about general splitting, but perhaps a similar problem exists so I've also included them just to be sure.

There are, I think, two solutions. This one - include congruence axioms for stuff we're not 100% sure about. Or, perhaps better - do the equality-proxy transform before clausification.