### PR TITLE
i386: fix the major problems at least

### DIFF
--- a/Indexing/LiteralSubstitutionTree.cpp
+++ b/Indexing/LiteralSubstitutionTree.cpp
@@ -55,7 +55,7 @@ SLQueryResultIterator LiteralSubstitutionTree::getVariants(Literal* query, bool 
 SLQueryResultIterator LiteralSubstitutionTree::getAll()
 {
   return pvi(
-        iterTraits(getRangeIterator((unsigned long)0, _trees.size()))
+        iterTraits(getRangeIterator((size_t)0, _trees.size()))
          .flatMap([this](auto i) { return LeafIterator(&_trees[i]); })
          .flatMap([](Leaf* l) { return l->allChildren(); })
          .map([](const LeafData& ld) { return SLQueryResult(ld.literal, ld.clause); })

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -108,10 +108,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 	altBindingPtrs++;
 	altBindingData+=numVars;
 	if(resolvedLit) {
-	  ::new (altBindingData++) TermList((uint64_t)0);
+	  (altBindingData++)->setContent(0);
 	} else {
           // add index of the literal in instance clause at the end of the binding sequence
-	  ::new (altBindingData++) TermList((uint64_t)instCl->getLiteralPosition(alit));
+	  (altBindingData++)->setContent(instCl->getLiteralPosition(alit));
 	}
       }
       if(MatchingUtils::matchReversedArgs(baseLit, alit)) {
@@ -121,10 +121,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 	altBindingPtrs++;
 	altBindingData+=numVars;
 	if(resolvedLit) {
-	  ::new (altBindingData++) TermList((uint64_t)0);
+	  (altBindingData++)->setContent(0);
 	} else {
           // add index of the literal in instance clause at the end of the binding sequence
-	  ::new (altBindingData++) TermList((uint64_t)instCl->getLiteralPosition(alit));
+	  (altBindingData++)->setContent(instCl->getLiteralPosition(alit));
 	}
       }
 
@@ -138,10 +138,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       altBindingPtrs++;
       altBindingData+=numVars;
       if(resolvedLit) {
-        ::new (altBindingData++) TermList((uint64_t)0);
+        (altBindingData++)->setContent(0);
       } else {
         // add index of the literal in instance clause at the end of the binding sequence
-        ::new (altBindingData++) TermList((uint64_t)instCl->getLiteralPosition(alit));
+        (altBindingData++)->setContent((uint64_t)instCl->getLiteralPosition(alit));
       }
     }
   }
@@ -154,7 +154,7 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       *altBindingPtrs=altBindingData;
       altBindingPtrs++;
       altBindingData+=numVars;
-      ::new (altBindingData++) TermList((uint64_t)1);
+      (altBindingData++)->setContent(1);
     }
     if(baseLit->isEquality() && MatchingUtils::matchReversedArgs(baseLit, resolvedLit)) {
       ArrayStoringBinder binder(altBindingData, variablePositions);
@@ -162,7 +162,7 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       *altBindingPtrs=altBindingData;
       altBindingPtrs++;
       altBindingData+=numVars;
-      ::new (altBindingData++) TermList((uint64_t)1);
+      (altBindingData++)->setContent(1);
     }
 
   }

--- a/Kernel/MLMatcher.cpp
+++ b/Kernel/MLMatcher.cpp
@@ -108,10 +108,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 	altBindingPtrs++;
 	altBindingData+=numVars;
 	if(resolvedLit) {
-	  ::new (altBindingData++) TermList((size_t)0);
+	  ::new (altBindingData++) TermList((uint64_t)0);
 	} else {
           // add index of the literal in instance clause at the end of the binding sequence
-	  ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+	  ::new (altBindingData++) TermList((uint64_t)instCl->getLiteralPosition(alit));
 	}
       }
       if(MatchingUtils::matchReversedArgs(baseLit, alit)) {
@@ -121,10 +121,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
 	altBindingPtrs++;
 	altBindingData+=numVars;
 	if(resolvedLit) {
-	  ::new (altBindingData++) TermList((size_t)0);
+	  ::new (altBindingData++) TermList((uint64_t)0);
 	} else {
           // add index of the literal in instance clause at the end of the binding sequence
-	  ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+	  ::new (altBindingData++) TermList((uint64_t)instCl->getLiteralPosition(alit));
 	}
       }
 
@@ -138,10 +138,10 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       altBindingPtrs++;
       altBindingData+=numVars;
       if(resolvedLit) {
-        ::new (altBindingData++) TermList((size_t)0);
+        ::new (altBindingData++) TermList((uint64_t)0);
       } else {
         // add index of the literal in instance clause at the end of the binding sequence
-        ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+        ::new (altBindingData++) TermList((uint64_t)instCl->getLiteralPosition(alit));
       }
     }
   }
@@ -154,7 +154,7 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       *altBindingPtrs=altBindingData;
       altBindingPtrs++;
       altBindingData+=numVars;
-      ::new (altBindingData++) TermList((size_t)1);
+      ::new (altBindingData++) TermList((uint64_t)1);
     }
     if(baseLit->isEquality() && MatchingUtils::matchReversedArgs(baseLit, resolvedLit)) {
       ArrayStoringBinder binder(altBindingData, variablePositions);
@@ -162,7 +162,7 @@ bool createLiteralBindings(Literal* baseLit, LiteralList const* alts, Clause* in
       *altBindingPtrs=altBindingData;
       altBindingPtrs++;
       altBindingData+=numVars;
-      ::new (altBindingData++) TermList((size_t)1);
+      ::new (altBindingData++) TermList((uint64_t)1);
     }
 
   }

--- a/Kernel/MLMatcherSD.cpp
+++ b/Kernel/MLMatcherSD.cpp
@@ -120,7 +120,7 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
         altBindingPtrs++;
         altBindingData+=numVars;
         // add index of the literal in instance clause at the end of the binding sequence
-        ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+        (altBindingData++)->setContent(instCl->getLiteralPosition(alit));
       }
       if(MatchingUtils::matchReversedArgs(baseLit, alit)) {
         ArrayStoringBinder binder(altBindingData, variablePositions);
@@ -129,7 +129,7 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
         altBindingPtrs++;
         altBindingData+=numVars;
         // add index of the literal in instance clause at the end of the binding sequence
-        ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+        (altBindingData++)->setContent(instCl->getLiteralPosition(alit));
       }
     } else {
       if(numVars) {
@@ -141,7 +141,7 @@ void createLiteralBindings(Literal* baseLit, LiteralList const* const alts, Clau
       altBindingPtrs++;
       altBindingData+=numVars;
       // add index of the literal in instance clause at the end of the binding sequence
-      ::new (altBindingData++) TermList((size_t)instCl->getLiteralPosition(alit));
+      (altBindingData++)->setContent(instCl->getLiteralPosition(alit));
     }
   }
 }

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -93,9 +93,7 @@ public:
   // divide by 4 because of the tag, by 2 to split the space evenly
   static const unsigned SPEC_UPPER_BOUND = (UINT_MAX / 4) / 2;
   /** dummy constructor, does nothing */
-  TermList() {}
-  /** creates a term list and initialises its content with data */
-  explicit TermList(uint64_t data) : _content(data) {}
+  TermList() = default;
   /** creates a term list containing a pointer to a term */
   explicit TermList(Term* t) : _content(0) {
     // NB we also zero-initialise _content so that the spare bits are zero on 32-bit platforms
@@ -156,6 +154,8 @@ public:
   { return sameContent(&t); }
   /** return the content, useful for e.g., term argument comparison */
   inline uint64_t content() const { return _content; }
+  /** set the content manually - hazardous, such terms should then only be used as integers */
+  void setContent(uint64_t content) { _content = content; }
   /** default hash is to hash the content */
   unsigned defaultHash() const { return DefaultHash::hash(content()); }
   unsigned defaultHash2() const { return content(); }

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -19,12 +19,6 @@ static_assert(
     "Vampire assumes that there are 8 bits in a `char`"
 );
 
-static_assert(
-    sizeof(void *) == 8,
-    "Vampire assumes that the size of a pointer is 8 bytes for efficiency reasons. "
-    "This may be fixed/relaxed in future, but for the moment expect problems if running on other architectures."
-);
-
 // enable warnings for unused results
 // C++17: replace this with [[nodiscard]]
 #ifdef __GNUC__

--- a/SAT/SATClause.hpp
+++ b/SAT/SATClause.hpp
@@ -51,6 +51,7 @@ public:
   void setInference(SATInference* val);
 
   void* operator new(size_t,unsigned length);
+  void operator delete(void *);
 
   /**
    * Return the (reference to) the nth literal


### PR DESCRIPTION
We are alerted in #512 that Vampire is broken on 32-bit platforms, which we knew, but weren't aware that anyone cared. We currently reject 32-bit systems at compile-time in `Lib/Portability.hpp`.

However, it doesn't actually seem that hard to get Vampire running on 32-bit systems. The biggest problem is that `sizeof(size_t)` is now 32, and we assume `sizeof(TermList) == sizeof(size_t)` to be at least 64 to get the bits we want into it - but this can be fixed by saying that `TermList` should be exactly 64 bits instead of `sizeof(size_t)`.

This patch produces a 32-bit Vampire that runs plausibly on my system. Since we have users who want 32-bit support, I propose that we relax our 64-bit-only policy until we end up in a situation where we really can't support 32-bit systems any more.

@barracuda156 - you might want to test on this branch. I don't guarantee this fixes PowerPC, or even that we don't have serious bugs even on i386, but it should be much less crashy.