### PR TITLE
actually remove `_id` from Term, fix goof with TERM_DIST_VAR_UNKNOWN

### DIFF
--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -40,8 +40,8 @@
 
 // the number of bits used for "TermList::_info::distinctVars"
 #define TERM_DIST_VAR_BITS 21
-// maximum number that fits in a 21-bit integer - update if TERM_DIST_VAR_BITS changes
-#define TERM_DIST_VAR_UNKNOWN 0x1FFFFF
+// maximum number that fits in a TERM_DIST_VAR_BITS-bit unsigned integer
+#define TERM_DIST_VAR_UNKNOWN ((1 << TERM_DIST_VAR_BITS)-1)
 
 namespace Kernel {
 

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -40,7 +40,8 @@
 
 // the number of bits used for "TermList::_info::distinctVars"
 #define TERM_DIST_VAR_BITS 21
-#define TERM_DIST_VAR_UNKNOWN ((2 ^ TERM_DIST_VAR_BITS) - 1)
+// maximum number that fits in a 21-bit integer - update if TERM_DIST_VAR_BITS changes
+#define TERM_DIST_VAR_UNKNOWN 0x1FFFFF
 
 namespace Kernel {
 
@@ -789,8 +790,6 @@ protected:
     _args[0]._info.order = val;
   }
 
-  /** For shared terms, this is a unique id used for deterministic comparison */
-  unsigned _id;
   /** The number of this symbol in a signature */
   unsigned _functor;
   /** Arity of the symbol */


### PR DESCRIPTION
In #337 there was two separate mishaps.
1. @quickbeam123 realised that `_id` could be moved from `Term` itself to its "info" `TermList`, but I failed to actually remove it from `Term` so there's been some waste bytes knocking around in `Term`. Aside: we might actually want to move it back if we can fit more useful stuff into the 32 bits in `TermList`.
2. I meant to actually compute `(2^21) - 1` to work out the maximum value of `TERM_DIST_VAR_UNKNOWN`, but instead wrote it down literally - where the `^` is interpreted as XOR. This means that since then `TERM_DIST_VAR_UNKNOWN` has been ...22. :facepalm: