### PR TITLE
fix a bug in DefinitionIntroduction

### DIFF
--- a/Inferences/DefinitionIntroduction.hpp
+++ b/Inferences/DefinitionIntroduction.hpp
@@ -26,21 +26,16 @@ public:
   void attach(SaturationAlgorithm *salg) override {
     GeneratingInferenceEngine::attach(salg);
     attachContainer(salg->getPassiveClauseContainer());
-    reset = false;
   }
 
   void handleClause(Clause *cl, bool adding) override {
-    if(reset)
-      _definitions.reset();
-
-    reset = false;
-    if(adding)
+    if(adding) {
       process(cl);
+    }
   }
 
   ClauseIterator generateClauses(Clause *cl) override {
-    reset = true;
-    return pvi(decltype(_definitions)::Iterator(_definitions));
+    return pvi(ownedArrayishIterator(std::move(_definitions)));
   }
 
 private:
@@ -56,7 +51,6 @@ private:
   DHSet<Term *> _defined;
   Stack<Stack<Entry>> _entries;
   Stack<Clause *> _definitions;
-  bool reset;
 };
 
 }

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1503,8 +1503,9 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   // create generating inference engine
   CompositeGIE* gie=new CompositeGIE();
 
-  if(opt.functionDefinitionIntroduction())
+  if(opt.functionDefinitionIntroduction()) {
     gie->addFront(new DefinitionIntroduction);
+  }
 
   //TODO here induction is last, is that right?
   if(opt.induction()!=Options::Induction::NONE){


### PR DESCRIPTION
- since handleClause is not guaranteed to be always called after generateClauses (it's listening on Passive!), the same definitions could be returned more than once
- in the worst case, a definition would have been deleted already (redundant), which could then lead to a segfault