### PR TITLE
Add Set unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -742,6 +742,7 @@ set(UNIT_TESTS
     UnitTests/tIterator.cpp
     UnitTests/tOption.cpp
     UnitTests/tStack.cpp
+    UnitTests/tSet.cpp
     )
 source_group(unit_tests FILES ${UNIT_TESTS})
 

--- a/UnitTests/dummyHash.hpp
+++ b/UnitTests/dummyHash.hpp
@@ -1,0 +1,15 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+class DummyHash {
+public:
+  template<typename T> static bool equals(T o1, T o2) { return o1 == o2; }
+  template<typename T> static unsigned hash(T val) { return 0; }
+};

--- a/UnitTests/tSet.cpp
+++ b/UnitTests/tSet.cpp
@@ -1,0 +1,44 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#include "Debug/Assertion.hpp"
+#include "Lib/Set.hpp"
+#include "Test/UnitTesting.hpp"
+
+TEST_FUN(find_remove_contains)
+{
+  Set<int> *test_set = new Set<int>();
+  int test_num = 42;
+  int found_num = 0;
+  test_set->insert(test_num);
+  // basic `find` test
+  ALWAYS(test_set->find(test_num, found_num));
+  ASS_EQ(test_num, found_num);
+  // basic `remove` test
+  ALWAYS(test_set->remove(test_num));
+  // `find` a deleted cell
+  found_num = 0;
+  NEVER(test_set->find(test_num, found_num));
+  ASS_EQ(found_num, 0);
+  // `contains` for a deleted cell
+  NEVER(test_set->contains(test_num));
+  // `remove` deleted
+  NEVER(test_set->remove(test_num));
+  // `insert` deleted
+  test_set->insert(test_num);
+}
+
+TEST_FUN(reset)
+{
+  Set<int> *test_set = new Set<int>();
+  test_set->insert(42);
+  ASS_EQ(test_set->size(), 1);
+  test_set->reset();
+  ASS_EQ(test_set->size(), 0);
+}

--- a/UnitTests/tSet.cpp
+++ b/UnitTests/tSet.cpp
@@ -10,6 +10,7 @@
 #include "Debug/Assertion.hpp"
 #include "Lib/Set.hpp"
 #include "Test/UnitTesting.hpp"
+#include "UnitTests/dummyHash.hpp"
 
 TEST_FUN(find_remove_contains)
 {
@@ -41,4 +42,19 @@ TEST_FUN(reset)
   ASS_EQ(test_set->size(), 1);
   test_set->reset();
   ASS_EQ(test_set->size(), 0);
+}
+
+TEST_FUN(dummy_hash)
+{
+  Set<int, DummyHash> *test_set = new Set<int, DummyHash>();
+  int test_num = 42;
+  // two different cells fall in the same hash bucket
+  test_set->insert(test_num + 1);
+  test_set->insert(test_num);
+  ASS_EQ(test_set->size(), 2);
+  int found_num = 0;
+  ALWAYS(test_set->find(test_num, found_num));
+  ASS_EQ(found_num, test_num);
+  ALWAYS(test_set->remove(test_num));
+  ASS_EQ(test_set->size(), 1);
 }


### PR DESCRIPTION
`Set.hpp` has relatively high coverage, but not 100%. I also added `DummyHash` to cover cases when calls to `hash` return the same value (or value with a reserved meaning in current implementation). One shouldn't use `DummyHash` anywhere but for unit-tests.