### PR TITLE
prevent loops with anc caused by AVATAR models flip-flopping

### DIFF
--- a/SAT/SATClause.cpp
+++ b/SAT/SATClause.cpp
@@ -59,6 +59,15 @@ void* SATClause::operator new(size_t sz,unsigned lits)
   return ALLOC_KNOWN(size,"SATClause");
 }
 
+void SATClause::operator delete(void *ptr, size_t sz) {
+  SATClause *self = static_cast<SATClause *>(ptr);
+  size_t size = sz + self->_length * sizeof(SATLiteral);
+  if(self->_length > 0)
+    size -= sizeof(SATLiteral);
+
+  DEALLOC_KNOWN(ptr, size, "SATClause");
+}
+
 SATClause::SATClause(unsigned length)
   : _length(length), _nonDestroyable(0), _inference(0)
 {

--- a/SAT/SATClause.hpp
+++ b/SAT/SATClause.hpp
@@ -51,7 +51,24 @@ public:
   void setInference(SATInference* val);
 
   void* operator new(size_t,unsigned length);
-  void operator delete(void *);
+  void operator delete(void *, size_t);
+
+  unsigned defaultHash() const {
+    unsigned hash = 0;
+    for(unsigned i = 0; i < length(); i++)
+      hash ^= DefaultHash::hash(_literals[i]);
+    return hash;
+  }
+
+  bool operator==(const SATClause &other) const {
+    if(length() != other.length())
+      return false;
+    for(unsigned i = 0; i < length(); i++)
+      if(_literals[i] != other[i])
+        return false;
+    return true;
+  }
+  bool operator!=(const SATClause &other) const { return !operator==(other); }
 
   /**
    * Return the (reference to) the nth literal

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -938,6 +938,12 @@ bool Splitter::handleNonSplittable(Clause* cl)
     satLits.push(getLiteralFromName(compName));
 
     SATClause* nsClause = SATClause::fromStack(satLits);
+    nsClause->sort();
+    if(_already_added.contains(nsClause)) {
+      delete nsClause;
+      return true;
+    }
+    _already_added.insert(nsClause);
 
     UnitList* ps = 0;
 
@@ -945,7 +951,7 @@ bool Splitter::handleNonSplittable(Clause* cl)
     // do compName first
     UnitList::push(getDefinitionFromName(compName),ps);
     FormulaList::push(new NamedFormula(getFormulaStringFromName(compName)),resLst);
- 
+
     // now do splits
     SplitSet::Iterator sit(*cl->splits());
     while(sit.hasNext()) {

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -20,6 +20,7 @@
 #include "Lib/Allocator.hpp"
 #include "Lib/ArrayMap.hpp"
 #include "Lib/DHMap.hpp"
+#include "Lib/Hash.hpp"
 #include "Lib/Stack.hpp"
 #include "Lib/ScopedPtr.hpp"
 
@@ -307,6 +308,10 @@ private:
   RCClauseStack _fastClauses;
   
   SaturationAlgorithm* _sa;
+
+  // clauses we already added to the SAT solver
+  // not just optimisation: also prevents the SAT solver oscillating between two models in some cases
+  Set<SATClause *, DerefPtrHash<DefaultHash>> _already_added;
 
 public:
   static vstring splPrefix;


### PR DESCRIPTION
As discussed with @quickbeam123, we can get into a situation with Minisat (Z3 may have the same problem, I'm not sure) where the solver flip-flops between one of two feasible models. This is not a problem per se - although annoying from a performance point of view - but it does lead to a looping scenario where we:
1. Be in model M1
2. Derive a SAT clause via "AVATAR known components" (`-anc`, partially-on by default)
3. Recompute model, get model M2
4. Derive another SAT clause
5. Recompute model, get model M1
6. Go to 1, loop indefinitely.

This quick fix prevents exactly this scenario by not adding duplicate clauses to the SAT solver. A longer-term solution would  try to fix the underlying flip-flopping.