### PR TITLE
Small demodulation improvement

### DIFF
--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -21,6 +21,7 @@
 #include "TermIterators.hpp"
 #include "ApplicativeHelper.hpp"
 #include "Lib/Metaiterators.hpp"
+#include "Matcher.hpp"
 
 #include "EqHelper.hpp"
 
@@ -406,6 +407,11 @@ VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit
       }
       if (t0.containsAllVariablesOf(t1)) {
         if (t1.containsAllVariablesOf(t0)) {
+          // If the equation is its own variant when oriented
+          // reversed, there's no need to index both sides
+          if (MatchingUtils::matchReversedArgs(lit, lit)) {
+            return withEqualitySort(lit, getSingletonIterator(t0) );
+          }
           return withEqualitySort(lit, getConcatenatedIterator(getSingletonIterator(t0),
               getSingletonIterator(t1)) );
         }


### PR DESCRIPTION
Equations such as the following
f(x,f(y,z)) = f(z,f(y,x))
give two identical ways to demodulate, but we index both variants.

Since these equations are by definition incomparable as well, it can hurt
the performance of demodulation a bit as such demodulators are tried twice
in the unsuccessful case.

Experiments show a slight improvement over TPTP-v8.1.2 with `-sa discount -t 10`:
avg time: 5.13053s (old), 5.11622s (new)
solved: 10852 (old), 10865 (new)
