### PR TITLE
check for perf headers so that we support old or otherwise perfless Linux

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -637,7 +637,7 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     env.beginOutput();
     addCommentSignForSZS(env.out()) << opt.testId() << " on " << opt.problemName() << 
       " for (" << opt.timeLimitInDeciseconds() << "ds"<<
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
       "/" << opt.instructionLimit() << "Mi" <<
 #endif
       ")" << endl;

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -23,6 +23,14 @@
 #include "Allocator.hpp"
 #include "VString.hpp"
 
+#define VAMPIRE_PERF_EXISTS 0
+#if defined __linux__  && defined __has_include
+#if __has_include(<linux/perf_event.h>)
+#undef VAMPIRE_PERF_EXISTS
+#define VAMPIRE_PERF_EXISTS 1
+#endif
+#endif
+
 namespace Lib
 {
 

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -104,7 +104,7 @@ long long LRS::estimatedReachableCount()
   int firstCheck=_opt.lrsFirstTimeCheck(); // (in percent)!
 
   long int opt_instruction_limit = 0; // (in mega-instructions)
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   opt_instruction_limit = _opt.simulatedInstructionLimit()
     ? _opt.simulatedInstructionLimit()
     : _opt.instructionLimit();

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -676,12 +676,12 @@ void Splitter::init(SaturationAlgorithm* sa)
 
   if (opts.splittingAvatimer() < 1.0) {
     _stopSplittingAtTime = opts.splittingAvatimer() * opts.timeLimitInDeciseconds() * 100;
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
     _stopSplittingAtInst = opts.splittingAvatimer() * opts.instructionLimit();
 #endif
   } else {
     _stopSplittingAtTime = 0;
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
     _stopSplittingAtInst = 0;
 #endif
   }
@@ -1080,7 +1080,7 @@ bool Splitter::doSplitting(Clause* cl)
     return false;
   }
   if ((_stopSplittingAtTime && (unsigned)env.timer->elapsedMilliseconds() >= _stopSplittingAtTime)
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
     || (_stopSplittingAtInst && env.timer->elapsedMegaInstructions() >= _stopSplittingAtInst)
 #endif
     ) {

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -294,7 +294,7 @@ private:
   /* as there can be both limits, it's hard to covert between them,
    * and we terminate at the earlier one, let's just keep checking both. */
   unsigned _stopSplittingAtTime; // time elapsed in milliseconds
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   unsigned _stopSplittingAtInst; // mega-instructions elapsed
 #endif
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -87,7 +87,7 @@ void Options::init()
     _memoryLimit.description="Memory limit in MB";
     _lookup.insert(&_memoryLimit);
 
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   _instructionLimit = UnsignedOptionValue("instruction_limit","i",0);
   _instructionLimit.description="Limit the number (in millions) of executed instructions (excluding the kernel ones).";
   _lookup.insert(&_instructionLimit);
@@ -3327,7 +3327,7 @@ vstring Options::generateEncodedOptions() const
     forbidden.insert(&_memoryLimit);
     forbidden.insert(&_proof);
     forbidden.insert(&_inputSyntax);
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
     forbidden.insert(&_parsingDoesNotCount);
 #endif
     forbidden.insert(&_ignoreMissing); // or maybe we do!

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -53,6 +53,7 @@
 #include "Lib/Allocator.hpp"
 #include "Lib/Comparison.hpp"
 #include "Lib/STL.hpp"
+#include "Lib/Timer.hpp"
 
 #include "Property.hpp"
 
@@ -2112,7 +2113,7 @@ public:
   int timeLimitInDeciseconds() const { return _timeLimitInDeciseconds.actualValue; }
   size_t memoryLimit() const { return _memoryLimit.actualValue; }
   void setMemoryLimitOptionValue(size_t newVal) { _memoryLimit.actualValue = newVal; }
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   unsigned instructionLimit() const { return _instructionLimit.actualValue; }
   void setInstructionLimit(unsigned newVal) { _instructionLimit.actualValue = newVal; }
   unsigned simulatedInstructionLimit() const { return _simulatedInstructionLimit.actualValue; }
@@ -2533,7 +2534,7 @@ private:
   ChoiceOptionValue<LTBLearning> _ltbLearning;
   StringOptionValue _ltbDirectory;
 
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   UnsignedOptionValue _instructionLimit;
   UnsignedOptionValue _simulatedInstructionLimit;
   BoolOptionValue _parsingDoesNotCount;

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -94,7 +94,7 @@ int vampireReturnValue = VAMP_RESULT_STATUS_UNKNOWN;
 VWARN_UNUSED
 Problem* getPreprocessedProblem()
 {
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   unsigned saveInstrLimit = env.options->instructionLimit();
   if (env.options->parsingDoesNotCount()) {
     env.options->setInstructionLimit(0);
@@ -103,7 +103,7 @@ Problem* getPreprocessedProblem()
 
   Problem* prb = UIHelper::getInputProblem(*env.options);
 
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   if (env.options->parsingDoesNotCount()) {
     Timer::updateInstructionCount();
     unsigned burnedParsing = Timer::elapsedMegaInstructions();
@@ -388,7 +388,7 @@ void spiderMode()
   env.options->setOutputMode(Options::Output::SPIDER);
   env.options->setNormalize(true);
   // to start counting instructions
-#ifdef __linux__
+#if VAMPIRE_PERF_EXISTS
   Timer::ensureTimerInitialized();
 #endif
 


### PR DESCRIPTION
Introduce a new preprocessor define `VAMPIRE_PERF_EXISTS` to be 1if there is a suitable header and 0 otherwise. This replaces the existing is-it-Linux check which turned out to be insufficient.