### PR TITLE
manual bitfield in `TermList` to improve portability

### DIFF
--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -41,7 +41,7 @@ void Term::setId(unsigned id)
       // (cf ProvingHelper::runVampire and getPreprocessedProblem in vampire.cpp)
     id += Random::getInteger(1 << 12) << 20; // the twelve most significant bits are randomized
   }
-   _args[0]._info.id = id;
+   _args[0]._setId(id);
 }
 
 /**
@@ -1500,9 +1500,9 @@ Term::Term(const Term& t) throw()
   ASS(!isSpecial()); //we do not copy special terms
 
   _args[0] = t._args[0];
-  _args[0]._info.shared = 0u;
-  _args[0]._info.order = 0u;
-  _args[0]._info.distinctVars = TERM_DIST_VAR_UNKNOWN;
+  _args[0]._setShared(false);
+  _args[0]._setOrder(AO_UNKNOWN);
+  _args[0]._setDistinctVars(TERM_DIST_VAR_UNKNOWN);
 } // Term::Term
 
 /** create a new literal and copy from l its content */
@@ -1528,15 +1528,9 @@ Term::Term() throw()
    _maxRedLen(0),
    _vars(0)
 {
-  _args[0]._info.polarity = 0;
-  _args[0]._info.commutative = 0;
-  _args[0]._info.shared = 0;
-  _args[0]._info.literal = 0;
-  _args[0]._info.sort = 0;
-  _args[0]._info.hasTermVar = 0;
-  _args[0]._info.order = 0;
-  _args[0]._info.tag = FUN;
-  _args[0]._info.distinctVars = TERM_DIST_VAR_UNKNOWN;
+  _args[0].setContent(0);
+  _args[0]._setTag(FUN);
+  _args[0]._setDistinctVars(TERM_DIST_VAR_UNKNOWN);
 } // Term::Term
 
 Literal::Literal()
@@ -1580,26 +1574,26 @@ vstring Term::headerToString() const
   s += Int::toString(_functor) + ", arity: " + Int::toString(_arity)
     + ", weight: " + Int::toString(_weight)
     + ", vars: " + Int::toString(_vars)
-    + ", polarity: " + Int::toString(_args[0]._info.polarity)
-    + ", commutative: " + Int::toString(_args[0]._info.commutative)
-    + ", shared: " + Int::toString(_args[0]._info.shared)
-    + ", literal: " + Int::toString(_args[0]._info.literal)
-    + ", order: " + Int::toString(_args[0]._info.order)
-    + ", tag: " + Int::toString(_args[0]._info.tag);
+    + ", polarity: " + Int::toString(_args[0]._polarity())
+    + ", commutative: " + Int::toString(_args[0]._commutative())
+    + ", shared: " + Int::toString(_args[0]._shared())
+    + ", literal: " + Int::toString(_args[0]._literal())
+    + ", order: " + Int::toString(_args[0]._order())
+    + ", tag: " + Int::toString(_args[0]._tag());
   return s;
 }
 
 void Term::assertValid() const
 {
   ASS_ALLOC_TYPE(this, "Term");
-  ASS_EQ(_args[0]._info.tag, FUN);
+  ASS_EQ(_args[0]._tag(), FUN);
 }
 
 void TermList::assertValid() const
 {
   if (this->isTerm()) {
     ASS_ALLOC_TYPE(_term, "Term");
-    ASS_EQ(_term->_args[0]._info.tag, FUN);
+    ASS_EQ(_term()->_args[0]._tag(), FUN);
   }
 }
 

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -338,23 +338,6 @@ private:
       return (_content & mask) >> lower;
   }
 
-  // getters
-#define GET(type, name, NAME) type _##name() const\
-  { return getBits<NAME##_BITS_START, NAME##_BITS_END>(); }
-  GET(unsigned, tag, TAG)
-  GET(bool, polarity, POLARITY)
-  GET(bool, commutative, COMMUTATIVE)
-  GET(bool, shared, SHARED)
-  GET(bool, literal, LITERAL)
-  GET(bool, sort, SORT)
-  GET(bool, hasTermVar, HAS_TERM_VAR)
-  GET(unsigned, order, ORDER)
-  GET(uint32_t, distinctVars, DISTINCT_VAR)
-  GET(uint32_t, id, ID)
-#undef GET
-  Term *_term() const
-  { return reinterpret_cast<Term *>(getBits<TERM_BITS_START, TERM_BITS_END>()); }
-
   // set the bits of `_content` between `lower` and `upper` to corresponding bits of `data`
   template<unsigned lower, unsigned upper>
   void setBits(uint64_t data) {
@@ -373,23 +356,25 @@ private:
       _content |= data;
   }
 
-  // setters
-#define SET(type, name, NAME) void _set##name(type val)\
-  { setBits<NAME##_BITS_START, NAME##_BITS_END>(val); }
-  SET(unsigned, Tag, TAG)
-  SET(bool, Polarity, POLARITY)
-  SET(bool, Commutative, COMMUTATIVE)
-  SET(bool, Shared, SHARED)
-  SET(bool, Literal, LITERAL)
-  SET(bool, Sort, SORT)
-  SET(bool, HasTermVar, HAS_TERM_VAR)
-  SET(unsigned, Order, ORDER)
-  SET(uint32_t, DistinctVars, DISTINCT_VAR)
-  SET(uint32_t, Id, ID)
-#undef SET
+  // getters and setters
+#define GET_AND_SET(type, name, Name, NAME) \
+  type _##name() const { return getBits<NAME##_BITS_START, NAME##_BITS_END>(); }\
+  void _set##Name(type val) { setBits<NAME##_BITS_START, NAME##_BITS_END>(val); }
+  GET_AND_SET(unsigned, tag, Tag, TAG)
+  GET_AND_SET(bool, polarity, Polarity, POLARITY)
+  GET_AND_SET(bool, commutative, Commutative, COMMUTATIVE)
+  GET_AND_SET(bool, shared, Shared, SHARED)
+  GET_AND_SET(bool, literal, Literal, LITERAL)
+  GET_AND_SET(bool, sort, Sort, SORT)
+  GET_AND_SET(bool, hasTermVar, HasTermVar, HAS_TERM_VAR)
+  GET_AND_SET(unsigned, order, Order, ORDER)
+  GET_AND_SET(uint32_t, distinctVars, DistinctVars, DISTINCT_VAR)
+  GET_AND_SET(uint32_t, id, Id, ID)
+#undef GET_AND_SET
+  Term *_term() const
+  { return reinterpret_cast<Term *>(getBits<TERM_BITS_START, TERM_BITS_END>()); }
   void _setTerm(Term *term)
   { setBits<TERM_BITS_START, TERM_BITS_END>(reinterpret_cast<uint64_t>(term)); }
-
   // end bitfield
 
   friend class Indexing::TermSharing;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -105,7 +105,7 @@ public:
   explicit TermList(Term* t) : _content(0) {
     // NB we also zero-initialise _content so that the spare bits are zero on 32-bit platforms
     // dead-store eliminated on 64-bit
-    _term = t;
+    _setTerm(t);
     ASS_EQ(tag(), REF);
   }
   /** creates a term list containing a variable. If @b special is true, then the variable
@@ -122,7 +122,7 @@ public:
   }
 
   /** the tag */
-  inline TermTag tag() const { return static_cast<TermTag>(_info.tag); }
+  inline TermTag tag() const { return static_cast<TermTag>(_tag()); }
   /** the term list is empty */
   inline bool isEmpty() const
   { return tag() == FUN; }
@@ -149,9 +149,9 @@ public:
   inline bool isTerm() const
   { return tag() == REF; }
   inline const Term* term() const
-  { ASS(isTerm()); return _term; }
+  { ASS(isTerm()); return _term(); }
   inline Term* term()
-  { ASS(isTerm()); return _term; }
+  { ASS(isTerm()); return _term(); }
   /** True of the terms have the same content. Useful for comparing
    * arguments of shared terms. */
   inline bool sameContent(const TermList* t) const
@@ -209,7 +209,7 @@ public:
     // NB we also zero-initialise _content so that the spare bits are zero on 32-bit platforms
     // dead-store eliminated on 64-bit
     _content = 0;
-    _term = t;
+    _setTerm(t);
     ASS_EQ(tag(), REF);
   }
   static bool sameTop(TermList ss, TermList tt);
@@ -245,53 +245,166 @@ public:
 private:
   vstring asArgsToString() const;
 
-  union {
-    /** raw content, can be anything */
-    uint64_t _content;
-    /** reference to another term */
-    Term* _term;
-    /** Used by Term, storing some information about the term using bits */
-    /*
-     * A note from 2022: the following bitfield is somewhat non-portable.
-     * Endianness or exotic pointers or some compiler/padding weirdness would probably break this.
-     * I'm leaving it as-is for now because of the bugs changing it might introduce,
-     * but a better solution long-term would be something like a struct wrapping a `uintptr_t`,
-     * with bits twiddled manually in getters/setters.
-     * ---
-     * However, if compiling this on a non-x86ish architecture (or even a new compiler)
-     * produces "unexpected results" in the vicinity of terms, then I'd look here first!
-     */
-    struct {
-      /** a TermTag indicating what is stored here */
-      unsigned tag : 2;
-      /** polarity, used only for literals */
-      unsigned polarity : 1;
-      /** true if commutative/symmetric */
-      unsigned commutative : 1;
-      /** true if shared */
-      unsigned shared : 1;
-      /** true if literal */
-      unsigned literal : 1;
-      /** true if atomic sort */
-      unsigned sort : 1;
-      /** true if term contains at least one term var */
-      unsigned hasTermVar : 1;
-      /** Ordering comparison result for commutative term arguments, one of
-       * 0 (unknown) 1 (less), 2 (equal), 3 (greater), 4 (incomparable)
-       * @see Term::ArgumentOrder */
-      unsigned order : 3;
-      static_assert(AO_INCOMPARABLE < 8, "must be able to squash this into 3 bits");
-      /** Number of distinct variables in the term, equal
-       * to TERM_DIST_VAR_UNKNOWN if the number has not been
-       * computed yet. */
+  // the actual content of a TermList
+  // this packs several things in:
+  // 1. a Term *
+  // 2. metadata (see below) such that _tag() is the lowest two bits of (1)
+  // 3. "other", rarely used and handled specially
+  uint64_t _content;
 
-      mutable unsigned distinctVars : TERM_DIST_VAR_BITS;
-      /** term id hiding in this _info */
-      // this should not be removed without care,
-      // otherwise the bitfield layout might shift, resulting in broken pointer tagging
-      unsigned id : 32;
+  // metadata used to be defined as this bitfield:
+#if 0
+  struct {
+    /** a TermTag indicating what is stored here */
+    unsigned tag : 2;
+    /** polarity, used only for literals */
+    unsigned polarity : 1;
+    /** true if commutative/symmetric */
+    unsigned commutative : 1;
+    /** true if shared */
+    unsigned shared : 1;
+    /** true if literal */
+    unsigned literal : 1;
+    /** true if atomic sort */
+    unsigned sort : 1;
+    /** true if term contains at least one term var */
+    unsigned hasTermVar : 1;
+    /** Ordering comparison result for commutative term arguments, one of
+     * 0 (unknown) 1 (less), 2 (equal), 3 (greater), 4 (incomparable)
+     * @see Term::ArgumentOrder */
+    unsigned order : 3;
+    /** Number of distinct variables in the term, equal
+     * to TERM_DIST_VAR_UNKNOWN if the number has not been
+     * computed yet. */
+
+    mutable unsigned distinctVars : TERM_DIST_VAR_BITS;
+    /** term id hiding in this _info */
+    // this should not be removed without care,
+    // otherwise the bitfield layout might shift, resulting in broken pointer tagging
+    unsigned id : 32;
     } _info;
-  };
+#endif
+  // but it was *not* portable because the layout of the bitfield is not guaranteed
+  //
+  // now we use a manual bitfield, as follows
+  static constexpr unsigned
+    TAG_BITS_START = 0,
+    TAG_BITS_END = TAG_BITS_START + 2,
+    POLARITY_BITS_START = TAG_BITS_END,
+    POLARITY_BITS_END = POLARITY_BITS_START + 1,
+    COMMUTATIVE_BITS_START = POLARITY_BITS_END,
+    COMMUTATIVE_BITS_END = COMMUTATIVE_BITS_START + 1,
+    SHARED_BITS_START = COMMUTATIVE_BITS_END,
+    SHARED_BITS_END = SHARED_BITS_START + 1,
+    LITERAL_BITS_START = SHARED_BITS_END,
+    LITERAL_BITS_END = LITERAL_BITS_START + 1,
+    SORT_BITS_START = LITERAL_BITS_END,
+    SORT_BITS_END = SORT_BITS_START + 1,
+    HAS_TERM_VAR_BITS_START = SORT_BITS_END,
+    HAS_TERM_VAR_BITS_END = HAS_TERM_VAR_BITS_START + 1,
+    ORDER_BITS_START = HAS_TERM_VAR_BITS_END,
+    ORDER_BITS_END = ORDER_BITS_START + 3,
+    DISTINCT_VAR_BITS_START = ORDER_BITS_END,
+    DISTINCT_VAR_BITS_END = DISTINCT_VAR_BITS_START + TERM_DIST_VAR_BITS,
+    ID_BITS_START = DISTINCT_VAR_BITS_END,
+    ID_BITS_END = ID_BITS_START + 32,
+    TERM_BITS_START = 0,
+    TERM_BITS_END = CHAR_BIT * sizeof(Term *);
+
+  // various properties we want to check
+  static_assert(TAG_BITS_START == 0, "tag must be the least significant bits");
+  static_assert(TERM_BITS_START == 0, "term must be the least significant bits");
+  static_assert(ID_BITS_END == 64, "whole thing must fit 64 bits exactly");
+  static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
+  static_assert(AO_INCOMPARABLE < 8, "must be able to squash orderings into 3 bits");
+
+  // compute a 64-bit mask starting at `lower` and ending just before `upper`
+  template<unsigned lower, unsigned upper>
+  static constexpr uint64_t bitmask64() {
+      static_assert(lower < upper, "empty range");
+      static_assert(upper - lower <= 64, "too many bits");
+      uint64_t mask = ~0;
+      mask >>= lower;
+      mask <<= lower;
+      mask <<= 64 - upper;
+      mask >>= 64 - upper;
+      return mask;
+  }
+
+  // get the bits of `_content` between `lower` and `upper`
+  template<unsigned lower, unsigned upper>
+  uint64_t getBits() const {
+      auto mask = bitmask64<lower, upper>();
+      return (_content & mask) >> lower;
+  }
+
+  // getters
+  unsigned _tag() const
+  { return getBits<TAG_BITS_START, TAG_BITS_END>();}
+  bool _polarity() const
+  { return getBits<POLARITY_BITS_START, POLARITY_BITS_END>();}
+  bool _commutative() const
+  { return getBits<COMMUTATIVE_BITS_START, COMMUTATIVE_BITS_END>();}
+  bool _shared() const
+  { return getBits<SHARED_BITS_START, SHARED_BITS_END>();}
+  bool _literal() const
+  { return getBits<LITERAL_BITS_START, LITERAL_BITS_END>(); }
+  bool _sort() const
+  { return getBits<SORT_BITS_START, SORT_BITS_END>(); }
+  bool _hasTermVar() const
+  { return getBits<HAS_TERM_VAR_BITS_START, HAS_TERM_VAR_BITS_END>();}
+  unsigned _order() const
+  { return getBits<ORDER_BITS_START, ORDER_BITS_END>(); }
+  uint32_t _distinctVars() const
+  { return getBits<DISTINCT_VAR_BITS_START, DISTINCT_VAR_BITS_END>(); }
+  uint32_t _id() const
+  { return getBits<ID_BITS_START, ID_BITS_END>(); }
+  Term *_term() const
+  { return reinterpret_cast<Term *>(getBits<TERM_BITS_START, TERM_BITS_END>()); }
+
+  // set the bits of `_content` between `lower` and `upper` to corresponding bits of `data`
+  template<unsigned lower, unsigned upper>
+  void setBits(uint64_t data) {
+      auto mask = bitmask64<lower, upper>();
+
+      // shift `data` into position
+      data <<= lower;
+
+      // mask out upper bits of `data`
+      // *probably* not strictly necessary if `data` always zero at `upper` and `above`,
+      // but doesn't cost us much (~2 instructions) to put this sanity check here
+      data &= mask;
+
+      // actually set the bits
+      _content &= ~mask;
+      _content |= data;
+  }
+
+  void _setTag(unsigned tag)
+  { setBits<TAG_BITS_START, TAG_BITS_END>(tag); }
+  void _setPolarity(bool polarity)
+  { setBits<POLARITY_BITS_START, POLARITY_BITS_END>(polarity); }
+  void _setCommutative(bool commutative)
+  { setBits<COMMUTATIVE_BITS_START, COMMUTATIVE_BITS_END>(commutative); }
+  void _setShared(bool shared)
+  { setBits<SHARED_BITS_START, SHARED_BITS_END>(shared); }
+  void _setLiteral(bool literal)
+  { setBits<LITERAL_BITS_START, LITERAL_BITS_END>(literal); }
+  void _setSort(bool sort)
+  { setBits<SORT_BITS_START, SORT_BITS_END>(sort); }
+  void _setHasTermVar(bool hasTermVar)
+  { setBits<HAS_TERM_VAR_BITS_START, HAS_TERM_VAR_BITS_END>(hasTermVar); }
+  void _setOrder(unsigned order)
+  { setBits<ORDER_BITS_START, ORDER_BITS_END>(order); }
+  void _setDistinctVars(uint32_t distinct)
+  { setBits<DISTINCT_VAR_BITS_START, DISTINCT_VAR_BITS_END>(distinct); }
+  void _setId(uint32_t id)
+  { setBits<ID_BITS_START, ID_BITS_END>(id); }
+  void _setTerm(Term *term)
+  { setBits<TERM_BITS_START, TERM_BITS_END>(reinterpret_cast<uint64_t>(term)); }
+
+  // end bitfield
+
   friend class Indexing::TermSharing;
   friend class Term;
   friend class Literal;
@@ -594,7 +707,7 @@ public:
   /** True if the term is ground. Only applicable to shared terms */
   bool ground() const
   {
-    ASS(_args[0]._info.shared);
+    ASS(_args[0]._shared());
     return numVarOccs() == 0;
   } // ground
 
@@ -602,13 +715,13 @@ public:
    *  Only applicable to shared terms */
   bool hasTermVar() const
   {
-    ASS(_args[0]._info.shared);
-    return _args[0]._info.hasTermVar;
+    ASS(shared());
+    return _args[0]._hasTermVar();
   } // ground
 
   /** True if the term is shared */
   bool shared() const
-  { return _args[0]._info.shared; } // shared
+  { return _args[0]._shared(); } // shared
 
   /**
    * True if the term's function/predicate symbol is commutative/symmetric.
@@ -616,7 +729,7 @@ public:
    */
   bool commutative() const
   {
-    return _args[0]._info.commutative;
+    return _args[0]._commutative();
   } // commutative
 
   // destructively swap arguments of a (binary) commutative term
@@ -648,7 +761,7 @@ public:
   void markShared()
   {
     ASS(! shared());
-    _args[0]._info.shared = 1u;
+    _args[0]._setShared(true);
   } // markShared
 
   /** Set term weight */
@@ -664,7 +777,7 @@ public:
   unsigned getId() const
   {
     ASS(shared());
-    return _args[0]._info.id;
+    return _args[0]._id();
   }
   
   void setMaxRedLen(int rl)
@@ -685,7 +798,7 @@ public:
   void setHasTermVar(bool b)
   {
     ASS(shared() && !isSort());
-    _args[0]._info.hasTermVar = b;
+    _args[0]._setHasTermVar(b);
   }
 
   /** Return the number of variable _occurrences_ */
@@ -713,9 +826,9 @@ public:
   const vstring& functionName() const;
 
   /** True if the term is, in fact, a literal */
-  bool isLiteral() const { return _args[0]._info.literal; }
+  bool isLiteral() const { return _args[0]._literal(); }
   /** True if the term is, in fact, a sort */
-  bool isSort() const { return _args[0]._info.sort; }
+  bool isSort() const { return _args[0]._sort(); }
   /** true if the term is an application */
   bool isApplication() const;
 
@@ -736,17 +849,17 @@ public:
   static TermIterator getVariableIterator(TermList tl);
 
   // the number of _distinct_ variables within the term
-  unsigned getDistinctVars() const
+  unsigned getDistinctVars()
   {
-    if(_args[0]._info.distinctVars==TERM_DIST_VAR_UNKNOWN) {
+    if(_args[0]._distinctVars()==TERM_DIST_VAR_UNKNOWN) {
       unsigned res=computeDistinctVars();
       if(res<TERM_DIST_VAR_UNKNOWN) {
-	_args[0]._info.distinctVars=res;
+        _args[0]._setDistinctVars(res);
       }
       return res;
     } else {
-      ASS_L(_args[0]._info.distinctVars,0x100000);
-      return _args[0]._info.distinctVars;
+      ASS_L(_args[0]._distinctVars(),0x100000);
+      return _args[0]._distinctVars();
     }
   }
 
@@ -825,7 +938,7 @@ protected:
    */
   ArgumentOrderVals getArgumentOrderValue() const
   {
-    return static_cast<ArgumentOrderVals>(_args[0]._info.order);
+    return static_cast<ArgumentOrderVals>(_args[0]._order());
   }
 
   /**
@@ -840,7 +953,7 @@ protected:
     ASS_GE(val,AO_UNKNOWN);
     ASS_LE(val,AO_INCOMPARABLE);
 
-    _args[0]._info.order = val;
+    _args[0]._setOrder(val);
   }
 
   /** The number of this symbol in a signature */
@@ -912,8 +1025,8 @@ public:
   {
     _functor = functor;
     _arity = arity;
-    _args[0]._info.literal = 0u;
-    _args[0]._info.sort = 1u;
+    _args[0]._setLiteral(false);
+    _args[0]._setSort(true);
   }
 
   static AtomicSort* create(unsigned typeCon, unsigned arity, const TermList* args);
@@ -974,10 +1087,10 @@ public:
   {
     _functor = functor;
     _arity = arity;
-    _args[0]._info.polarity = polarity;
-    _args[0]._info.commutative = commutative;
-    _args[0]._info.sort = 0u;
-    _args[0]._info.literal = 1u;
+    _args[0]._setPolarity(polarity);
+    _args[0]._setCommutative(commutative);
+    _args[0]._setSort(false);
+    _args[0]._setLiteral(true);
   }
 
   /**
@@ -996,7 +1109,7 @@ public:
   static bool headersMatch(Literal* l1, Literal* l2, bool complementary);
   /** set polarity to true or false */
   void setPolarity(bool positive)
-  { _args[0]._info.polarity = positive ? 1 : 0; }
+  { _args[0]._setPolarity(positive); }
   static Literal* create(unsigned predicate, unsigned arity, bool polarity, bool commutative, TermList* args);
   static Literal* create(unsigned predicate, bool polarity, std::initializer_list<TermList>, bool commutative = false);
   static Literal* create(Literal* l,bool polarity);
@@ -1070,19 +1183,19 @@ public:
   /** true if positive */
   bool isPositive() const
   {
-    return _args[0]._info.polarity;
+    return polarity();
   } // isPositive
 
   /** true if negative */
   bool isNegative() const
   {
-    return ! _args[0]._info.polarity;
+    return !polarity();
   } // isNegative
 
   /** return polarity, 1 if positive and 0 if negative */
   int polarity() const
   {
-    return _args[0]._info.polarity;
+    return _args[0]._polarity();
   } // polarity
 
   /**

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -339,26 +339,19 @@ private:
   }
 
   // getters
-  unsigned _tag() const
-  { return getBits<TAG_BITS_START, TAG_BITS_END>();}
-  bool _polarity() const
-  { return getBits<POLARITY_BITS_START, POLARITY_BITS_END>();}
-  bool _commutative() const
-  { return getBits<COMMUTATIVE_BITS_START, COMMUTATIVE_BITS_END>();}
-  bool _shared() const
-  { return getBits<SHARED_BITS_START, SHARED_BITS_END>();}
-  bool _literal() const
-  { return getBits<LITERAL_BITS_START, LITERAL_BITS_END>(); }
-  bool _sort() const
-  { return getBits<SORT_BITS_START, SORT_BITS_END>(); }
-  bool _hasTermVar() const
-  { return getBits<HAS_TERM_VAR_BITS_START, HAS_TERM_VAR_BITS_END>();}
-  unsigned _order() const
-  { return getBits<ORDER_BITS_START, ORDER_BITS_END>(); }
-  uint32_t _distinctVars() const
-  { return getBits<DISTINCT_VAR_BITS_START, DISTINCT_VAR_BITS_END>(); }
-  uint32_t _id() const
-  { return getBits<ID_BITS_START, ID_BITS_END>(); }
+#define GET(type, name, NAME) type _##name() const\
+  { return getBits<NAME##_BITS_START, NAME##_BITS_END>(); }
+  GET(unsigned, tag, TAG)
+  GET(bool, polarity, POLARITY)
+  GET(bool, commutative, COMMUTATIVE)
+  GET(bool, shared, SHARED)
+  GET(bool, literal, LITERAL)
+  GET(bool, sort, SORT)
+  GET(bool, hasTermVar, HAS_TERM_VAR)
+  GET(unsigned, order, ORDER)
+  GET(uint32_t, distinctVars, DISTINCT_VAR)
+  GET(uint32_t, id, ID)
+#undef GET
   Term *_term() const
   { return reinterpret_cast<Term *>(getBits<TERM_BITS_START, TERM_BITS_END>()); }
 
@@ -380,26 +373,20 @@ private:
       _content |= data;
   }
 
-  void _setTag(unsigned tag)
-  { setBits<TAG_BITS_START, TAG_BITS_END>(tag); }
-  void _setPolarity(bool polarity)
-  { setBits<POLARITY_BITS_START, POLARITY_BITS_END>(polarity); }
-  void _setCommutative(bool commutative)
-  { setBits<COMMUTATIVE_BITS_START, COMMUTATIVE_BITS_END>(commutative); }
-  void _setShared(bool shared)
-  { setBits<SHARED_BITS_START, SHARED_BITS_END>(shared); }
-  void _setLiteral(bool literal)
-  { setBits<LITERAL_BITS_START, LITERAL_BITS_END>(literal); }
-  void _setSort(bool sort)
-  { setBits<SORT_BITS_START, SORT_BITS_END>(sort); }
-  void _setHasTermVar(bool hasTermVar)
-  { setBits<HAS_TERM_VAR_BITS_START, HAS_TERM_VAR_BITS_END>(hasTermVar); }
-  void _setOrder(unsigned order)
-  { setBits<ORDER_BITS_START, ORDER_BITS_END>(order); }
-  void _setDistinctVars(uint32_t distinct)
-  { setBits<DISTINCT_VAR_BITS_START, DISTINCT_VAR_BITS_END>(distinct); }
-  void _setId(uint32_t id)
-  { setBits<ID_BITS_START, ID_BITS_END>(id); }
+  // setters
+#define SET(type, name, NAME) void _set##name(type val)\
+  { setBits<NAME##_BITS_START, NAME##_BITS_END>(val); }
+  SET(unsigned, Tag, TAG)
+  SET(bool, Polarity, POLARITY)
+  SET(bool, Commutative, COMMUTATIVE)
+  SET(bool, Shared, SHARED)
+  SET(bool, Literal, LITERAL)
+  SET(bool, Sort, SORT)
+  SET(bool, HasTermVar, HAS_TERM_VAR)
+  SET(unsigned, Order, ORDER)
+  SET(uint32_t, DistinctVars, DISTINCT_VAR)
+  SET(uint32_t, Id, ID)
+#undef SET
   void _setTerm(Term *term)
   { setBits<TERM_BITS_START, TERM_BITS_END>(reinterpret_cast<uint64_t>(term)); }
 


### PR DESCRIPTION
In `TermList` we use a bitfield for some metadata, which for pointer-tagging reasons we *really* need not to shift around: this could happen by the compiler either inserting padding or by moving members around. This has worked so far, but the standard doesn't say that it will continue to work. In #512 we see that indeed it *doesn't* work on some architectures.

As I'm not aware of a better way to do it, I have implemented manual bit-twiddling to replace the current bitfield. I have attempted to make this as safe/portable as possible.