### PR TITLE
Minor improvement in instruction limiting, randomization, and strategy sampling

### DIFF
--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -37,7 +37,9 @@ constexpr unsigned Term::SPECIAL_FUNCTOR_LOWER_BOUND;
 
 void Term::setId(unsigned id)
 {
-  if (env.options->randomTraversals()) {
+  if (env.options->randomTraversals() &&
+      Random::seed() != 1) { // not until a proper seed has been set (i.e. after parsing!)
+      // (cf ProvingHelper::runVampire and getPreprocessedProblem in vampire.cpp)
     id += Random::getInteger(1 << 12) << 20; // the twelve most significant bits are randomized
   }
    _args[0]._info.id = id;

--- a/Saturation/ProvingHelper.cpp
+++ b/Saturation/ProvingHelper.cpp
@@ -86,10 +86,12 @@ using namespace Shell;
  */
 void ProvingHelper::runVampire(Problem& prb, const Options& opt)
 {
-  // when running a portfolio-mode worker, randomize for the first time for the preprocessing 
-  // (second time is in ProvingHelper::runVampireSaturationImpl, but not so important there)
+  // Here officially starts preprocessing of the porfolio mode (separately for each worker)
+  // and that's the moment we want to set the random seed
+  // (no randomness in parsing, for the peace of mind - parsing was done by the master process!)
+  // the main reason being that we want to stay in sync with what vampire mode does
+  // cf getPreprocessedProblem in vampire.cpp
   Lib::Random::setSeed(opt.randomSeed());
-  // addCommentSignForSZS(cout) << "runVampire -- setSeed: " << opt.randomSeed() << endl;
 
   try
   {
@@ -132,14 +134,6 @@ void ProvingHelper::runVampire(Problem& prb, const Options& opt)
     UIHelper::outputAllPremises(env.out(), prb.units(), "New: ");
     env.endOutput();
   }
-
-  //this point is reached both by the vampire mode (single strategy) and the portfolio mode (strategy schedule) when inside a strategy
-  /* Set random seed one more time, this time in the title of "seed for proof search".
-   * This should help improve reproducibility when using vampire mode + "--decode" to replay a behavior of a strat from a schedule
-   */
-  Lib::Random::setSeed(opt.randomSeed());
-
-  // addCommentSignForSZS(cout) << "runVampireSaturationImpl -- setSeed: " << opt.randomSeed() << endl;
 
   //decide whether to use poly or mono well-typedness test
   //after options have been read. Equality Proxy can introduce poly in mono.

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -675,9 +675,17 @@ void Splitter::init(SaturationAlgorithm* sa)
 #endif
 
   if (opts.splittingAvatimer() < 1.0) {
-    _stopSplittingAtTime = opts.splittingAvatimer() * opts.timeLimitInDeciseconds() * 100;
+    unsigned timeLimit = opts.simulatedTimeLimit(); // is also stored in deciseconds
+    if (timeLimit == 0) {
+      timeLimit = opts.timeLimitInDeciseconds();
+    }
+    _stopSplittingAtTime = opts.splittingAvatimer() * timeLimit * 100;
 #if VAMPIRE_PERF_EXISTS
-    _stopSplittingAtInst = opts.splittingAvatimer() * opts.instructionLimit();
+    unsigned instrLimit = opts.simulatedInstructionLimit();
+    if (instrLimit == 0) {
+      instrLimit = opts.instructionLimit();
+    }
+    _stopSplittingAtInst = opts.splittingAvatimer() * instrLimit;
 #endif
   } else {
     _stopSplittingAtTime = 0;

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -95,7 +95,7 @@ void Options::init()
   _simulatedInstructionLimit = UnsignedOptionValue("simulated_instruction_limit","sil",0);
   _simulatedInstructionLimit.description=
     "Instruction limit (in millions) of executed instructions for the purpose of reachability estimations of the LRS saturation algorithm (if 0, the actual instruction limit is used)";
-  _simulatedInstructionLimit.onlyUsefulWith(Or(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)),_splittingAvatimer.is(notEqual(1.0f))));
+  // _simulatedInstructionLimit.onlyUsefulWith(Or(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)),_splittingAvatimer.is(notEqual(1.0f))));
   _lookup.insert(&_simulatedInstructionLimit);
   _simulatedInstructionLimit.tag(OptionTag::LRS);
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -95,7 +95,7 @@ void Options::init()
   _simulatedInstructionLimit = UnsignedOptionValue("simulated_instruction_limit","sil",0);
   _simulatedInstructionLimit.description=
     "Instruction limit (in millions) of executed instructions for the purpose of reachability estimations of the LRS saturation algorithm (if 0, the actual instruction limit is used)";
-  _simulatedInstructionLimit.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
+  _simulatedInstructionLimit.onlyUsefulWith(Or(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)),_splittingAvatimer.is(notEqual(1.0f))));
   _lookup.insert(&_simulatedInstructionLimit);
   _simulatedInstructionLimit.tag(OptionTag::LRS);
 
@@ -1095,7 +1095,7 @@ void Options::init()
     _simulatedTimeLimit = TimeLimitOptionValue("simulated_time_limit","stl",0);
     _simulatedTimeLimit.description=
     "Time limit in seconds for the purpose of reachability estimations of the LRS saturation algorithm (if 0, the actual time limit is used)";
-    _simulatedTimeLimit.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
+    _simulatedTimeLimit.onlyUsefulWith(Or(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)),_splittingAvatimer.is(notEqual(1.0f))));
     _lookup.insert(&_simulatedTimeLimit);
     _simulatedTimeLimit.tag(OptionTag::LRS);
 

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -454,6 +454,7 @@ void Statistics::print(ostream& out)
   Timer::printMSString(out,env.timer->elapsedMilliseconds());
   out << endl;
   
+  Timer::updateInstructionCount();
   unsigned instr = Timer::elapsedMegaInstructions();
   if (instr) {
     addCommentSignForSZS(out);

--- a/samplerFOL.txt
+++ b/samplerFOL.txt
@@ -86,10 +86,11 @@ $ls=on > lsd ~cat 0:20,1:1,5:1,10:1,20:1,50:1,100:1
 sa=lrs > lwlo ~cat off:5,on:1
 
 # lrs_estimate_correction_coef
-> $lecc ~cat 1:1
-sa=lrs > $lecc ~cat 1:10,666:1
-sa=lrs $lecc=1 > lecc ~cat 1.0:1
-sa=lrs $lecc!=1 > lecc ~uf 0.5,2.0
+# > $lecc ~cat 1:1
+# sa=lrs > $lecc ~cat 1:10,666:1
+# sa=lrs $lecc=1 > lecc ~cat 1.0:1
+# sa=lrs $lecc!=1 > lecc ~uf 0.5,2.0
+# TODO: leaving out weird timing dependent options
 
 # age_weight_ratio_shape
 > awrs ~cat constant:8,decay:1,converge:1
@@ -288,9 +289,10 @@ av=on > alpa ~cat none:300,false:13,true:6,random:4
 av=on > anc ~cat known:300,all_dependent:38,all:45,none:48
 
 # avatar_turn_off_time_frac
-av=on > $atotf ~cat 1:10,666:1
-av=on $atotf=1 > atotf ~cat 1:1
-av=on $atotf!=1 > atotf ~uf 0.0,0.7
+# av=on > $atotf ~cat 1:10,666:1
+# av=on $atotf=1 > atotf ~cat 1:1
+# av=on $atotf!=1 > atotf ~uf 0.0,0.7
+# TODO: leaving out weird timing dependent options
 
 # avatar_flush_period
 av=on > $afp ~cat 0:15,666:1

--- a/samplerFOL.txt
+++ b/samplerFOL.txt
@@ -29,7 +29,9 @@ $nm=Z > nm ~cat 0:1
 $nm=NZ > nm ~sgd 0.07,2
 
 # inequality_splitting
-> ins ~cat 0:20,1:4,2:3,3:2,4:1
+> $ins ~cat Z:2,NZ:1
+$ins=Z > ins ~cat 0:1
+$ins=NZ > ins ~sgd 0.4,1
 
 # random_polarities
 > rp ~cat off:3,on:1
@@ -84,8 +86,10 @@ $ls=on > lsd ~cat 0:20,1:1,5:1,10:1,20:1,50:1,100:1
 sa=lrs > lwlo ~cat off:5,on:1
 
 # lrs_estimate_correction_coef
-sa=lrs > lecc ~cat 1:10,666:1
-lecc!=1 > lecc ~uf 0.5,2.0
+> $lecc ~cat 1:1
+sa=lrs > $lecc ~cat 1:10,666:1
+sa=lrs $lecc=1 > lecc ~cat 1.0:1
+sa=lrs $lecc!=1 > lecc ~uf 0.5,2.0
 
 # age_weight_ratio_shape
 > awrs ~cat constant:8,decay:1,converge:1
@@ -94,8 +98,10 @@ lecc!=1 > lecc ~uf 0.5,2.0
 awrs!=constant > awrsf ~ui 1,500
 
 # nongoal_weight_coefficient
-> nwc ~cat 1:2,2:1
-nwc!=1 > nwc ~ui 2,15
+> $nwc ~cat 1:2,666:1
+$nwc=1 > nwc ~cat 1:1
+$nwc!=1 > nwc ~uf 0.5,15.0
+# TODO: we will most likely want a new distribution here for ($nwc!=1) just above!
 
 # restrict_nwc_to_goal_constants
 nwc!=1 > rnwc ~cat off:5,on:1
@@ -160,9 +166,6 @@ bsd=on > bsdmm ~cat 0:10,1:3,2:2,3:1
 # condensation
 > cond ~cat off:500,on:89,fast:61
 
-# demodulation_redundancy_check
-> drc ~cat encompass:500,on:500,off:354
-
 # equational_tautology_removal
 > etr ~cat off:500,on:30
 
@@ -180,6 +183,12 @@ er!=off > erml ~cat 0:3,2:1,3:1
 
 # forward_demodulation
 > fd ~cat all:500,off:41,preordered:168
+
+# demodulation_redundancy_check
+> $drc ~cat 0:1
+fd!=off > $drc ~cat 1:1
+bd!=off > $drc ~cat 1:1
+$drc=1 > drc ~cat encompass:500,on:500,off:354
 
 # forward_literal_rewriting
 > flr ~cat off:8,on:1
@@ -279,13 +288,14 @@ av=on > alpa ~cat none:300,false:13,true:6,random:4
 av=on > anc ~cat known:300,all_dependent:38,all:45,none:48
 
 # avatar_turn_off_time_frac
-av=on > atotf ~cat 1.0:10,0.5:1
-# careful that 1.0 becomes "1" by the ->toFloat->toStr internal transformation
-atotf!=1 > atotf ~uf 0.0,0.5
+av=on > $atotf ~cat 1:10,666:1
+av=on $atotf=1 > atotf ~cat 1:1
+av=on $atotf!=1 > atotf ~uf 0.0,0.7
 
 # avatar_flush_period
-av=on > afp ~cat 0:15,1:1
-afp!=0 > afp ~cat 1:1,10:1,50:1,300:1,1000:1,2000:1,4000:1,10000:1,40000:1,100000:1,1000000:1
+av=on > $afp ~cat 0:15,666:1
+av=on $afp=0 > afp ~cat 0:1
+av=on $afp!=0 > afp ~cat 1:1,10:1,50:1,300:1,1000:1,2000:1,4000:1,10000:1,40000:1,100000:1,1000000:1
 
 # avatar_flush_quotient
 afp!=0 > afq ~uf 1.0,3.0

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -117,6 +117,12 @@ Problem* getPreprocessedProblem()
   }
 #endif
 
+  // Here officially starts preprocessing of vampireMode
+  // and that's the moment we want to set the random seed (no randomness in parsing, for the peace of mind)
+  // the main reason being that we want to stay in sync with what profolio mode will do
+  // cf ProvingHelper::runVampire
+  Lib::Random::setSeed(env.options->randomSeed());
+
   TIME_TRACE(TimeTrace::PREPROCESSING);
 
   // this will provide warning if options don't make sense for problem
@@ -599,7 +605,6 @@ int main(int argc, char* argv[])
     }
 
     Lib::setMemoryLimit(env.options->memoryLimit() * 1048576ul);
-    Lib::Random::setSeed(env.options->randomSeed());
 
     switch (env.options->mode())
     {


### PR DESCRIPTION
- Making sure random seed is set consistently for both vampireMode and portfolioMode
- one last call to `Timer::updateInstructionCount();` in Statistics (to report a more realistic value on successful termination; otherwise it would be the one from the last timer tick)
- don't warn in `Options.cpp` for using `_simulatedInstructionLimit` (it's actually useful to have it turned on during strategy sampling where we don't know up front if we will end up with lrs or not)
- `atotf` is compatible with `sil` now
- don't randomize `termId` until a seed is set to non-default, e.g., not until after parsing