### PR TITLE
enable tracebacks for unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -999,4 +999,5 @@ endif()
 # FIXME this guard should not be necessary but is currently because of how we do static linking above
 if(BUILD_SHARED_LIBS)
   set_property(TARGET vampire PROPERTY POSITION_INDEPENDENT_CODE false)
+  set_property(TARGET vtest PROPERTY POSITION_INDEPENDENT_CODE false)
 endif()

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1962,6 +1962,7 @@ public:
   bool minimizeSatProofs() const { return _minimizeSatProofs.actualValue; }
   ProofExtra proofExtra() const { return _proofExtra.actualValue; }
   bool traceback() const { return _traceback.actualValue; }
+  void setTraceback(bool traceback) { _traceback.actualValue = traceback; }
   vstring printProofToFile() const { return _printProofToFile.actualValue; }
   int naming() const { return _naming.actualValue; }
 

--- a/Test/UnitTesting.cpp
+++ b/Test/UnitTesting.cpp
@@ -15,7 +15,10 @@
 #include <iomanip>
 #include <fstream>
 
+#include "Lib/Environment.hpp"
+#include "Lib/System.hpp"
 #include "Lib/Sys/Multiprocessing.hpp"
+#include "Shell/Options.hpp"
 
 #include "Lib/Comparison.hpp"
 #include "Lib/Int.hpp"
@@ -221,6 +224,11 @@ int main(int argc, const char** argv)
 {
   using namespace Lib;
   using namespace std;
+
+  // enable tracebacks in failing unit tests by default
+  System::registerArgv0(argv[0]);
+  env.options->setTraceback(true);
+
   bool success;
   auto cmd = vstring(argv[1]);
   auto args = Stack<vstring>(argc - 2);


### PR DESCRIPTION
@mezpusz noticed that unit test tracebacks fail. I thought this was a CI problem, but it's actually just that they're broken because (i) we don't save what `argv[0]` is for unit tests, and then (ii) we still have PIE code for unit tests.

Fix these.