### PR TITLE
Simple interactive mode for Vampire

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -49,7 +49,7 @@ using namespace std;
 using namespace Lib;
 using namespace CASC;
 
-PortfolioMode::PortfolioMode() : _slowness(1.0), _syncSemaphore(2) {
+PortfolioMode::PortfolioMode(Problem* problem) : _prb(problem), _slowness(env.options->slowness()), _syncSemaphore(2) {
   unsigned cores = System::getNumberOfCores();
   cores = cores < 1 ? 1 : cores;
   _numWorkers = min(cores, env.options->multicore());
@@ -80,10 +80,9 @@ PortfolioMode::PortfolioMode() : _slowness(1.0), _syncSemaphore(2) {
  * The function that does all the job: reads the input files and runs
  * Vampires to solve problems.
  */
-bool PortfolioMode::perform(float slowness)
+bool PortfolioMode::perform(Problem* problem)
 {
-  PortfolioMode pm;
-  pm._slowness = slowness;
+  PortfolioMode pm(problem);
 
   bool resValue;
   try {
@@ -128,8 +127,6 @@ bool PortfolioMode::perform(float slowness)
 
 bool PortfolioMode::searchForProof()
 {
-  _prb = UIHelper::getInputProblem(*env.options);
-
   /* CAREFUL: Make sure that the order
    * 1) getProperty, 2) normalise, 3) TheoryFinder::search
    * is the same as in profileMode (vampire.cpp)

--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -23,6 +23,8 @@
 #include "Lib/VString.hpp"
 #include "Lib/Sys/Semaphore.hpp"
 
+#include "Kernel/Problem.hpp"
+
 #include "Shell/Property.hpp"
 #include "Schedules.hpp"
 
@@ -38,9 +40,9 @@ class PortfolioMode {
     SEM_PRINTED = 1
   };
 
-  PortfolioMode();
+  PortfolioMode(Kernel::Problem* problem);
 public:
-  static bool perform(float slowness);
+  static bool perform(Kernel::Problem* problem);
 
   static void rescaleScheduleLimits(const Schedule& sOld, Schedule& sNew, float limit_multiplier);
   static void addScheduleExtra(const Schedule& sOld, Schedule& sNew, vstring extra);
@@ -60,10 +62,7 @@ private:
 #if VDEBUG
   DHSet<pid_t> childIds;
 #endif
-
   unsigned _numWorkers;
-  float _slowness;
-
   const char * _tmpFileNameForProof;
 
   /**
@@ -73,6 +72,7 @@ private:
    * will be using the problem object.
    */
   ScopedPtr<Problem> _prb;
+  float _slowness;
 
   Semaphore _syncSemaphore; // semaphore for synchronizing proof printing
 };

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -38,7 +38,7 @@ using namespace Kernel;
 class ModelCheck{
 
 public:
-static void doCheck(Problem*& prb)
+static void doCheck(UnitList* units)
 {
   // find model size
   // looking for a domain axiom
@@ -47,7 +47,7 @@ static void doCheck(Problem*& prb)
   unsigned modelSize = 0;
   Set<Term*> domainConstants;
   {
-    UnitList::Iterator uit(prb->units());
+    UnitList::Iterator uit(units);
     while(uit.hasNext()){
       Unit* u = uit.next();
       if(u->inputType()!= UnitInputType::MODEL_DEFINITION) continue;
@@ -102,7 +102,7 @@ static void doCheck(Problem*& prb)
   FiniteModel model(modelSize);
 
   {
-    UnitList::Iterator uit(prb->units());
+    UnitList::Iterator uit(units);
     while(uit.hasNext()){
       Unit* u = uit.next();
       if(u->inputType()!= UnitInputType::MODEL_DEFINITION) continue;
@@ -146,7 +146,7 @@ static void doCheck(Problem*& prb)
     std::cout << "Model loaded" << std::endl;
     std::cout << "Checking formulas..." << std::endl;
     {
-      UnitList::Iterator uit(prb->units());
+      UnitList::Iterator uit(units);
       while(uit.hasNext()){
         Unit* u = uit.next();
         if(u->inputType()== UnitInputType::MODEL_DEFINITION) continue;

--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -50,7 +50,7 @@ Clause* Choice::createChoiceAxiom(TermList op, TermList set)
   TermList setType = ApplicativeHelper::getNthArg(opType, 1);
 
   unsigned max = 0;
-  FormulaVarIterator fvi(&set);
+  FormulaVarIterator fvi(set);
   while (fvi.hasNext()) {
     unsigned var = fvi.next();
     if (var > max) {

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -32,6 +32,7 @@
 #include "Kernel/SubstHelper.hpp"
 #include "Kernel/OperatorType.hpp"
 #include "Kernel/Theory.hpp"
+#include "Kernel/FormulaVarIterator.hpp"
 
 #include "Saturation/SaturationAlgorithm.hpp"
 #include "Saturation/Splitter.hpp"
@@ -233,7 +234,7 @@ bool TheoryInstAndSimp::isPure(Literal* lit) {
 bool TheoryInstAndSimp::isXeqTerm(TermList left, TermList right) {
   bool r = left.isVar() &&
     right.isTerm() &&
-    !VList::member(left.var(), right.term()->freeVariables());
+    !VList::member(left.var(), freeVariables(right.term()));
   return r;
 }
 
@@ -248,7 +249,7 @@ unsigned TheoryInstAndSimp::varOfXeqTerm(const Literal* lit,bool flip) {
     if (isXeqTerm(right,left)){ return right.var();}
     ASS(lit->isTwoVarEquality());
     if(flip){
-      return left.var(); 
+      return left.var();
     }else{
       return right.var();
     }
@@ -818,7 +819,7 @@ Stack<Literal*> computeGuards(Stack<Literal*> const& lits)
 
             case Theory::INT_QUOTIENT_F:
             case Theory::INT_REMAINDER_F:
-            case Theory::INT_QUOTIENT_E: 
+            case Theory::INT_QUOTIENT_E:
             case Theory::INT_QUOTIENT_T:
             case Theory::INT_REMAINDER_T:
             case Theory::INT_REMAINDER_E:
@@ -827,7 +828,7 @@ Stack<Literal*> computeGuards(Stack<Literal*> const& lits)
 
             default:; /* no guard */
           }
-        } else if (sym->termAlgebraDest()) { 
+        } else if (sym->termAlgebraDest()) {
           out.push(destructorGuard(term, sym->fnType()->arg(0), /* predicate */ false));
         }
       }
@@ -842,8 +843,8 @@ Stack<Literal*> filterLiterals(Stack<Literal*> lits, Options::TheoryInstSimp mod
   { return ( lit->isEquality() && lit->isNegative())
         || (!lit->isEquality() && theory->isInterpretedPredicate(lit->functor())); };
 
-  auto freeVars = [](Literal* lit) 
-  { return iterTraits(VList::Iterator(lit->freeVariables())); };
+  auto freeVars = [](Literal* lit)
+  { return iterTraits(VList::Iterator(freeVariables(lit))); };
 
   switch(mode) {
     case Options::TheoryInstSimp::ALL:
@@ -856,7 +857,7 @@ Stack<Literal*> filterLiterals(Stack<Literal*> lits, Options::TheoryInstSimp mod
 
     case Options::TheoryInstSimp::NEG_EQ:
       return iterTraits(lits.iterFifo())
-                            .filter([](Literal* lit) 
+                            .filter([](Literal* lit)
                                { return lit->isEquality() && lit->isNegative(); } )
                             .collect<Stack>();
 

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -268,41 +268,6 @@ bool Formula::parenthesesRequired (Connective outer) const
   ASSERTION_VIOLATION;
 } // Formula::parenthesesRequired
 
-
-/**
- * Return the list of all free variables of the formula
- *
- * Each variable in the formula is returned just once.
- *
- * NOTE: don't use this function, if you don't actually need a List
- * (FormulaVarIterator is a better choice)
- *
- * NOTE: remember to free the list when done with it
- * (otherwise we leak memory!)
- *
- * @since 12/12/2004 Manchester
- */
-VList* Formula::freeVariables () const
-{
-  FormulaVarIterator fvi(this);
-  VList::FIFO result;
-  while (fvi.hasNext()) {
-    result.pushBack(fvi.next());
-  }
-  return result.list();
-} // Formula::freeVariables
-
-bool Formula::isFreeVariable(unsigned var) const
-{
-  FormulaVarIterator fvi(this);
-  while (fvi.hasNext()) {
-    if (var == fvi.next()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /**
  * Return the list of all bound variables of the formula
  *

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -285,12 +285,11 @@ bool Formula::parenthesesRequired (Connective outer) const
 VList* Formula::freeVariables () const
 {
   FormulaVarIterator fvi(this);
-  VList* result = VList::empty();
-  VList::FIFO stack(result);
+  VList::FIFO result;
   while (fvi.hasNext()) {
-    stack.pushBack(fvi.next());
+    result.pushBack(fvi.next());
   }
-  return result;
+  return result.list();
 } // Formula::freeVariables
 
 bool Formula::isFreeVariable(unsigned var) const
@@ -464,14 +463,12 @@ Formula* Formula::quantify(Formula* f)
   SortHelper::collectVariableSorts(f,tMap,/*ignoreBound=*/true);
 
   //we have to quantify the formula
-  VList* varLst = VList::empty();
-  SList* sortLst = SList::empty();
-  VList::FIFO quantifiedVars(varLst);
-  SList::FIFO theirSorts(sortLst);
+  VList::FIFO quantifiedVars;
+  SList::FIFO theirSorts;
 
   DHMap<unsigned,TermList>::Iterator tmit(tMap);
   while(tmit.hasNext()) {
-    unsigned v; 
+    unsigned v;
     TermList s;
     tmit.next(v, s);
     if(s.isTerm() && s.term()->isSuper()){
@@ -483,15 +480,15 @@ Formula* Formula::quantify(Formula* f)
       theirSorts.pushBack(s);
     }
   }
-  if(varLst) {
-    f=new QuantifiedFormula(FORALL, varLst, sortLst, f);
+  if(!quantifiedVars.empty()) {
+    f = new QuantifiedFormula(FORALL, quantifiedVars.list(), theirSorts.list(), f);
   }
   return f;
 }
 
 
 /**
- * Return formula equal to @b cl 
+ * Return formula equal to @b cl
  * that has all variables quantified
  */
 Formula* Formula::fromClause(Clause* cl)

--- a/Kernel/Formula.hpp
+++ b/Kernel/Formula.hpp
@@ -72,8 +72,6 @@ public:
   Literal* literal();
   const TermList getBooleanTerm() const;
   TermList getBooleanTerm();
-  VList* freeVariables () const;
-  bool isFreeVariable(unsigned var) const;
   VList* boundVariables () const;
 
   // output

--- a/Kernel/FormulaUnit.cpp
+++ b/Kernel/FormulaUnit.cpp
@@ -20,6 +20,7 @@
 #include "FormulaUnit.hpp"
 #include "Inference.hpp"
 #include "SubformulaIterator.hpp"
+#include "FormulaVarIterator.hpp"
 #include "Term.hpp"
 
 using namespace std;
@@ -51,7 +52,7 @@ vstring FormulaUnit::toString() const
 unsigned FormulaUnit::varCnt()
 {
   Formula* frm = formula();
-  VList* fv = frm->freeVariables();
+  VList* fv = freeVariables(frm);
   VList* bv = frm->boundVariables();
 
   unsigned res = VList::length(fv) + VList::length(bv);

--- a/Kernel/FormulaVarIterator.cpp
+++ b/Kernel/FormulaVarIterator.cpp
@@ -50,11 +50,11 @@ FormulaVarIterator::FormulaVarIterator(const Term* t)
  * Build an iterator over a list of terms.
  * @since 15/05/2015 Gothenburg
  */
-FormulaVarIterator::FormulaVarIterator(const TermList* ts)
+FormulaVarIterator::FormulaVarIterator(const TermList ts)
   : _found(false)
 {
   _instructions.push(FVI_TERM_LIST);
-  _termLists.push(*ts);
+  _termLists.push(ts);
 } // FormulaVarIterator::FormulaVarIterator
 
 /**

--- a/Kernel/FormulaVarIterator.hpp
+++ b/Kernel/FormulaVarIterator.hpp
@@ -48,7 +48,7 @@ public:
   DECL_ELEMENT_TYPE(unsigned);
   explicit FormulaVarIterator(const Formula*);
   explicit FormulaVarIterator(const Term*);
-  explicit FormulaVarIterator(const TermList*);
+  explicit FormulaVarIterator(const TermList);
 
   bool hasNext();
   unsigned next();
@@ -88,6 +88,43 @@ private:
   /** Stack of lists of variables to process */
   Stack<const VList*> _vars;
 }; // class FormulaVarIterator
+
+template<typename T> // a template to work with Term*, TermList*, and Formula*
+bool isFreeVariableOf(T thing, unsigned var)
+{
+  FormulaVarIterator fvi(thing);
+  while (fvi.hasNext()) {
+    if (var == fvi.next()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Return the list of all free variables of the term.
+ * The result is only non-empty when there are quantified
+ * formulas or $let-terms inside the term.
+ * Each variable in the term is returned just once.
+ *
+ * NOTE: don't use this function, if you don't actually need a List
+ * (FormulaVarIterator is a better choice)
+ *
+ * NOTE: remember to free the list when done with it
+ * (otherwise we leak memory!)
+ *
+ * @since 07/05/2015 Gothenburg
+ */
+template<typename T> // a template to work with Term*, TermList*, and Formula*
+VList* freeVariables(T thing)
+{
+  FormulaVarIterator fvi(thing);
+  VList::FIFO result;
+  while (fvi.hasNext()) {
+    result.pushBack(fvi.next());
+  }
+  return result.list();
+} // Term::freeVariables
 
 }
 

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -70,8 +70,6 @@ Problem::Problem(ClauseIterator clauses, bool copy)
 
 Problem::~Problem()
 {
-  //TODO: decrease reference counter of clauses (but make sure there's no segfault...)
-
   // Don't delete the property as it is owned by Environment
 }
 

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -72,7 +72,6 @@ Problem::~Problem()
 {
   //TODO: decrease reference counter of clauses (but make sure there's no segfault...)
 
-  UnitList::destroy(_units);
   // Don't delete the property as it is owned by Environment
 }
 

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -143,12 +143,11 @@ bool TermList::isSafe() const
 VList* TermList::freeVariables() const
 {
   FormulaVarIterator fvi(this);
-  VList* result = VList::empty();
-  VList::FIFO stack(result);
+  VList::FIFO result;
   while (fvi.hasNext()) {
-    stack.pushBack(fvi.next());
+    result.pushBack(fvi.next());
   }
-  return result;
+  return result.list();
 } // TermList::freeVariables
 
 
@@ -1251,12 +1250,11 @@ TermList AtomicSort::tupleSort(unsigned arity, TermList* sorts)
 VList* Term::freeVariables() const
 {
   FormulaVarIterator fvi(this);
-  VList* result = VList::empty();
-  VList::FIFO stack(result);
+  VList::FIFO result;
   while (fvi.hasNext()) {
-    stack.pushBack(fvi.next());
+    result.pushBack(fvi.next());
   }
-  return result;
+  return result.list();
 } // Term::freeVariables
 
 bool Term::isFreeVariable(unsigned var) const

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -27,7 +27,6 @@
 #include "Lib/Metaiterators.hpp"
 
 #include "Term.hpp"
-#include "FormulaVarIterator.hpp"
 
 using namespace std;
 using namespace Lib;
@@ -124,44 +123,6 @@ bool TermList::isSafe() const
 {
   return isVar() || term()->shared();
 }
-
-/**
- * Return the list of all free variables of the term.
- * The result is only non-empty when there are quantified
- * formulas or $let-terms inside the term.
- *
- * Each variable in the term is returned just once.
- *
- * NOTE: don't use this function, if you don't actually need a List
- * (FormulaVarIterator is a better choice)
- *
- * NOTE: remember to free the list when done with it
- * (otherwise we leak memory!)
- *
- * @since 15/05/2015 Gothenburg
- */
-VList* TermList::freeVariables() const
-{
-  FormulaVarIterator fvi(this);
-  VList::FIFO result;
-  while (fvi.hasNext()) {
-    result.pushBack(fvi.next());
-  }
-  return result.list();
-} // TermList::freeVariables
-
-
-bool TermList::isFreeVariable(unsigned var) const
-{
-  FormulaVarIterator fvi(this);
-  while (fvi.hasNext()) {
-    if (var == fvi.next()) {
-      return true;
-    }
-  }
-  return false;
-}
-
 
 /**
  * Return true if @b ss and @b tt have the same top symbols, that is,
@@ -1231,42 +1192,6 @@ TermList AtomicSort::arraySort(TermList indexSort, TermList innerSort)
 
 TermList AtomicSort::tupleSort(unsigned arity, TermList* sorts)
 { return TermList(Term::create(env.signature->getTupleConstructor(arity), arity, sorts)); }
-
-
-/**
- * Return the list of all free variables of the term.
- * The result is only non-empty when there are quantified
- * formulas or $let-terms inside the term.
- * Each variable in the term is returned just once.
- *
- * NOTE: don't use this function, if you don't actually need a List
- * (FormulaVarIterator is a better choice)
- *
- * NOTE: remember to free the list when done with it
- * (otherwise we leak memory!)
- *
- * @since 07/05/2015 Gothenburg
- */
-VList* Term::freeVariables() const
-{
-  FormulaVarIterator fvi(this);
-  VList::FIFO result;
-  while (fvi.hasNext()) {
-    result.pushBack(fvi.next());
-  }
-  return result.list();
-} // Term::freeVariables
-
-bool Term::isFreeVariable(unsigned var) const
-{
-  FormulaVarIterator fvi(this);
-  while (fvi.hasNext()) {
-    if (var == fvi.next()) {
-      return true;
-    }
-  }
-  return false;
-}
 
 unsigned Term::computeDistinctVars() const
 {

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -231,9 +231,6 @@ public:
   bool ground() const;
   bool isSafe() const;
 
-  VList* freeVariables() const;
-  bool isFreeVariable(unsigned var) const;
-
 #if VDEBUG
   void assertValid() const;
 #endif
@@ -450,7 +447,6 @@ public:
   static Term* foolFalse(); 
 
   VList* freeVariables() const;
-  bool isFreeVariable(unsigned var) const;
 
   /** Return number of bytes before the start of the term that belong to it */
   size_t getPreDataSize() { return isSpecial() ? sizeof(SpecialTermData) : 0; }

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -55,7 +55,6 @@ Environment::Environment()
 
   // statistics calls the timer
   timer = Timer::instance();
-  timer->start();
 
   statistics = new Statistics;
   signature = new Signature;

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -30,10 +30,10 @@ class ThrowableBase
 {
 };
 
-template<class... Ms> 
+template<class... Ms>
 struct OutputAll;
 
-template<class M, class... Ms> 
+template<class M, class... Ms>
 struct OutputAll<M,Ms...> {
   static void apply(std::ostream& out, M m, Ms... ms) {
     out << m;
@@ -41,7 +41,7 @@ struct OutputAll<M,Ms...> {
   }
 };
 
-template<> 
+template<>
 struct OutputAll<> {
   static void apply(std::ostream& out) { }
 };
@@ -65,7 +65,7 @@ public:
   explicit Exception (const vstring msg) : _message(msg) {}
 
   template<class... Msg>
-  explicit Exception(Msg... msg) 
+  explicit Exception(Msg... msg)
    : Exception(toString(msg...))
   { }
 
@@ -86,6 +86,8 @@ protected:
 }; // Exception
 
 
+class ParsingRelatedException : public Exception { using Exception::Exception; };
+
 /**
  * Class UserErrorException. A UserErrorException is thrown
  * when a user error occurred, for example, a file name is
@@ -93,19 +95,11 @@ protected:
  * was given, or there is a syntax error in the input file.
  */
 class UserErrorException
-  : public Exception
+  : public ParsingRelatedException
 {
  public:
-  UserErrorException (const char* msg)
-    : Exception(msg)
-  {}
-  template<class... Msgs>
-  UserErrorException (Msgs... ms)
-    : Exception(ms...)
-  {}
-  UserErrorException (const vstring msg)
-    : Exception(msg)
-  {}
+  using ParsingRelatedException::ParsingRelatedException;
+
   void cry (std::ostream&) const;
 }; // UserErrorException
 

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -85,7 +85,6 @@ protected:
 
 }; // Exception
 
-
 class ParsingRelatedException : public Exception { using Exception::Exception; };
 
 /**

--- a/Lib/List.hpp
+++ b/Lib/List.hpp
@@ -762,7 +762,7 @@ public:
       _last = newLast;
     }
 
-    List* list()
+    List* list() const
     {
       return _first;
     }

--- a/Lib/List.hpp
+++ b/Lib/List.hpp
@@ -767,6 +767,23 @@ public:
       return _first;
     }
 
+    /**
+     * @brief If last's tail is not null, set it to null.
+     *
+     * @return Whatever was last's tail pointing to.
+     *
+     * Note that this will only return non-null,
+     * if the list inside was modified outside this objects interface.
+     */
+    List* clipAtLast() const
+    {
+      List* beyondLast = List::empty();
+      if (_last) {
+        std::swap(_last->_tail,beyondLast);
+      }
+      return beyondLast;
+    }
+
   protected:
     List* _first;
     List* _last;

--- a/Lib/List.hpp
+++ b/Lib/List.hpp
@@ -727,45 +727,49 @@ public:
   USE_ALLOCATOR(List);
 
   /**
-   * Class that allows to create a list initially by pushing elements
-   * at the end of it.
+   * Class that allows to create a list initially by pushing element both at the beginning (pushFront, the usual push)
+   * and at the end of it (pushBack, the FIFO style).
+   *
+   * The interal list is not owned by the FIFO. In a typical use case, the list will be retrieved via list() call
+   * and kept after FIFO passes out of scope.
    * @since 06/04/2006 Bellevue
    */
   class FIFO {
   public:
-    /** constructor */
-    explicit FIFO(List* &lst)
-      : _last(0), _initial(lst)
-    {
-      ASS_EQ(_initial,0);
+    explicit FIFO() : _first(0), _last(0) {}
+
+    bool empty() const {
+      return !_first;
     }
-    
-    /** add element at the end of the original list */
+
+    /* If you only need pushFront, you probably don't need FIFO. */
+    void pushFront(C elem)
+    {
+      _first = cons(elem, _first);
+      if (!_last) {
+        _last = _first;
+      }
+    }
+
     void pushBack(C elem)
     {
       List* newLast = new List(elem);
       if (_last) {
         _last->setTail(newLast);
       } else {
-        _initial = newLast;
+        _first = newLast;
       }
-
       _last = newLast;
     }
 
-    void pushFront(C elem)
+    List* list()
     {
-      _initial = new List(elem, _initial);
-      if (!_last) {
-        _last = _initial;
-      }
+      return _first;
     }
 
-  private:
-    /** last element */
+  protected:
+    List* _first;
     List* _last;
-    /** reference to the initial element */
-    List* &_initial;
   }; // class List::FIFO
 
 protected:  // structure

--- a/Lib/Stack.hpp
+++ b/Lib/Stack.hpp
@@ -188,11 +188,7 @@ public:
   }
 
   /* a first-in-first-out iterator  */
-  BottomFirstIterator iterFifo() const 
-  { return BottomFirstIterator(*this); }
-
-  /* a first-in-first-out iterator  */
-  BottomFirstIterator iterFifoMut() const 
+  BottomFirstIterator iterFifo() const
   { return BottomFirstIterator(*this); }
 
   /**

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -65,7 +65,6 @@ SMTLIB2::SMTLIB2(const Options& opts)
 : _logicSet(false),
   _logic(SMT_UNDEFINED),
   _numeralsAreReal(false),
-  _formulas(nullptr),
   _topLevelExpr(nullptr)
 {
 }
@@ -838,7 +837,7 @@ void SMTLIB2::readDefineFun(const vstring& name, LExprList* iArgs, LExpr* oSort,
 
   FormulaUnit* fu = new FormulaUnit(fla, FromInput(UnitInputType::ASSUMPTION));
 
-  UnitList::push(fu, _formulas);
+  _formulas.pushBack(fu);
 }
 
 void SMTLIB2::readTypeParameters(LispListReader& rdr, TermLookup* lookup, TermStack* ts)
@@ -2853,7 +2852,7 @@ void SMTLIB2::readAssert(LExpr* body)
   }
 
   FormulaUnit* fu = new FormulaUnit(fla, FromInput(UnitInputType::ASSUMPTION));
-  UnitList::push(fu, _formulas);
+  _formulas.pushBack(fu);
 }
 
 void SMTLIB2::readAssertClaim(LExpr* body)
@@ -2871,7 +2870,7 @@ void SMTLIB2::readAssertClaim(LExpr* body)
   static unsigned claim_id = 0;
 
   FormulaUnit* fu = new FormulaUnit(fla, FromInput(UnitInputType::ASSUMPTION));
-  UnitList::push(TPTP::processClaimFormula(fu,fla,"claim"+Int::toString(claim_id++)), _formulas);
+  _formulas.pushBack(TPTP::processClaimFormula(fu,fla,"claim"+Int::toString(claim_id++)));
 }
 
 void SMTLIB2::readAssertNot(LExpr* body)
@@ -2889,7 +2888,7 @@ void SMTLIB2::readAssertNot(LExpr* body)
   FormulaUnit* fu = new FormulaUnit(fla, FromInput(UnitInputType::CONJECTURE));
   fu = new FormulaUnit(new NegatedFormula(fla),
                        FormulaTransformation(InferenceRule::NEGATED_CONJECTURE, fu));
-  UnitList::push(fu, _formulas);
+  _formulas.pushBack(fu);
 }
 
 void SMTLIB2::readAssertTheory(LExpr* body)
@@ -2905,7 +2904,7 @@ void SMTLIB2::readAssertTheory(LExpr* body)
   }
 
   FormulaUnit* fu = new FormulaUnit(theoryAxiom, Inference(TheoryAxiom(InferenceRule::EXTERNAL_THEORY_AXIOM)));
-  UnitList::push(fu, _formulas);
+  _formulas.pushBack(fu);
 }
 
 Signature::Symbol* SMTLIB2::getSymbol(DeclaredSymbol& s) {

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -61,7 +61,7 @@ using namespace std;
 static const char* PAR = "par";
 static const char* TYPECON_POSTFIX = "()";
 
-SMTLIB2::SMTLIB2(const Options& opts)
+SMTLIB2::SMTLIB2()
 : _logicSet(false),
   _logic(SMT_UNDEFINED),
   _numeralsAreReal(false),

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -61,10 +61,11 @@ using namespace std;
 static const char* PAR = "par";
 static const char* TYPECON_POSTFIX = "()";
 
-SMTLIB2::SMTLIB2()
+SMTLIB2::SMTLIB2(UnitList::FIFO formulaBuffer)
 : _logicSet(false),
   _logic(SMT_UNDEFINED),
   _numeralsAreReal(false),
+  _formulas(formulaBuffer),
   _topLevelExpr(nullptr)
 {
 }

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -35,7 +35,16 @@ using namespace Shell;
 
 class SMTLIB2 {
 public:
-  SMTLIB2();
+  /**
+   * @brief Construct a new SMTLIB2 parser
+   *
+   * @param formulaBuffer is FIFO to which newly parsed Formulas will be added (via pushBack);
+   *
+   *  if left unspeficied, and empty fifo is created and used instead.
+   *  (use this default behaviour if you do not want to collect formulas
+   *  from multiple parser calls)
+   */
+  SMTLIB2(UnitList::FIFO formulaBuffer = UnitList::FIFO());
 
   /** Parse from an open stream */
   void parse(std::istream& str);
@@ -51,6 +60,8 @@ public:
    *  We don't know what the conjecture is.
    **/
   UnitList* getFormulas() const { return _formulas.list(); }
+  /** Return the current formulaBuffer (on top of getFormulas() you also get a pointer to the last added unit in constant time). */
+  UnitList::FIFO formulaBuffer() const { return _formulas; }
 
   /**
    * Return the parsed logic (or LO_INVALID if not set).

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -35,7 +35,7 @@ using namespace Shell;
 
 class SMTLIB2 {
 public:
-  SMTLIB2(const Options& opts);
+  SMTLIB2();
 
   /** Parse from an open stream */
   void parse(std::istream& str);

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -50,7 +50,7 @@ public:
    *
    *  We don't know what the conjecture is.
    **/
-  UnitList* getFormulas() const { return _formulas; }
+  UnitList* getFormulas() const { return _formulas.list(); }
 
   /**
    * Return the parsed logic (or LO_INVALID if not set).
@@ -486,7 +486,7 @@ private:
   /**
    * Units collected during parsing.
    */
-  UnitList* _formulas;
+  UnitList::FIFO _formulas;
 
   /**
    * To support a mechanism for dealing with large arithmetic constants.

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -3660,7 +3660,7 @@ void TPTP::endFof()
   default:
     break;
   }
-  _units.push(unit);
+  _units.pushBack(unit);
 } // tag
 
 /*
@@ -3670,7 +3670,7 @@ void TPTP::endFof()
 * that will serve as the name of the predice we introduce:
 *
 * Now instead of returning it directly, we turn it into an equivalence
-* with a fresh predicate symbol (of name nm) and return that one. 
+* with a fresh predicate symbol (of name nm) and return that one.
 * The new symbo is marked not to be eliminated during preprocessing.
 */
 Unit* TPTP::processClaimFormula(Unit* unit, Formula * f, const vstring& nm)

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -83,11 +83,12 @@ UnitList* TPTP::parse(istream& input)
  * Initialise a lexer.
  * @since 27/07/2004 Torrevieja
  */
-TPTP::TPTP(istream& in)
+TPTP::TPTP(istream& in, UnitList::FIFO unitBuffer)
   : _containsConjecture(false),
     _allowedNames(0),
     _in(&in),
     _includeDirectory(""),
+    _units(unitBuffer),
     _isThf(false),
     _containsPolymorphism(false),
     _currentColor(COLOR_TRANSPARENT),

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -28,6 +28,7 @@
 #include "Kernel/SortHelper.hpp"
 #include "Kernel/Theory.hpp"
 #include "Kernel/RobSubstitution.hpp"
+#include "Kernel/FormulaVarIterator.hpp"
 
 #include "Shell/Options.hpp"
 #include "Shell/Statistics.hpp"
@@ -3639,7 +3640,7 @@ void TPTP::endFof()
         unit = new FormulaUnit(f,FormulaTransformation(InferenceRule::ANSWER_LITERAL,unit));
     }
     else {
-      VList* vs = f->freeVariables();
+      VList* vs = freeVariables(f);
       if (VList::isEmpty(vs)) {
         f = new NegatedFormula(f);
       }
@@ -3681,7 +3682,7 @@ Unit* TPTP::processClaimFormula(Unit* unit, Formula * f, const vstring& nm)
   }
   env.signature->getPredicate(pred)->markLabel();
   Formula* claim = new AtomicFormula(Literal::create(pred, /* polarity */ true, {}));
-  VList* vs = f->freeVariables();
+  VList* vs = freeVariables(f);
   if (VList::isNonEmpty(vs)) {
     //TODO can we use sortOf to get sorts of vs?
     f = new QuantifiedFormula(FORALL,vs,0,f);

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -109,11 +109,20 @@ TPTP::~TPTP()
 {
 } // TPTP::~TPTP
 
+void TPTP::parse()
+{
+  try{
+    parseImpl();
+  } catch (UserErrorException& exception) {
+    throw ParseErrorException(exception.msg(),lineNumber());
+  }
+}
+
 /**
  * Read all tokens one by one 
  * @since 08/04/2011 Manchester
  */
-void TPTP::parse()
+void TPTP::parseImpl()
 {
   // bulding tokens one by one
   _gpos = 0;
@@ -1081,7 +1090,7 @@ TPTP::ParseErrorException::ParseErrorException(vstring message,Token& tok, unsig
  */
 void TPTP::ParseErrorException::cry(ostream& str) const
 {
-  str << "Parsing Error on line " << _ln << "\n";
+  str << "Parsing Error on line " << _ln << ": ";
   str << _message << "\n";
 }
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -440,37 +440,6 @@ private:
      VList* _vars;
   }; // ProductType
 
-  /**
-   * Class that allows to create a list initially by pushing elements
-   * at the end of it.
-   * @since 10/05/2007 Manchester, updated from List::FIFO
-   */
-  class UnitStack {
-  public:
-    /** constructor */
-    inline explicit UnitStack()
-      : _initial(0),
-	_last(&_initial)
-    {}
-
-    /** add element at the end of the original list */
-    inline void push(Unit* u)
-    {
-      UnitList* newList = new UnitList(u);
-      *_last = newList;
-      _last = reinterpret_cast<UnitList**>(&newList->tailReference());
-    }
-
-    /** Return the collected list */
-    UnitList* list() { return _initial; }
-
-  private:
-    /** reference to the initial element */
-    UnitList* _initial;
-    /** last element */
-    UnitList** _last;
-  }; // class UnitStack
-
   enum TheorySort {
     /** $array theoy */
     TS_ARRAY,
@@ -569,8 +538,8 @@ private:
   int _tend;
   /** line number */
   unsigned _lineNumber;
-  /** The stack of units read */
-  UnitStack _units;
+  /** The list of units read (with additions directed to the end) */
+  UnitList::FIFO _units;
   /** stack of unprocessed states */
   Stack<State> _states;
   /** input type of the last read unit */ // it must be int since -1 can be used as a value

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -301,8 +301,8 @@ public:
   /**
    * Implements lexer and parser exceptions.
    */
-  class ParseErrorException 
-    : public ::Exception
+  class ParseErrorException
+    : public ParsingRelatedException
   {
   public:
     ParseErrorException(vstring message,unsigned ln) : _message(message), _ln(ln) {}

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -324,7 +324,7 @@ public:
   void parse();
   static UnitList* parse(std::istream& str);
   /** Return the list of parsed units */
-  inline UnitList* units() { return _units.list(); }
+  UnitList* units() const { return _units.list(); }
   /**
    * Return true if there was a conjecture formula among the parsed units
    *

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -314,17 +314,29 @@ public:
     vstring _message;
     unsigned _ln;
   }; // TPTP::ParseErrorException
-  friend class Exception;
 
 #define PARSE_ERROR(msg,tok) \
   throw ParseErrorException(msg,tok,_lineNumber)
 
-  TPTP(std::istream& in);
+  /**
+   * @brief Construct a new TPTP parser.
+   *
+   * @param in is the stream with the raw input to read
+   * @param unitBuffer is FIFO of units to which newly parsed Clauses/Formulas
+   *   will be added (via pushBack);
+   *
+   *  if left unspeficied, and empty fifo is created and used instead.
+   *  (use this default behaviour if you do not want to collect formulas
+   *   from multiple parser calls)
+   */
+  TPTP(std::istream& in, UnitList::FIFO unitBuffer = UnitList::FIFO());
   ~TPTP();
   void parse();
   static UnitList* parse(std::istream& str);
   /** Return the list of parsed units */
   UnitList* units() const { return _units.list(); }
+  /** Return the current unitBuffer (on top of units() you also get a pointer to the last added unit in constant time). */
+  UnitList::FIFO unitBuffer() const { return _units; }
   /**
    * Return true if there was a conjecture formula among the parsed units
    *

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -351,6 +351,7 @@ public:
   static void assignAxiomName(const Unit* unit, vstring& name);
   unsigned lineNumber(){ return _lineNumber; }
 private:
+  void parseImpl();
   /** Return the input string of characters */
   const char* input() { return _chars.content(); }
 

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -1799,9 +1799,8 @@ UnitList* Splitter::preprendCurrentlyAssumedComponentClauses(UnitList* clauses)
 {
   DHSet<Clause*> seen;
 
-  UnitList*   res = nullptr;
   // to keep the nice order
-  UnitList::FIFO fifo(res);
+  UnitList::FIFO res;
 
   ArraySet::Iterator ait(_branchSelector._selected);
   while(ait.hasNext()) {
@@ -1810,8 +1809,7 @@ UnitList* Splitter::preprendCurrentlyAssumedComponentClauses(UnitList* clauses)
 
     //cout << "selected level: " level << " has clause: " << cl->toString() << endl;
     seen.insert(cl);
-
-    fifo.pushBack(cl);
+    res.pushBack(cl);
   }
 
   // OK, for simplicity's sake, let's not even try keeping any of the old links
@@ -1822,13 +1820,13 @@ UnitList* Splitter::preprendCurrentlyAssumedComponentClauses(UnitList* clauses)
 
     if (seen.insert(cl)) {
       // cout << "a new guy: " << cl->toString() << endl;
-      fifo.pushBack(cl);
+      res.pushBack(cl);
     } else {
       // cout << "seen already: " << cl->toString() << endl;
     }
   }
 
-  return res;
+  return res.list();
 }
 
 }

--- a/Shell/CommandLine.cpp
+++ b/Shell/CommandLine.cpp
@@ -95,17 +95,6 @@ void CommandLine::interpret (Options& options)
       options.setInputFile(arg);
     }
   }
-  // Don't force options if in Portfolio mode as the
-  // forced options should apply to inner strategies only
-  // Don't check global option constraints in Portoflio mode
-  // as these are checked oon each inner strategy
-  if(options.mode() != Options::Mode::PORTFOLIO){
-    options.setForcedOptionValues();
-    options.checkGlobalOptionConstraints();
-  }
-  if(options.encodeStrategy()){
-    cout << options.generateEncodedOptions() << "\n";
-  }
 } // CommandLine::interpret
 
 

--- a/Shell/CommandLine.cpp
+++ b/Shell/CommandLine.cpp
@@ -32,7 +32,7 @@ namespace Shell {
 
 using namespace std;
 
-CommandLine::CommandLine (int argc, char* argv [])
+CommandLine::CommandLine (int argc, const char * const argv [])
   : _next(argv+1),
     _last(argv+argc)
 {
@@ -63,9 +63,9 @@ void CommandLine::interpret (Options& options)
     // If --help or -h are used without arguments we still print help
     // If --help is used at all we print help
     // If -h is included at the end of the argument list we print help
-    if(strcmp(arg,"--help")==0 || 
+    if(strcmp(arg,"--help")==0 ||
        (strcmp(arg,"-h")==0 && _next==_last) //if -h and there is no more
-      ){ 
+      ){
       // cout << _next << " " << _last << endl;
       options.set("help","on");
       env.beginOutput();
@@ -75,7 +75,7 @@ void CommandLine::interpret (Options& options)
     }
     if (arg[0] == '-') {
       if (_next == _last) {
-	USER_ERROR((vstring)"no value specified for option " + arg);
+	      USER_ERROR((vstring)"no value specified for option " + arg);
       }
       else{
          if (arg[1] == '-') {
@@ -89,7 +89,7 @@ void CommandLine::interpret (Options& options)
     }
     else { // next is not an option but a file name
       if (fileGiven) {
-	USER_ERROR("two input file names specified");
+	      USER_ERROR("two input file names specified");
       }
       fileGiven = true;
       options.setInputFile(arg);

--- a/Shell/CommandLine.hpp
+++ b/Shell/CommandLine.hpp
@@ -29,13 +29,13 @@ class Options;
 class CommandLine
 {
 public:
-  CommandLine(int argc, char* argv []);
+  CommandLine(int argc, const char* const argv []);
   void interpret(Options&);
 private:
   /** Next string to process */
-  char** _next;
+  const char* const * _next;
   /** (After) last string to process */
-  char** _last;
+  const char* const * _last;
 }; // class CommandLine
 
 }

--- a/Shell/EqResWithDeletion.cpp
+++ b/Shell/EqResWithDeletion.cpp
@@ -18,6 +18,7 @@
 #include "Kernel/SubstHelper.hpp"
 #include "Kernel/Term.hpp"
 #include "Kernel/Unit.hpp"
+#include "Kernel/FormulaVarIterator.hpp"
 
 #include "EqResWithDeletion.hpp"
 
@@ -115,15 +116,17 @@ TermList EqResWithDeletion::apply(unsigned var)
 
 bool EqResWithDeletion::scan(Literal* lit)
 {
+  using Kernel::isFreeVariableOf;
+
   if(lit->isEquality() && lit->isNegative()) {
     TermList t0=*lit->nthArgument(0);
     TermList t1=*lit->nthArgument(1);
-    if( t0.isVar() && !t1.containsSubterm(t0) && (!_ansLit || !t1.isTerm() || t1.term()->computableOrVar() || !_ansLit->isFreeVariable(t0.var()))) {
+    if( t0.isVar() && !t1.containsSubterm(t0) && (!_ansLit || !t1.isTerm() || t1.term()->computableOrVar() || !isFreeVariableOf(_ansLit,t0.var()))) {
       if(_subst.insert(t0.var(), t1)) {
         return true;
       }
     }
-    if( t1.isVar() && !t0.containsSubterm(t1) && (!_ansLit || !t0.isTerm() || t0.term()->computableOrVar() || !_ansLit->isFreeVariable(t1.var()))) {
+    if( t1.isVar() && !t0.containsSubterm(t1) && (!_ansLit || !t0.isTerm() || t0.term()->computableOrVar() || !isFreeVariableOf(_ansLit,t1.var()))) {
       if(_subst.insert(t1.var(), t0)) {
         return true;
       }

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -426,7 +426,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
   // it becomes the quantified variables of a formula,
   // and leaks with the formula. In other situations, it leaks
   // form this function.
-  VList* freeVars = term->freeVariables();
+  VList* freeVars = freeVariables(term);
   TermStack termVarSorts;
   TermStack termVars;
   TermStack typeVars;
@@ -606,7 +606,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
 
         // collect variables B1,...,Bj,X1, ..., Xn
         VList* bodyFreeVars = VList::empty();
-        FormulaVarIterator bfvi(&binding);
+        FormulaVarIterator bfvi(binding);
         while (bfvi.hasNext()) {
           unsigned var = bfvi.next();
           if (!VList::member(var, argumentVars)) {

--- a/Shell/Lexer.hpp
+++ b/Shell/Lexer.hpp
@@ -35,10 +35,10 @@ class Lexer;
  * Class LexerException. Implements lexer exceptions.
  * @since 14/07/2004 Turku
  */
-class LexerException 
-  : public Exception
+class LexerException
+  : public ParsingRelatedException
 {
- public:                                
+ public:
   LexerException(vstring message,const Lexer&);
   void cry(std::ostream&) const;
   ~LexerException() {}
@@ -51,7 +51,7 @@ class LexerException
  * Class Lexer, implements a generic lexer.
  * @since 27/07/2004 Torrevieja
  */
-class Lexer 
+class Lexer
 {
 public:
   Lexer(std::istream& in);

--- a/Shell/LispParser.hpp
+++ b/Shell/LispParser.hpp
@@ -90,10 +90,10 @@ public:
    * Class Exception. Implements parser exceptions.
    * @since 17/07/2004 Helsinki airport
    */
-  class Exception 
-    : public Lib::Exception
+  class Exception
+    : public Lib::ParsingRelatedException
   {
-  public:                                
+  public:
     Exception (vstring message,const Token&);
     void cry (std::ostream&) const;
     ~Exception () {}

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -388,22 +388,21 @@ FormulaList* NNF::ennf (FormulaList* fs, bool polarity)
     return fs;
   }
 
-  FormulaList* result = FormulaList::empty();
-  FormulaList::FIFO stack(result);
+  FormulaList::FIFO result;
   bool changed = false;
   FormulaList::Iterator it(fs);
   while (it.hasNext()) {
     Formula* f = it.next();
     Formula* g = ennf(f,polarity);
-    stack.pushBack(g);
+    result.pushBack(g);
     if (f != g) {
       changed = true;
     }
   }
   if (changed) {
-    return result;
+    return result.list();
   }
-  FormulaList::destroy(result);
+  FormulaList::destroy(result.list());
   return fs;
 } // NNF::ennf(FormulaList...)
 
@@ -535,22 +534,21 @@ FormulaList* NNF::nnf (FormulaList* fs, bool polarity)
     return fs;
   }
 
-  FormulaList* result = FormulaList::empty();
-  FormulaList::FIFO stack(result);
+  FormulaList::FIFO result;
   bool changed = false;
   FormulaList::Iterator it(fs);
   while (it.hasNext()) {
     Formula* f = it.next();
     Formula* g = nnf(f,polarity);
-    stack.pushBack(g);
+    result.pushBack(g);
     if (f != g) {
       changed = true;
     }
   }
   if (changed) {
-    return result;
+    return result.list();
   }
-  FormulaList::destroy(result);
+  FormulaList::destroy(result.list());
   return fs;
 } // NNF::nnf(FormulaList...)
 

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -27,6 +27,7 @@
 #include "Kernel/Signature.hpp"
 #include "Kernel/SortHelper.hpp"
 #include "Kernel/SubformulaIterator.hpp"
+#include "Kernel/FormulaVarIterator.hpp"
 #include "Kernel/Term.hpp"
 #include "Kernel/ApplicativeHelper.hpp"
 
@@ -65,7 +66,7 @@ Naming::Naming(int threshold, bool preserveEpr, bool appify) :
  */
 FormulaUnit* Naming::apply(FormulaUnit* unit, UnitList*& defs) {
   ASS(!unit->isClause());
-  ASS_REP(unit->formula()->freeVariables() == 0, *unit);
+  ASS_REP(!FormulaVarIterator(unit->formula()).hasNext(), *unit);
   ASS(!_varsInScope); //_varsInScope can be true only when traversing inside a formula
 
   if (env.options->showPreprocessing()) {
@@ -1069,11 +1070,9 @@ bool Naming::canBeInDefinition(Formula* f, Where where) {
     }
   }
 
-  VList* fvars = f->freeVariables();
-  bool freeVars = fvars;
-  VList::destroy(fvars);
+  bool hasFreeVars = FormulaVarIterator(f).hasNext();
 
-  if (!_varsInScope && freeVars
+  if (!_varsInScope && hasFreeVars
       && (exQuant || (unQuant && where == UNDER_IFF))) {
     return false;
   }
@@ -1163,8 +1162,7 @@ Formula* Naming::introduceDefinition(Formula* f, bool iff) {
 
   RSTAT_CTR_INC("naming_introduced_defs");
 
-  VList* vs;
-  vs = f->freeVariables();
+  VList* vs = freeVariables(f);
   Literal* atom = getDefinitionLiteral(f, vs);
   Formula* name = new AtomicFormula(atom);
 

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -196,8 +196,8 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
       }
     } else {
       VarSet* fv = freeVars(condition);
-      fv = fv->getUnion(VarSet::getFromIterator(FormulaVarIterator(&thenBranch)));
-      fv = fv->getUnion(VarSet::getFromIterator(FormulaVarIterator(&elseBranch)));
+      fv = fv->getUnion(VarSet::getFromIterator(FormulaVarIterator(thenBranch)));
+      fv = fv->getUnion(VarSet::getFromIterator(FormulaVarIterator(elseBranch)));
 
       VList* vars = VList::singleton(variable);
       VList::pushFromIterator(fv->iter(), vars);
@@ -817,7 +817,7 @@ void NewCNF::processLet(Term::SpecialTermData* sd, TermList contents, Occurrence
 TermList NewCNF::nameLetBinding(unsigned symbol, VList* bindingVariables, TermList binding, TermList contents)
 {
   VList* bindingFreeVars = VList::empty();
-  FormulaVarIterator bfvi(&binding);
+  FormulaVarIterator bfvi(binding);
   while (bfvi.hasNext()) {
     unsigned var = bfvi.next();
     if (!VList::member(var, bindingVariables)) {
@@ -1349,7 +1349,7 @@ void NewCNF::toClauses(SPGenClause gc, Stack<Clause*>& output)
         List<GenLit>::Iterator glsit(gls);
         while (glsit.hasNext()) {
           GenLit gl = glsit.next();
-          if (formula(gl)->isFreeVariable(variable)) {
+          if (isFreeVariableOf(formula(gl),variable)) {
             occurs = true;
             break;
           }
@@ -1391,7 +1391,7 @@ void NewCNF::toClauses(SPGenClause gc, Stack<Clause*>& output)
         List<GenLit>::Iterator glsit(gls);
         while (glsit.hasNext()) {
           GenLit gl = glsit.next();
-          if (formula(gl)->isFreeVariable(variable)) {
+          if (isFreeVariableOf(formula(gl),variable)) {
             occurs = true;
             break;
           }

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -105,6 +105,11 @@ void Options::init()
   _parsingDoesNotCount.tag(OptionTag::DEVELOPMENT);
 #endif
 
+    _interactive = BoolOptionValue("interactive","",false);
+    _interactive.description = "An experimental interactive mode (commands to use: load <file to parse>, read <line to parse>, pop (to drop the last added set of formulas), run [options to supply], exit).";
+    _interactive.setExperimental();
+    _lookup.insert(&_interactive);
+
     _mode = ChoiceOptionValue<Mode>("mode","",Mode::VAMPIRE,
                                     {"axiom_selection",
                                         "casc",

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -382,11 +382,7 @@ void Options::init()
     _inputFile.tag(OptionTag::INPUT);
     _inputFile.setExperimental();
 
-    _inputSyntax= ChoiceOptionValue<InputSyntax>("input_syntax","",
-                                                 //in case we compile vampire with bpa, then the default input syntax is smtlib
-                                                 InputSyntax::AUTO,
-                                                 //{"simplify","smtlib","smtlib2","tptp"});//,"xhuman","xmps","xnetlib"});
-                                                 {"smtlib2","tptp","auto"});//,"xhuman","xmps","xnetlib"});
+    _inputSyntax= ChoiceOptionValue<InputSyntax>("input_syntax","",InputSyntax::AUTO,{"smtlib2","tptp","auto"});
     _inputSyntax.description=
     "Input syntax. Historic input syntaxes have been removed as they are not actively maintained. Contact developers for help with these.";
     _lookup.insert(&_inputSyntax);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1982,6 +1982,7 @@ public:
   LTBLearning ltbLearning() const { return _ltbLearning.actualValue; }
   vstring ltbDirectory() const { return _ltbDirectory.actualValue; }
   Mode mode() const { return _mode.actualValue; }
+  void setMode(Mode mode) { _mode.actualValue = mode; }
   Schedule schedule() const { return _schedule.actualValue; }
   vstring scheduleName() const { return _schedule.getStringOfValue(_schedule.actualValue); }
   void setSchedule(Schedule newVal) {  _schedule.actualValue = newVal; }
@@ -2001,6 +2002,7 @@ public:
   vstring include() const { return _include.actualValue; }
   void setInclude(vstring val) { _include.actualValue = val; }
   vstring inputFile() const { return _inputFile.actualValue; }
+  void resetInputFile() { _inputFile.actualValue = ""; }
   int activationLimit() const { return _activationLimit.actualValue; }
   unsigned randomSeed() const { return _randomSeed.actualValue; }
   void setRandomSeed(unsigned seed) { _randomSeed.actualValue = seed; }

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2125,6 +2125,8 @@ public:
   unsigned setSimulatedInstructionLimit() const { return _simulatedInstructionLimit.actualValue; }
   bool parsingDoesNotCount() const { return _parsingDoesNotCount.actualValue; }
 #endif
+  bool interactive() const { return _interactive.actualValue; }
+  void setInteractive(bool v) { _interactive.actualValue = v; }
   int inequalitySplitting() const { return _inequalitySplitting.actualValue; }
   int ageRatio() const { return _ageWeightRatio.actualValue; }
   void setAgeRatio(int v){ _ageWeightRatio.actualValue = v; }
@@ -2546,6 +2548,9 @@ private:
 #endif
 
   UnsignedOptionValue _memoryLimit; // should be size_t, making an assumption
+
+  BoolOptionValue _interactive;
+
   ChoiceOptionValue<Mode> _mode;
   ChoiceOptionValue<Schedule> _schedule;
   StringOptionValue _scheduleFile;

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -390,22 +390,21 @@ Formula* Skolem::skolemise (Formula* f)
       typeVars.reset();
 
       // for proof recording purposes, see below
-      VList* varArgs = VList::empty();
       //We use a FIFO structure since in the polymorphic case
       //a variable list must be of the form [typevars, termvars]
-      VList::FIFO vArgs(varArgs);
+      VList::FIFO vArgs;
       Formula* before = SubstHelper::apply(f, _subst);
-      
+
       ExVarDepInfo& depInfo = _varDeps.get(f);
 
       VarSet* dep = depInfo.univ;
 
       /*
-       * Universals occuring below are not enough, 
+       * Universals occuring below are not enough,
        * because some existential from above could depend on them
        * and its corresponding skolem will bring them here...
-       * 
-       * Ex: ! [A] : ? [B] : ( p(A,B) | ? [C] : r(B,C) & something ) 
+       *
+       * Ex: ! [A] : ? [B] : ( p(A,B) | ? [C] : r(B,C) & something )
        * when skolimising the subformula
        * ? [C] : r(B,C) & something
        * univ dep of C is empty, but A will sneak into the actual dep
@@ -473,10 +472,10 @@ Formula* Skolem::skolemise (Formula* f)
           //sk(typevars, termvars).
           if(skolemisingTypeVar){
             sym = addSkolemTypeCon(arity);
-            skolemTerm = AtomicSort::create(sym, arity, allVars.begin());    
+            skolemTerm = AtomicSort::create(sym, arity, allVars.begin());
           } else {
             sym = addSkolemFunction(arity, termVarSorts.begin(), rangeSort, v, typeVars.size());
-            skolemTerm = Term::create(sym, arity, allVars.begin());    
+            skolemTerm = Term::create(sym, arity, allVars.begin());
           }
         } else {
           //The higher-order case. Create the term
@@ -485,7 +484,7 @@ Formula* Skolem::skolemise (Formula* f)
           sym = addSkolemFunction(typeVars.size(), 0, skSymSort, v, typeVars.size());
           TermList head = TermList(Term::create(sym, typeVars.size(), typeVars.begin()));
           skolemTerm = ApplicativeHelper::createAppTerm(
-            SortHelper::getResultSort(head.term()), head, termVars).term();      
+            SortHelper::getResultSort(head.term()), head, termVars).term();
         }
         _introducedSkolemSyms.push(make_pair(skolemisingTypeVar, sym));
 
@@ -520,7 +519,7 @@ Formula* Skolem::skolemise (Formula* f)
         Formula* def = new BinaryFormula(IMP, before, after);
 
         if (arity > 0) {
-          def = new QuantifiedFormula(FORALL,varArgs,nullptr,def);
+          def = new QuantifiedFormula(FORALL,vArgs.list(),nullptr,def);
         }
 
         Unit* defUnit = new FormulaUnit(def,NonspecificInference0(UnitInputType::AXIOM,InferenceRule::CHOICE_AXIOM));

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -397,7 +397,7 @@ Problem* UIHelper::getInputProblem()
 
 void UIHelper::listLoadedPieces(ostream& out)
 {
-  Stack<LoadedPiece>::BottomFirstIterator it(_loadedPieces);
+  auto it = _loadedPieces.iterFifo();
   ALWAYS(it.next()._id.empty()); // skip the first, empty, entry
   while (it.hasNext()) {
     out << " " << it.next()._id << endl;

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -404,6 +404,14 @@ void UIHelper::listLoadedPieces(ostream& out)
   }
 }
 
+void UIHelper::popLoadedPiece()
+{
+  if (_loadedPieces.size() > 1) {
+    _loadedPieces.pop();
+    UnitList::destroy(_loadedPieces.top()._units.clipAtLast());
+  }
+}
+
 /**
  * Output result based on the content of
  * @b env.statistics->terminationReason

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -67,7 +67,7 @@ bool outputAllowed(bool debug)
   return !Lib::env.options ||
     (
      Lib::env.options->outputMode() != Shell::Options::Output::SPIDER
-     && Lib::env.options->outputMode() != Shell::Options::Output::SMTCOMP 
+     && Lib::env.options->outputMode() != Shell::Options::Output::SMTCOMP
      && Lib::env.options->outputMode() != Shell::Options::Output::UCORE
      );
 }
@@ -141,7 +141,7 @@ bool UIHelper::portfolioParent=false;
 bool UIHelper::satisfiableStatusWasAlreadyOutput=false;
 
 bool UIHelper::spiderOutputDone = false;
-  
+
 void UIHelper::outputAllPremises(ostream& out, UnitList* units, vstring prefix)
 {
 #if 1
@@ -311,19 +311,10 @@ Problem* UIHelper::getInputProblem(const Options& opts)
          try{
            units = tryParseSMTLIB2(input,smtLibLogic);
          }
-         catch (UserErrorException& exception) {
+         catch (ParsingRelatedException& exception) {
            resetParsing(exception,inputFile,input,"TPTP");
            units = tryParseTPTP(input);
          }
-         catch (LexerException& exception) {
-           resetParsing(exception,inputFile,input,"TPTP");
-           units = tryParseTPTP(input);
-         }
-         catch (LispParser::Exception& exception) {
-           resetParsing(exception,inputFile,input,"TPTP");
-           units = tryParseTPTP(input);
-         }
-
        }
        else {
          if (mode != Options::Mode::SPIDER && mode != Options::Mode::PROFILE) {
@@ -374,7 +365,7 @@ void UIHelper::outputResult(ostream& out)
 {
   switch (env.statistics->terminationReason) {
   case Statistics::REFUTATION:
-    if(env.options->outputMode() == Options::Output::SMTCOMP){ 
+    if(env.options->outputMode() == Options::Output::SMTCOMP){
       out << "unsat" << endl;
       return;
     }
@@ -583,7 +574,7 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, 
   } else if(typeCon){
     sym = env.signature->getTypeCon(symNumber);
   } else {
-    sym = env.signature->getPredicate(symNumber);    
+    sym = env.signature->getPredicate(symNumber);
   }
 
   if (typeCon && (env.signature->isArrayCon(symNumber) ||
@@ -591,7 +582,7 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, 
     return;
   }
 
-  if(typeCon && env.signature->isDefaultSortCon(symNumber) && 
+  if(typeCon && env.signature->isDefaultSortCon(symNumber) &&
     (!env.signature->isBoolCon(symNumber) || !env.options->showFOOL())){
     return;
   }
@@ -618,7 +609,7 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, 
     }
   }
 
-  OperatorType* type = function ? sym->fnType() : 
+  OperatorType* type = function ? sym->fnType() :
                (typeCon ? sym->typeConType() : sym->predType());
 
   if (type->isAllDefault()) {//TODO required
@@ -637,7 +628,7 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(ostream& out, bool function, 
   //don't output type of app. It is an internal Vampire thing
   if(!(function && env.signature->isAppFun(symNumber))){
     out << (env.getMainProblem()->isHigherOrder() ? "thf(" : "tff(")
-        << (function ? "func" : (typeCon ?  "type" : "pred")) 
+        << (function ? "func" : (typeCon ?  "type" : "pred"))
         << "_def_" << symNumber << ", type, "
         << symName << ": ";
     out << type->toString();

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -219,9 +219,9 @@ UnitList* UIHelper::tryParseTPTP(istream* input)
   return parser.units();
 }
 
-UnitList* UIHelper::tryParseSMTLIB2(const Options& opts,istream* input,SMTLIBLogic& smtLibLogic)
+UnitList* UIHelper::tryParseSMTLIB2(istream* input, SMTLIBLogic& smtLibLogic)
 {
-  Parse::SMTLIB2 parser(opts);
+  Parse::SMTLIB2 parser;
   parser.parse(*input);
   Unit::onParsingEnd();
 
@@ -300,7 +300,7 @@ Problem* UIHelper::getInputProblem(const Options& opts)
        // First lets pick a place to start based on the input file name
        bool smtlib = hasEnding(inputFile,"smt") || hasEnding(inputFile,"smt2");
        Options::Mode mode = env.options->mode();
-       
+
        if (smtlib){
          if (mode != Options::Mode::SPIDER && mode != Options::Mode::PROFILE) {
            env.beginOutput();
@@ -309,7 +309,7 @@ Problem* UIHelper::getInputProblem(const Options& opts)
            env.endOutput();
          }
          try{
-           units = tryParseSMTLIB2(opts,input,smtLibLogic);
+           units = tryParseSMTLIB2(input,smtLibLogic);
          }
          catch (UserErrorException& exception) {
            resetParsing(exception,inputFile,input,"TPTP");
@@ -333,21 +333,21 @@ Problem* UIHelper::getInputProblem(const Options& opts)
            env.endOutput();
          }
          try{
-           units = tryParseTPTP(input); 
+           units = tryParseTPTP(input);
          }
          catch (Parse::TPTP::ParseErrorException& exception) {
-           resetParsing(exception,inputFile,input,"SMTLIB2"); 
-           units = tryParseSMTLIB2(opts,input,smtLibLogic); 
+           resetParsing(exception,inputFile,input,"SMTLIB2");
+           units = tryParseSMTLIB2(input,smtLibLogic);
          }
        }
-       
+
     }
     break;
   case Options::InputSyntax::TPTP:
     units = tryParseTPTP(input);
     break;
   case Options::InputSyntax::SMTLIB2:
-    units = tryParseSMTLIB2(opts,input,smtLibLogic);
+    units = tryParseSMTLIB2(input,smtLibLogic);
     break;
   }
   if (inputFile!="") {

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -404,11 +404,13 @@ void UIHelper::listLoadedPieces(ostream& out)
   }
 }
 
-void UIHelper::popLoadedPiece()
+void UIHelper::popLoadedPiece(int numPops)
 {
-  if (_loadedPieces.size() > 1) {
-    _loadedPieces.pop();
-    UnitList::destroy(_loadedPieces.top()._units.clipAtLast());
+  while (numPops-- > 0) {
+    if (_loadedPieces.size() > 1) {
+      _loadedPieces.pop();
+      UnitList::destroy(_loadedPieces.top()._units.clipAtLast());
+    }
   }
 }
 

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -375,7 +375,6 @@ void UIHelper::parseFile(const vstring& inputFile, Options::InputSyntax inputSyn
   }
 }
 
-
 /**
  * After a single call (or a series of calls) to parse* functions,
  * return a problem object with the obtained units.
@@ -389,11 +388,20 @@ void UIHelper::parseFile(const vstring& inputFile, Options::InputSyntax inputSyn
  */
 Problem* UIHelper::getInputProblem()
 {
-  LoadedPiece topPiece = _loadedPieces.top();
+  LoadedPiece& topPiece = _loadedPieces.top();
   Problem* res = new Problem(topPiece._units.list());
   res->setSMTLIBLogic(topPiece._smtLibLogic);
   env.setMainProblem(res);
   return res;
+}
+
+void UIHelper::listLoadedPieces(ostream& out)
+{
+  Stack<LoadedPiece>::BottomFirstIterator it(_loadedPieces);
+  ALWAYS(it.next()._id.empty()); // skip the first, empty, entry
+  while (it.hasNext()) {
+    out << " " << it.next()._id << endl;
+  }
 }
 
 /**

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -210,14 +210,9 @@ static bool hasEnding (vstring const &fullString, vstring const &ending) {
 void UIHelper::tryParseTPTP(istream* input)
 {
   Parse::TPTP parser(*input,_allLoadedUnits);
-  try{
+  try {
     parser.parse();
-  }
-  catch (UserErrorException& exception) {
-    UnitList::destroy(_allLoadedUnits.clipAtLast()); // destroy units that perhaps got already parsed
-    throw ParsingRelatedException(exception.msg()," at line ",parser.lineNumber());
-  }
-  catch (ParsingRelatedException& exception) {
+  } catch (ParsingRelatedException& exception) {
     UnitList::destroy(_allLoadedUnits.clipAtLast()); // destroy units that perhaps got already parsed
     throw;
   }

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -269,20 +269,22 @@ void resetParsing(ParsingRelatedException& exception, vstring inputFile, istream
 }
 
 /**
- * Return problem object with units obtained according to the content of
- * @b env.options
+ * Return problem object with units obtained through parsing inputFile (may be empty, which means read stdin)
+ * according to inputSyntax (may be auto, which triggers input syntax auto detection)
  *
  * No preprocessing is performed on the units.
+ *
+ * The Options object should intentionally not be part of this game,
+ * as any form of "conditional parsing" compromises the effective use of the correspoding conditioning option
+ * as a part of strategy development and use in portfolios. In other words, if you need getInputProblem
+ * to depend on an option, think twice, and if really needed, make it an explicit argument of this function.
  */
-Problem* UIHelper::getInputProblem(const Options& opts)
+Problem* UIHelper::getInputProblem(const vstring& inputFile, Options::InputSyntax inputSyntax, bool verbose)
 {
   TIME_TRACE(TimeTrace::PARSING);
   env.statistics->phase = Statistics::PARSING;
 
   SMTLIBLogic smtLibLogic = SMT_UNDEFINED;
-
-  vstring inputFile = opts.inputFile();
-  auto inputSyntax = opts.inputSyntax();
 
   istream* input;
   if (inputFile=="") {
@@ -308,10 +310,9 @@ Problem* UIHelper::getInputProblem(const Options& opts)
     {
        // First lets pick a place to start based on the input file name
        bool smtlib = hasEnding(inputFile,"smt") || hasEnding(inputFile,"smt2");
-       Options::Mode mode = env.options->mode();
 
        if (smtlib){
-         if (mode != Options::Mode::SPIDER && mode != Options::Mode::PROFILE) {
+         if (verbose) {
            env.beginOutput();
            addCommentSignForSZS(env.out());
            env.out() << "Running in auto input_syntax mode. Trying SMTLIB2\n";
@@ -326,7 +327,7 @@ Problem* UIHelper::getInputProblem(const Options& opts)
          }
        }
        else {
-         if (mode != Options::Mode::SPIDER && mode != Options::Mode::PROFILE) {
+         if (verbose) {
            env.beginOutput();
            addCommentSignForSZS(env.out());
            env.out() << "Running in auto input_syntax mode. Trying TPTP\n";

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -58,6 +58,8 @@ public:
 
   static Problem* getInputProblem();
 
+  static void listLoadedPieces(std::ostream& out);
+
   static void outputResult(std::ostream& out);
 
   /**

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -36,7 +36,7 @@ private:
   static void tryParseTPTP(std::istream* input);
   static void tryParseSMTLIB2(std::istream* input,SMTLIBLogic& logic);
 public:
-  static Problem* getInputProblem(const Options& opts);
+  static Problem* getInputProblem(const vstring& inputFile, Options::InputSyntax inputSyntax, bool verbose);
   static void outputResult(std::ostream& out);
 
   /**

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -20,6 +20,8 @@
 #include "Forwards.hpp"
 #include "Options.hpp"
 
+#include "Lib/Stack.hpp"
+
 namespace Shell {
 
 using namespace Lib;
@@ -33,10 +35,29 @@ bool outputAllowed(bool debug=false);
 
 class UIHelper {
 private:
-  static void tryParseTPTP(std::istream* input);
-  static void tryParseSMTLIB2(std::istream* input,SMTLIBLogic& logic);
+  // a helper class to live on a stack of loaded pieces in interactive metamode
+  // (in the standard modes, only a single instance lives on top of _loadedPieces)
+  struct LoadedPiece {
+    vstring _id;
+    UnitList::FIFO _units;
+    SMTLIBLogic _smtLibLogic;
+    bool _hasConjecture;
+    bool _proofHasConjecture;
+    LoadedPiece() : _smtLibLogic(SMT_UNDEFINED), _hasConjecture(false), _proofHasConjecture(true) {}
+  };
+  static Stack<LoadedPiece> _loadedPieces;
+
+  static void tryParseTPTP(std::istream& input);
+  static void tryParseSMTLIB2(std::istream& input);
 public:
-  static Problem* getInputProblem(const vstring& inputFile, Options::InputSyntax inputSyntax, bool verbose);
+  static void parseSingleLine(const vstring& lineToParse, Options::InputSyntax inputSyntax);
+
+  static void parseStream(std::istream& input, Options::InputSyntax inputSyntax, bool verbose, bool preferSMTonAuto);
+  static void parseStandardInput(Options::InputSyntax inputSyntax);
+  static void parseFile(const vstring& inputFile, Options::InputSyntax inputSyntax, bool verbose);
+
+  static Problem* getInputProblem();
+
   static void outputResult(std::ostream& out);
 
   /**
@@ -46,13 +67,12 @@ public:
    * SZS ontology, we decide whether to output "Theorem" or "Unsatisfiable"
    * based on this value.
    */
-  static bool haveConjecture() { return s_haveConjecture; }
-  static void setConjecturePresence(bool haveConjecture) { s_haveConjecture=haveConjecture; }
-  static bool haveConjectureInProof() { return s_proofHasConjecture; }
-  static void setConjectureInProof(bool haveConjectureInProof) { s_proofHasConjecture = haveConjectureInProof; }
+  static bool haveConjecture() { return _loadedPieces.top()._hasConjecture; }
+  static void setConjecturePresence(bool hasConjecture) { _loadedPieces.top()._hasConjecture=hasConjecture; }
+  static bool haveConjectureInProof() { return _loadedPieces.top()._proofHasConjecture; }
+  static void setConjectureInProof(bool hasConjectureInProof) { _loadedPieces.top()._proofHasConjecture = hasConjectureInProof; }
 
   static void outputAllPremises(std::ostream& out, UnitList* units, vstring prefix="");
-
 
   static void outputSatisfiableResult(std::ostream& out);
   static void outputSaturatedSet(std::ostream& out, UnitIterator uit);
@@ -67,26 +87,20 @@ public:
   static bool portfolioParent;
   /**
    * Hack not to output satisfiable status twice (we may output it earlier in
-   * IGAlgorithm, before we start generating model)
+   * FiniteModelBuilder, before we start generating model)
    */
   static bool satisfiableStatusWasAlreadyOutput;
 
   static void setExpectingSat(){ s_expecting_sat=true; }
   static void setExpectingUnsat(){ s_expecting_unsat=true; }
 
-  /** To avoid duplicate Spider outputs, which are are hard to control 
+  /** To avoid duplicate Spider outputs, which are are hard to control
    *  in presence of exceptions */
   static bool spiderOutputDone;
 
 private:
-  static UnitList::FIFO _allLoadedUnits;
-
   static bool s_expecting_sat;
   static bool s_expecting_unsat;
-
-  static bool s_haveConjecture;
-  static bool s_proofHasConjecture;
-
 };
 
 }

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -87,10 +87,6 @@ private:
   static bool s_haveConjecture;
   static bool s_proofHasConjecture;
 
-#if VDEBUG
-  static bool _inputHasBeenRead;
-#endif
-
 };
 
 }

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -32,9 +32,10 @@ void reportSpiderStatus(char status);
 bool outputAllowed(bool debug=false);
 
 class UIHelper {
+private:
+  static void tryParseTPTP(std::istream* input);
+  static void tryParseSMTLIB2(std::istream* input,SMTLIBLogic& logic);
 public:
-  static UnitList* tryParseTPTP(std::istream* input);
-  static UnitList* tryParseSMTLIB2(std::istream* input,SMTLIBLogic& logic);
   static Problem* getInputProblem(const Options& opts);
   static void outputResult(std::ostream& out);
 
@@ -78,6 +79,8 @@ public:
   static bool spiderOutputDone;
 
 private:
+  static UnitList::FIFO _allLoadedUnits;
+
   static bool s_expecting_sat;
   static bool s_expecting_unsat;
 

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -34,7 +34,7 @@ bool outputAllowed(bool debug=false);
 class UIHelper {
 public:
   static UnitList* tryParseTPTP(std::istream* input);
-  static UnitList* tryParseSMTLIB2(const Options& opts,std::istream* input,SMTLIBLogic& logic);
+  static UnitList* tryParseSMTLIB2(std::istream* input,SMTLIBLogic& logic);
   static Problem* getInputProblem(const Options& opts);
   static void outputResult(std::ostream& out);
 

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -59,7 +59,7 @@ public:
   static Problem* getInputProblem();
 
   static void listLoadedPieces(std::ostream& out);
-  static void popLoadedPiece();
+  static void popLoadedPiece(int numPops);
 
   static void outputResult(std::ostream& out);
 

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -94,6 +94,7 @@ public:
    */
   static bool satisfiableStatusWasAlreadyOutput;
 
+  static void unsetExpecting() { s_expecting_sat = s_expecting_unsat = false; }
   static void setExpectingSat(){ s_expecting_sat=true; }
   static void setExpectingUnsat(){ s_expecting_unsat=true; }
 

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -59,6 +59,7 @@ public:
   static Problem* getInputProblem();
 
   static void listLoadedPieces(std::ostream& out);
+  static void popLoadedPiece();
 
   static void outputResult(std::ostream& out);
 

--- a/UnitTests/tInduction.cpp
+++ b/UnitTests/tInduction.cpp
@@ -21,6 +21,7 @@
 #include "Indexing/TermIndex.hpp"
 #include "Indexing/TermSubstitutionTree.hpp"
 #include "Kernel/RobSubstitution.hpp"
+#include "Kernel/FormulaVarIterator.hpp"
 
 #include "Inferences/Induction.hpp"
 
@@ -109,7 +110,7 @@ public:
         _btd.backtrack();
         return false;
       }
-      VList::Iterator vit(r->freeVariables());
+      VList::Iterator vit(freeVariables(r));
       while (vit.hasNext()) {
         auto v = vit.next();
         if (!_varsMatched.count(v)) {

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -30,6 +30,7 @@
 #include "Lib/Metaiterators.hpp"
 #include "Lib/StringUtils.hpp"
 #include "Lib/Sys/Multiprocessing.hpp"
+#include "Lib/Int.hpp"
 
 #include "Kernel/Clause.hpp"
 #include "Kernel/Formula.hpp"
@@ -769,7 +770,14 @@ void interactiveMetamode()
     } else if (line.rfind("list",0) == 0) {
       UIHelper::listLoadedPieces(cout);
     } else if (line.rfind("pop",0) == 0) {
-      UIHelper::popLoadedPiece();
+      Stack<vstring> pieces;
+      StringUtils::splitStr(line.c_str(),' ',pieces);
+      StringUtils::dropEmpty(pieces);
+      int numPops = 1;
+      if (pieces.size() > 1) {
+        Int::stringToInt(pieces[1],numPops);
+      }
+      UIHelper::popLoadedPiece(numPops);
       prb = UIHelper::getInputProblem();
     } else {
       cout << "Unreconginzed command! Try 'run [options] [filename_to_load]', 'load <filenames>', 'tptp <one_line_input_in_tptp>',\n"

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -745,6 +745,8 @@ void interactiveMetamode()
       } catch (ParsingRelatedException& exception) {
         explainException(exception);
       }
+    } else if (line.rfind("list",0) == 0) {
+      UIHelper::listLoadedPieces(cout);
     } else {
       cout << "Unreconginzed command! Try 'run [options]', 'load <filename>', 'read <one_line_input>', 'pop [how many levels]', or 'exit'." << endl;
     }

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -747,6 +747,9 @@ void interactiveMetamode()
       }
     } else if (line.rfind("list",0) == 0) {
       UIHelper::listLoadedPieces(cout);
+    } else if (line.rfind("pop",0) == 0) {
+      UIHelper::popLoadedPiece();
+      prb = UIHelper::getInputProblem();
     } else {
       cout << "Unreconginzed command! Try 'run [options]', 'load <filename>', 'read <one_line_input>', 'pop [how many levels]', or 'exit'." << endl;
     }

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -713,9 +713,8 @@ void interactiveMetamode()
 
   while (true) {
     vstring line;
-    getline(cin, line);
-
-    if (line.rfind("exit",0) == 0) {
+    if (!getline(cin, line) || line.rfind("exit",0) == 0) {
+      cout << "Bye." << endl;
       break;
     } else if (line.rfind("run",0) == 0) {
       Stack<vstring> pieces;

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -723,6 +723,9 @@ void interactiveMetamode()
       pid_t process = Multiprocessing::instance()->fork();
       ASS_NEQ(process, -1);
       if(process == 0) {
+        // probably garbage at this point
+        UIHelper::unsetExpecting();
+
         Stack<vstring> pieces;
         StringUtils::splitStr(line.c_str(),' ',pieces);
         StringUtils::dropEmpty(pieces);

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -150,8 +150,10 @@ Problem *doProving()
   // a new strategy randomization mechanism
   if (!env.options->strategySamplerFilename().empty()) {
     env.options->sampleStrategy(env.options->strategySamplerFilename());
-    env.options->checkGlobalOptionConstraints();
   }
+
+  env.options->setForcedOptionValues();
+  env.options->checkGlobalOptionConstraints();
 
   Problem *prb = getPreprocessedProblem();
 
@@ -588,6 +590,11 @@ int main(int argc, char* argv[])
     // read the command line and interpret it
     Shell::CommandLine cl(argc, argv);
     cl.interpret(*env.options);
+
+    if(env.options->encodeStrategy()){
+      cout << env.options->generateEncodedOptions() << "\n";
+    }
+
 #if VTIME_PROFILING
     TimeTrace::instance().setEnabled(env.options->timeStatistics());
 #endif

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -577,6 +577,7 @@ void axiomSelectionMode(Problem* problem)
 
 void dispatchByMode(Problem* problem)
 {
+  Timer::instance()->start();
   switch (env.options->mode())
   {
   case Options::Mode::AXIOM_SELECTION:
@@ -816,6 +817,7 @@ int main(int argc, char* argv[])
 
     // CASC_LTB is treated specially, all other modes are happy to receive a Problem* as input and take it from there
     if (opts.mode() == Options::Mode::CASC_LTB) {
+      Timer::instance()->start();
       bool learning = opts.ltbLearning()!=Options::LTBLearning::OFF;
       try {
         if(learning){


### PR DESCRIPTION
Enabled by `--interactive on`. Note that this a not a mode per set, but rather a meta-mode, as any mode can be requested when running vampire interactively.

We maintain a stack of loaded files (as well as formula one-liners), which can be extended by
```
load <file>,
tptp <tptp_line>,
smt2 <smt2_line>
```
and cleaned by `pop <num_to_pop>` and listed by `list`.

Command `run <options>` the executes vampire as if run from command line with the loaded files and `<options>`.

The main use case is to load a large file of axioms only once and then be able to pose many queries.

The branch name refers to fixing https://github.com/vprover/vampire/issues/246, which this does, but not by reanimating the batch mode itself, but by the above.