### PR TITLE
add guard for HOL for now until support makes it to mainline

### DIFF
--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -356,6 +356,13 @@ Problem* UIHelper::getInputProblem(const Options& opts)
   }
 
   Problem* res = new Problem(units);
+  if(res->isHigherOrder())
+    USER_ERROR(
+      "This version of Vampire is not yet HOLy.\n\n"
+      "Support for higher-order logic is currently on the ahmed-new-hol branch.\n"
+      "HOL should be coming to mainline 'soon'."
+    );
+
   res->setSMTLIBLogic(smtLibLogic);
   env.statistics->phase=Statistics::UNKNOWN_PHASE;
   env.setMainProblem(res);


### PR DESCRIPTION
As widely requested, until HOL support makes it into mainline we should reject HOL problems before starting any work.

The precise point of intervention is up for debate. I chose "after the problem is loaded but before preprocessing" because it's arguably simplest for a temporary fix, and I think we at least *parse* the majority of HOL. We should also report `SZS status Inappropriate`, but as this is temporary I'm inclined not to.