### PR TITLE
remove env.out()

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -95,32 +95,30 @@ bool PortfolioMode::perform(Problem* problem)
   }
 
   if (outputAllowed()) {
-    env.beginOutput();
     if (resValue) {
-      addCommentSignForSZS(env.out());
-      env.out()<<"Success in time "<<Timer::msToSecondsString(env.timer->elapsedMilliseconds())<<endl;
+      addCommentSignForSZS(std::cout);
+      std::cout<<"Success in time "<<Timer::msToSecondsString(env.timer->elapsedMilliseconds())<<endl;
     }
     else {
-      addCommentSignForSZS(env.out());
-      env.out()<<"Proof not found in time "<<Timer::msToSecondsString(env.timer->elapsedMilliseconds())<<endl;
+      addCommentSignForSZS(std::cout);
+      std::cout<<"Proof not found in time "<<Timer::msToSecondsString(env.timer->elapsedMilliseconds())<<endl;
       if (env.remainingTime()/100>0) {
-        addCommentSignForSZS(env.out());
-        env.out()<<"SZS status GaveUp for "<<env.options->problemName()<<endl;
+        addCommentSignForSZS(std::cout);
+        std::cout<<"SZS status GaveUp for "<<env.options->problemName()<<endl;
       }
       else {
         //From time to time we may also be terminating in the timeLimitReached()
         //function in Lib/Timer.cpp in case the time runs out. We, however, output
         //the same string there as well.
-        addCommentSignForSZS(env.out());
-        env.out()<<"SZS status Timeout for "<<env.options->problemName()<<endl;
+        addCommentSignForSZS(std::cout);
+        std::cout<<"SZS status Timeout for "<<env.options->problemName()<<endl;
       }
     }
 #if VTIME_PROFILING
     if (env.options && env.options->timeStatistics()) {
-      TimeTrace::instance().printPretty(env.out());
+      TimeTrace::instance().printPretty(std::cout);
     }
 #endif // VTIME_PROFILING
-    env.endOutput();
   }
 
   return resValue;
@@ -464,10 +462,8 @@ bool PortfolioMode::runSchedule(Schedule schedule) {
       }
     } else if (signalled) {
       // killed by an external agency (could be e.g. a slurm cluster killing for too much memory allocated)
-      env.beginOutput();
-      Shell::addCommentSignForSZS(env.out());
-      env.out()<<"Child killed by signal " << code << endl;
-      env.endOutput();
+      Shell::addCommentSignForSZS(std::cout);
+      std::cout<<"Child killed by signal " << code << endl;
       ALWAYS(processes.remove(process));
     }
   }
@@ -504,14 +500,10 @@ bool PortfolioMode::runScheduleAndRecoverProof(Schedule schedule)
     bool openSucceeded = !input.fail();
 
     if (openSucceeded) {
-      env.beginOutput();
-      env.out() << input.rdbuf();
-      env.endOutput();
+      std::cout << input.rdbuf();
     } else {
       if (outputAllowed()) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out()) << "Failed to restore proof from tempfile " << _tmpFileNameForProof << endl;
-        env.endOutput();
+        addCommentSignForSZS(std::cout) << "Failed to restore proof from tempfile " << _tmpFileNameForProof << endl;
       }
     }
 
@@ -537,10 +529,8 @@ unsigned PortfolioMode::getSliceTime(const vstring &sliceCode)
 
   if (sliceTime == 0 && !Timer::instructionLimitingInPlace()) {
     if (outputAllowed()) {
-      env.beginOutput();
-      addCommentSignForSZS(env.out());
-      env.out() << "WARNING: time unlimited strategy and instruction limiting not in place - attempting to translate instructions to time" << endl;
-      env.endOutput();
+      addCommentSignForSZS(std::cout);
+      std::cout << "WARNING: time unlimited strategy and instruction limiting not in place - attempting to translate instructions to time" << endl;
     }
 
     size_t bidx = sliceCode.find(":i=");
@@ -632,14 +622,12 @@ void PortfolioMode::runSlice(Options& strategyOpt)
   *env.options = opt; //just temporarily until we get rid of dependencies on env.options in solving
 
   if (outputAllowed()) {
-    env.beginOutput();
-    addCommentSignForSZS(env.out()) << opt.testId() << " on " << opt.problemName() << 
+    addCommentSignForSZS(std::cout) << opt.testId() << " on " << opt.problemName() <<
       " for (" << opt.timeLimitInDeciseconds() << "ds"<<
 #if VAMPIRE_PERF_EXISTS
       "/" << opt.instructionLimit() << "Mi" <<
 #endif
       ")" << endl;
-    env.endOutput();
   }
 
   Saturation::ProvingHelper::runVampire(*_prb, opt);
@@ -674,9 +662,7 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     ASS(!resultValue);
 
     if (outputAllowed() && env.options->multicore() != 1) {
-      env.beginOutput();
-      addCommentSignForSZS(env.out()) << "First to succeed." << endl;
-      env.endOutput();
+      addCommentSignForSZS(std::cout) << "First to succeed." << endl;
     }
 
     // At the moment we only save one proof. We could potentially
@@ -689,26 +675,20 @@ void PortfolioMode::runSlice(Options& strategyOpt)
     ofstream output(fname.c_str());
     if (output.fail()) {
       // fallback to old printing method
-      env.beginOutput();
-      addCommentSignForSZS(env.out()) << "Solution printing to a file '" << fname <<  "' failed. Outputting to stdout" << endl;
-      UIHelper::outputResult(env.out());
-      env.endOutput();
+      addCommentSignForSZS(std::cout) << "Solution printing to a file '" << fname <<  "' failed. Outputting to stdout" << endl;
+      UIHelper::outputResult(std::cout);
     } else {
       UIHelper::outputResult(output);
       if (!env.options->printProofToFile().empty() && outputAllowed()) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out()) << "Solution written to " << fname << endl;
-        env.endOutput();
+        addCommentSignForSZS(std::cout) << "Solution written to " << fname << endl;
       }
     }
   } else if (outputAllowed()) {
-    env.beginOutput();
     if (resultValue) {
-      UIHelper::outputResult(env.out());
+      UIHelper::outputResult(std::cout);
     } else if (Lib::env.options && Lib::env.options->multicore() != 1) {
-      addCommentSignForSZS(env.out()) << "Also succeeded, but the first one will report." << endl;
+      addCommentSignForSZS(std::cout) << "Also succeeded, but the first one will report." << endl;
     }
-    env.endOutput();
   }
 
   if (outputResult) {

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -97,10 +97,8 @@ FiniteModelBuilder::FiniteModelBuilder(Problem& prb, const Options& opt)
       env.getMainProblem()->hasInterpretedOperations()) {
 
       if(outputAllowed()) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out());
-        env.out() << "WARNING: trying to run FMB on interpreted or otherwise provably infinite-domain problem!" << endl;
-        env.endOutput();
+        addCommentSignForSZS(std::cout);
+        std::cout << "WARNING: trying to run FMB on interpreted or otherwise provably infinite-domain problem!" << endl;
       }
 
      _isAppropriate = false;
@@ -1875,7 +1873,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
   // Giles: In CASC mode we should only print GaveUp at the very end
   if(UIHelper::szsOutput) {
     env.beginOutput();
-    env.out() << "% SZS status GaveUp for " << _opt.problemName() << endl;
+    std::cout << "% SZS status GaveUp for " << _opt.problemName() << endl;
     env.endOutput();
   }
   */
@@ -1897,10 +1895,8 @@ void FiniteModelBuilder::onModelFound()
 
  //we need to print this early because model generating can take some time
  if(szsOutputMode()) {
-   env.beginOutput();
-   env.out() << "% SZS status "<<( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
+   std::cout << "% SZS status "<<( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
        << " for " << _opt.problemName() << endl << flush;
-   env.endOutput();
    UIHelper::satisfiableStatusWasAlreadyOutput = true;
  }
   // Prevent timing out whilst the model is being printed
@@ -2572,14 +2568,12 @@ unsigned FiniteModelBuilder::SmtBasedDSAE::loadSizesFromSmt(DArray<unsigned>& sz
 
 void FiniteModelBuilder::SmtBasedDSAE::reportZ3OutOfMemory()
 {
-  env.beginOutput();
   reportSpiderStatus('m');
-  env.out() << "Z3 ran out of memory" << endl;
+  std::cout << "Z3 ran out of memory" << endl;
   if(env.statistics) {
-    env.statistics->print(env.out());
+    env.statistics->print(std::cout);
   }
-  Debug::Tracer::printStack(env.out());
-  env.endOutput();
+  Debug::Tracer::printStack(std::cout);
   System::terminateImmediately(1);
 }
 

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -674,12 +674,11 @@ isRedundant:
         replacement = newCl;
 
 #if BSD_LOG_INFERENCES
-        env.beginOutput();
-        env.out() << "\% Begin Inference \"BSD-" << newCl->number() << "\"\n";
-        env.out() << "\% eqLit: " << eqLit->toString() << "\n";
-        env.out() << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
-        env.out() << "\% dlit: " << dlit->toString() << "\n";
-        // env.out() << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
+        std::cout << "\% Begin Inference \"BSD-" << newCl->number() << "\"\n";
+        std::cout << "\% eqLit: " << eqLit->toString() << "\n";
+        std::cout << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
+        std::cout << "\% dlit: " << dlit->toString() << "\n";
+        // std::cout << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
         TPTPPrinter tptp;
         // NOTE: do not output the splitLevels here, because those will be set for newCl only later
         tptp.printWithRole("side_premise", "hypothesis", sideCl, false);
@@ -691,8 +690,7 @@ isRedundant:
         //       Problem: how to detect that situation??
         //       probably if the input only contains FOF and no TFF
         // TODO: Also don't output type defs for $$false and $$true, see problem SYO091^5.p
-        env.out() << "\% End Inference \"BSD-" << newCl->number() << "\"" << std::endl;
-        env.endOutput();
+        std::cout << "\% End Inference \"BSD-" << newCl->number() << "\"" << std::endl;
 #endif
 
 #if VDEBUG && BSD_VDEBUG_REDUNDANCY_ASSERTIONS

--- a/Inferences/BinaryResolution.cpp
+++ b/Inferences/BinaryResolution.cpp
@@ -124,9 +124,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, Cla
   if(!ColorHelper::compatible(queryCl->color(),resultCl->color()) ) {
     env.statistics->inferencesSkippedDueToColors++;
     if(opts.showBlocked()) {
-      env.beginOutput();
-      env.out() << "Blocked resolution of " << *queryCl << " and " << * resultCl << endl;
-      env.endOutput();
+      std::cout << "Blocked resolution of " << *queryCl << " and " << * resultCl << endl;
     }
     if(opts.colorUnblocking()) {
       SaturationAlgorithm* salg = SaturationAlgorithm::tryGetInstance();

--- a/Inferences/ExtensionalityResolution.cpp
+++ b/Inferences/ExtensionalityResolution.cpp
@@ -209,9 +209,7 @@ Clause* ExtensionalityResolution::performExtensionalityResolution(
   if(!ColorHelper::compatible(extCl->color(),otherCl->color()) ) {
     env.statistics->inferencesSkippedDueToColors++;
     if(opts.showBlocked()) {
-      env.beginOutput();
-      env.out()<<"Blocked extensionality resolution of "<<extCl->toString()<<" and "<<otherCl->toString()<<endl;
-      env.endOutput();
+      std::cout<<"Blocked extensionality resolution of "<<extCl->toString()<<" and "<<otherCl->toString()<<endl;
     }
     return 0;
   }

--- a/Inferences/ForwardSubsumptionDemodulation.cpp
+++ b/Inferences/ForwardSubsumptionDemodulation.cpp
@@ -626,12 +626,11 @@ isRedundant:
               replacement = newCl;
 
 #if FSD_LOG_INFERENCES
-              env.beginOutput();
-              env.out() << "\% Begin Inference \"FSD-" << newCl->number() << "\"\n";
-              env.out() << "\% eqLit: " << eqLit->toString() << "\n";
-              env.out() << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
-              env.out() << "\% dlit: " << dlit->toString() << "\n";
-              env.out() << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
+              std::cout << "\% Begin Inference \"FSD-" << newCl->number() << "\"\n";
+              std::cout << "\% eqLit: " << eqLit->toString() << "\n";
+              std::cout << "\% eqLitS: " << binder.applyTo(eqLit)->toString() << "\n";
+              std::cout << "\% dlit: " << dlit->toString() << "\n";
+              std::cout << "\% numMatches+1: success at match #" << (numMatches+1) << "\n";
               TPTPPrinter tptp;
               // NOTE: do not output the splitLevels here, because those will be set for newCl only later
               tptp.printWithRole("side_premise_mcl", "hypothesis", mcl,   false);
@@ -643,8 +642,7 @@ isRedundant:
               //       Problem: how to detect that situation??
               //       probably if the input only contains FOF and no TFF
               // TODO: Also don't output type defs for $$false and $$true, see problem SYO091^5.p
-              env.out() << "\% End Inference \"FSD-" << newCl->number() << "\"" << std::endl;
-              env.endOutput();
+              std::cout << "\% End Inference \"FSD-" << newCl->number() << "\"" << std::endl;
 #endif
 
               RSTAT_MCTR_INC("FSD, successes by MLMatch", numMatches + 1);  // +1 so it fits with the previous output

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -377,9 +377,7 @@ private:
 void InductionClauseIterator::processLiteral(Clause* premise, Literal* lit)
 {
   if(_opt.showInduction()){
-    env.beginOutput();
-    env.out() << "[Induction] process " << lit->toString() << " in " << premise->toString() << endl;
-    env.endOutput();
+    std::cout << "[Induction] process " << lit->toString() << " in " << premise->toString() << endl;
   }
 
   if (lit->ground()) {
@@ -600,9 +598,7 @@ ClauseStack InductionClauseIterator::produceClauses(Formula* hypothesis, Inferen
   inf.setInductionDepth(maxInductionDepth+1);
   FormulaUnit* fu = new FormulaUnit(hypothesis,inf);
   if(_opt.showInduction()){
-    env.beginOutput();
-    env.out() << "[Induction] formula " << fu->toString() << endl;
-    env.endOutput();
+    std::cout << "[Induction] formula " << fu->toString() << endl;
   }
   cnf.clausify(NNF::ennf(fu), hyp_clauses);
 
@@ -875,9 +871,7 @@ void InductionClauseIterator::resolveClauses(const ClauseStack& cls, const Induc
     IntUnionFind::ElementIterator eIt = cit.next();
     _clauses.push(resolveClausesHelper(context, cls, eIt, subst, generalized, applySubst));
     if(_opt.showInduction()){
-      env.beginOutput();
-      env.out() << "[Induction] generate " << _clauses.top()->toString() << endl;
-      env.endOutput();
+      std::cout << "[Induction] generate " << _clauses.top()->toString() << endl;
     }
   }
 }

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -174,9 +174,7 @@ bool Superposition::checkClauseColorCompatibility(Clause* eqClause, Clause* rwCl
     return true;
   }
   if(getOptions().showBlocked()) {
-    env.beginOutput();
-    env.out()<<"Blocked superposition of "<<eqClause->toString()<<" into "<<rwClause->toString()<<std::endl;
-    env.endOutput();
+    std::cout<<"Blocked superposition of "<<eqClause->toString()<<" into "<<rwClause->toString()<<std::endl;
   }
   if(getOptions().colorUnblocking()) {
     SaturationAlgorithm* salg = SaturationAlgorithm::tryGetInstance();

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -79,9 +79,7 @@ Options::TheoryInstSimp manageDeprecations(Options::TheoryInstSimp mode)
     case Options::TheoryInstSimp::FULL:
     case Options::TheoryInstSimp::NEW:
       if(outputAllowed()) {
-        env.beginOutput();
-        env.out() << "WARNING: the modes full & new are deprecated for theory instantiation. using all instead." << std::endl;
-        env.endOutput();
+        std::cout << "WARNING: the modes full & new are deprecated for theory instantiation. using all instead." << std::endl;
       }
       return Options::TheoryInstSimp::ALL;
     default:

--- a/Kernel/ColorHelper.cpp
+++ b/Kernel/ColorHelper.cpp
@@ -220,9 +220,7 @@ void ColorHelper::tryUnblock(Clause* c, SaturationAlgorithm* salg)
     Clause* unblocked = skolemizeColoredTerms(c);
     if (unblocked) {
       if (env.options->showBlocked()) {
-	env.beginOutput();
-	env.out()<<"Unblocking clause "<<unblocked->toString()<<endl;
-	env.endOutput();
+        cout<<"Unblocking clause "<<unblocked->toString()<<endl;
       }
       salg->addNewClause(unblocked);
     }

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -517,7 +517,7 @@ struct InferenceStore::TPTPProofPrinter
   void print()
   {
     //outputSymbolDeclarations also deals with sorts for now
-    //UIHelper::outputSortDeclarations(env.out());
+    //UIHelper::outputSortDeclarations(out);
     UIHelper::outputSymbolDeclarations(out);
     ProofPrinter::print();
   }

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -497,10 +497,8 @@ KboWeightMap<SigTraits> KBO::weightsFromFile(const Options& opts) const
 }
 
 void throwError(UserErrorException e) { throw e; }
-void warnError(UserErrorException e) { 
-  env.beginOutput();
-  env.out() << "WARNING: Your KBO is probably not well-founded. Reason: " << e.msg() << std::endl;
-  env.endOutput();
+void warnError(UserErrorException e) {
+  std::cout << "WARNING: Your KBO is probably not well-founded. Reason: " << e.msg() << std::endl;
 }
 
 

--- a/Kernel/LookaheadLiteralSelector.cpp
+++ b/Kernel/LookaheadLiteralSelector.cpp
@@ -62,9 +62,7 @@ struct LookaheadLiteralSelector::GenIteratorIterator
       static bool errAnnounced = false;
       if(!errAnnounced) {
 	errAnnounced = true;
-	env.beginOutput();
-	env.out()<<"Using LookaheadLiteralSelector without having an SaturationAlgorithm object\n";
-	env.endOutput();
+  std::cout<<"Using LookaheadLiteralSelector without having an SaturationAlgorithm object\n";
       }
       //we are too early, there's no saturation algorithm and therefore no generating inferences
       prepared=false;

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -143,9 +143,7 @@ Ordering* Ordering::create(Problem& prb, const Options& opt)
   }
   //TODO currently do not show SKIKBO
   if (opt.showSimplOrdering()) {
-    env.beginOutput();
-    out->show(env.out());
-    env.endOutput();
+    out->show(std::cout);
   }
   return out;
 }

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -73,10 +73,6 @@ Environment::~Environment()
 {
   Timer::setLimitEnforcement(false);
 
-  //in the usual cases the _outputDepth should be zero at this point, but in case of
-  //thrown exceptions this might not be true.
-//  ASS_EQ(_outputDepth,0);
-
 // #if CHECK_LEAKS
   delete sharing;
   delete signature;

--- a/Lib/Environment.cpp
+++ b/Lib/Environment.cpp
@@ -44,7 +44,6 @@ Environment::Environment()
     maxSineLevel(1),
     predicateSineLevels(nullptr),
     colorUsed(false),
-    _outputDepth(0),
     _problem(0)
 {
   options = new Options;
@@ -77,10 +76,6 @@ Environment::~Environment()
   //in the usual cases the _outputDepth should be zero at this point, but in case of
   //thrown exceptions this might not be true.
 //  ASS_EQ(_outputDepth,0);
-
-  while(_outputDepth!=0) {
-    endOutput();
-  }
 
 // #if CHECK_LEAKS
   delete sharing;
@@ -117,51 +112,6 @@ int Environment::remainingTime() const
     return 3600000;
   }
   return options->timeLimitInDeciseconds()*100 - timer->elapsedMilliseconds();
-}
-
-/**
- * Acquire an output stream
- *
- * A process cannot hold an output stream during forking.
- */
-void Environment::beginOutput()
-{
-  ASS_GE(_outputDepth,0);
-
-  _outputDepth++;
-}
-
-/**
- * Release the output stream
- */
-void Environment::endOutput()
-{
-  ASS_G(_outputDepth,0);
-
-  _outputDepth--;
-  if(_outputDepth==0) {
-    cout.flush();
-  }
-}
-
-/**
- * Return true if we have an output stream acquired
- */
-bool Environment::haveOutput()
-{
-  return _outputDepth;
-}
-
-/**
- * Return the output stream if we have it acquired
- *
- * Process must have an output stream acquired in order to call
- * this function.
- */
-ostream& Environment::out()
-{
-  ASS(_outputDepth);
-  return cout;
 }
 
 // global environment object, constructed before main() and used everywhere

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -55,11 +55,6 @@ public:
 
   DHMap<const Kernel::Unit*,vstring>* proofExtra; // maps Unit* pointers to the associated proof extra string, if available
 
-  bool haveOutput();
-  void beginOutput();
-  void endOutput();
-  std::ostream& out();
-
   bool timeLimitReached() const;
 
   template<int Period>
@@ -91,7 +86,6 @@ public:
   void setMainProblem(Kernel::Problem* p) { _problem = p; }
 
 private:
-  int _outputDepth;
   Kernel::Problem* _problem;
 }; // class Environment
 

--- a/Lib/Sys/Multiprocessing.cpp
+++ b/Lib/Sys/Multiprocessing.cpp
@@ -77,8 +77,6 @@ void Multiprocessing::executeFuncList(VoidFuncList* lst)
 
 pid_t Multiprocessing::fork()
 {
-  ASS(!env.haveOutput());
-
   executeFuncList(_preFork);
   errno=0;
   pid_t res=::fork();

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -113,9 +113,7 @@ void handleSignal (int sigNum)
       handled = true;
       if(Shell::outputAllowed(true)) {
 	if(env.options) {
-	  env.beginOutput();
-	  env.out() << "Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
-	  env.endOutput();
+    cout << "Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
 	} else {
 	  cout << "Aborted by signal " << signalDescription << "\n";
 	}
@@ -124,9 +122,7 @@ void handleSignal (int sigNum)
     case SIGXCPU:
       if(Shell::outputAllowed(true)) {
 	if(env.options) {
-	  env.beginOutput();
-	  env.out() << "External time out (SIGXCPU) on " << env.options->inputFile() << "\n";
-	  env.endOutput();
+    cout << "External time out (SIGXCPU) on " << env.options->inputFile() << "\n";
 	} else {
 	  cout << "External time out (SIGXCPU)\n";
 	}
@@ -165,11 +161,9 @@ void handleSignal (int sigNum)
 	handled = true;
 	if(Shell::outputAllowed()) {
 	  if(env.options && env.statistics) {
-	    env.beginOutput();
-	    env.out() << getpid() << " Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
-	    env.statistics->print(env.out());
-	    Debug::Tracer::printStack(env.out());
-	    env.endOutput();
+      cout << getpid() << " Aborted by signal " << signalDescription << " on " << env.options->inputFile() << "\n";
+	    env.statistics->print(cout);
+	    Debug::Tracer::printStack(cout);
 	  } else {
 	    cout << getpid() << "Aborted by signal " << signalDescription << "\n";
 	    Debug::Tracer::printStack(cout);

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -75,33 +75,31 @@ unsigned Timer::elapsedMegaInstructions() {
   // so any code below that allocates might corrupt the allocator state.
   // Therefore, the printing below should avoid allocations!
 
-  env.beginOutput();
   reportSpiderStatus('t');
   if (outputAllowed()) {
-    addCommentSignForSZS(env.out());
-    env.out() << REACHED[whichLimit];
+    addCommentSignForSZS(std::cout);
+    std::cout << REACHED[whichLimit];
 
     if (UIHelper::portfolioParent) { // the boss
-      addCommentSignForSZS(env.out());
-      env.out() << "Proof not found in time ";
-      Timer::printMSString(env.out(),env.timer->elapsedMilliseconds());
+      addCommentSignForSZS(std::cout);
+      std::cout << "Proof not found in time ";
+      Timer::printMSString(std::cout,env.timer->elapsedMilliseconds());
 
 #if VAMPIRE_PERF_EXISTS
       if (last_instruction_count_read > -1) {
-        env.out() << " nor after " << last_instruction_count_read << " (user) instruction executed.";
+        std::cout << " nor after " << last_instruction_count_read << " (user) instruction executed.";
       }
 #endif
-      env.out() << endl;
+      std::cout << endl;
 
       if (szsOutputMode()) {
-        env.out() << STATUS[whichLimit] << (env.options ? env.options->problemName().c_str() : "unknown") << endl;
+        std::cout << STATUS[whichLimit] << (env.options ? env.options->problemName().c_str() : "unknown") << endl;
       }
     } else // the actual child
       if (env.statistics) {
-        env.statistics->print(env.out());
+        env.statistics->print(std::cout);
     }
   }
-  env.endOutput();
 
   System::terminateImmediately(1);
 }

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -411,9 +411,7 @@ void SMTLIB2::readBenchmark(LExprList* bench)
       // can't read anything else (and it does not make sense to read get-unsat-core more than once)
       // so let's just warn and exit
       if(env.options->mode()!=Options::Mode::SPIDER) {
-        env.beginOutput();
-        env.out() << "% Warning: check-sat is not the last entry. Skipping the rest!" << endl;
-        env.endOutput();
+        std::cout << "% Warning: check-sat is not the last entry. Skipping the rest!" << endl;
       }
       break;
     }
@@ -1829,7 +1827,7 @@ void SMTLIB2::parseAnnotatedTerm(LExpr* exp)
 
   if (!annotation_warning) {
     //env.beginOutput();
-    //env.out() << "% Warning: term annotations ignored!" << endl;
+    //std::cout << "% Warning: term annotations ignored!" << endl;
     //env.endOutput();
     annotation_warning = true;
   }

--- a/SAT/MinisatInterfacingNewSimp.cpp
+++ b/SAT/MinisatInterfacingNewSimp.cpp
@@ -47,14 +47,12 @@ MinisatInterfacingNewSimp::MinisatInterfacingNewSimp(const Shell::Options& opts,
 }
 
 void MinisatInterfacingNewSimp::reportMinisatOutOfMemory() {
-  env.beginOutput();
   reportSpiderStatus('m');
-  env.out() << "Minisat ran out of memory" << endl;
+  std::cout << "Minisat ran out of memory" << endl;
   if(env.statistics) {
-    env.statistics->print(env.out());
+    env.statistics->print(std::cout);
   }
-  Debug::Tracer::printStack(env.out());
-  env.endOutput();
+  Debug::Tracer::printStack(std::cout);
   System::terminateImmediately(1);
 }
 

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -177,9 +177,7 @@ void Z3Interfacing::addClause(SATClause* cl)
   auto z3clause = getRepresentation(cl);
 
   if(_showZ3){
-    env.beginOutput();
-    env.out() << "[Z3] add (clause): " << z3clause.expr << std::endl;
-    env.endOutput();
+    std::cout << "[Z3] add (clause): " << z3clause.expr << std::endl;
   }
 
   auto add = [&](auto x) {
@@ -268,9 +266,7 @@ SATSolver::Status Z3Interfacing::solve()
   z3::check_result result = _solver.check(_assumptions.size(), _assumptions.begin());
 
   if(_showZ3){
-    env.beginOutput();
-    env.out() << "[Z3] solve result: " << result << std::endl;
-    env.endOutput();
+    std::cout << "[Z3] solve result: " << result << std::endl;
   }
 
   if (_unsatCore) {
@@ -1106,9 +1102,7 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATLiteral slit)
       repr.expr = bname;
 
       if(_showZ3){
-        env.beginOutput();
-        env.out() << "[Z3] add (naming): " << naming << std::endl;
-        env.endOutput();
+        std::cout << "[Z3] add (naming): " << naming << std::endl;
       }
 
       if(slit.isNegative()) {

--- a/Saturation/ConsequenceFinder.cpp
+++ b/Saturation/ConsequenceFinder.cpp
@@ -83,9 +83,7 @@ void ConsequenceFinder::onNewPropositionalClause(Clause* cl)
     }
   }
 
-  env.beginOutput();
-  env.out() << "Pure cf clause: " << cl->toNiceString() <<endl;
-  env.endOutput();
+  std::cout << "Pure cf clause: " << cl->toNiceString() <<endl;
 
   if(!horn || !pos) {
     return;
@@ -101,9 +99,7 @@ void ConsequenceFinder::onNewPropositionalClause(Clause* cl)
   //of the saturation algorithm loop
   _redundantsToHandle.push(red);
 
-  env.beginOutput();
-  env.out() << "Consequence found: " << env.signature->predicateName(red) << endl;
-  env.endOutput();
+  std::cout << "Consequence found: " << env.signature->predicateName(red) << endl;
 }
 
 void ConsequenceFinder::onAllProcessed()

--- a/Saturation/ProvingHelper.cpp
+++ b/Saturation/ProvingHelper.cpp
@@ -129,10 +129,8 @@ void ProvingHelper::runVampire(Problem& prb, const Options& opt)
 {
   Unit::onPreprocessingEnd();
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] onPreprocessingEnd(), Proving Helper" << std::endl;
-    UIHelper::outputAllPremises(env.out(), prb.units(), "New: ");
-    env.endOutput();
+    std::cout << "[PP] onPreprocessingEnd(), Proving Helper" << std::endl;
+    UIHelper::outputAllPremises(std::cout, prb.units(), "New: ");
   }
 
   //decide whether to use poly or mono well-typedness test

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -355,10 +355,8 @@ ClauseIterator SaturationAlgorithm::activeClauses()
 void SaturationAlgorithm::onActiveAdded(Clause* c)
 {
   if (env.options->showActive()) {
-    env.beginOutput();    
-    env.out() << "[SA] active: " << c->toString() << std::endl;
-    env.endOutput();             
-  }          
+    std::cout << "[SA] active: " << c->toString() << std::endl;
+  }
 }
 
 /**
@@ -394,11 +392,9 @@ void SaturationAlgorithm::onAllProcessed()
 void SaturationAlgorithm::onPassiveAdded(Clause* c)
 {
   if (env.options->showPassive()) {
-    env.beginOutput();
-    env.out() << "[SA] passive: " << c->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[SA] passive: " << c->toString() << std::endl;
   }
-  
+
   //when a clause is added to the passive container,
   //we know it is not redundant
   onNonRedundantClause(c);
@@ -459,9 +455,7 @@ void SaturationAlgorithm::onNewClause(Clause* cl)
   }
 
   if (env.options->showNew()) {
-    env.beginOutput();
-    env.out() << "[SA] new: " << cl->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[SA] new: " << cl->toString() << std::endl;
   }
 
   if (cl->isPropositional()) {
@@ -478,9 +472,7 @@ void SaturationAlgorithm::onNewUsefulPropositionalClause(Clause* c)
   ASS(c->isPropositional());
   
   if (env.options->showNewPropositional()) {
-    env.beginOutput();
-    env.out() << "[SA] new propositional: " << c->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[SA] new propositional: " << c->toString() << std::endl;
   }
 
   if (_consFinder) {
@@ -533,19 +525,17 @@ void SaturationAlgorithm::onClauseReduction(Clause* cl, Clause** replacements, u
   Clause* replacement = numOfReplacements ? *replacements : 0;
 
   if (env.options->showReductions()) {
-    env.beginOutput();
-    env.out() << "[SA] " << (forward ? "forward" : "backward") << " reduce: " << cl->toString() << endl;
+    std::cout << "[SA] " << (forward ? "forward" : "backward") << " reduce: " << cl->toString() << endl;
     for(unsigned i = 0; i < numOfReplacements; i++){
       Clause* replacement = *replacements;
-      if(replacement){ env.out() << "      replaced by " << replacement->toString() << endl; }
+      if(replacement){ std::cout << "      replaced by " << replacement->toString() << endl; }
       replacements++;
     }
     ClauseStack::Iterator pit(premStack);
     while(pit.hasNext()){
       Clause* premise = pit.next();
-      if(premise){ env.out() << "     using " << premise->toString() << endl; }
+      if(premise){ std::cout << "     using " << premise->toString() << endl; }
     }
-    env.endOutput();
   }
 
   if (_splitter) {

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -813,17 +813,15 @@ void Splitter::onAllProcessed()
   _branchSelector.recomputeModel(toAdd, toRemove, flushing);
   
   if (_showSplitting) { // TODO: this is just one of many ways Splitter could report about changes
-    env.beginOutput();
-    env.out() << "[AVATAR] recomputeModel: + ";
+    std::cout << "[AVATAR] recomputeModel: + ";
     for (unsigned i = 0; i < toAdd.size(); i++) {
-      env.out() << getLiteralFromName(toAdd[i]) << ",";
+      std::cout << getLiteralFromName(toAdd[i]) << ",";
     }
-    env.out() << "\t - ";
+    std::cout << "\t - ";
     for (unsigned i = 0; i < toRemove.size(); i++) {
-      env.out() << getLiteralFromName(toRemove[i]) << ",";
+      std::cout << getLiteralFromName(toRemove[i]) << ",";
     }
-    env.out() << std::endl;
-    env.endOutput();
+    std::cout << std::endl;
   }
 
   {
@@ -976,9 +974,7 @@ bool Splitter::handleNonSplittable(Clause* cl)
     nsClause->setInference(new FOConversionInference(scl));
 
     if (_showSplitting) {
-      env.beginOutput();
-      env.out() << "[AVATAR] registering a non-splittable: "<< cl->toString() << std::endl;
-      env.endOutput();
+      std::cout << "[AVATAR] registering a non-splittable: "<< cl->toString() << std::endl;
     }
 
     addSatClauseToSolver(nsClause, false);
@@ -1099,9 +1095,7 @@ bool Splitter::doSplitting(Clause* cl)
 #endif
     ) {
     if (_showSplitting) {
-      env.beginOutput();
-      env.out() << "[AVATAR] Stopping the splitting process."<< std::endl;
-      env.endOutput();
+      std::cout << "[AVATAR] Stopping the splitting process."<< std::endl;
     }
     hasStopped = true;
     return false;
@@ -1148,9 +1142,7 @@ bool Splitter::doSplitting(Clause* cl)
   SATClause* splitClause = SATClause::fromStack(satClauseLits);
 
   if (_showSplitting) {
-    env.beginOutput();
-    env.out() << "[AVATAR] split a clause: "<< cl->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[AVATAR] split a clause: "<< cl->toString() << std::endl;
   }
 
   // now do splits
@@ -1660,15 +1652,13 @@ bool Splitter::handleEmptyClause(Clause* cl)
   addSatClauseToSolver(confl,true);
 
     if (_showSplitting) {
-      env.beginOutput();
-      env.out() << "[AVATAR] proved ";
+      std::cout << "[AVATAR] proved ";
       auto sit = cl->splits()->iter();
       while(sit.hasNext()){
-        env.out() << (_db[sit.next()]->component)->toString();
-        if(sit.hasNext()){ env.out() << " | "; }
+        std::cout << (_db[sit.next()]->component)->toString();
+        if(sit.hasNext()){ std::cout << " | "; }
       }
-      env.out() << endl; 
-      env.endOutput();
+      std::cout << endl;
     }
 
 

--- a/Saturation/SymElOutput.cpp
+++ b/Saturation/SymElOutput.cpp
@@ -127,17 +127,14 @@ void SymElOutput::outputSymbolElimination(Color eliminated, Clause* c)
   ASS_EQ(c->color(),COLOR_TRANSPARENT);
   ASS(!c->skip());
 
-  env.beginOutput();
-
-  //BDD::instance()->allowDefinitionOutput(false);
-  env.out()<<"%";
+  std::cout<<"%";
   if(eliminated==COLOR_LEFT) {
-    env.out()<<"Left";
+    std::cout<<"Left";
   } else {
     ASS_EQ(eliminated, COLOR_RIGHT);
-    env.out()<<"Right";
+    std::cout<<"Right";
   }
-  env.out()<<" symbol elimination"<<endl;
+  std::cout<<" symbol elimination"<<endl;
 
   vstring cname = "inv"+Int::toString(_symElNextClauseNumber);
   while(env.signature->isPredicateName(cname, 0)) {
@@ -147,10 +144,7 @@ void SymElOutput::outputSymbolElimination(Color eliminated, Clause* c)
 
   _printer.printAsClaim(cname, c);
 
-  //BDD::instance()->allowDefinitionOutput(true);
   _symElNextClauseNumber++;
-
-  env.endOutput();
 }
 
 

--- a/Shell/AnswerExtractor.cpp
+++ b/Shell/AnswerExtractor.cpp
@@ -62,13 +62,12 @@ void AnswerExtractor::tryOutputAnswer(Clause* refutation)
       }
     }
   }
-  env.beginOutput();
   if (hasALManager) {
     AnswerLiteralManager::getInstance()->tryOutputInputUnits();
   } else if (hasSyntManager) {
     SynthesisManager::getInstance()->tryOutputInputUnits();
   }
-  env.out() << "% SZS answers Tuple [[";
+  std::cout << "% SZS answers Tuple [[";
   Stack<TermList>::BottomFirstIterator ait(answer);
   while(ait.hasNext()) {
     TermList aLit = ait.next();
@@ -89,21 +88,20 @@ void AnswerExtractor::tryOutputAnswer(Clause* refutation)
       }
     }
 
-    env.out() << aLit.toString();
+    std::cout << aLit.toString();
     if(ait.hasNext()) {
-      env.out() << ',';
+      std::cout << ',';
     }
   }
-  env.out() << "]|_] for " << env.options->problemName() << endl;
-  env.endOutput();
+  std::cout << "]|_] for " << env.options->problemName() << endl;
 }
 
 void AnswerExtractor::tryOutputInputUnits() {
   if (!UnitList::isEmpty(_inputs)) {
-    env.out() << "% Inputs for question answering:" << endl;
+    std::cout << "% Inputs for question answering:" << endl;
     UnitList::Iterator it(_inputs);
     while (it.hasNext()) {
-      env.out() << it.next()->toString() << endl;
+      std::cout << it.next()->toString() << endl;
     }
   }
 }

--- a/Shell/CommandLine.cpp
+++ b/Shell/CommandLine.cpp
@@ -68,9 +68,7 @@ void CommandLine::interpret (Options& options)
       ){
       // cout << _next << " " << _last << endl;
       options.set("help","on");
-      env.beginOutput();
-      options.output(env.out());
-      env.endOutput();
+      options.output(std::cout);
       exit(0);
     }
     if (arg[0] == '-') {

--- a/Shell/DistinctGroupExpansion.cpp
+++ b/Shell/DistinctGroupExpansion.cpp
@@ -71,7 +71,7 @@ bool DistinctGroupExpansion::apply(UnitList*& units)
         added=true;
         Formula* expansion = expand(*members);
         if(env.options->showPreprocessing()){
-          env.out() << "  expansion adding " << expansion->toString() << endl;
+          std::cout << "  expansion adding " << expansion->toString() << endl;
         }
         // Currently we just say that these are from the Input, not $distinct or theory of ints
         UnitList::push(

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -157,10 +157,8 @@ FormulaUnit* FOOLElimination::apply(FormulaUnit* unit) {
   _currentDefs = UnitList::empty();
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] " << unit->toString() << endl;
-    env.out() << "[PP] " << processedUnit->toString()  << endl;
-    env.endOutput();
+    std::cout << "[PP] " << unit->toString() << endl;
+    std::cout << "[PP] " << processedUnit->toString()  << endl;
   }
 
   return processedUnit;
@@ -677,9 +675,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
           InferenceStore::instance()->recordIntroducedSymbol(defUnit,bindingContext == FORMULA_CONTEXT ? SymbolType::PRED : SymbolType::FUNC, freshSymbol);
 
           if (env.options->showPreprocessing()) {
-            env.beginOutput();
-            env.out() << "[PP] FOOL replace in: " << contents.toString() << endl;
-            env.endOutput();
+            std::cout << "[PP] FOOL replace in: " << contents.toString() << endl;
           }
 
           SymbolOccurrenceReplacement replacement(bindingContext == FORMULA_CONTEXT,
@@ -688,9 +684,7 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
           contents = replacement.process(contents);
 
           if (env.options->showPreprocessing()) {
-            env.beginOutput();
-            env.out() << "[PP] FOOL replace out: " << contents.toString() << endl;
-            env.endOutput();
+            std::cout << "[PP] FOOL replace out: " << contents.toString() << endl;
           }
         }
 
@@ -975,9 +969,7 @@ void FOOLElimination::addDefinition(FormulaUnit* def) {
   UnitList::push(def, _currentDefs);
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] FOOL added definition: " << def->toString() << endl;
-    env.endOutput();
+    std::cout << "[PP] FOOL added definition: " << def->toString() << endl;
   }
 }
 
@@ -1007,15 +999,13 @@ unsigned FOOLElimination::introduceFreshSymbol(Context context, const char* pref
   }
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] FOOL: introduced fresh ";
+    std::cout << "[PP] FOOL: introduced fresh ";
     if (context == FORMULA_CONTEXT) {
-      env.out() << "predicate symbol " << env.signature->predicateName(symbol);
+      std::cout << "predicate symbol " << env.signature->predicateName(symbol);
     } else {
-      env.out() << "function symbol " << env.signature->functionName(symbol);
+      std::cout << "function symbol " << env.signature->functionName(symbol);
     }
-    env.out() << " of the sort " << type->toString() << endl;
-    env.endOutput();
+    std::cout << " of the sort " << type->toString() << endl;
   }
 
   return symbol;
@@ -1031,9 +1021,7 @@ void FOOLElimination::reportProcessed(vstring inputRepr, vstring outputRepr) {
      * the output seeming the same, we will not log such processings at
      * all. Setting show_fool to on, however, will display everything.
      */
-    env.beginOutput();
-    env.out() << "[PP] FOOL in:  " << inputRepr  << endl;
-    env.out() << "[PP] FOOL out: " << outputRepr << endl;
-    env.endOutput();
+    std::cout << "[PP] FOOL in:  " << inputRepr  << endl;
+    std::cout << "[PP] FOOL out: " << outputRepr << endl;
   }
 }

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -69,10 +69,8 @@ FormulaUnit* Flattening::flatten (FormulaUnit* unit)
   FormulaUnit* res = new FormulaUnit(g,
       FormulaTransformation(InferenceRule::FLATTEN,unit));
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] flatten in: " << unit->toString() << std::endl;
-    env.out() << "[PP] flatten out: " << res->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[PP] flatten in: " << unit->toString() << std::endl;
+    std::cout << "[PP] flatten out: " << res->toString() << std::endl;
   }
   return res;
 } // Flattening::flatten

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -352,9 +352,7 @@ bool FunctionDefinition::removeAllDefinitions(UnitList*& units, bool inHigherOrd
     }
 
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] fn def discovered: "<<(*d->defCl)<<"\n  unfolded: "<<(*d->rhs) << std::endl;
-      env.endOutput();
+      std::cout << "[PP] fn def discovered: "<<(*d->defCl)<<"\n  unfolded: "<<(*d->rhs) << std::endl;
     }
     env.statistics->functionDefinitions++;
   }
@@ -552,9 +550,7 @@ Term* FunctionDefinition::applyDefinitions(Literal* lit, Stack<Def*>* usedDefs)
   //cout << "applying definitions to " + lit->toString() << endl;
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] applying function definitions to literal "<<(*lit) << std::endl;
-    env.endOutput();
+    std::cout << "[PP] applying function definitions to literal "<<(*lit) << std::endl;
   }
   BindingMap bindings;
   UnfoldedSet unfolded;
@@ -659,13 +655,11 @@ Term* FunctionDefinition::applyDefinitions(Literal* lit, Stack<Def*>* usedDefs)
       ASS_EQ(d->mark, Def::UNFOLDED);
       usedDefs->push(d);
       if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] definition of "<<(*t)<<"\n  expanded to "<<(*d->rhs) << std::endl;
-        env.endOutput();
+        std::cout << "[PP] definition of "<<(*t)<<"\n  expanded to "<<(*d->rhs) << std::endl;
       }
 
       defIndex=nextDefIndex++;
-      
+
       //bind arguments of definition lhs
       TermList* dargs=d->lhs->args();
       TermList* targs=t->args();

--- a/Shell/LambdaElimination.cpp
+++ b/Shell/LambdaElimination.cpp
@@ -461,12 +461,12 @@ void LambdaElimination::addCombinatorAxioms(Problem& prb)
   UnitList::push(iAxiom, prb.units());
 
   if (env.options->showPreprocessing()) {
-    env.out() << "Added combinator axioms: " << std::endl;
-    env.out() << sAxiom->toString() << std::endl;
-    env.out() << cAxiom->toString() << std::endl;
-    env.out() << bAxiom->toString() << std::endl;
-    env.out() << kAxiom->toString() << std::endl;  
-    env.out() << iAxiom->toString() << std::endl;        
+    std::cout << "Added combinator axioms: " << std::endl;
+    std::cout << sAxiom->toString() << std::endl;
+    std::cout << cAxiom->toString() << std::endl;
+    std::cout << bAxiom->toString() << std::endl;
+    std::cout << kAxiom->toString() << std::endl;
+    std::cout << iAxiom->toString() << std::endl;
   }
 }
 
@@ -496,8 +496,8 @@ void LambdaElimination::addFunctionExtensionalityAxiom(Problem& prb)
 
 
   if (env.options->showPreprocessing()) {
-    env.out() << "Added functional extensionality axiom: " << std::endl;
-    env.out() << funcExtAx->toString() << std::endl;       
+    std::cout << "Added functional extensionality axiom: " << std::endl;
+    std::cout << funcExtAx->toString() << std::endl;
   }
 }
 
@@ -522,8 +522,8 @@ void LambdaElimination::addChoiceAxiom(Problem& prb)
 
 
   if (env.options->showPreprocessing()) {
-    env.out() << "Added Hilbert choice axiom: " << std::endl;
-    env.out() << choiceAx->toString() << std::endl;       
+    std::cout << "Added Hilbert choice axiom: " << std::endl;
+    std::cout << choiceAx->toString() << std::endl;
   }
 }
 
@@ -674,28 +674,27 @@ void LambdaElimination::addProxyAxioms(Problem& prb)
   //TODO iff and xor
 
   if (env.options->showPreprocessing()) {
-    env.out() << "Added proxy axioms: " << std::endl;
-    env.out() << eqAxiom1->toString() << std::endl;
-    env.out() << eqAxiom2->toString() << std::endl;
-    env.out() << notAxiom1->toString() << std::endl;
-    env.out() << notAxiom2->toString() << std::endl;  
-    env.out() << piAxiom1->toString() << std::endl;
-    env.out() << piAxiom2->toString() << std::endl;            
-    env.out() << sigmaAxiom1->toString() << std::endl;
-    env.out() << sigmaAxiom2->toString() << std::endl;
-    env.out() << impAxiom1->toString() << std::endl;  
-    env.out() << impAxiom2->toString() << std::endl;
-    env.out() << impAxiom3->toString() << std::endl;  
-    env.out() << andAxiom1->toString() << std::endl;  
-    env.out() << andAxiom2->toString() << std::endl;
-    env.out() << andAxiom3->toString() << std::endl;   
-    env.out() << orAxiom1->toString() << std::endl;  
-    env.out() << orAxiom2->toString() << std::endl;
-    env.out() << orAxiom3->toString() << std::endl;      
+    std::cout << "Added proxy axioms: " << std::endl;
+    std::cout << eqAxiom1->toString() << std::endl;
+    std::cout << eqAxiom2->toString() << std::endl;
+    std::cout << notAxiom1->toString() << std::endl;
+    std::cout << notAxiom2->toString() << std::endl;
+    std::cout << piAxiom1->toString() << std::endl;
+    std::cout << piAxiom2->toString() << std::endl;
+    std::cout << sigmaAxiom1->toString() << std::endl;
+    std::cout << sigmaAxiom2->toString() << std::endl;
+    std::cout << impAxiom1->toString() << std::endl;
+    std::cout << impAxiom2->toString() << std::endl;
+    std::cout << impAxiom3->toString() << std::endl;
+    std::cout << andAxiom1->toString() << std::endl;
+    std::cout << andAxiom2->toString() << std::endl;
+    std::cout << andAxiom3->toString() << std::endl;
+    std::cout << orAxiom1->toString() << std::endl;
+    std::cout << orAxiom2->toString() << std::endl;
+    std::cout << orAxiom3->toString() << std::endl;
   }
-    
 }
- 
+
 Literal* LambdaElimination::toEquality(TermList booleanTerm, bool polarity) {
   TermList boolVal = polarity ? TermList(Term::foolTrue()) : TermList(Term::foolFalse());
   return Literal::createEquality(true, booleanTerm, boolVal, AtomicSort::boolSort());

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -45,10 +45,8 @@ FormulaUnit* NNF::ennf(FormulaUnit* unit)
   FormulaUnit* res = new FormulaUnit(g,FormulaTransformation(InferenceRule::ENNF,unit));
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] ennf in: " << unit->toString() << std::endl;
-    env.out() << "[PP] ennf out: " << res->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[PP] ennf in: " << unit->toString() << std::endl;
+    std::cout << "[PP] ennf out: " << res->toString() << std::endl;
   }
 
   return res;

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -70,9 +70,7 @@ FormulaUnit* Naming::apply(FormulaUnit* unit, UnitList*& defs) {
   ASS(!_varsInScope); //_varsInScope can be true only when traversing inside a formula
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] naming args: " << unit->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[PP] naming args: " << unit->toString() << std::endl;
   }
 
   Formula* f = unit->formula();
@@ -1190,9 +1188,7 @@ Formula* Naming::introduceDefinition(Formula* f, bool iff) {
   UnitList::push(definition, _defs);
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] naming defs: " << definition->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[PP] naming defs: " << definition->toString() << std::endl;
   }
 
   return name;

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -692,12 +692,10 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
     ASS(!bit.hasNext());
 
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
       Term* tupleLet = Term::createTupleLet(tupleFunctor, symbols, binding, contents, tupleType->result());
-      env.out() << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << std::endl;
+      std::cout << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << std::endl;
       Term* processedLet = Term::createLet(symbol, 0, processedBinding, processedContents, bodySort);
-      env.out() << "[PP] clausify (detuplify let) out: " << processedLet->toString() << std::endl;
-      env.endOutput();
+      std::cout << "[PP] clausify (detuplify let) out: " << processedLet->toString() << std::endl;
     }
 
     variables = VList::empty();
@@ -737,12 +735,10 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
     }
 
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
       Term* tupleLet = Term::createTupleLet(tupleFunctor, symbols, binding, contents, tupleType->result());
-      env.out() << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << std::endl;
+      std::cout << "[PP] clausify (detuplify let) in:  " << tupleLet->toString() << std::endl;
       Term* processedLet = Term::createLet(tuple, 0, binding, detupledContents, bodySort);
-      env.out() << "[PP] clausify (detuplify let) out: " << processedLet->toString() << std::endl;
-      env.endOutput();
+      std::cout << "[PP] clausify (detuplify let) out: " << processedLet->toString() << std::endl;
     }
 
     symbol = tuple;
@@ -782,20 +778,16 @@ TermList NewCNF::eliminateLet(Term::SpecialTermData *sd, TermList contents)
   if (inlineLet) {
     processedContents = inlineLetBinding(symbol, variables, binding, contents);
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify (inline let) binding: " << binding.toString() << std::endl;
-      env.out() << "[PP] clausify (inline let) in:  " << contents.toString() << std::endl;
-      env.out() << "[PP] clausify (inline let) out: " << processedContents.toString() << std::endl;
-      env.endOutput();
+      std::cout << "[PP] clausify (inline let) binding: " << binding.toString() << std::endl;
+      std::cout << "[PP] clausify (inline let) in:  " << contents.toString() << std::endl;
+      std::cout << "[PP] clausify (inline let) out: " << processedContents.toString() << std::endl;
     }
   } else {
     processedContents = nameLetBinding(symbol, variables, binding, contents);
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify (name let) binding: " << binding.toString() << std::endl;
-      env.out() << "[PP] clausify (name let) in:  " << contents.toString() << std::endl;
-      env.out() << "[PP] clausify (name let) out: " << processedContents.toString() << std::endl;
-      env.endOutput();
+      std::cout << "[PP] clausify (name let) binding: " << binding.toString() << std::endl;
+      std::cout << "[PP] clausify (name let) in:  " << contents.toString() << std::endl;
+      std::cout << "[PP] clausify (name let) out: " << processedContents.toString() << std::endl;
     }
   }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2331,10 +2331,8 @@ void Options::set(const char* name,const char* value, bool longOpt)
         break;
       case IgnoreMissing::WARN:
         if (outputAllowed()) {
-          env.beginOutput();
-          addCommentSignForSZS(env.out());
-          env.out() << "WARNING: invalid value "<< value << " for option " << name << endl;
-          env.endOutput();
+          addCommentSignForSZS(std::cout);
+          std::cout << "WARNING: invalid value "<< value << " for option " << name << endl;
         }
         break;
       case IgnoreMissing::ON:
@@ -2347,10 +2345,8 @@ void Options::set(const char* name,const char* value, bool longOpt)
       vstring msg = (vstring)name + (longOpt ? " is not a valid option" : " is not a valid short option (did you mean --?)");
       if (_ignoreMissing.actualValue == IgnoreMissing::WARN) {
         if (outputAllowed()) {
-          env.beginOutput();
-          addCommentSignForSZS(env.out());
-          env.out() << "WARNING: " << msg << endl;
-          env.endOutput();
+          addCommentSignForSZS(std::cout);
+          std::cout << "WARNING: " << msg << endl;
         }
         return;
       } // else:
@@ -3151,10 +3147,8 @@ void Options::readOptionsString(vstring optionsString,bool assign)
                 break;
               case IgnoreMissing::WARN:
                 if (outputAllowed()) {
-                  env.beginOutput();
-                  addCommentSignForSZS(env.out());
-                  env.out() << "WARNING: value " << value << " for option "<< param <<" not known" << endl;
-                  env.endOutput();
+                  addCommentSignForSZS(std::cout);
+                  std::cout << "WARNING: value " << value << " for option "<< param <<" not known" << endl;
                 }
                 break;
               case IgnoreMissing::ON:
@@ -3175,12 +3169,9 @@ void Options::readOptionsString(vstring optionsString,bool assign)
         USER_ERROR("option "+param+" not known");
         break;
       case IgnoreMissing::WARN:
-        env.beginOutput();
         if (outputAllowed()) {
-          env.beginOutput();
-          addCommentSignForSZS(env.out());
-          env.out() << "WARNING: option "<< param << " not known." << endl;
-          env.endOutput();
+          addCommentSignForSZS(std::cout);
+          std::cout << "WARNING: option "<< param << " not known." << endl;
         }
         break;
       case IgnoreMissing::ON:
@@ -3466,7 +3457,6 @@ bool Options::checkGlobalOptionConstraints(bool fail_early)
   return result;
 }
 
-//TODO should not use cout, should use env.out
 template <typename T>
 bool Options::OptionValue<T>::checkConstraints()
 {

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -113,19 +113,15 @@ struct PredicateDefinition::PredData
       pdObj->_eliminable.push(pred);
       enqueuedForDefEl=true;
       if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] pred marked for removing unused predicate definition: " 
+        std::cout << "[PP] pred marked for removing unused predicate definition: "
                 << env.signature->predicateName(pred) << std::endl;
-        env.endOutput();
-      }            
+      }
     } else if(!enqueuedForReplacement && isPure()) {
       pdObj->_pureToReplace.push(pred);
       enqueuedForReplacement=true;
       if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] " << stateToString() << " to be replaced by " 
+        std::cout << "[PP] " << stateToString() << " to be replaced by "
                 << ((nocc==0) ? "$false" : "$true") << std::endl;
-        env.endOutput();
       }
     }
   }
@@ -179,11 +175,9 @@ void PredicateDefinition::addBuiltInPredicate(unsigned pred)
   _preds[pred].builtIn = true;
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] pred marked as built-in: " 
+    std::cout << "[PP] pred marked as built-in: "
             << env.signature->predicateName(pred) << std::endl;
-    env.endOutput();
-  }  
+  }
 }
 
 Unit* PredicateDefinition::getReplacement(Unit* u, ReplMap& replacements)
@@ -218,9 +212,7 @@ void PredicateDefinition::eliminatePredicateDefinition(unsigned pred, ReplMap& r
     //pred does not occur anywhere else, hence can be deleted
     repl = 0;
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] definition " << (*def) << " removed" << std::endl;
-      env.endOutput();
+      std::cout << "[PP] definition " << (*def) << " removed" << std::endl;
     }
     _processedPrb->addEliminatedPredicate(pred,def);
   }
@@ -236,25 +228,21 @@ void PredicateDefinition::eliminatePredicateDefinition(unsigned pred, ReplMap& r
       //the definition formula was simplified by other transformation to the      
       //point it is no longer definition that can be eliminated
       if (env.options->showPreprocessing()) {
-        env.beginOutput();
-        env.out() << "[PP] Formula " << (*def) 
+        std::cout << "[PP] Formula " << (*def)
                 << " is no longer in the shape of definition of "
-                << env.signature->predicateName(pred) 
-                << ". The original definition was " << (*def0) 
+                << env.signature->predicateName(pred)
+                << ". The original definition was " << (*def0)
                 << "." << std::endl;
-        env.endOutput();
       }
-      
+
       return;
     }
     _processedPrb->addPartiallyEliminatedPredicate(pred,def);
 
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] definition " << (*def) << " replaced by " 
+      std::cout << "[PP] definition " << (*def) << " replaced by "
               << (*repl) << std::endl;
-      env.endOutput();
-    }    
+    }
   }
   if(repl) {
     count(repl, 1);
@@ -285,15 +273,13 @@ void PredicateDefinition::replacePurePred(unsigned pred, ReplMap& replacements)
 
     ASS_NEQ(u,v);
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
         if (v) {
-          env.out() << "unit " << (*u) << " replaced by " << (*v) << endl;
+          std::cout << "unit " << (*u) << " replaced by " << (*v) << endl;
         } else {
-          env.out() << "unit " << (*u) << " removed" << endl;
+          std::cout << "unit " << (*u) << " removed" << endl;
         }
-      env.endOutput();
     }
-    
+
     count(v,1);
     count(u,-1);
     ALWAYS(replacements.insert(u,v));
@@ -314,14 +300,12 @@ void PredicateDefinition::collectReplacements(UnitList* units, ReplMap& replacem
   }
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
     for (unsigned i = 0; i < _predCnt; ++i) {
       if (!_preds[i].pocc && !_preds[i].nocc && !_preds[i].docc)
-        continue;      
-      env.out() << _preds[i].stateToString() << endl;
-    }    
-    env.endOutput();
-  }  
+        continue;
+      std::cout << _preds[i].stateToString() << endl;
+    }
+  }
 
   for(unsigned pred=1; pred<_predCnt; pred++) {
     _preds[pred].check(this);
@@ -338,12 +322,10 @@ void PredicateDefinition::collectReplacements(UnitList* units, ReplMap& replacem
     }
   }
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
     for(unsigned i=0; i<_predCnt; ++i) {
       if(!_preds[i].pocc && !_preds[i].nocc  && !_preds[i].docc ) { continue; }
-      env.out() << _preds[i].stateToString() << endl;
-    }    
-    env.endOutput();
+      std::cout << _preds[i].stateToString() << endl;
+    }
   }
 }
 

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -79,12 +79,11 @@ void Preprocess::preprocess(Problem& prb)
   }
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "preprocessing started" << std::endl;
+    std::cout << "preprocessing started" << std::endl;
     UnitList::Iterator uit(prb.units());
     while(uit.hasNext()) {
       Unit* u = uit.next();
-      env.out() << "[PP] input: " << u->toString() << std::endl;
+      std::cout << "[PP] input: " << u->toString() << std::endl;
     }
   }
 
@@ -100,7 +99,7 @@ void Preprocess::preprocess(Problem& prb)
   if (_options.normalize()) { // reorder units
     env.statistics->phase=Statistics::NORMALIZATION;
     if (env.options->showPreprocessing())
-      env.out() << "normalization" << std::endl;
+      std::cout << "normalization" << std::endl;
 
     Normalisation().normalise(prb);
   }
@@ -110,7 +109,7 @@ void Preprocess::preprocess(Problem& prb)
     env.statistics->phase=Statistics::SHUFFLING;    
 
     if (env.options->showPreprocessing())
-      env.out() << "shuffling1" << std::endl;
+      std::cout << "shuffling1" << std::endl;
 
     // shuffling at the very beginning
     Shuffling::shuffle(prb);
@@ -131,7 +130,7 @@ void Preprocess::preprocess(Problem& prb)
     if( _options.theoryAxioms() != Options::TheoryAxiomLevel::OFF){
       env.statistics->phase=Statistics::INCLUDING_THEORY_AXIOMS;
       if (env.options->showPreprocessing())
-        env.out() << "adding theory axioms" << std::endl;
+        std::cout << "adding theory axioms" << std::endl;
 
       TheoryAxioms(prb).apply();
     }
@@ -143,7 +142,7 @@ void Preprocess::preprocess(Problem& prb)
 
     if (!_options.newCNF() || prb.hasPolymorphicSym() || prb.isHigherOrder()) {
       if (env.options->showPreprocessing())
-        env.out() << "FOOL elimination" << std::endl;
+        std::cout << "FOOL elimination" << std::endl;
   
       TheoryAxioms(prb).applyFOOL();
       FOOLElimination().apply(prb);
@@ -177,7 +176,7 @@ void Preprocess::preprocess(Problem& prb)
   // If a distinct group is small enough it will add inequality to describe it
   if(env.signature->hasDistinctGroups()){
     if(env.options->showPreprocessing())
-      env.out() << "distinct group expansion" << std::endl;
+      std::cout << "distinct group expansion" << std::endl;
     DistinctGroupExpansion(_options.distinctGroupExpansionLimit()).apply(prb);
   }
 
@@ -196,7 +195,7 @@ void Preprocess::preprocess(Problem& prb)
   if (_options.sineSelection()!=Options::SineSelection::OFF) {
     env.statistics->phase=Statistics::SINE_SELECTION;
     if (env.options->showPreprocessing())
-      env.out() << "sine selection" << std::endl;
+      std::cout << "sine selection" << std::endl;
 
     SineSelector(_options).perform(prb);
   }
@@ -204,13 +203,13 @@ void Preprocess::preprocess(Problem& prb)
   if (_options.questionAnswering()==Options::QuestionAnsweringMode::ANSWER_LITERAL) {
     env.statistics->phase=Statistics::ANSWER_LITERAL;
     if (env.options->showPreprocessing())
-      env.out() << "answer literal addition" << std::endl;
+      std::cout << "answer literal addition" << std::endl;
 
     AnswerLiteralManager::getInstance()->addAnswerLiterals(prb);
   } else if (_options.questionAnswering()==Options::QuestionAnsweringMode::SYNTHESIS) {
     env.statistics->phase=Statistics::ANSWER_LITERAL;
     if (env.options->showPreprocessing())
-      env.out() << "answer literal addition for synthesis" << std::endl;
+      std::cout << "answer literal addition for synthesis" << std::endl;
 
     SynthesisManager::getInstance()->addAnswerLiterals(prb);
   }
@@ -222,7 +221,7 @@ void Preprocess::preprocess(Problem& prb)
 
   if (prb.mayHaveFormulas()) {
     if (env.options->showPreprocessing())
-      env.out() << "preprocess1 (rectify, simplify false true, flatten)" << std::endl;
+      std::cout << "preprocess1 (rectify, simplify false true, flatten)" << std::endl;
 
     preprocess1(prb);
   }
@@ -231,7 +230,7 @@ void Preprocess::preprocess(Problem& prb)
    TIME_TRACE(TimeTrace::SHUFFLING);
     env.statistics->phase=Statistics::SHUFFLING;
     if (env.options->showPreprocessing())
-      env.out() << "shuffling2" << std::endl;
+      std::cout << "shuffling2" << std::endl;
 
     // axioms have been added, fool eliminated; moreover, after flattening, more opportunity for shuffling inside
     Shuffling::shuffle(prb);
@@ -251,7 +250,7 @@ void Preprocess::preprocess(Problem& prb)
   if (_options.unusedPredicateDefinitionRemoval()) {
     env.statistics->phase=Statistics::UNUSED_PREDICATE_DEFINITION_REMOVAL;
     if (env.options->showPreprocessing())
-      env.out() << "unused predicate definition removal" << std::endl;
+      std::cout << "unused predicate definition removal" << std::endl;
 
     PredicateDefinition pdRemover;
     pdRemover.removeUnusedDefinitionsAndPurePredicates(prb);
@@ -259,7 +258,7 @@ void Preprocess::preprocess(Problem& prb)
 
   if (prb.mayHaveFormulas()) {
     if (env.options->showPreprocessing())
-      env.out() << "preprocess 2 (ennf,flatten)" << std::endl;
+      std::cout << "preprocess 2 (ennf,flatten)" << std::endl;
 
     preprocess2(prb);
   }
@@ -268,7 +267,7 @@ void Preprocess::preprocess(Problem& prb)
     TIME_TRACE(TimeTrace::SHUFFLING);
     env.statistics->phase=Statistics::SHUFFLING;
     if (env.options->showPreprocessing())
-      env.out() << "shuffling3" << std::endl;
+      std::cout << "shuffling3" << std::endl;
 
     // more flattening -> more shuffling
     Shuffling::shuffle(prb);
@@ -277,37 +276,35 @@ void Preprocess::preprocess(Problem& prb)
   if (prb.mayHaveFormulas() && _options.newCNF() && 
      !prb.hasPolymorphicSym() && !prb.isHigherOrder()) {
     if (env.options->showPreprocessing())
-      env.out() << "newCnf" << std::endl;
+      std::cout << "newCnf" << std::endl;
 
     newCnf(prb);
   } else {
     if (prb.mayHaveFormulas() && _options.newCNF()) { // TODO: update newCNF to deal with polymorphism / higher-order
       ASS(prb.hasPolymorphicSym() || prb.isHigherOrder());
       if (outputAllowed()) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out());
-        env.out() << "WARNING: Not using newCnf currently not compatible with polymorphic/higher-order inputs." << endl;
-        env.endOutput();
+        addCommentSignForSZS(std::cout);
+        std::cout << "WARNING: Not using newCnf currently not compatible with polymorphic/higher-order inputs." << endl;
       }
     }
 
     if (prb.mayHaveFormulas() && _options.naming()) {
       if (env.options->showPreprocessing())
-        env.out() << "naming" << std::endl;
+        std::cout << "naming" << std::endl;
 
       naming(prb);
     }
 
     if (prb.mayHaveFormulas()) {
       if (env.options->showPreprocessing())
-        env.out() << "preprocess3 (nnf, flatten, skolemize)" << std::endl;
+        std::cout << "preprocess3 (nnf, flatten, skolemize)" << std::endl;
 
       preprocess3(prb);
     }
 
     if (prb.mayHaveFormulas()) {
       if (env.options->showPreprocessing())
-        env.out() << "clausify" << std::endl;
+        std::cout << "clausify" << std::endl;
 
       clausify(prb);
     }
@@ -318,7 +315,7 @@ void Preprocess::preprocess(Problem& prb)
   if (prb.mayHaveFunctionDefinitions()) {
     env.statistics->phase=Statistics::FUNCTION_DEFINITION_ELIMINATION;
     if (env.options->showPreprocessing())
-      env.out() << "function definition elimination" << std::endl;
+      std::cout << "function definition elimination" << std::endl;
 
     if (_options.functionDefinitionElimination() == Options::FunctionDefinitionElimination::ALL) {
       FunctionDefinition fd;
@@ -332,7 +329,7 @@ void Preprocess::preprocess(Problem& prb)
 
   if (prb.mayHaveEquality() && _options.inequalitySplitting() != 0) {
     if (env.options->showPreprocessing())
-      env.out() << "inequality splitting" << std::endl;
+      std::cout << "inequality splitting" << std::endl;
 
     env.statistics->phase=Statistics::INEQUALITY_SPLITTING;
     InequalitySplitting is(_options);
@@ -360,7 +357,7 @@ void Preprocess::preprocess(Problem& prb)
    if (_options.equalityResolutionWithDeletion() && prb.mayHaveInequalityResolvableWithDeletion() ) {
      env.statistics->phase=Statistics::EQUALITY_RESOLUTION_WITH_DELETION;
      if (env.options->showPreprocessing())
-      env.out() << "equality resolution with deletion" << std::endl;
+      std::cout << "equality resolution with deletion" << std::endl;
 
      EqResWithDeletion resolver;
      resolver.apply(prb);
@@ -369,15 +366,13 @@ void Preprocess::preprocess(Problem& prb)
    if (_options.generalSplitting()) {
      if (prb.isHigherOrder() || prb.hasPolymorphicSym()) {  // TODO: extend GeneralSplitting to support polymorphism (would higher-order make sense?)
        if (outputAllowed()) {
-         env.beginOutput();
-         addCommentSignForSZS(env.out());
-         env.out() << "WARNING: Not using GeneralSplitting currently not compatible with polymorphic/higher-order inputs." << endl;
-         env.endOutput();
+         addCommentSignForSZS(std::cout);
+         std::cout << "WARNING: Not using GeneralSplitting currently not compatible with polymorphic/higher-order inputs." << endl;
        }
      } else {
        env.statistics->phase=Statistics::GENERAL_SPLITTING;
        if (env.options->showPreprocessing())
-         env.out() << "general splitting" << std::endl;
+         std::cout << "general splitting" << std::endl;
 
        GeneralSplitting gs;
        gs.apply(prb);
@@ -387,7 +382,7 @@ void Preprocess::preprocess(Problem& prb)
    if(env.options->tweeGoalTransformation() != Options::TweeGoalTransformation::OFF) {
      env.statistics->phase = Statistics::TWEE;
      if(env.options->showPreprocessing())
-       env.out() << "twee goal transformation" << std::endl;
+       std::cout << "twee goal transformation" << std::endl;
 
      TweeGoalTransformation twee;
      twee.apply(prb,(env.options->tweeGoalTransformation() == Options::TweeGoalTransformation::GROUND));
@@ -396,7 +391,7 @@ void Preprocess::preprocess(Problem& prb)
    if (!prb.isHigherOrder() && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
      env.statistics->phase=Statistics::EQUALITY_PROXY;
      if (env.options->showPreprocessing())
-       env.out() << "equality proxy" << std::endl;
+       std::cout << "equality proxy" << std::endl;
 
      // refresh symbol usage counts, can skip unused symbols for equality proxy
      prb.getProperty();
@@ -414,14 +409,12 @@ void Preprocess::preprocess(Problem& prb)
    if(_options.theoryFlattening()) {
      if (prb.hasPolymorphicSym()) { // TODO: extend theoryFlattening to support polymorphism?
        if (outputAllowed()) {
-         env.beginOutput();
-         addCommentSignForSZS(env.out());
-         env.out() << "WARNING: Not using TheoryFlattening currently not compatible with polymorphic inputs." << endl;
-         env.endOutput();
+         addCommentSignForSZS(std::cout);
+         std::cout << "WARNING: Not using TheoryFlattening currently not compatible with polymorphic inputs." << endl;
        }
      } else {
        if(env.options->showPreprocessing())
-         env.out() << "theory flattening" << std::endl;
+         std::cout << "theory flattening" << std::endl;
 
        TheoryFlattening tf;
        tf.apply(prb);
@@ -431,7 +424,7 @@ void Preprocess::preprocess(Problem& prb)
    if (_options.blockedClauseElimination()) {
      env.statistics->phase=Statistics::BLOCKED_CLAUSE_ELIMINATION;
      if(env.options->showPreprocessing())
-       env.out() << "blocked clause elimination" << std::endl;
+       std::cout << "blocked clause elimination" << std::endl;
 
      BlockedClauseElimination bce;
      bce.apply(prb);
@@ -441,7 +434,7 @@ void Preprocess::preprocess(Problem& prb)
      TIME_TRACE(TimeTrace::SHUFFLING);
      env.statistics->phase=Statistics::SHUFFLING;
      if (env.options->showPreprocessing())
-       env.out() << "shuffling4" << std::endl;
+       std::cout << "shuffling4" << std::endl;
 
      // cnf and many other things happened - shuffle one more time
      Shuffling::shuffle(prb);
@@ -451,7 +444,7 @@ void Preprocess::preprocess(Problem& prb)
      TIME_TRACE(TimeTrace::SHUFFLING);
      env.statistics->phase=Statistics::SHUFFLING;
      if (env.options->showPreprocessing())
-       env.out() << "flipping polarities" << std::endl;
+       std::cout << "flipping polarities" << std::endl;
 
      Shuffling::polarityFlip(prb);
    }
@@ -460,7 +453,7 @@ void Preprocess::preprocess(Problem& prb)
      UnitList::Iterator uit(prb.units());
      while(uit.hasNext()) {
       Unit* u = uit.next();
-      env.out() << "[PP] final: " << u->toString() << std::endl;
+      std::cout << "[PP] final: " << u->toString() << std::endl;
      }
    }
 
@@ -469,8 +462,7 @@ void Preprocess::preprocess(Problem& prb)
    }
 
    if (env.options->showPreprocessing()) {
-     env.out() << "preprocessing finished" << std::endl;
-     env.endOutput();
+     std::cout << "preprocessing finished" << std::endl;
    }
 } // Preprocess::preprocess ()
 
@@ -612,9 +604,7 @@ void Preprocess::newCnf(Problem& prb)
   while (us.hasNext()) {
     Unit* u = us.next();
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify: " << u->toString() << std::endl;
-      env.endOutput();
+      std::cout << "[PP] clausify: " << u->toString() << std::endl;
     }
     if (u->isClause()) {
       if (static_cast<Clause*>(u)->isEmpty()) {
@@ -725,9 +715,7 @@ void Preprocess::clausify(Problem& prb)
   while (us.hasNext()) {
     Unit* u = us.next();
     if (env.options->showPreprocessing()) {
-      env.beginOutput();
-      env.out() << "[PP] clausify: " << u->toString() << std::endl;
-      env.endOutput();
+      std::cout << "[PP] clausify: " << u->toString() << std::endl;
     }
     if (u->isClause()) {
       if (static_cast<Clause*>(u)->isEmpty()) {

--- a/Shell/SimplifyFalseTrue.cpp
+++ b/Shell/SimplifyFalseTrue.cpp
@@ -51,10 +51,8 @@ FormulaUnit* SimplifyFalseTrue::simplify (FormulaUnit* unit)
   FormulaUnit* res = new FormulaUnit(g,FormulaTransformation(InferenceRule::REDUCE_FALSE_TRUE,unit));
 
   if (env.options->showPreprocessing()) {
-    env.beginOutput();
-    env.out() << "[PP] simplify in: " << unit->toString() << std::endl;
-    env.out() << "[PP] simplify out: " << res->toString() << std::endl;
-    env.endOutput();
+    std::cout << "[PP] simplify in: " << unit->toString() << std::endl;
+    std::cout << "[PP] simplify out: " << res->toString() << std::endl;
   }
   return res;
 } // SimplifyFalseTrue::simplify

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -493,15 +493,12 @@ Formula* Skolem::skolemise (Formula* f)
         _subst.bind(v,skolemTerm);
 
         if (env.options->showSkolemisations()) {
-          env.beginOutput();
-          env.out() << "Skolemising: "<<skolemTerm->toString()<<" for X"<< v
+          std::cout << "Skolemising: "<<skolemTerm->toString()<<" for X"<< v
             <<" in "<<f->toString()<<" in formula "<<_beingSkolemised->toString() << endl;
-          env.endOutput();
         }
 
         if (env.options->showNonconstantSkolemFunctionTrace() && arity!=0) {
-          env.beginOutput();
-          ostream& out = env.out();
+          ostream& out = std::cout;
             out <<"Nonconstant skolem function introduced: "
             <<skolemTerm->toString()<<" for X"<<v<<" in "<<f->toString()
             <<" in formula "<<_beingSkolemised->toString()<<endl;
@@ -510,7 +507,6 @@ Formula* Skolem::skolemise (Formula* f)
           Refutation ref(_beingSkolemised, true);
           ref.output(out);
           */
-          env.endOutput();
         }
       }
 

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -53,10 +53,8 @@ void TPTPPrinter::print(Unit* u)
 {
   vstring body = getBodyStr(u, true);
 
-  beginOutput();
   ensureHeadersPrinted(u);
   printTffWrapper(u, body);
-  endOutput();
 }
 
 /**
@@ -73,10 +71,8 @@ void TPTPPrinter::printWithRole(vstring name, vstring role, Unit* u, bool includ
 {
   vstring body = getBodyStr(u, includeSplitLevels);
 
-  beginOutput();
   ensureHeadersPrinted(u);
   tgt() << "tff(" << name << ", " << role << ", " << body << ")." << endl;
-  endOutput();
 }
 
 /**
@@ -328,22 +324,8 @@ ostream& TPTPPrinter::tgt()
     return *_tgtStream;
   }
   else {
-    return env.out();
+    return std::cout;
   }
-}
-
-/**
- * In case there is no specified output stream, than print to the one
- * specified in the env.beginOutput();
- */
-void TPTPPrinter::beginOutput()
-{
-  if(!_tgtStream) { env.beginOutput(); }
-}
-
-void TPTPPrinter::endOutput()
-{
-  if(!_tgtStream) { env.endOutput(); }
 }
 
 /**

--- a/Shell/TPTPPrinter.hpp
+++ b/Shell/TPTPPrinter.hpp
@@ -53,11 +53,9 @@ private:
   void ensureNecesarySorts();
   void printTffWrapper(Unit* u, vstring bodyStr);
 
-  void beginOutput();
-  void endOutput();
   std::ostream& tgt();
 
-  /** if zero, we print to env.out() */
+  /** if zero, we print to std::cout */
   std::ostream* _tgtStream;
 
   bool _headersPrinted;

--- a/Shell/TweeGoalTransformation.cpp
+++ b/Shell/TweeGoalTransformation.cpp
@@ -161,7 +161,7 @@ class Definizator : public BottomUpTermTransformer {
         // record globally
         UnitList::push(newDef,newUnits);
         if(env.options->showPreprocessing()) {
-          env.out() << "[PP] twee: " << newDef->toString() << std::endl;
+          std::cout << "[PP] twee: " << newDef->toString() << std::endl;
         }
         symAndDef.first = newSym;
         symAndDef.second = newDef;

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -105,8 +105,7 @@ void reportSpiderStatus(char status)
   vstring problemName = Lib::env.options->problemName();
   Timer* timer = Lib::env.timer;
 
-  env.beginOutput();
-  env.out()
+  std::cout
     << status << " "
     << (problemName.length() == 0 ? "unknown" : problemName) << " "
     << (timer ? timer->elapsedDeciseconds() : 0) << " "
@@ -114,7 +113,6 @@ void reportSpiderStatus(char status)
     << Lib::getUsedMemory()/1048576 << " "
     << (Lib::env.options ? Lib::env.options->testId() : "unknown") << " "
     << commitNumber << ':' << z3Version << endl;
-  env.endOutput();
 #endif
 }
 
@@ -276,14 +274,12 @@ void UIHelper::parseSingleLine(const vstring& lineToParse, Options::InputSyntax 
 void resetParsing(ParsingRelatedException& exception, istream& input, vstring nowtry)
 {
   if (env.options->mode()!=Options::Mode::SPIDER) {
-    env.beginOutput();
-    addCommentSignForSZS(env.out());
-    env.out() << "Failed with\n";
-    addCommentSignForSZS(env.out());
-    exception.cry(env.out());
-    addCommentSignForSZS(env.out());
-    env.out() << "Trying " << nowtry  << endl;
-    env.endOutput();
+    addCommentSignForSZS(std::cout);
+    std::cout << "Failed with\n";
+    addCommentSignForSZS(std::cout);
+    exception.cry(std::cout);
+    addCommentSignForSZS(std::cout);
+    std::cout << "Trying " << nowtry  << endl;
   }
 
   input.clear();
@@ -296,10 +292,8 @@ void UIHelper::parseStream(std::istream& input, Options::InputSyntax inputSyntax
   case Options::InputSyntax::AUTO:
     if (preferSMTonAuto){
       if (verbose) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out());
-        env.out() << "Running in auto input_syntax mode. Trying SMTLIB2\n";
-        env.endOutput();
+        addCommentSignForSZS(std::cout);
+        std::cout << "Running in auto input_syntax mode. Trying SMTLIB2\n";
       }
       try {
         tryParseSMTLIB2(input);
@@ -309,10 +303,8 @@ void UIHelper::parseStream(std::istream& input, Options::InputSyntax inputSyntax
       }
     } else {
       if (verbose) {
-        env.beginOutput();
-        addCommentSignForSZS(env.out());
-        env.out() << "Running in auto input_syntax mode. Trying TPTP\n";
-        env.endOutput();
+        addCommentSignForSZS(std::cout);
+        std::cout << "Running in auto input_syntax mode. Trying TPTP\n";
       }
       try {
         tryParseTPTP(input);
@@ -338,10 +330,8 @@ void UIHelper::parseStandardInput(Options::InputSyntax inputSyntax)
   _loadedPieces.push(std::move(newPiece));
 
   if (inputSyntax == Options::InputSyntax::AUTO) {
-    env.beginOutput();
-    addCommentSignForSZS(env.out());
-    env.out() << "input_syntax=auto not supported for standard input parsing, switching to tptp.\n";
-    env.endOutput();
+    addCommentSignForSZS(std::cout);
+    std::cout << "input_syntax=auto not supported for standard input parsing, switching to tptp.\n";
 
     inputSyntax = Options::InputSyntax::TPTP;
   }

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -109,10 +109,8 @@ Problem* preprocessProblem(Problem* prb)
     Timer::updateInstructionCount();
     unsigned burnedParsing = Timer::elapsedMegaInstructions();
 
-    env.beginOutput();
-    addCommentSignForSZS(env.out());
-    env.out() << "Instructions burned parsing: " << burnedParsing << " (million)" << endl;
-    env.endOutput();
+    addCommentSignForSZS(std::cout);
+    std::cout << "Instructions burned parsing: " << burnedParsing << " (million)" << endl;
 
     env.options->setInstructionLimit(saveInstrLimit+burnedParsing);
   }
@@ -140,9 +138,7 @@ Problem* preprocessProblem(Problem* prb)
 
 void explainException(Exception& exception)
 {
-  env.beginOutput();
-  exception.cry(env.out());
-  env.endOutput();
+  exception.cry(std::cout);
 } // explainException
 
 VWARN_UNUSED
@@ -183,10 +179,8 @@ void profileMode(Problem* problem)
   Normalisation().normalise(*prb);
   TheoryFinder(prb->units(), property).search();
 
-  env.beginOutput();
-  env.out() << property->categoryString() << ' ' << property->props() << ' '
+  std::cout << property->categoryString() << ' ' << property->props() << ' '
 	  << property->atoms() << "\n";
-  env.endOutput();
 
   //we have succeeded with the profile mode, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -291,10 +285,9 @@ void preprocessMode(Problem* problem, bool theory)
   }
   prepro.preprocess(*prb);
 
-  env.beginOutput();
   //outputSymbolDeclarations also deals with sorts for now
-  //UIHelper::outputSortDeclarations(env.out());
-  UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(std::cout);
+  UIHelper::outputSymbolDeclarations(std::cout);
   UnitList::Iterator units(prb->units());
   while (units.hasNext()) {
     Unit* u = units.next();
@@ -313,12 +306,11 @@ void preprocessMode(Problem* problem, bool theory)
       }
 
       FormulaUnit* fu = new FormulaUnit(f,u->inference()); // we are stealing u's inference which is not nice
-      env.out() << TPTPPrinter::toString(fu) << "\n";
+      std::cout << TPTPPrinter::toString(fu) << "\n";
     } else {
-      env.out() << TPTPPrinter::toString(u) << "\n";
+      std::cout << TPTPPrinter::toString(u) << "\n";
     }
   }
-  env.endOutput();
 
   if(env.options->latexOutput()!="off"){ outputProblemToLaTeX(prb.ptr()); }
 
@@ -354,17 +346,15 @@ void outputMode(Problem* problem)
 {
   ScopedPtr<Problem> prb(problem);
 
-  env.beginOutput();
   //outputSymbolDeclarations also deals with sorts for now
-  //UIHelper::outputSortDeclarations(env.out());
-  UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(std::cout);
+  UIHelper::outputSymbolDeclarations(std::cout);
   UnitList::Iterator units(prb->units());
 
   while (units.hasNext()) {
     Unit* u = units.next();
-    env.out() << TPTPPrinter::toString(u) << "\n";
+    std::cout << TPTPPrinter::toString(u) << "\n";
   }
-  env.endOutput();
 
   if(env.options->latexOutput()!="off"){ outputProblemToLaTeX(prb.ptr()); }
 
@@ -380,9 +370,7 @@ void vampireMode(Problem* problem)
 
   ScopedPtr<Problem> prb(doProving(problem));
 
-  env.beginOutput();
-  UIHelper::outputResult(env.out());
-  env.endOutput();
+  UIHelper::outputResult(std::cout);
 
   if (env.statistics->terminationReason == Statistics::REFUTATION
       || env.statistics->terminationReason == Statistics::SATISFIABLE) {
@@ -421,27 +409,22 @@ void spiderMode(Problem* problem)
     exceptionRaised = true;
   }
 
-  env.beginOutput();
   if (!exceptionRaised) {
     switch (env.statistics->terminationReason) {
     case Statistics::REFUTATION:
       reportSpiderStatus('+');
       vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
       break;
-      
     case Statistics::TIME_LIMIT:
       reportSpiderStatus('t');
       break;
-      
     case Statistics::MEMORY_LIMIT:
       reportSpiderStatus('m');
       break;
-      
     case Statistics::UNKNOWN:
     case Statistics::INAPPROPRIATE:
       reportSpiderStatus('u');
       break;
-      
     case Statistics::REFUTATION_NOT_FOUND:
       if (env.statistics->discardedNonRedundantClauses > 0) {
         reportSpiderStatus('n');
@@ -450,17 +433,13 @@ void spiderMode(Problem* problem)
         reportSpiderStatus('i');
       }
       break;
-      
     case Statistics::SATISFIABLE:
       reportSpiderStatus('-');
       vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
       break;
-      
     default:
       ASSERTION_VIOLATION;
     }
-    
-    env.endOutput();
     return;
   }
 
@@ -476,13 +455,11 @@ void spiderMode(Problem* problem)
       reportSpiderFail();
     }
 
-    env.endOutput();
     return;
   }
 #endif
 
   reportSpiderFail();
-  env.endOutput();
 
   ASS(exception);
   explainException(*exception);
@@ -497,10 +474,9 @@ void clausifyMode(Problem* problem, bool theory)
 
   ScopedPtr<Problem> prb(preprocessProblem(problem));
 
-  env.beginOutput();
   //outputSymbolDeclarations deals with sorts as well for now
-  //UIHelper::outputSortDeclarations(env.out());
-  UIHelper::outputSymbolDeclarations(env.out());
+  //UIHelper::outputSortDeclarations(std::cout);
+  UIHelper::outputSymbolDeclarations(std::cout);
 
   ClauseIterator cit = prb->clauseIterator();
   bool printed_conjecture = false;
@@ -521,9 +497,9 @@ void clausifyMode(Problem* problem, bool theory)
 
       FormulaUnit* fu = new FormulaUnit(f,cl->inference()); // we are stealing cl's inference, which is not nice!
       fu->overwriteNumber(cl->number()); // we are also making sure it's number is the same as that of the original (for Kostya from Russia to CASC, with love, and back again)
-      env.out() << TPTPPrinter::toString(fu) << "\n";
+      std::cout << TPTPPrinter::toString(fu) << "\n";
     } else {
-      env.out() << TPTPPrinter::toString(cl) << "\n";
+      std::cout << TPTPPrinter::toString(cl) << "\n";
     }
   }
   if(!printed_conjecture && UIHelper::haveConjecture()){
@@ -531,9 +507,8 @@ void clausifyMode(Problem* problem, bool theory)
     Clause* c = new(2) Clause(2,NonspecificInference0(UnitInputType::NEGATED_CONJECTURE,InferenceRule::INPUT));
     (*c)[0] = Literal::create(p, /* polarity */ true , {});
     (*c)[1] = Literal::create(p, /* polarity */ false, {});
-    env.out() << TPTPPrinter::toString(c) << "\n";
+    std::cout << TPTPPrinter::toString(c) << "\n";
   }
-  env.endOutput();
 
   if (env.options->latexOutput() != "off") { outputClausesToLaTeX(prb.ptr()); }
 
@@ -564,12 +539,10 @@ void axiomSelectionMode(Problem* problem)
   env.statistics->phase = Statistics::FINALIZATION;
 
   UnitList::Iterator uit(prb->units());
-  env.beginOutput();
   while (uit.hasNext()) {
     Unit* u = uit.next();
-    env.out() << TPTPPrinter::toString(u) << "\n";
+    std::cout << TPTPPrinter::toString(u) << "\n";
   }
-  env.endOutput();
 
   //we have successfully output the selected units, so we'll terminate with zero return value
   vampireReturnValue = VAMP_RESULT_STATUS_SUCCESS;
@@ -809,9 +782,7 @@ int main(int argc, char* argv[])
     // If any of these options are set then we just need to output and exit
     if (opts.showHelp() || opts.showOptions() || opts.showExperimentalOptions() ||
        !opts.explainOption().empty() || opts.printAllTheoryAxioms()) {
-      env.beginOutput();
-      opts.output(env.out());
-      env.endOutput();
+      opts.output(std::cout);
       exit(0);
     }
 
@@ -865,18 +836,14 @@ catch (Parse::TPTP::ParseErrorException& exception) {
 #if CHECK_LEAKS
     MemoryLeak::cancelReport();
 #endif
-    env.beginOutput();
     explainException(exception);
-    env.endOutput();
   } catch (std::bad_alloc& _) {
     vampireReturnValue = VAMP_RESULT_STATUS_UNHANDLED_EXCEPTION;
     reportSpiderFail();
 #if CHECK_LEAKS
     MemoryLeak::cancelReport();
 #endif
-    env.beginOutput();
-    env.out() << "Insufficient system memory" << '\n';
-    env.endOutput();
+    std::cout << "Insufficient system memory" << '\n';
   }
 
   return vampireReturnValue;


### PR DESCRIPTION
See #157 and #533. `env.out()` and friends no longer do much, so they can be replaced with `std::cout` mechanically.