### PR TITLE
fixed use after free bug

### DIFF
--- a/Indexing/LiteralSubstitutionTree.cpp
+++ b/Indexing/LiteralSubstitutionTree.cpp
@@ -56,7 +56,7 @@ SLQueryResultIterator LiteralSubstitutionTree::getAll()
 {
   return pvi(
         iterTraits(getRangeIterator((size_t)0, _trees.size()))
-         .flatMap([this](auto i) { return LeafIterator(&_trees[i]); })
+         .flatMap([this](auto i) { return LeafIterator(&*_trees[i]); })
          .flatMap([](Leaf* l) { return l->allChildren(); })
          .map([](auto* ld) { return SLQueryResult(ld->literal, ld->clause, ResultSubstitutionSP()); })
       );

--- a/Indexing/LiteralSubstitutionTree.cpp
+++ b/Indexing/LiteralSubstitutionTree.cpp
@@ -56,7 +56,7 @@ SLQueryResultIterator LiteralSubstitutionTree::getAll()
 {
   return pvi(
         iterTraits(getRangeIterator((size_t)0, _trees.size()))
-         .flatMap([this](auto i) { return LeafIterator(&*_trees[i]); })
+         .flatMap([this](auto i) { return LeafIterator(_trees[i].get()); })
          .flatMap([](Leaf* l) { return l->allChildren(); })
          .map([](auto* ld) { return SLQueryResult(ld->literal, ld->clause, ResultSubstitutionSP()); })
       );

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -92,10 +92,10 @@ public:
     int i = 0;
     out << "{ ";
     for (auto& t : self._trees) {
-      if (!t.isEmpty()) {
+      if (!t->isEmpty()) {
         auto f = env.signature->getPredicate(idxToFunctor(i));
         if (idxIsNegative(i)) out << "~";
-        out << *f << "(" << t << "), "; 
+        out << *f << "(" << *t << "), "; 
       }
       i++;
     }
@@ -106,10 +106,10 @@ public:
     int i = 0;
     out << "{ " << std::endl;
     for (auto& t : self.self._trees) {
-      if (!t.isEmpty()) {
+      if (!t->isEmpty()) {
         auto f = env.signature->getPredicate(idxToFunctor(i));
         OutputMultiline<LiteralSubstitutionTree>::outputIndent(out, self.indent);
-        out << (idxIsNegative(i) ? "~" : " ") << *f << "(" << multiline(t, self.indent + 1) << ")" << std::endl; 
+        out << (idxIsNegative(i) ? "~" : " ") << *f << "(" << multiline(*t, self.indent + 1) << ")" << std::endl; 
       }
       i++;
     }
@@ -130,12 +130,12 @@ private:
   {
     auto idx = complementary ? lit->header() : lit->complementaryHeader();
     while (idx >= _trees.size()) {
-      _trees.push(SubstitutionTree());
+      _trees.push(std::make_unique<SubstitutionTree>());
     }
-    return _trees[idx];
+    return *_trees[idx];
   }
 
-  Stack<SubstitutionTree> _trees;
+  Stack<std::unique_ptr<SubstitutionTree>> _trees;
 };
 
 };


### PR DESCRIPTION
Fixes a use after free bug in `LiteralSubstitutionTree` that occurs when the signature has been extended during proof search.