### PR TITLE
switch to C++17

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -13,6 +13,9 @@
  * Implements class PortfolioMode.
  */
 
+//only for detecting number of cores, no threading here!
+#include <thread>
+
 #include "Lib/Environment.hpp"
 #include "Lib/Int.hpp"
 #include "Lib/Portability.hpp"
@@ -53,7 +56,7 @@ using std::cerr;
 using std::endl;
 
 PortfolioMode::PortfolioMode(Problem* problem) : _prb(problem), _slowness(env.options->slowness()), _syncSemaphore(2) {
-  unsigned cores = System::getNumberOfCores();
+  unsigned cores = std::thread::hardware_concurrency();
   cores = cores < 1 ? 1 : cores;
   _numWorkers = std::min(cores, env.options->multicore());
   if(!_numWorkers)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ project(Vampire)
 include(CheckIPOSupported)
 include(CheckPIESupported)
 
-# require the compiler to use C++14
-set(CMAKE_CXX_STANDARD 14)
+# require the compiler to use C++17
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/Debug/TimeProfiling.cpp
+++ b/Debug/TimeProfiling.cpp
@@ -20,21 +20,6 @@ namespace Shell {
 using namespace std;
 using namespace Lib;
 
-// TODO: these should be dispensable with C++17 onwards
-const char* const TimeTrace::CLAUSE_GENERATION;
-const char* const TimeTrace::CONSEQUENCE_FINDING;
-const char* const TimeTrace::FMB_DEFINITION_INTRODUCTION;
-const char* const TimeTrace::HYPER_SUP;
-const char* const TimeTrace::LITERAL_ORDER_AFTERCHECK;
-const char* const TimeTrace::PARSING;
-const char* const TimeTrace::PASSIVE_CONTAINER_MAINTENANCE;
-const char* const TimeTrace::PREPROCESSING;
-const char* const TimeTrace::PROPERTY_EVALUATION;
-const char* const TimeTrace::AVATAR_SAT_SOLVER;
-const char* const TimeTrace::SHUFFLING;
-const char* const TimeTrace::SINE_SELECTION;
-const char* const TimeTrace::TERM_SHARING;
-
 TimeTrace::TimeTrace() 
   : _root("[root]")
   , _stack({ {&_root, Clock::now(), }, }) 

--- a/Debug/TimeProfiling.hpp
+++ b/Debug/TimeProfiling.hpp
@@ -86,19 +86,19 @@ public:
   // Let's fake a big enum like the one we used to have using a bunch of constexpr's
   // (NB: TimeTrace can only group TIME_TRACE calls with identical identifiers as pointers
   //  so always going through one place to declare a TIME_TRACE-able call site sounds like a nice routine)
-  static constexpr const char* const CLAUSE_GENERATION = "clause generation";
-  static constexpr const char* const CONSEQUENCE_FINDING = "consequence finding";
-  static constexpr const char* const FMB_DEFINITION_INTRODUCTION = "fmb definition introduction";
-  static constexpr const char* const HYPER_SUP = "hyper superposition";
-  static constexpr const char* const LITERAL_ORDER_AFTERCHECK = "literal order aftercheck";
-  static constexpr const char* const PARSING = "parsing";
-  static constexpr const char* const PASSIVE_CONTAINER_MAINTENANCE = "passive container maintenance";
-  static constexpr const char* const PREPROCESSING = "preprocessing";
-  static constexpr const char* const PROPERTY_EVALUATION = "property evaluation";
-  static constexpr const char* const AVATAR_SAT_SOLVER = "SAT solver";
-  static constexpr const char* const SHUFFLING = "shuffling things";
-  static constexpr const char* const SINE_SELECTION = "sine selection";
-  static constexpr const char* const TERM_SHARING = "term sharing";
+  static inline constexpr const char* const CLAUSE_GENERATION = "clause generation";
+  static inline constexpr const char* const CONSEQUENCE_FINDING = "consequence finding";
+  static inline constexpr const char* const FMB_DEFINITION_INTRODUCTION = "fmb definition introduction";
+  static inline constexpr const char* const HYPER_SUP = "hyper superposition";
+  static inline constexpr const char* const LITERAL_ORDER_AFTERCHECK = "literal order aftercheck";
+  static inline constexpr const char* const PARSING = "parsing";
+  static inline constexpr const char* const PASSIVE_CONTAINER_MAINTENANCE = "passive container maintenance";
+  static inline constexpr const char* const PREPROCESSING = "preprocessing";
+  static inline constexpr const char* const PROPERTY_EVALUATION = "property evaluation";
+  static inline constexpr const char* const AVATAR_SAT_SOLVER = "SAT solver";
+  static inline constexpr const char* const SHUFFLING = "shuffling things";
+  static inline constexpr const char* const SINE_SELECTION = "sine selection";
+  static inline constexpr const char* const TERM_SHARING = "term sharing";
   
 private:
   using Clock = std::chrono::steady_clock;

--- a/Debug/TimeProfiling.hpp
+++ b/Debug/TimeProfiling.hpp
@@ -86,7 +86,6 @@ public:
   // Let's fake a big enum like the one we used to have using a bunch of constexpr's
   // (NB: TimeTrace can only group TIME_TRACE calls with identical identifiers as pointers
   //  so always going through one place to declare a TIME_TRACE-able call site sounds like a nice routine)
-  // Also: don't forget to add definition to the cpp file (until we swith to C++17)
   static constexpr const char* const CLAUSE_GENERATION = "clause generation";
   static constexpr const char* const CONSEQUENCE_FINDING = "consequence finding";
   static constexpr const char* const FMB_DEFINITION_INTRODUCTION = "fmb definition introduction";

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -19,8 +19,6 @@
  * @since 25/12/2023 Mísečky invoke system binary for backtrace
  */
 
-#ifdef __has_include
-
 #if __has_include(<execinfo.h>)
 #include <execinfo.h>
 #define HAVE_EXECINFO
@@ -86,5 +84,3 @@ void Debug::Tracer::printStack(std::ostream& str) {
   str << "no call stack support for this platform yet" << std::endl;
 #endif
 } // Tracer::printStack (ostream& str)
-
-#endif

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -43,20 +43,20 @@ public:
   ~LPO() override = default;
 
   using PrecedenceOrdering::compare;
-  VWARN_UNUSED Result compare(TermList tl1, TermList tl2) const override;
+  [[nodiscard]] Result compare(TermList tl1, TermList tl2) const override;
   void showConcrete(std::ostream&) const override;
 protected:
-  VWARN_UNUSED Result comparePredicates(Literal* l1, Literal* l2) const override;
-  VWARN_UNUSED Result comparePrecedences(Term* t1, Term* t2) const;
+  [[nodiscard]] Result comparePredicates(Literal* l1, Literal* l2) const override;
+  [[nodiscard]] Result comparePrecedences(Term* t1, Term* t2) const;
 
-  VWARN_UNUSED Result cLMA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
-  VWARN_UNUSED Result cMA(Term* t, TermList* tl, unsigned arity) const;
-  VWARN_UNUSED Result cAA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity1, unsigned arity2) const;
-  VWARN_UNUSED Result alpha(TermList* tl, unsigned arity, Term *t) const;
-  VWARN_UNUSED Result clpo(Term* t1, TermList tl2) const;
-  VWARN_UNUSED Result lpo(TermList tl1, TermList tl2) const;
-  VWARN_UNUSED Result lexMAE(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
-  VWARN_UNUSED Result majo(Term* s, TermList* tl, unsigned arity) const;
+  [[nodiscard]] Result cLMA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
+  [[nodiscard]] Result cMA(Term* t, TermList* tl, unsigned arity) const;
+  [[nodiscard]] Result cAA(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity1, unsigned arity2) const;
+  [[nodiscard]] Result alpha(TermList* tl, unsigned arity, Term *t) const;
+  [[nodiscard]] Result clpo(Term* t1, TermList tl2) const;
+  [[nodiscard]] Result lpo(TermList tl1, TermList tl2) const;
+  [[nodiscard]] Result lexMAE(Term* s, Term* t, TermList* sl, TermList* tl, unsigned arity) const;
+  [[nodiscard]] Result majo(Term* s, TermList* tl, unsigned arity) const;
 
 };
 

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -46,7 +46,7 @@ public:
    * in the @c ArgumentOrderVals enum, so that one can convert between the
    * enums using static_cast.
    */
-  enum VWARN_UNUSED_TYPE Result {
+  enum [[nodiscard]] Result {
     GREATER=1,
     LESS=2,
     GREATER_EQ=3,

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -549,7 +549,7 @@ public:
   template<class GetArg>
   static unsigned termHash(unsigned functor, GetArg getArg, unsigned arity) {
     return DefaultHash::hashIter(
-        range(0, arity).map([&](auto i) { 
+        range(0, arity).map([&](auto i) {
           TermList t = getArg(i);
           return DefaultHash::hashBytes(
               reinterpret_cast<const unsigned char*>(&t),

--- a/Lib/Allocator.hpp
+++ b/Lib/Allocator.hpp
@@ -48,8 +48,7 @@ void setMemoryLimit(size_t bytes);
 #ifdef INDIVIDUAL_ALLOCATIONS
 namespace Lib {
 inline void *alloc(size_t size, size_t align = alignof(std::max_align_t)) {
-  // C++17: aligned operator new
-  return ::operator new(size);
+  return ::operator new(size, (std::max_align_t)align);
 }
 
 inline void free(void *pointer, size_t size, size_t align = alignof(std::max_align_t)) {
@@ -169,7 +168,7 @@ public:
   [[gnu::alloc_align(3)]] // implicit `this` argument
   [[gnu::returns_nonnull]]
   [[gnu::malloc]]
-  VWARN_UNUSED
+  [[nodiscard]]
   inline void *alloc(size_t size, size_t align) {
     ASS_EQ(size % align, 0)
     // no support for overaligned objects yet, but there is nothing stopping it in principle
@@ -192,8 +191,7 @@ public:
       return FSA8.alloc();
 
     // fall back to the system allocator for larger allocations
-    // C++17: aligned operators
-    return ::operator new(size);
+    return ::operator new(size, (std::align_val_t)align);
   }
 
   // deallocate a `pointer` to a memory chunk of known `size`
@@ -217,8 +215,7 @@ public:
     if(size <= 8 * sizeof(void *))
       return FSA8.free(pointer);
 
-    // C++17: aligned operators
-    ::operator delete(pointer, size);
+    ::operator delete(pointer, size, (std::align_val_t)align);
   }
 
 private:
@@ -248,7 +245,7 @@ extern SmallObjectAllocator GLOBAL_SMALL_OBJECT_ALLOCATOR;
 [[gnu::alloc_align(2)]]
 [[gnu::returns_nonnull]]
 [[gnu::malloc]]
-VWARN_UNUSED
+[[nodiscard]]
 inline void *alloc(size_t size, size_t align) {
   return GLOBAL_SMALL_OBJECT_ALLOCATOR.alloc(size, align);
 }
@@ -259,7 +256,7 @@ inline void *alloc(size_t size, size_t align) {
 [[gnu::alloc_size(1)]]
 [[gnu::returns_nonnull]]
 [[gnu::malloc]]
-VWARN_UNUSED
+[[nodiscard]]
 inline void *alloc(size_t size) {
   const size_t align = alignof(std::max_align_t);
   // round up to the nearest multiple of align
@@ -287,10 +284,11 @@ inline void free(void *pointer, size_t size) {
 }
 
 // overload class-specific operator new to call the global small-object allocator
-// C++17: aligned operators
 #define USE_GLOBAL_SMALL_OBJECT_ALLOCATOR(C) \
   void *operator new(size_t size) { return Lib::alloc(size, alignof(C)); }\
-  void operator delete(void *ptr, size_t size) { Lib::free(ptr, size, alignof(C)); }
+  void *operator new(size_t size, std::align_val_t align) { return Lib::alloc(size, (size_t)align); }\
+  void operator delete(void *ptr, size_t size) { Lib::free(ptr, size, alignof(C)); } \
+  void operator delete(void *ptr, size_t size, std::align_val_t align) { Lib::free(ptr, size, (size_t)align); }
 
 #endif // INDIVIDUAL_ALLOCATIONS's else
 

--- a/Lib/BacktrackIterators.hpp
+++ b/Lib/BacktrackIterators.hpp
@@ -103,7 +103,7 @@ private:
   State _initState;
   ChoiceArr _choices;
   size_t _chLen;
-  Stack<std::result_of_t<Fn(State)> > _chits; //choice iterators
+  Stack<std::invoke_result_t<Fn, State>> _chits; //choice iterators
   Stack<State> _states;
   Fn _functor;
 };

--- a/Lib/Hash.hpp
+++ b/Lib/Hash.hpp
@@ -116,24 +116,11 @@ struct VectorHash {
 };
 
 template<class InnerHash> 
-struct TupleHash {
-
-  template <std::size_t Index, typename... Ts>
-  static inline typename std::enable_if<Index == sizeof...(Ts), unsigned>::type
-  tuple_hash_impl(const std::tuple<Ts...> &t) { return 0; }
-
-  template <std::size_t Index, typename... Ts>
-  static inline typename std::enable_if<Index < sizeof...(Ts), unsigned>::type
-  tuple_hash_impl(const std::tuple<Ts...> &t) 
-  { return Lib::HashUtils::combine(tuple_hash_impl<Index + 1>(t), InnerHash::hash(std::get<Index>(t))); }
-
-
+struct TupleHash 
+{
   template<typename... T>
-  static unsigned hash(std::tuple<T...> const& s) {
-    //TODO: repace with std::apply:
-    // return std::apply(s, [](auto... args) { return HashUtils::combine(hash(args)...); });
-    return tuple_hash_impl<0>(s);
-  }
+  static unsigned hash(std::tuple<T...> const& s) 
+  { return std::apply([](auto... args) { return HashUtils::combine(InnerHash::hash(args)...); }, s); }
 };
 
 /**

--- a/Lib/Hash.hpp
+++ b/Lib/Hash.hpp
@@ -130,7 +130,7 @@ struct TupleHash {
 
   template<typename... T>
   static unsigned hash(std::tuple<T...> const& s) {
-    //C++17: repace with std::apply:
+    //TODO: repace with std::apply:
     // return std::apply(s, [](auto... args) { return HashUtils::combine(hash(args)...); });
     return tuple_hash_impl<0>(s);
   }
@@ -154,8 +154,7 @@ public:
   template<typename T>
   static typename std::enable_if<
     std::is_same<
-      //C++17: repace with std::invoke_result
-      typename std::result_of<decltype(&T::defaultHash)(T)>::type,
+      typename std::invoke_result<decltype(&T::defaultHash), T>::type,
       unsigned
     >::value,
     unsigned
@@ -281,8 +280,7 @@ public:
   template<typename T>
   static typename std::enable_if<
     std::is_same<
-      //C++17: repace with std::invoke_result
-      typename std::result_of<decltype(&T::defaultHash2)(T)>::type,
+      typename std::invoke_result<decltype(&T::defaultHash2), T>::type,
       unsigned
     >::value,
     unsigned
@@ -290,7 +288,7 @@ public:
     return ref.defaultHash2();
   }
 
-  // special-case for Units (and their descendants) as they have a unique incrementing identifier  
+  // special-case for Units (and their descendants) as they have a unique incrementing identifier
   template<typename T>
   static typename std::enable_if<
     std::is_base_of<Kernel::Unit, T>::value,

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -274,7 +274,7 @@ template<class Inner, class Functor>
 class FilterMapIter
 {
 public:
-  DECL_ELEMENT_TYPE(typename std::result_of<Functor(ELEMENT_TYPE(Inner))>::type::Content);
+  DECL_ELEMENT_TYPE(typename std::invoke_result<Functor, ELEMENT_TYPE(Inner)>::type::Content);
   DEFAULT_CONSTRUCTORS(FilterMapIter)
 
   FilterMapIter(Inner inn, Functor func)
@@ -451,7 +451,7 @@ private:
  * The @b knowsSize() and @b size() functions of this iterator can be
  * called only if the underlying iterator contains these functions.
  */
-template<typename Inner, typename Functor, typename ResultType=std::result_of_t<Functor(ELEMENT_TYPE(Inner))>>
+template<typename Inner, typename Functor, typename ResultType=std::invoke_result_t<Functor, ELEMENT_TYPE(Inner)>>
 class MappingIterator
 {
 public:
@@ -1312,7 +1312,7 @@ struct CompositionFn {
    : _outer(outer), _inner(inner) { }
 
   template<typename Arg>
-  std::result_of_t<OuterFn(std::result_of_t<InnerFn(Arg)>)> operator()(Arg a) {
+  std::invoke_result_t<OuterFn, std::invoke_result_t<InnerFn, Arg>> operator()(Arg a) {
     return _outer(_inner(a));
   }
 private:

--- a/Lib/Option.hpp
+++ b/Lib/Option.hpp
@@ -320,8 +320,8 @@ public:
    * if the Option was None an empty option of the function's return type is returned.    \
    */                                                                                     \
   template<class Clsr>                                                                    \
-  Option<typename std::result_of<Clsr(A REF)>::type> map(Clsr clsr) REF {                 \
-    using OptOut = Option<typename std::result_of<Clsr(A REF)>::type>;                    \
+  Option<typename std::invoke_result<Clsr, A REF>::type> map(Clsr clsr) REF {                 \
+    using OptOut = Option<typename std::invoke_result<Clsr, A REF>::type>;                    \
     return this->isSome() ? OptOut(clsr(MOVE(unwrap())))                                  \
                           : OptOut();                                                     \
   }                                                                                       \
@@ -332,7 +332,7 @@ public:
    * \pre both CaseSome and CaseNone must have the same return type                       \
    */                                                                                     \
   template<class CaseSome, class CaseNone>                                                \
-  typename std::result_of<CaseSome( A REF)>::type match(CaseSome present, CaseNone none) REF {      \
+  typename std::invoke_result<CaseSome, A REF>::type match(CaseSome present, CaseNone none) REF {      \
     if (this->isSome()) {                                                                 \
       return present(MOVE((*this)).unwrap());                                             \
     } else {                                                                              \
@@ -368,7 +368,7 @@ public:
    * Returns this, if this is Some, or uses the closure to create an alternative option if this is None.      \
    */                                                                                     \
   template<class Clsr,                                                                    \
-           typename std::enable_if<std::is_same< typename std::result_of<Clsr()>::type    \
+           typename std::enable_if<std::is_same< typename std::invoke_result<Clsr>::type    \
                                       , Option                                            \
                                       >::value                                            \
                          , bool                                                           \
@@ -379,7 +379,7 @@ public:
                                                                                           \
   /** Returns the value of this, if this is Some, or uses the closure to create a value othewise. */\
   template<class Clsr,                                                                    \
-           typename std::enable_if<std::is_same< typename std::result_of<Clsr()>::type    \
+           typename std::enable_if<std::is_same< typename std::invoke_result<Clsr>::type    \
                                       , A                                                 \
                                       >::value                                            \
                          , bool                                                           \
@@ -395,8 +395,8 @@ public:
    * This function is the same as flatMap/andThen/(>>=)  in other programming languages with monads.\
    */                                                                                     \
   template<class Clsr>                                                                    \
-  typename std::result_of<Clsr(A REF)>::type andThen(Clsr clsr) REF {                     \
-    using OptOut = typename std::result_of<Clsr(A REF)>::type;                            \
+  typename std::invoke_result<Clsr, A REF>::type andThen(Clsr clsr) REF {                     \
+    using OptOut = typename std::invoke_result<Clsr, A REF>::type;                            \
     return this->isSome() ? clsr(MOVE(*this).unwrap())                                    \
                           : OptOut();                                                     \
   }                                                                                       \

--- a/Lib/Portability.hpp
+++ b/Lib/Portability.hpp
@@ -19,19 +19,4 @@ static_assert(
     "Vampire assumes that there are 8 bits in a `char`"
 );
 
-// enable warnings for unused results
-// C++17: replace this with [[nodiscard]]
-#ifdef __GNUC__
-#define VWARN_UNUSED [[gnu::warn_unused_result]]
-#else
-#define VWARN_UNUSED
-#endif
-
-// clang can attach to class, struct etc, but GCC cannot
-#ifdef __clang__
-#define VWARN_UNUSED_TYPE [[clang::warn_unused_result]]
-#else
-#define VWARN_UNUSED_TYPE
-#endif
-
 #endif /*__Portability__*/

--- a/Lib/ScopeGuard.hpp
+++ b/Lib/ScopeGuard.hpp
@@ -87,38 +87,18 @@ class ScopeGuard final
     bool active;
     Callable f;
 
-    bool stackUnwindingInProgress() const {
-      return std::uncaught_exception();
-    }
-
-    /*  C++17 only
     int exception_count = std::uncaught_exceptions();
 
     bool stackUnwindingInProgress() const {
       return exception_count != std::uncaught_exceptions();
     }
-    */
 };
-
-template <typename Callable>
-ScopeGuard<Callable> make_scope_guard(Callable&& f)
-{
-  return ScopeGuard<Callable>(std::forward<Callable>(f));
-}
-
 
 #define ON_SCOPE_EXIT_CONCAT_HELPER(X,Y) X ## Y
 #define ON_SCOPE_EXIT_CONCAT(X,Y) ON_SCOPE_EXIT_CONCAT_HELPER(X,Y)
 
 #define ON_SCOPE_EXIT(stmt) \
-  auto ON_SCOPE_EXIT_CONCAT(on_scope_exit_guard_on_line_,__LINE__) = make_scope_guard([&]() { stmt; });
-
-// We don't need make_scope_guard in C++17 or later:
-// feature is called "class template argument deduction"
-/*
-#define ON_SCOPE_EXIT(stmt) \
   ScopeGuard ON_SCOPE_EXIT_CONCAT(on_scope_exit_guard_on_line_,__LINE__){[&]() { stmt; }};
-*/
 
 }
 

--- a/Lib/System.cpp
+++ b/Lib/System.cpp
@@ -16,8 +16,6 @@
 #include "Portability.hpp"
 
 #include <csignal>
-#include <fstream>
-#include <thread>
 
 // TODO these should probably be guarded
 // for getpid, _exit
@@ -36,11 +34,6 @@
 #include "Environment.hpp"
 
 #include "System.hpp"
-
-unsigned Lib::System::getNumberOfCores()
-{
-  return std::thread::hardware_concurrency();
-}
 
 namespace Lib {
 
@@ -277,12 +270,6 @@ bool System::extractDirNameFromPath(vstring path, vstring& dir)
   }
   dir = path.substr(0, index);
   return true;
-}
-
-bool System::fileExists(vstring fname)
-{
-  ifstream ifile(fname.c_str());
-  return ifile.good();
 }
 
 };

--- a/Lib/System.hpp
+++ b/Lib/System.hpp
@@ -46,13 +46,6 @@ public:
   static void registerArgv0(const char* argv0) { s_argv0 = argv0; }
   static const char *getArgv0() { return s_argv0; }
 
-  /**
-   * Return number of CPU cores
-   */
-  static unsigned getNumberOfCores();
-
-  static bool fileExists(vstring fname);
-
 private:
   /**
    * Lists of functions that will be called before Vampire terminates

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -24,7 +24,7 @@
 #include "VString.hpp"
 
 #define VAMPIRE_PERF_EXISTS 0
-#if defined __linux__  && defined __has_include
+#ifdef __linux__
 #if __has_include(<linux/perf_event.h>)
 #undef VAMPIRE_PERF_EXISTS
 #define VAMPIRE_PERF_EXISTS 1

--- a/Lib/TypeList.hpp
+++ b/Lib/TypeList.hpp
@@ -15,7 +15,7 @@
 
 namespace Lib {
 
-  template<class F, class... As> using ResultOf = typename std::result_of<F(As...)>::type;
+  template<class F, class... As> using ResultOf = typename std::invoke_result<F, As...>::type;
 
 namespace TypeList {
 
@@ -236,7 +236,7 @@ namespace TypeList {
        static_assert(__VA_ARGS__, "TEST FAIL: values don't match fail");
 
     STATIC_TEST_TYPE_EQ(
-        std::result_of<MkTuple(A,B)>::type,
+        std::invoke_result<MkTuple, A, B>::type,
         Tuple<A, B>)
 
     STATIC_TEST_TYPE_EQ(

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ CXX = g++
 CC = gcc
 endif
 
-CXXFLAGS = $(XFLAGS) -Wall -fno-threadsafe-statics -fno-rtti -std=c++14  $(INCLUDES) # -Wno-unknown-warning-option for clang
+CXXFLAGS = $(XFLAGS) -Wall -fno-threadsafe-statics -fno-rtti -std=c++17  $(INCLUDES) # -Wno-unknown-warning-option for clang
 CCFLAGS = -Wall -O3 -DNDBLSCR -DNLGLOG -DNDEBUG -DNCHKSOL -DNLGLPICOSAT
 
 ################################################################

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -21,6 +21,7 @@
 
 // Visual does not know the round function
 #include <cmath>
+#include <filesystem>
 #include <fstream>
 #include <random>
 
@@ -2446,7 +2447,7 @@ vstring Options::includeFileName (const vstring& relativeName)
     return relativeName;
   }
 
-  if (System::fileExists(relativeName)) {
+  if (std::filesystem::exists(relativeName)) {
     return relativeName;
   }
 
@@ -2460,7 +2461,7 @@ vstring Options::includeFileName (const vstring& relativeName)
     // i.e. the input file
     vstring currentFile = inputFile();
     System::extractDirNameFromPath(currentFile,dir); 
-    if(System::fileExists(dir+"/"+relativeName)){
+    if(std::filesystem::exists(dir+"/"+relativeName)){
       return dir + "/" + relativeName;
     }
 

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -94,7 +94,7 @@ int vampireReturnValue = VAMP_RESULT_STATUS_UNKNOWN;
  *
  * The problem is modified destructively.
  */
-VWARN_UNUSED
+[[nodiscard]]
 Problem* preprocessProblem(Problem* prb)
 {
 #if VAMPIRE_PERF_EXISTS
@@ -141,7 +141,7 @@ void explainException(Exception& exception)
   exception.cry(std::cout);
 } // explainException
 
-VWARN_UNUSED
+[[nodiscard]]
 Problem *doProving(Problem* problem)
 {
   // a new strategy randomization mechanism


### PR DESCRIPTION
It's been about three years since we switched to C++14 in #197. C++17 has things we would like, so let's switch.

This:
1. Switches the compiler flags appropriately.
2. Fixes resulting warnings (`std::result_of` deprecated in favour of `std::invoke_result`)
3. Goes through the code fixing all "when we have C++17" comments - except for one in `Hash.hpp` @joe-hauns - I couldn't figure out what you meant, maybe you remember?
4. Replaces a few `Lib::System` functions that are now trivial in C++17.

I've asked anyone whose code I've touched to review. But anyone is welcome to review!