### PR TITLE
Demodulation cosmetics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/BackwardSubsumptionResolution.cpp
     Inferences/BinaryResolution.cpp
     Inferences/Condensation.cpp
+    Inferences/DemodulationHelper.cpp
     Inferences/DistinctEqualitySimplifier.cpp
     Inferences/EqualityFactoring.cpp
     Inferences/EqualityResolution.cpp
@@ -432,6 +433,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/BackwardSubsumptionResolution.hpp
     Inferences/BinaryResolution.hpp
     Inferences/Condensation.hpp
+    Inferences/DemodulationHelper.hpp
     Inferences/DistinctEqualitySimplifier.hpp
     Inferences/EqualityFactoring.hpp
     Inferences/EqualityResolution.hpp

--- a/Indexing/TermIndex.cpp
+++ b/Indexing/TermIndex.cpp
@@ -121,7 +121,8 @@ void DemodulationLHSIndex::handleClause(Clause* c, bool adding)
   TIME_TRACE("forward demodulation index maintenance");
 
   Literal* lit=(*c)[0];
-  auto lhsi = EqHelper::getDemodulationLHSIterator(lit, true, _ord, _opt);
+  auto lhsi = EqHelper::getDemodulationLHSIterator(lit,
+                    _opt.forwardDemodulation()== Options::Demodulation::PREORDERED, _ord);
   while (lhsi.hasNext()) {
     _is->handle(lhsi.next(), lit, c, adding);
   }

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -242,7 +242,9 @@ void BackwardDemodulation::perform(Clause* cl,
     pvi( getFilteredIterator(
 	    getMappingIterator(
 		    getMapAndFlattenIterator(
-			    EqHelper::getDemodulationLHSIterator(lit, false, _salg->getOrdering(), _salg->getOptions()),
+			    EqHelper::getDemodulationLHSIterator(lit,
+            _salg->getOptions().backwardDemodulation() == Options::Demodulation::PREORDERED,
+            _salg->getOrdering()),
 			    RewritableClausesFn(_index)),
 		    ResultFn(cl, *this)),
  	    RemovedIsNonzeroFn()) );

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -56,6 +56,7 @@ void BackwardDemodulation::attach(SaturationAlgorithm* salg)
   BackwardSimplificationEngine::attach(salg);
   _index=static_cast<DemodulationSubtermIndex*>(
 	  _salg->getIndexManager()->request(DEMODULATION_SUBTERM_SUBST_TREE) );
+  _helper = DemodulationHelper(getOptions(), &_salg->getOrdering());
 }
 
 void BackwardDemodulation::detach()
@@ -89,15 +90,12 @@ struct BackwardDemodulation::ResultFn
 {
   typedef DHMultiset<Clause*> ClauseSet;
 
-  ResultFn(Clause* cl, BackwardDemodulation& parent)
-  : _cl(cl), _ordering(parent._salg->getOrdering())
+  ResultFn(Clause* cl, BackwardDemodulation& parent, const DemodulationHelper& helper)
+  : _cl(cl), _helper(helper), _ordering(parent._salg->getOrdering())
   {
     ASS_EQ(_cl->length(),1);
     _eqLit=(*_cl)[0];
-    _eqSort = SortHelper::getEqualityArgumentSort(_eqLit);
     _removed=SmartPtr<ClauseSet>(new ClauseSet());
-    _redundancyCheck = parent.getOptions().demodulationRedundancyCheck() != Options::DemodulationRedunancyCheck::OFF;
-    _encompassing = parent.getOptions().demodulationRedundancyCheck() == Options::DemodulationRedunancyCheck::ENCOMPASS;
   }
 
   /**
@@ -130,14 +128,16 @@ struct BackwardDemodulation::ResultFn
     TermList lhsS=qr.term;
     TermList rhsS;
 
-    if(!qr.unifier->isIdentityOnResultWhenQueryBound()) {
+    auto subs=qr.unifier;
+
+    if(!subs->isIdentityOnResultWhenQueryBound()) {
       //When we apply substitution to the rhs, we get a term, that is
       //a variant of the term we'd like to get, as new variables are
       //produced in the substitution application.
       //We'd rather rename variables in the rhs, than in the whole clause
       //that we're simplifying.
-      TermList lhsSBadVars=qr.unifier->applyToQuery(lhs);
-      TermList rhsSBadVars=qr.unifier->applyToQuery(rhs);
+      TermList lhsSBadVars=subs->applyToQuery(lhs);
+      TermList rhsSBadVars=subs->applyToQuery(rhs);
       Renaming rNorm, qNorm, qDenorm;
       rNorm.normalizeVariables(lhsSBadVars);
       qNorm.normalizeVariables(lhsS);
@@ -145,48 +145,17 @@ struct BackwardDemodulation::ResultFn
       ASS_EQ(lhsS,qDenorm.apply(rNorm.apply(lhsSBadVars)));
       rhsS=qDenorm.apply(rNorm.apply(rhsSBadVars));
     } else {
-      rhsS=qr.unifier->applyToBoundQuery(rhs);
+      rhsS=subs->applyToBoundQuery(rhs);
     }
 
     if(_ordering.compare(lhsS,rhsS)!=Ordering::GREATER) {
       return BwSimplificationRecord(0);
     }
 
-    if(_redundancyCheck && qr.literal->isEquality() && (qr.term==*qr.literal->nthArgument(0) || qr.term==*qr.literal->nthArgument(1)) &&
-      // encompassment has issues only with positive units
-      (!_encompassing || (qr.literal->isPositive() && qr.clause->length() == 1))) {
-      TermList other=EqHelper::getOtherEqualitySide(qr.literal, qr.term);
-      Ordering::Result tord=_ordering.compare(rhsS, other);
-      if(tord!=Ordering::LESS && tord!=Ordering::LESS_EQ) {
-        if (_encompassing) {
-          if (qr.unifier->isRenamingOn(lhs,false /* we talk of a non-result, i.e., a query term */)) {
-            // under _encompassing, we know there are no other literals in qr.clause
-            return BwSimplificationRecord(0);
-          }
-        } else {
-          TermList eqSort = SortHelper::getEqualityArgumentSort(qr.literal);
-          Literal* eqLitS=Literal::createEquality(true, lhsS, rhsS, eqSort);
-          bool isMax=true;
-          for (Literal* lit2 : qr.clause->iterLits()) {
-            if(qr.literal==lit2) {
-              continue;
-            }
-            if(_ordering.compare(eqLitS, lit2)==Ordering::LESS) {
-              isMax=false;
-              break;
-            }
-          }
-          if(isMax) {
-            //	  RSTAT_CTR_INC("bw subsumptions prevented by tlCheck");
-            //The demodulation is this case which doesn't preserve completeness:
-            //s = t     s = t1 \/ C
-            //---------------------
-            //     t = t1 \/ C
-            //where t > t1 and s = t > C
-            return BwSimplificationRecord(0);
-          }
-        }
-      }
+    if (_helper.redundancyCheckNeededForPremise(qr.clause,qr.literal,qr.term) &&
+      !_helper.isPremiseRedundant(qr.clause,qr.literal,qr.term,rhsS,lhs,subs.ptr(),false))
+    {
+      return BwSimplificationRecord(0);
     }
 
     Literal* resLit=EqHelper::replace(qr.literal,lhsS,rhsS);
@@ -215,13 +184,11 @@ struct BackwardDemodulation::ResultFn
     return BwSimplificationRecord(qr.clause,res);
   }
 private:
-  TermList _eqSort;
   Literal* _eqLit;
   Clause* _cl;
   SmartPtr<ClauseSet> _removed;
 
-  bool _redundancyCheck;
-  bool _encompassing;
+  const DemodulationHelper& _helper;
 
   Ordering& _ordering;
 };
@@ -246,7 +213,7 @@ void BackwardDemodulation::perform(Clause* cl,
             _salg->getOptions().backwardDemodulation() == Options::Demodulation::PREORDERED,
             _salg->getOrdering()),
 			    RewritableClausesFn(_index)),
-		    ResultFn(cl, *this)),
+		    ResultFn(cl, *this, _helper)),
  	    RemovedIsNonzeroFn()) );
 
   //here we know that the getPersistentIterator evaluates all items of the

--- a/Inferences/BackwardDemodulation.hpp
+++ b/Inferences/BackwardDemodulation.hpp
@@ -19,6 +19,8 @@
 #include "Forwards.hpp"
 #include "Indexing/TermIndex.hpp"
 
+#include "DemodulationHelper.hpp"
+
 #include "InferenceEngine.hpp"
 
 namespace Inferences {
@@ -40,6 +42,7 @@ private:
   struct ResultFn;
 
   DemodulationSubtermIndex* _index;
+  DemodulationHelper _helper;
 };
 
 };

--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+#include "Indexing/ResultSubstitution.hpp"
+
+#include "Kernel/Clause.hpp"
+#include "Kernel/EqHelper.hpp"
+#include "Kernel/Term.hpp"
+
+#include "Shell/Options.hpp"
+
+#include "DemodulationHelper.hpp"
+
+namespace Inferences {
+
+using namespace Kernel;
+
+DemodulationHelper::DemodulationHelper(const Options& opts, const Ordering* ord)
+: _redundancyCheck(opts.demodulationRedundancyCheck() != Options::DemodulationRedundancyCheck::OFF),
+  _encompassing(opts.demodulationRedundancyCheck() == Options::DemodulationRedundancyCheck::ENCOMPASS),
+  _ord(ord)
+{
+}
+
+bool DemodulationHelper::redundancyCheckNeededForPremise(Clause* rwCl, Literal* rwLit, TermList rwTerm) const
+{
+  if (!rwLit->isEquality() || (rwTerm!=*rwLit->nthArgument(0) && rwTerm!=*rwLit->nthArgument(1))) {
+    return false;
+  }
+
+  // check is needed if encompassment demodulation is off or we demodulate a positive unit
+  return !_encompassing || (rwLit->isPositive() && (rwCl->length() == 1));
+}
+
+bool DemodulationHelper::isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm,
+  TermList tgtTerm, TermList eqLHS, ResultSubstitution* subst, bool eqIsResult) const
+{
+  ASS(redundancyCheckNeededForPremise(rwCl, rwLit, rwTerm));
+
+  TermList other=EqHelper::getOtherEqualitySide(rwLit, rwTerm);
+  Ordering::Result tord = _ord->compare(tgtTerm, other);
+  if (tord == Ordering::LESS || tord == Ordering::LESS_EQ) {
+    return true;
+  }
+
+  if (_encompassing) {
+    // under _encompassing, we know there are no other literals in rwCl
+    return !subst->isRenamingOn(eqLHS,eqIsResult);
+  }
+
+  TermList eqSort = SortHelper::getEqualityArgumentSort(rwLit);
+  Literal* eqLitS=Literal::createEquality(true, rwTerm, tgtTerm, eqSort);
+
+  // The demodulation which does not preserve completeness:
+  // s = t     s = t1 \/ C
+  // ---------------------
+  //      t = t1 \/ C
+  // where t > t1 and s = t > C.
+  //
+  // Hence we need to check if there are any literals
+  // in rwCl greater than eqLitS.
+  return rwCl->iterLits().any([rwLit,this,eqLitS](Literal* lit) {
+    return lit != rwLit && _ord->compare(eqLitS, lit)==Ordering::LESS;
+  });
+}
+
+}  // namespace Inferences

--- a/Inferences/DemodulationHelper.hpp
+++ b/Inferences/DemodulationHelper.hpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+#ifndef __DemodulationHelper__
+#define __DemodulationHelper__
+
+#include "Forwards.hpp"
+
+namespace Inferences {
+
+using namespace Indexing;
+using namespace Kernel;
+using namespace Shell;
+
+class DemodulationHelper {
+public:
+  DemodulationHelper() = default;
+  DemodulationHelper(const Options& opts, const Ordering* ord);
+
+  bool redundancyCheckNeededForPremise(Clause* rwCl, Literal* rwLit, TermList rwTerm) const;
+  bool isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm,
+    TermList eqLHS, ResultSubstitution* subst, bool eqIsResult) const;
+
+private:
+  bool _redundancyCheck;
+  bool _encompassing;
+  const Ordering* _ord;
+};
+
+};
+
+#endif /* !__DemodulationHelper__ */

--- a/Inferences/ForwardDemodulation.hpp
+++ b/Inferences/ForwardDemodulation.hpp
@@ -37,8 +37,8 @@ public:
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override = 0;
 protected:
   bool _preorderedOnly;
-  bool _redundancyCheck;
   bool _encompassing;
+  DemodulationHelper _helper;
   DemodulationLHSIndex* _index;
 };
 

--- a/Inferences/FunctionDefinitionRewriting.cpp
+++ b/Inferences/FunctionDefinitionRewriting.cpp
@@ -37,90 +37,11 @@ using namespace Lib;
 using namespace Kernel;
 using namespace Saturation;
 
-Kernel::ClauseIterator FunctionDefinitionRewriting::generateClauses(Clause *premise)
+Clause* performRewriting(
+    Clause *rwClause, Literal *rwLit, TermList rwTerm, Clause *eqClause,
+    Literal *eqLit, TermList eqLHS, ResultSubstitutionSP subst,
+    DemodulationHelper* helper, bool& isEqTautology, Inference&& inf)
 {
-  return pvi(premise->iterLits()
-    .flatMap([](Literal *lit) {
-      NonVariableNonTypeIterator nvi(lit);
-      return pvi(pushPairIntoRightIterator(lit, getUniquePersistentIteratorFromPtr(&nvi)));
-    })
-    .flatMap([this](std::pair<Literal*, Term*> arg){
-      return pvi(pushPairIntoRightIterator(arg,
-        GeneratingInferenceEngine::_salg->getFunctionDefinitionHandler().getGeneralizations(arg.second)));
-    })
-    .map([premise](std::pair<std::pair<Literal*, Term*>, TermQueryResult> arg) {
-      TermQueryResult &qr = arg.second;
-      bool temp;
-      return (Clause*)FunctionDefinitionRewriting::perform(premise, arg.first.first, TermList(arg.first.second), qr.clause,
-        qr.literal, qr.term, qr.unifier, false, temp,
-        Inference(GeneratingInference2(InferenceRule::FUNCTION_DEFINITION_REWRITING, premise, qr.clause)));
-    })
-    .filter(NonzeroFn()));
-}
-
-bool FunctionDefinitionRewriting::perform(Clause* cl, Clause*& replacement, ClauseIterator& premises)
-{
-  auto salg = ForwardSimplificationEngine::_salg;
-
-  Ordering& ordering = salg->getOrdering();
-
-  static DHSet<Term*> attempted;
-  attempted.reset();
-
-  unsigned cLen = cl->length();
-  for (unsigned li = 0; li < cLen; li++) {
-    Literal* lit = (*cl)[li];
-    NonVariableNonTypeIterator it(lit);
-    while (it.hasNext()) {
-      TypedTermList trm = it.next();
-      if (!attempted.insert(trm.term())) {
-        it.right();
-        continue;
-      }
-
-      bool toplevelCheck = salg->getOptions().demodulationRedundancyCheck()!=Options::DemodulationRedunancyCheck::OFF &&
-        lit->isEquality() && (trm==*lit->nthArgument(0) || trm==*lit->nthArgument(1));
-
-      auto git = salg->getFunctionDefinitionHandler().getGeneralizations(trm);
-      while (git.hasNext()) {
-        TermQueryResult qr = git.next();
-        if (qr.clause->length() != 1) {
-          continue;
-        }
-        auto rhs = EqHelper::getOtherEqualitySide(qr.literal, qr.term);
-        // TODO shouldn't allow demodulation with incomparables in the non-ground case
-        if (Ordering::isGorGEorE(ordering.compare(rhs,qr.term))) {
-          continue;
-        }
-        bool isEqTautology = false;
-        auto res = FunctionDefinitionRewriting::perform(cl, lit, trm, qr.clause, qr.literal, qr.term, qr.unifier, toplevelCheck,
-          isEqTautology, Inference(SimplifyingInference2(InferenceRule::FUNCTION_DEFINITION_DEMODULATION, cl, qr.clause)), salg);
-        if (!res && !isEqTautology) {
-          continue;
-        }
-        if (!isEqTautology) {
-          replacement = res;
-        }
-        premises = pvi(getSingletonIterator(qr.clause));
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-Clause *FunctionDefinitionRewriting::perform(
-    Clause *rwClause, Literal *rwLit, TermList rwTerm,
-    Clause *eqClause, Literal *eqLit, TermList eqLHS,
-    ResultSubstitutionSP subst, bool toplevelCheck, bool& isEqTautology,
-    const Inference& inf, SaturationAlgorithm* salg)
-{
-  if (SortHelper::getResultSort(rwTerm.term()) != SortHelper::getEqualityArgumentSort(eqLit)) {
-    // sorts don't match
-    return 0;
-  }
-
   ASS(!eqLHS.isVar());
 
   TermList tgtTerm = EqHelper::getOtherEqualitySide(eqLit, eqLHS);
@@ -129,27 +50,8 @@ Clause *FunctionDefinitionRewriting::perform(
   ASS(subst->isIdentityOnQueryWhenResultBound());
   TermList tgtTermS = subst->applyToBoundResult(tgtTerm);
 
-  // update this to latest encompassment-considering version
-  if (toplevelCheck) {
-    Ordering& ordering = salg->getOrdering();
-    TermList other=EqHelper::getOtherEqualitySide(rwLit, rwTerm);
-    Ordering::Result tord = ordering.compare(tgtTermS, other);
-    if (tord != Ordering::LESS && tord != Ordering::LESS_EQ) {
-      Literal* eqLitS = subst->applyToBoundResult(eqLit);
-      bool isMax=true;
-      for (unsigned i = 0; i < rwClause->length(); i++) {
-        if (rwLit == (*rwClause)[i]) {
-          continue;
-        }
-        if (ordering.compare(eqLitS, (*rwClause)[i]) == Ordering::LESS) {
-          isMax=false;
-          break;
-        }
-      }
-      if (isMax) {
-        return 0;
-      }
-    }
+  if (helper && !helper->isPremiseRedundant(rwClause,rwLit,rwTerm,tgtTermS,eqLHS,subst.ptr(),true)) {
+    return 0;
   }
 
   Literal *tgtLitS = EqHelper::replace(rwLit, rwTerm, tgtTermS);
@@ -200,4 +102,87 @@ Clause *FunctionDefinitionRewriting::perform(
   }
 
   return res;
+}
+
+void FunctionDefinitionRewriting::attach(SaturationAlgorithm* salg)
+{
+  GeneratingInferenceEngine::attach(salg);
+  _helper = DemodulationHelper(salg->getOptions(), &salg->getOrdering());
+}
+
+Kernel::ClauseIterator FunctionDefinitionRewriting::generateClauses(Clause *premise)
+{
+  return pvi(premise->iterLits()
+    .flatMap([](Literal *lit) {
+      NonVariableNonTypeIterator nvi(lit);
+      return pvi(pushPairIntoRightIterator(lit, getUniquePersistentIteratorFromPtr(&nvi)));
+    })
+    .flatMap([this](std::pair<Literal*, Term*> arg){
+      return pvi(pushPairIntoRightIterator(arg,
+        GeneratingInferenceEngine::_salg->getFunctionDefinitionHandler().getGeneralizations(arg.second)));
+    })
+    .map([premise](std::pair<std::pair<Literal*, Term*>, TermQueryResult> arg) {
+      TermQueryResult &qr = arg.second;
+      bool temp;
+      return (Clause*)performRewriting(premise, arg.first.first, TermList(arg.first.second), qr.clause,
+        qr.literal, qr.term, qr.unifier, nullptr, temp,
+        Inference(GeneratingInference2(InferenceRule::FUNCTION_DEFINITION_REWRITING, premise, qr.clause)));
+    })
+    .filter(NonzeroFn()));
+}
+
+void FunctionDefinitionDemodulation::attach(SaturationAlgorithm* salg)
+{
+  ForwardSimplificationEngine::attach(salg);
+  _helper = DemodulationHelper(salg->getOptions(), &salg->getOrdering());
+}
+
+bool FunctionDefinitionDemodulation::perform(Clause* cl, Clause*& replacement, ClauseIterator& premises)
+{
+  Ordering& ordering = _salg->getOrdering();
+
+  static DHSet<Term*> attempted;
+  attempted.reset();
+
+  unsigned cLen = cl->length();
+  for (unsigned li = 0; li < cLen; li++) {
+    Literal* lit = (*cl)[li];
+    NonVariableNonTypeIterator it(lit);
+    while (it.hasNext()) {
+      TypedTermList trm = it.next();
+      if (!attempted.insert(trm.term())) {
+        it.right();
+        continue;
+      }
+
+      bool redundancyCheck = _helper.redundancyCheckNeededForPremise(cl, lit, trm);
+
+      auto git = _salg->getFunctionDefinitionHandler().getGeneralizations(trm);
+      while (git.hasNext()) {
+        TermQueryResult qr = git.next();
+        if (qr.clause->length() != 1) {
+          continue;
+        }
+        auto rhs = EqHelper::getOtherEqualitySide(qr.literal, qr.term);
+        // TODO shouldn't allow demodulation with incomparables in the non-ground case
+        if (Ordering::isGorGEorE(ordering.compare(rhs,qr.term))) {
+          continue;
+        }
+        bool isEqTautology = false;
+        auto res = performRewriting(
+          cl, lit, trm, qr.clause, qr.literal, qr.term, qr.unifier, redundancyCheck ? &_helper : nullptr,
+          isEqTautology, Inference(SimplifyingInference2(InferenceRule::FUNCTION_DEFINITION_DEMODULATION, cl, qr.clause)));
+        if (!res && !isEqTautology) {
+          continue;
+        }
+        if (!isEqTautology) {
+          replacement = res;
+        }
+        premises = pvi(getSingletonIterator(qr.clause));
+        return true;
+      }
+    }
+  }
+
+  return false;
 }

--- a/Inferences/FunctionDefinitionRewriting.hpp
+++ b/Inferences/FunctionDefinitionRewriting.hpp
@@ -23,6 +23,8 @@
 
 #include "Forwards.hpp"
 
+#include "DemodulationHelper.hpp"
+
 namespace Inferences {
 
 using namespace Kernel;
@@ -37,20 +39,28 @@ using namespace Shell;
  */
 class FunctionDefinitionRewriting
   : public GeneratingInferenceEngine
-  , public ForwardSimplificationEngine
   {
 public:
-  USE_ALLOCATOR(FunctionDefinitionRewriting);
-
+  void attach(SaturationAlgorithm* salg) override;
   ClauseIterator generateClauses(Clause *premise) override;
+
+private:
+  DemodulationHelper _helper;
+};
+
+/**
+ * Simplifying version of the above inference, where we check if the rewriting
+ * coincides with a demodulation under the current options and ordering.
+ */
+class FunctionDefinitionDemodulation
+  : public ForwardSimplificationEngine
+  {
+public:
+  void attach(SaturationAlgorithm* salg) override;
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
 
 private:
-  static Clause *perform(
-      Clause *rwClause, Literal *rwLiteral, TermList rwTerm,
-      Clause *eqClause, Literal *eqLiteral, TermList eqLHS,
-      ResultSubstitutionSP subst, bool toplevelCheck,
-      bool& isEqTautology, const Inference& inf, SaturationAlgorithm* salg = nullptr);
+  DemodulationHelper _helper;
 };
 
 }; // namespace Inferences

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -388,7 +388,7 @@ VirtualIterator<TypedTermList> EqHelper::getSubVarSupLHSIterator(Literal* lit, c
  *
  * If the literal @b lit is not a positive equality, empty iterator is returned.
  */
-VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit, bool forward, const Ordering& ord, const Options& opt)
+VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit, bool preordered, const Ordering& ord)
 {
   if (lit->isEquality()) {
     if (lit->isNegative()) {
@@ -399,8 +399,7 @@ VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit
     switch(ord.getEqualityArgumentOrder(lit))
     {
     case Ordering::INCOMPARABLE:
-      if ( forward ? (opt.forwardDemodulation() == Options::Demodulation::PREORDERED)
-		  : (opt.backwardDemodulation() == Options::Demodulation::PREORDERED) ) {
+      if ( preordered ) {
         return withEqualitySort(lit, TermIterator::getEmpty());
       }
       if (t0.containsAllVariablesOf(t1)) {

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -29,13 +29,21 @@ namespace Kernel {
 
 using namespace Shell;
 
-/* turns an iterator with TermList elemenst to an iterator of TypedTermList elements 
- * with the sort of the provided equality literal 
+/*
+ * Turns an iterator with TermList elemenst to an iterator of TypedTermList elements
+ * with the sort of the provided equality literal.
+ *
+ * Computes the sort exactly once, so it's wastful to call if the the iterator is empty.
+ * (Or if the sort is already known.)
  */
 template<class TermListIter>
 auto withEqualitySort(Literal* eq, TermListIter iter)
-{ return pvi(iterTraits(std::move(iter))
-    .map([eq](TermList t) { return TypedTermList(t, SortHelper::getEqualityArgumentSort(eq)); })); }
+{
+  ASS(iter.hasNext());
+  auto sort = SortHelper::getEqualityArgumentSort(eq);
+  return pvi(iterTraits(std::move(iter))
+    .map([sort](TermList t) { return TypedTermList(t, sort); }));
+}
 
 /**
  * Return the other side of an equality @b eq than the @b lhs
@@ -279,7 +287,7 @@ VirtualIterator<TypedTermList> EqHelper::getLHSIterator(Literal* lit, const Orde
 {
   if (lit->isEquality()) {
     if (lit->isNegative()) {
-      return withEqualitySort(lit,TermIterator::getEmpty());
+      return VirtualIterator<TypedTermList>::getEmpty();
     }
     TermList t0=*lit->nthArgument(0);
     TermList t1=*lit->nthArgument(1);
@@ -297,9 +305,9 @@ VirtualIterator<TypedTermList> EqHelper::getLHSIterator(Literal* lit, const Orde
     case Ordering::EQUAL:
       ASSERTION_VIOLATION;
     }
-    return withEqualitySort(lit,TermIterator::getEmpty());
+    return VirtualIterator<TypedTermList>::getEmpty();
   } else {
-    return withEqualitySort(lit,TermIterator::getEmpty());
+    return VirtualIterator<TypedTermList>::getEmpty();
   }
 }
 
@@ -338,7 +346,7 @@ VirtualIterator<TypedTermList> EqHelper::getSubVarSupLHSIterator(Literal* lit, c
 
   if (eqSort.isVar() || eqSort.isArrowSort()) {
     if (lit->isNegative()) {
-      return withEqualitySort(lit, TermIterator::getEmpty());
+      return VirtualIterator<TypedTermList>::getEmpty();
     }
 
     TermList t0=*lit->nthArgument(0);
@@ -351,24 +359,24 @@ VirtualIterator<TypedTermList> EqHelper::getSubVarSupLHSIterator(Literal* lit, c
     switch(ord.getEqualityArgumentOrder(lit))
     {
     case Ordering::INCOMPARABLE:
-      if(t0hisVarOrComb && t1hisVarOrComb){ 
-        return withEqualitySort(lit, iterItems(t0, t1) );
+      if(t0hisVarOrComb && t1hisVarOrComb){
+        return pvi(iterItems(TypedTermList(t0,eqSort), TypedTermList(t1,eqSort)));
       } else if( t0hisVarOrComb ){
-        return withEqualitySort(lit, getSingletonIterator(t1) );      
+        return pvi(getSingletonIterator(TypedTermList(t1,eqSort)));
       } else if( t1hisVarOrComb ) {
-        return withEqualitySort(lit, getSingletonIterator(t0) );
+        return pvi(getSingletonIterator(TypedTermList(t0,eqSort)));
       }
       break;
     case Ordering::GREATER:
     case Ordering::GREATER_EQ:
       if(t1hisVarOrComb){
-        return withEqualitySort(lit, getSingletonIterator(t0) );
+        return pvi(getSingletonIterator(TypedTermList(t0,eqSort)));
       }
       break;
     case Ordering::LESS:
     case Ordering::LESS_EQ:
       if(t0hisVarOrComb){
-        return withEqualitySort(lit, getSingletonIterator(t1) );
+        return pvi(getSingletonIterator(TypedTermList(t1,eqSort)));
       }
       break;
     case Ordering::EQUAL:
@@ -376,10 +384,10 @@ VirtualIterator<TypedTermList> EqHelper::getSubVarSupLHSIterator(Literal* lit, c
     default:
       ASSERTION_VIOLATION;
     }
-    return withEqualitySort(lit, TermIterator::getEmpty());
+    return VirtualIterator<TypedTermList>::getEmpty();
   } else {
-    return withEqualitySort(lit, TermIterator::getEmpty());
-  }  
+    return VirtualIterator<TypedTermList>::getEmpty();
+  }
 }
 
 /**
@@ -392,7 +400,7 @@ VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit
 {
   if (lit->isEquality()) {
     if (lit->isNegative()) {
-      return withEqualitySort(lit, TermIterator::getEmpty());
+      return VirtualIterator<TypedTermList>::getEmpty();
     }
     TermList t0=*lit->nthArgument(0);
     TermList t1=*lit->nthArgument(1);
@@ -400,7 +408,7 @@ VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit
     {
     case Ordering::INCOMPARABLE:
       if ( preordered ) {
-        return withEqualitySort(lit, TermIterator::getEmpty());
+        return VirtualIterator<TypedTermList>::getEmpty();
       }
       if (t0.containsAllVariablesOf(t1)) {
         if (t1.containsAllVariablesOf(t0)) {
@@ -429,9 +437,9 @@ VirtualIterator<TypedTermList> EqHelper::getDemodulationLHSIterator(Literal* lit
     case Ordering::EQUAL:
       ASSERTION_VIOLATION;
     }
-    return withEqualitySort(lit,TermIterator::getEmpty());
+    return VirtualIterator<TypedTermList>::getEmpty();
   } else {
-    return withEqualitySort(lit,TermIterator::getEmpty());
+    return VirtualIterator<TypedTermList>::getEmpty();
   }
 }
 

--- a/Kernel/EqHelper.hpp
+++ b/Kernel/EqHelper.hpp
@@ -44,7 +44,7 @@ public:
   static VirtualIterator<TypedTermList> getLHSIterator(Literal* lit, const Ordering& ord);
   static VirtualIterator<TypedTermList> getSuperpositionLHSIterator(Literal* lit, const Ordering& ord, const Options& opt);
   static VirtualIterator<TypedTermList> getSubVarSupLHSIterator(Literal* lit, const Ordering& ord);
-  static VirtualIterator<TypedTermList> getDemodulationLHSIterator(Literal* lit, bool forward, const Ordering& ord, const Options& opt);
+  static VirtualIterator<TypedTermList> getDemodulationLHSIterator(Literal* lit, bool preordered, const Ordering& ord);
   static TermIterator getEqualityArgumentIterator(Literal* lit);
 
   //WARNING, this function cannot be used when @param t is a sort.

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ VINF_OBJ=Inferences/BackwardDemodulation.o\
          Inferences/BackwardSubsumptionDemodulation.o\
          Inferences/BinaryResolution.o\
          Inferences/Condensation.o\
+         Inferences/DemodulationHelper.o\
          Inferences/DistinctEqualitySimplifier.o\
          Inferences/DefinitionIntroduction.o\
          Inferences/EqualityFactoring.o\

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1586,7 +1586,7 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
   if (env.options->functionDefinitionRewriting()) {
     gie->addFront(new FunctionDefinitionRewriting());
-    res->addForwardSimplifierToFront(new FunctionDefinitionRewriting());
+    res->addForwardSimplifierToFront(new FunctionDefinitionDemodulation());
   }
 
   CompositeSGI* sgi = new CompositeSGI();

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1524,7 +1524,7 @@ void Options::init()
     _condensation.tag(OptionTag::INFERENCES);
     _condensation.onlyUsefulWith(ProperSaturationAlgorithm());
 
-    _demodulationRedundancyCheck = ChoiceOptionValue<DemodulationRedunancyCheck>("demodulation_redundancy_check","drc",DemodulationRedunancyCheck::ON,{"off","encompass","on"});
+    _demodulationRedundancyCheck = ChoiceOptionValue<DemodulationRedundancyCheck>("demodulation_redundancy_check","drc",DemodulationRedundancyCheck::ON,{"off","encompass","on"});
     _demodulationRedundancyCheck.description=
        "The following cases of backward and forward demodulation do not preserve completeness:\n"
        "s = t     s = t1 \\/ C \t s = t     s != t1 \\/ C\n"
@@ -3456,7 +3456,7 @@ bool Options::complete(const Problem& prb) const
     return prop.category() == Property::HNE; // enough URR is complete for Horn problems
   }
 
-  if (_demodulationRedundancyCheck.actualValue == DemodulationRedunancyCheck::OFF) {
+  if (_demodulationRedundancyCheck.actualValue == DemodulationRedundancyCheck::OFF) {
     return false;
   }
   if (!_superpositionFromVariables.actualValue) return false;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -289,7 +289,7 @@ public:
     GOAL_PLUS,                // above plus skolem terms introduced in induction inferences
   };
 
-  enum class DemodulationRedunancyCheck : unsigned int {
+  enum class DemodulationRedundancyCheck : unsigned int {
     OFF,
     ENCOMPASS,
     ON
@@ -2083,7 +2083,7 @@ public:
   bool arityCheck() const { return _arityCheck.actualValue; }
   //void setArityCheck(bool newVal) { _arityCheck=newVal; }
   Demodulation backwardDemodulation() const { return _backwardDemodulation.actualValue; }
-  DemodulationRedunancyCheck demodulationRedundancyCheck() const { return _demodulationRedundancyCheck.actualValue; }
+  DemodulationRedundancyCheck demodulationRedundancyCheck() const { return _demodulationRedundancyCheck.actualValue; }
   //void setBackwardDemodulation(Demodulation newVal) { _backwardDemodulation = newVal; }
   Subsumption backwardSubsumption() const { return _backwardSubsumption.actualValue; }
   //void setBackwardSubsumption(Subsumption newVal) { _backwardSubsumption = newVal; }
@@ -2443,7 +2443,7 @@ private:
   BoolOptionValue _colorUnblocking;
   ChoiceOptionValue<Condensation> _condensation;
 
-  ChoiceOptionValue<DemodulationRedunancyCheck> _demodulationRedundancyCheck;
+  ChoiceOptionValue<DemodulationRedundancyCheck> _demodulationRedundancyCheck;
 
   ChoiceOptionValue<EqualityProxy> _equalityProxy;
   BoolOptionValue _useMonoEqualityProxy;


### PR DESCRIPTION
1) getDemodulationLHSIterator does not need to be given the options object (we already know at the sites where we use it, whether we are doing FWD or BWD)
2) call SortHelper::getEqualityArgumentSort exactly once in withEqualitySort (and not potentially twice); but don't use on empty iterators

These are almost trivial changes. Just something I noticed before the breakfast...