### PR TITLE
have the TermList default constructor zero-initialise

### DIFF
--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -144,6 +144,7 @@ void TermSharing::computeAndSetSharedTermData(Term* t)
       }
       else 
       {
+        ASS(tt->isTerm());
         ASS_REP(tt->term()->shared(), tt->term()->toString());
         
         Term* r = tt->term();

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -101,7 +101,8 @@ class TermList {
 public:
   // divide by 4 because of the tag, by 2 to split the space evenly
   static const unsigned SPEC_UPPER_BOUND = (UINT_MAX / 4) / 2;
-  TermList() : _content(0) {};
+  /* default constructor, satisfying isEmpty() */
+  TermList() : _content(FUN) {}
   /** creates a term list containing a pointer to a term */
   explicit TermList(Term* t) : _content(0) {
     // NB we also zero-initialise _content so that the spare bits are zero on 32-bit platforms
@@ -176,9 +177,11 @@ public:
   /** make the term into a special variable with a given number */
   inline void makeSpecialVar(unsigned vnumber)
   { _content = vnumber * 4 + SPEC_VAR; }
-  /** create an term empty (so that isEmpty() returns true) */
+  /** create an term empty (so that isEmpty() returns true)
+   *  (can just be the default constructor now)
+   */
   inline static TermList empty()
-  { TermList out; out._content = FUN; return out; }
+  { return TermList(); }
   /** the top of a term is either a function symbol or a variable id. this class is model this */
   class Top {
     using Inner = Coproduct<unsigned, unsigned>;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -101,8 +101,7 @@ class TermList {
 public:
   // divide by 4 because of the tag, by 2 to split the space evenly
   static const unsigned SPEC_UPPER_BOUND = (UINT_MAX / 4) / 2;
-  /** dummy constructor, does nothing */
-  TermList() = default;
+  TermList() : _content(0) {};
   /** creates a term list containing a pointer to a term */
   explicit TermList(Term* t) : _content(0) {
     // NB we also zero-initialise _content so that the spare bits are zero on 32-bit platforms

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -99,8 +99,6 @@ enum ArgumentOrderVals {
  */
 class TermList {
 public:
-  // divide by 4 because of the tag, by 2 to split the space evenly
-  static const unsigned SPEC_UPPER_BOUND = (UINT_MAX / 4) / 2;
   /* default constructor, satisfying isEmpty() */
   TermList() : _content(FUN) {}
   /** creates a term list containing a pointer to a term */
@@ -142,7 +140,7 @@ public:
   /** the term contains an ordinary variable as its head */
   inline bool isOrdinaryVar() const { return tag() == ORD_VAR; }
   /** the term contains a special variable as its head */
-  inline bool isSpecialVar() const { return tag() == SPEC_VAR && var() < SPEC_UPPER_BOUND; }
+  inline bool isSpecialVar() const { return tag() == SPEC_VAR; }
 
   /** return the variable number */
   inline unsigned var() const


### PR DESCRIPTION
Somewhat trivial, but in discussion with @quickbeam123 have `TermList` zero-initialise its content. In (almost?) all cases this should be immediately overwritten, but it means that when there is a bug, we will get a hard null-dereference crash rather than...something else.