### PR TITLE
Code tree search structs refactor + lazily expanded flat terms

### DIFF
--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -312,7 +312,7 @@ bool ClauseCodeTree::removeOneOfAlternatives(CodeOp* op, Clause* cl, Stack<CodeO
 {
   unsigned initDepth=firstsInBlocks->size();
 
-  while(!op->isSuccess() || op->getSuccessResult()!=cl) {
+  while(!op->isSuccess() || op->getSuccessResult<Clause>()!=cl) {
     op=op->alternative();
     if(!op) {
       firstsInBlocks->truncate(initDepth);
@@ -574,7 +574,7 @@ Clause* ClauseCodeTree::ClauseMatcher::next(int& resolvedQueryLit)
       }
     }
     else if(lm->op->isSuccess()) {
-      Clause* candidate=static_cast<Clause*>(lm->op->getSuccessResult());
+      Clause* candidate=lm->op->getSuccessResult<Clause>();
       RSTAT_MCTR_INC("candidates", lms.size()-1);
       if(checkCandidate(candidate, resolvedQueryLit)) {
 	RSTAT_MCTR_INC("candidates (success)", lms.size()-1);

--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -74,6 +74,7 @@ void ClauseCodeTree::insert(Clause* cl)
   cctx.init();
 
   for(unsigned i=0;i<clen;i++) {
+    cctx.nextLit();
     compileTerm(lits[i], code, cctx, true);
   }
   code.push(CodeOp::getSuccess(cl));
@@ -185,7 +186,7 @@ void ClauseCodeTree::matchCode(CodeStack& code, CodeOp* startOp, size_t& matched
       if(treeOp->isSearchStruct()) {
 	SearchStruct* ss=treeOp->getSearchStruct();
 	CodeOp** toPtr;
-	if(ss->getTargetOpPtr(code[i], toPtr) && *toPtr) {
+	if(ss->getTargetOpPtr<false>(code[i], toPtr) && *toPtr) {
 	  treeOp=*toPtr;
 	  continue;
 	}

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -35,6 +35,9 @@
 namespace Indexing
 {
 
+#define GET_CONTAINING_OBJECT(ContainingClass,MemberField,object) \
+  reinterpret_cast<ContainingClass*>(reinterpret_cast<size_t>(object)-offsetof(ContainingClass,MemberField))
+
 using namespace std;
 using namespace Lib;
 using namespace Kernel;
@@ -71,7 +74,7 @@ CodeTree::LitInfo CodeTree::LitInfo::getOpposite(const LitInfo& li)
   ft->changeLiteralPolarity();
 #if GROUND_TERM_CHECK
   ASS_EQ((*ft)[1].tag(), FlatTerm::FUN_TERM_PTR);
-  (*ft)[1]._ptr=Literal::oppositeLiteral(static_cast<Literal*>((*ft)[1].ptr()));
+  (*ft)[1]._ptr=Literal::complementaryLiteral(static_cast<Literal*>((*ft)[1].ptr()));
 #endif
 
   LitInfo res=li;
@@ -127,7 +130,7 @@ void CodeTree::MatchInfo::init(ILStruct* ils, unsigned liIndex_, DArray<TermList
 }
 
 
-CodeTree::ILStruct::ILStruct(Literal* lit, unsigned varCnt, Stack<unsigned>& gvnStack)
+CodeTree::ILStruct::ILStruct(const Literal* lit, unsigned varCnt, Stack<unsigned>& gvnStack)
 : varCnt(varCnt), sortedGlobalVarNumbers(0), globalVarPermutation(0), timestamp(0)
 {
   ASS_EQ(matches.size(), 0); //we don't want any uninitialized pointers in the array
@@ -321,7 +324,7 @@ CodeTree::CodeOp CodeTree::CodeOp::getTermOp(InstructionSuffix i, unsigned num)
   return res;
 }
 
-CodeTree::CodeOp CodeTree::CodeOp::getGroundTermCheck(Term* trm)
+CodeTree::CodeOp CodeTree::CodeOp::getGroundTermCheck(const Term* trm)
 {
   ASS(trm->ground());
 
@@ -357,109 +360,137 @@ bool CodeTree::CodeOp::equalsForOpMatching(const CodeOp& o) const
   }
 }
 
-CodeTree::SearchStruct* CodeTree::CodeOp::getSearchStruct()
+CodeTree::SearchStruct* CodeTree::CodeOp::getSearchStruct() const
 {
-  //the following line gives warning for not being according
-  //to the standard, so we have to work around
-//  static const size_t opOfs=offsetof(SearchStruct,landingOp);
-  static const size_t opOfs=reinterpret_cast<size_t>(
-	&reinterpret_cast<SearchStruct*>(8)->landingOp)-8;
-
-  SearchStruct* res=reinterpret_cast<SearchStruct*>(
-      reinterpret_cast<size_t>(this)-opOfs);
-
-  return res;
+  ASS(isSearchStruct());
+  return GET_CONTAINING_OBJECT(CodeTree::SearchStruct,landingOp,this);
 }
 
-CodeTree::SearchStruct::SearchStruct(Kind kind)
+std::ostream& operator<<(std::ostream& out, const CodeTree::CodeOp& op)
+{
+  switch (op.instrPrefix()) {
+  case CodeTree::SUCCESS_OR_FAIL:
+    if (op.isSuccess()) {
+      out << "success";
+    } else {
+      out << "fail";
+    }
+    break;
+  case CodeTree::LIT_END:
+    out << "lit end";
+    break;
+  case CodeTree::CHECK_GROUND_TERM:
+    out << "check ground term " << *op.getTargetTerm();
+    break;
+  case CodeTree::SUFFIX_INSTR:
+    switch(op.instrSuffix()) {
+    case CodeTree::CHECK_FUN:
+      out << "check fun " << env.signature->getFunction(op.arg())->name();
+      break;
+    case CodeTree::ASSIGN_VAR:
+      out << "assign var X" << op.arg();
+      break;
+    case CodeTree::CHECK_VAR:
+      out << "check var X" << op.arg();
+      break;
+    case CodeTree::SEARCH_STRUCT:
+      out << "search struct ";
+      auto ss = op.getSearchStruct();
+      switch(ss->kind) {
+        case CodeTree::SearchStruct::FN_STRUCT: {
+          auto fn_ss = static_cast<CodeTree::FnSearchStruct*>(ss);
+          out << "length " << fn_ss->length();
+          for (unsigned i = 0; i < fn_ss->length(); i++) {
+            out << " " << fn_ss->values[i] << " ";
+            if (fn_ss->targets[i]) {
+              out << *fn_ss->targets[i];
+            } else {
+              out << "nullptr";
+            }
+          }
+          break;
+        }
+        case CodeTree::SearchStruct::GROUND_TERM_STRUCT: {
+          auto gt_ss = static_cast<CodeTree::GroundTermSearchStruct*>(ss);
+          out << "length " << gt_ss->length();
+          for (unsigned i = 0; i < gt_ss->length(); i++) {
+            out << " " << *gt_ss->values[i] << " ";
+            if (gt_ss->targets[i]) {
+              out << *gt_ss->targets[i];
+            } else {
+              out << "nullptr";
+            }
+          }
+          break;
+        }
+      }
+      break;
+    }
+    break;
+  }
+  return out;
+}
+
+CodeTree::SearchStruct::SearchStruct(Kind kind, size_t length)
 : kind(kind)
 {
   landingOp.setAlternative(0);
   landingOp.setLongInstr(SEARCH_STRUCT);
+  ASS(length);
+
+  targets.reserve(length);
 }
 
-void CodeTree::SearchStruct::destroy()
-{
-  switch(kind) {
-  case FN_STRUCT:
-    delete static_cast<FnSearchStruct*>(this);
-    break;
-  case GROUND_TERM_STRUCT:
-    delete static_cast<GroundTermSearchStruct*>(this);
-    break;
-  }
-}
-
+template<bool doInsert>
 bool CodeTree::SearchStruct::getTargetOpPtr(const CodeOp& insertedOp, CodeOp**& tgt)
 {
   switch(kind) {
   case FN_STRUCT:
     if(!insertedOp.isCheckFun()) { return false; }
-    tgt=&static_cast<FnSearchStruct*>(this)->targetOp(insertedOp.arg());
+    tgt=&static_cast<FnSearchStruct*>(this)->targetOp<doInsert>(insertedOp.arg());
     return true;
   case GROUND_TERM_STRUCT:
     if(!insertedOp.isCheckGroundTerm()) { return false; }
-    tgt=&static_cast<GroundTermSearchStruct*>(this)->targetOp(insertedOp.getTargetTerm());
+    tgt=&static_cast<GroundTermSearchStruct*>(this)->targetOp<doInsert>(insertedOp.getTargetTerm());
     return true;
   default:
     ASSERTION_VIOLATION;
   }
 }
+
+// expose for ClauseCodeTree.cpp
+template bool CodeTree::SearchStruct::getTargetOpPtr<false>(const CodeOp&, CodeOp**&);
 
 CodeTree::CodeOp* CodeTree::SearchStruct::getTargetOp(const FlatTerm::Entry* ftPos)
 {
   if(!ftPos->isFun()) { return 0; }
   switch(kind) {
   case FN_STRUCT:
-    return static_cast<FnSearchStruct*>(this)->targetOp(ftPos->number());
+    return static_cast<FnSearchStruct*>(this)->targetOp<false>(ftPos->number());
   case GROUND_TERM_STRUCT:
     ftPos++;
     ASS_EQ(ftPos->tag(), FlatTerm::FUN_TERM_PTR);
-    return static_cast<GroundTermSearchStruct*>(this)->targetOp(ftPos->ptr());
+    return static_cast<GroundTermSearchStruct*>(this)->targetOp<false>(ftPos->ptr());
   default:
     ASSERTION_VIOLATION;
   }
 }
 
-CodeTree::FixedSearchStruct::FixedSearchStruct(Kind kind, size_t length)
-: SearchStruct(kind), length(length)
+template<CodeTree::SearchStruct::Kind k>
+CodeTree::SearchStructImpl<k>::SearchStructImpl(size_t length)
+: SearchStruct(k, length)
 {
-  ASS(length);
-
-  size_t tgtSize=sizeof(CodeOp*)*length;
-  targets=static_cast<CodeOp**>(
-      ALLOC_KNOWN(tgtSize, "CodeTree::FixedSearchStruct::targets"));
 }
 
-CodeTree::FixedSearchStruct::~FixedSearchStruct()
-{
-  size_t tgtSize=sizeof(CodeOp*)*length;
-    DEALLOC_KNOWN(targets, tgtSize, "CodeTree::FixedSearchStruct::targets");
-}
-
-CodeTree::GroundTermSearchStruct::GroundTermSearchStruct(size_t length)
-: FixedSearchStruct(GROUND_TERM_STRUCT, length)
-{
-  ASS(length);
-
-  size_t valSize=sizeof(Term*)*length;
-  values=static_cast<Term**>(
-      ALLOC_KNOWN(valSize, "CodeTree::GroundTermSearchStruct::values"));
-}
-
-CodeTree::GroundTermSearchStruct::~GroundTermSearchStruct()
-{
-  size_t valSize=sizeof(Term*)*length;
-  DEALLOC_KNOWN(values, valSize, "CodeTree::GroundTermSearchStruct::values");
-}
-
-CodeTree::CodeOp*& CodeTree::GroundTermSearchStruct::targetOp(const Term* trm)
+template<CodeTree::SearchStruct::Kind k>
+template<bool doInsert>
+CodeTree::CodeOp*& CodeTree::SearchStructImpl<k>::targetOp(const T& val)
 {
   size_t left=0;
-  size_t right=length-1;
+  size_t right=length()-1;
   while(left<right) {
     size_t mid=(left+right)/2;
-    switch(Int::compare(trm, values[mid])) {
+    switch(Int::compare(val, values[mid])) {
     case LESS:
       right=mid;
       break;
@@ -471,82 +502,22 @@ CodeTree::CodeOp*& CodeTree::GroundTermSearchStruct::targetOp(const Term* trm)
     }
   }
   ASS_EQ(left,right);
-  ASS(left==length-1 || trm<=values[left]);
+  ASS(left==length()-1 || val<=values[left]);
+
+  if constexpr (!doInsert) {
+    return targets[left];
+  }
+  if (val==values[left]) {
+    return targets[left];
+  }
+
+  if (val>=values[left]) {
+    left++;
+  }
+  targets.insert(targets.begin()+left,0);
+  values.insert(values.begin()+left,val);
   return targets[left];
 }
-
-/**
- * Comparator that compares two CHECK_GROUND_TERM operations for the
- * purpose of insertion into the FnSearchStruct.
- *
- * Is used in the @b compressCheckGroundTermOps function.
- */
-struct CodeTree::GroundTermSearchStruct::OpComparator
-{
-  static Comparison compare(CodeOp* op1, CodeOp* op2)
-  {
-    return Int::compare(op1->getTargetTerm(), op2->getTargetTerm());
-  }
-};
-
-CodeTree::FnSearchStruct::FnSearchStruct(size_t length)
-: FixedSearchStruct(FN_STRUCT, length)
-{
-  ASS(length);
-
-  size_t valSize=sizeof(unsigned)*length;
-  values=static_cast<unsigned*>(
-      ALLOC_KNOWN(valSize, "CodeTree::SearchStruct::values"));
-}
-
-CodeTree::FnSearchStruct::~FnSearchStruct()
-{
-  size_t valSize=sizeof(unsigned)*length;
-  DEALLOC_KNOWN(values, valSize, "CodeTree::SearchStruct::values");
-}
-
-CodeTree::CodeOp*& CodeTree::FnSearchStruct::targetOp(unsigned fn)
-{
-  size_t left=0;
-  size_t right=length-1;
-  while(left<right) {
-    size_t mid=(left+right)/2;
-    switch(Int::compare(fn, values[mid])) {
-    case LESS:
-      right=mid;
-      break;
-    case GREATER:
-      left=mid+1;
-      break;
-    case EQUAL:
-      return targets[mid];
-    }
-  }
-  ASS_EQ(left,right);
-  ASS(left==length-1 || fn<=values[left]);
-  return targets[left];
-//  if(fn>values[left]) {
-//    return &targets[length];
-//  }
-//  else {
-//    return &targets[left];
-//  }
-}
-
-/**
- * Comparator that compares two CHECK_FUN operations for the
- * purpose of insertion into the FnSearchStruct.
- *
- * Is used in the @b compressCheckFnOps function.
- */
-struct CodeTree::FnSearchStruct::OpComparator
-{
-  static Comparison compare(CodeOp* op1, CodeOp* op2)
-  {
-    return Int::compare(op1->arg(), op2->arg());
-  }
-};
-
 
 inline bool CodeTree::BaseMatcher::doCheckGroundTerm()
 {
@@ -595,14 +566,13 @@ CodeTree::~CodeTree()
         top_ops.push(top_op->alternative());
       }
       
-      FixedSearchStruct* ss = static_cast<FixedSearchStruct*> (top_op->getSearchStruct());
-      ASS(ss->isFixedSearchStruct());      
-      for (size_t i = 0; i < ss->length; i++) {
+      auto ss = top_op->getSearchStruct();
+      for (size_t i = 0; i < ss->length(); i++) {
         if (ss->targets[i]!=0) { // zeros are allowed as targets (they are holes after removals)
           top_ops.push(ss->targets[i]);
         }
       }
-      ss->destroy();
+      delete ss;
     } else {
       CodeBlock* cb=firstOpToCodeBlock(top_op);
 
@@ -627,45 +597,36 @@ CodeTree::~CodeTree()
 CodeTree::CodeBlock* CodeTree::firstOpToCodeBlock(CodeOp* op)
 {
   ASS(!op->isSearchStruct());
-
-  //the following line gives warning for not being according
-  //to the standard, so we have to work around
-//  static const size_t opOfs=offsetof(CodeBlock,_array);
-  static const size_t opOfs=reinterpret_cast<size_t>(
-	&reinterpret_cast<CodeBlock*>(8)->_array[0])-8;
-
-  CodeBlock* res=reinterpret_cast<CodeBlock*>(
-      reinterpret_cast<size_t>(op)-opOfs);
-  ASS_ALLOC_TYPE(res,"Vector");
-  return res;
+  return GET_CONTAINING_OBJECT(CodeTree::CodeBlock,_array,op);
 }
 
 
 template<class Visitor>
-void CodeTree::visitAllOps(Visitor visitor)
+void CodeTree::visitAllOps(Visitor visitor) const
 {
-  static Stack<CodeOp*> top_ops; 
+  static Stack<pair<CodeOp*,unsigned>> top_ops;
   // each top_op is either a first op of a Block or a SearchStruct
   // but it cannot be both since SearchStructs don't occur inside blocks
   top_ops.reset();
 
-  if(!isEmpty()) { top_ops.push(getEntryPoint()); }
+  if(!isEmpty()) { top_ops.push(make_pair(getEntryPoint(),0)); }
 
   while(top_ops.isNonEmpty()) {
-    CodeOp* top_op = top_ops.pop();
+    auto kv = top_ops.pop();
+    CodeOp* top_op = kv.first;
+    unsigned depth = kv.second;
             
     if (top_op->isSearchStruct()) {
-      visitor(top_op); // visit the landingOp inside the SearchStruct
+      visitor(top_op, depth); // visit the landingOp inside the SearchStruct
       
       if(top_op->alternative()) {
-        top_ops.push(top_op->alternative());
+        top_ops.push(make_pair(top_op->alternative(),depth));
       }
       
-      FixedSearchStruct* ss = static_cast<FixedSearchStruct*> (top_op->getSearchStruct());
-      ASS(ss->isFixedSearchStruct());      
-      for (size_t i = 0; i < ss->length; i++) {
+      auto ss = top_op->getSearchStruct();
+      for (size_t i = 0; i < ss->length(); i++) {
         if (ss->targets[i]!=0) { // zeros are allowed as targets (they are holes after removals)
-          top_ops.push(ss->targets[i]);
+          top_ops.push(make_pair(ss->targets[i],depth+1));
         }
       }              
     } else {
@@ -674,13 +635,24 @@ void CodeTree::visitAllOps(Visitor visitor)
       CodeOp* op=&(*cb)[0];
       ASS_EQ(top_op,op);
       for(size_t rem=cb->length(); rem; rem--,op++) {
-        visitor(op);        
+        visitor(op, depth+(cb->length()-rem));
         if(op->alternative()) {
-          top_ops.push(op->alternative());
+          top_ops.push(make_pair(op->alternative(),depth+(cb->length()-rem)));
         }
       }
     }
   }
+}
+
+std::ostream& operator<<(std::ostream& out, const CodeTree& ct)
+{
+  ct.visitAllOps([&out](const CodeTree::CodeOp* op, unsigned depth) {
+    for (unsigned i = 0; i < depth; i++) {
+      out << "  ";
+    }
+    out << *op << std::endl;
+  });
+  return out;
 }
 
 //////////////// insertion ////////////////////
@@ -714,19 +686,17 @@ void CodeTree::CompileContext::deinit(CodeTree* tree, bool discarded)
 }
 
 
-void CodeTree::compileTerm(Term* trm, CodeStack& code, CompileContext& cctx, bool addLitEnd)
+void CodeTree::compileTerm(const Term* trm, CodeStack& code, CompileContext& cctx, bool addLitEnd)
 {
   static Stack<unsigned> globalCounterparts;
   globalCounterparts.reset();
-
-  cctx.nextLit();
 
   if(GROUND_TERM_CHECK && trm->ground()) {
     code.push(CodeOp::getGroundTermCheck(trm));
   }
   else {
     if(trm->isLiteral()) {
-      Literal* lit=static_cast<Literal*>(trm);
+      auto lit=static_cast<const Literal*>(trm);
       code.push(CodeOp::getTermOp(CHECK_FUN, lit->header()));
     }
     else {
@@ -774,7 +744,7 @@ void CodeTree::compileTerm(Term* trm, CodeStack& code, CompileContext& cctx, boo
     ASS(trm->isLiteral());  //LIT_END operation makes sense only for literals
     unsigned varCnt=cctx.nextVarNum;
     ASS_EQ(varCnt, globalCounterparts.size());
-    ILStruct* ils=new ILStruct(static_cast<Literal*>(trm), varCnt, globalCounterparts);
+    ILStruct* ils=new ILStruct(static_cast<const Literal*>(trm), varCnt, globalCounterparts);
     code.push(CodeOp::getLitEnd(ils));
   }
 
@@ -841,7 +811,7 @@ void CodeTree::incorporate(CodeStack& code)
           //handle the SEARCH_STRUCT
           SearchStruct* ss = treeOp->getSearchStruct();
           CodeOp** toPtr;
-          if (ss->getTargetOpPtr(code[i], toPtr)) {
+          if (ss->getTargetOpPtr<true>(code[i], toPtr)) {
             if (!*toPtr) {
               tailTarget = toPtr;
               matchedCnt = i;
@@ -872,7 +842,7 @@ void CodeTree::incorporate(CodeStack& code)
           if (checkFunOps > checkFunOpThreshold) {
             //we put CHECK_FUN ops into the SEARCH_STRUCT op, and
             //restart with the chain
-            compressCheckOps(chainStart, SearchStruct::FN_STRUCT);
+            compressCheckOps<SearchStruct::FN_STRUCT>(chainStart);
             treeOp = chainStart;
             checkFunOps = 0;
             checkGroundTermOps = 0;
@@ -887,7 +857,7 @@ void CodeTree::incorporate(CodeStack& code)
           if (checkGroundTermOps > checkGroundTermOpThreshold) {
             //we put CHECK_GROUND_TERM ops into the SEARCH_STRUCT op, and
             //restart with the chain
-            compressCheckOps(chainStart, SearchStruct::GROUND_TERM_STRUCT);
+            compressCheckOps<SearchStruct::GROUND_TERM_STRUCT>(chainStart);
             treeOp = chainStart;
             checkFunOps = 0;
             checkGroundTermOps = 0;
@@ -940,7 +910,8 @@ matching_done:
   }
 }
 
-void CodeTree::compressCheckOps(CodeOp* chainStart, SearchStruct::Kind kind)
+template<CodeTree::SearchStruct::Kind k>
+void CodeTree::compressCheckOps(CodeOp* chainStart)
 {
   ASS(chainStart->alternative());
 
@@ -957,19 +928,24 @@ void CodeTree::compressCheckOps(CodeOp* chainStart, SearchStruct::Kind kind)
     if (op->alternative()) {
       toDo.push(op->alternative());
     }
-    if ((kind == SearchStruct::FN_STRUCT && op->isCheckFun()) ||
-            (kind == SearchStruct::GROUND_TERM_STRUCT && op->isCheckGroundTerm())) {
+    bool ofKind;
+    if constexpr (k == SearchStruct::FN_STRUCT) {
+      ofKind = op->isCheckFun();
+    } else {
+      ofKind = op->isCheckGroundTerm();
+    }
+
+    if (ofKind) {
       chfOps.push(op);
     } else if (op->isSearchStruct()) {
-      FixedSearchStruct* ss = static_cast<FixedSearchStruct*> (op->getSearchStruct());
-      ASS(ss->isFixedSearchStruct());
-      if (ss->kind == kind) {
-        for (size_t i = 0; i < ss->length; i++) {
+      auto ss = op->getSearchStruct();
+      if (ss->kind == k) {
+        for (size_t i = 0; i < ss->length(); i++) {
           if (ss->targets[i]) {
             toDo.push(ss->targets[i]);
           }
         }
-        ss->destroy();
+        delete ss;
       } else {
         otherOps.push(op);
       }
@@ -980,36 +956,29 @@ void CodeTree::compressCheckOps(CodeOp* chainStart, SearchStruct::Kind kind)
 
   ASS_G(chfOps.size(),1);
   size_t slen=chfOps.size();
-  SearchStruct* ss;
-  if(kind==SearchStruct::FN_STRUCT) {
-    FnSearchStruct* res=new FnSearchStruct(slen);
+  auto res=new SearchStructImpl<k>(slen);
 
-    sort<FnSearchStruct::OpComparator>(chfOps.begin(), chfOps.end());
+  sort(chfOps.begin(), chfOps.end(), [](CodeOp* op1, CodeOp* op2) {
+    if constexpr (k==SearchStruct::FN_STRUCT) {
+      return op1->arg() < op2->arg();
+    } else {
+      return op1->getTargetTerm() < op2->getTargetTerm();
+    }
+  });
 
-    for(size_t i=0;i<slen;i++) {
+  for(size_t i=0;i<slen;i++) {
+    if constexpr (k==SearchStruct::FN_STRUCT) {
       ASS(chfOps[i]->isCheckFun());
-      res->values[i]=chfOps[i]->arg();
-      res->targets[i]=chfOps[i];
-      chfOps[i]->setAlternative(0);
-    }
-    ss=res;
-  }
-  else {
-    ASS_EQ(kind, SearchStruct::GROUND_TERM_STRUCT);
-    GroundTermSearchStruct* res=new GroundTermSearchStruct(slen);
-
-    sort<GroundTermSearchStruct::OpComparator>(chfOps.begin(), chfOps.end());
-
-    for(size_t i=0;i<slen;i++) {
+      res->values.push_back(chfOps[i]->arg());
+    } else {
       ASS(chfOps[i]->isCheckGroundTerm());
-      res->values[i]=chfOps[i]->getTargetTerm();
-      res->targets[i]=chfOps[i];
-      chfOps[i]->setAlternative(0);
+      res->values.push_back(chfOps[i]->getTargetTerm());
     }
-    ss=res;
+    res->targets.push_back(chfOps[i]);
+    chfOps[i]->setAlternative(0);
   }
 
-  CodeOp* op=&ss->landingOp;
+  CodeOp* op=&res->landingOp;
   chainStart->setAlternative(op);
   while(otherOps.isNonEmpty()) {
     CodeOp* next=otherOps.pop();
@@ -1092,10 +1061,9 @@ void CodeTree::optimizeMemoryAfterRemoval(Stack<CodeOp*>* firstsInBlocks, CodeOp
 	prevFirstOp->setAlternative(alt);
 	return;
       }
-      FixedSearchStruct* ss=static_cast<FixedSearchStruct*>(prevFirstOp->getSearchStruct());
-      ASS(ss->isFixedSearchStruct());
+      auto ss = prevFirstOp->getSearchStruct();
       CodeOp** tgtPtr;
-      ALWAYS(ss->getTargetOpPtr(firstOpCopy, tgtPtr));
+      ALWAYS(ss->getTargetOpPtr<false>(firstOpCopy, tgtPtr));
       ASS_EQ(*tgtPtr, firstOp);
       *tgtPtr=alt;
       if(alt) {
@@ -1103,7 +1071,7 @@ void CodeTree::optimizeMemoryAfterRemoval(Stack<CodeOp*>* firstsInBlocks, CodeOp
 	    (ss->kind==SearchStruct::GROUND_TERM_STRUCT && alt->isCheckGroundTerm()) );
 	return;
       }
-      for(size_t i=0; i<ss->length; i++) {
+      for(size_t i=0; i<ss->length(); i++) {
 	if(ss->targets[i]!=0) {
 	  //the SearchStruct still contains something, so we won't delete it
 	  //TODO: we might want to compress the SearchStruct, if there are too many zeroes
@@ -1114,7 +1082,7 @@ void CodeTree::optimizeMemoryAfterRemoval(Stack<CodeOp*>* firstsInBlocks, CodeOp
       //if we're at this point, the SEARCH_STRUCT will be deleted
       firstOp=&ss->landingOp;
       alt=ss->landingOp.alternative();
-      ss->destroy();
+      delete ss;
 
       //now let's continue as if there wasn't any SEARCH_STRUCT operation:)
 
@@ -1303,10 +1271,11 @@ inline bool CodeTree::RemovingMatcher::doCheckFun()
   ASS_EQ(op->instrSuffix(), CHECK_FUN);
 
   unsigned functor=op->arg();
-  const FlatTerm::Entry& fte=(*ft)[tp];
+  FlatTerm::Entry& fte=(*ft)[tp];
   if(!fte.isFun(functor)) {
     return false;
   }
+  fte.expand();
   tp+=FlatTerm::functionEntryCount;
   return true;
 }
@@ -1487,10 +1456,11 @@ inline bool CodeTree::Matcher::doCheckFun()
   ASS_EQ(op->instrSuffix(), CHECK_FUN);
 
   unsigned functor=op->arg();
-  const FlatTerm::Entry& fte=(*ft)[tp];
+  FlatTerm::Entry& fte=(*ft)[tp];
   if(!fte.isFun(functor)) {
     return false;
   }
+  fte.expand();
   tp+=FlatTerm::functionEntryCount;
   return true;
 }
@@ -1506,7 +1476,7 @@ inline void CodeTree::Matcher::doAssignVar()
     tp++;
   }
   else {
-    ASS_EQ(fte->tag(), FlatTerm::FUN);
+    ASS(fte->isFun());
     fte++;
     ASS_EQ(fte->tag(), FlatTerm::FUN_TERM_PTR);
     ASS(fte->ptr());
@@ -1530,7 +1500,7 @@ inline bool CodeTree::Matcher::doCheckVar()
     tp++;
   }
   else {
-    ASS_EQ(fte->tag(), FlatTerm::FUN);
+    ASS(fte->isFun());
     fte++;
     ASS_EQ(fte->tag(), FlatTerm::FUN_TERM_PTR);
     if(bindings[var]!=TermList(fte->ptr())) {

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -35,8 +35,11 @@
 namespace Indexing
 {
 
+#define GET_CONTAINING_OBJECT_CONST(ContainingClass,MemberField,object) \
+  reinterpret_cast<const ContainingClass*>(reinterpret_cast<const char*>(object)-offsetof(ContainingClass,MemberField))
+
 #define GET_CONTAINING_OBJECT(ContainingClass,MemberField,object) \
-  reinterpret_cast<ContainingClass*>(reinterpret_cast<size_t>(object)-offsetof(ContainingClass,MemberField))
+  reinterpret_cast<ContainingClass*>(reinterpret_cast<char*>(object)-offsetof(ContainingClass,MemberField))
 
 using namespace std;
 using namespace Lib;
@@ -352,7 +355,13 @@ bool CodeTree::CodeOp::equalsForOpMatching(const CodeOp& o) const
   }
 }
 
-CodeTree::SearchStruct* CodeTree::CodeOp::getSearchStruct() const
+const CodeTree::SearchStruct* CodeTree::CodeOp::getSearchStruct() const
+{
+  ASS(isSearchStruct());
+  return GET_CONTAINING_OBJECT_CONST(CodeTree::SearchStruct,landingOp,this);
+}
+
+CodeTree::SearchStruct* CodeTree::CodeOp::getSearchStruct()
 {
   ASS(isSearchStruct());
   return GET_CONTAINING_OBJECT(CodeTree::SearchStruct,landingOp,this);
@@ -388,7 +397,7 @@ std::ostream& operator<<(std::ostream& out, const CodeTree::CodeOp& op)
       auto ss = op.getSearchStruct();
       switch(ss->kind) {
         case CodeTree::SearchStruct::FN_STRUCT: {
-          auto fn_ss = static_cast<CodeTree::FnSearchStruct*>(ss);
+          auto fn_ss = static_cast<const CodeTree::FnSearchStruct*>(ss);
           out << "length " << fn_ss->length();
           for (unsigned i = 0; i < fn_ss->length(); i++) {
             out << " " << fn_ss->values[i] << " ";
@@ -401,7 +410,7 @@ std::ostream& operator<<(std::ostream& out, const CodeTree::CodeOp& op)
           break;
         }
         case CodeTree::SearchStruct::GROUND_TERM_STRUCT: {
-          auto gt_ss = static_cast<CodeTree::GroundTermSearchStruct*>(ss);
+          auto gt_ss = static_cast<const CodeTree::GroundTermSearchStruct*>(ss);
           out << "length " << gt_ss->length();
           for (unsigned i = 0; i < gt_ss->length(); i++) {
             out << " " << *gt_ss->values[i] << " ";

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -263,6 +263,7 @@ public:
    */
   struct SearchStruct
   {
+    void destroy();
     /**
      * Fills out pointer @b tgt where @b insertedOp should be
      * (or is) inserted in the structure. If @b doInsert is true
@@ -301,8 +302,6 @@ public:
   struct SearchStructImpl
   : public SearchStruct
   {
-    USE_ALLOCATOR(SearchStructImpl);
-
     SearchStructImpl(size_t length);
 
     using T = typename std::conditional<k==SearchStruct::FN_STRUCT,unsigned,Term*>::type;

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -216,7 +216,8 @@ public:
       return _data<ILStruct>();
     }
 
-    SearchStruct* getSearchStruct() const;
+    const SearchStruct* getSearchStruct() const;
+    SearchStruct* getSearchStruct();
 
     inline CodeOp* alternative() const { return _alternative; }
     inline CodeOp*& alternative() { return _alternative; }
@@ -239,23 +240,13 @@ public:
     static_assert(SEARCH_STRUCT < 8, "must be able to squash instructions into 3 bits");
     static_assert(alignof(Term) == 8);
 
-    template<unsigned lower, unsigned upper, class T> friend uint64_t BitUtils::getBits(const T&);
-    template<unsigned lower, unsigned upper, class T> friend void BitUtils::setBits(T&, uint64_t);
     // getters and setters
-#define GET_AND_SET(type, name, Name, NAME) \
-    type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(*this); }\
-    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(*this, val); }
-    GET_AND_SET(unsigned, instruction, Instruction, INSTRUCTION)
-    GET_AND_SET(unsigned, arg, Arg, ARG)
-#undef GET_AND_SET
-    template<class T> T* _data() const {
-      // static_assert(alignof(T)==8);
-      return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(*this));
-    }
-    template<class T> void _setData(T* data) {
-      // static_assert(alignof(T)==8);
-      BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(*this, reinterpret_cast<uint64_t>(data));
-    }
+    BITFIELD64_GET_AND_SET(unsigned, instruction, Instruction, INSTRUCTION)
+    BITFIELD64_GET_AND_SET(unsigned, arg, Arg, ARG)
+    template<class T> T* _data() const
+    { return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(this->_content)); }
+    template<class T> void _setData(T* data)
+    { BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(this->_content, reinterpret_cast<uint64_t>(data)); }
     // end bitfield
 
   private:

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -107,7 +107,7 @@ public:
   /**
    * Structure with information about an indexed literal
    */
-  struct ILStruct
+  struct alignas(8) ILStruct
   {
     ILStruct(const Literal* lit, unsigned varCnt, Stack<unsigned>& gvnStack);
     ~ILStruct();
@@ -154,29 +154,32 @@ public:
     DArray<MatchInfo*> matches;
   };
 
-  enum InstructionPrefix
+  enum Instruction
   {
     //it means fail if data==0
     SUCCESS_OR_FAIL = 0,
     CHECK_GROUND_TERM = 1,
     LIT_END = 2,
-    /** One of instructions that are determined by the instruction suffix */
-    SUFFIX_INSTR = 3
-  };
-  enum InstructionSuffix
-  {
-    CHECK_FUN = 0,
-    ASSIGN_VAR = 1,
-    CHECK_VAR = 2,
-    SEARCH_STRUCT = 3
+    CHECK_FUN = 3,
+    ASSIGN_VAR = 4,
+    CHECK_VAR = 5,
+    SEARCH_STRUCT = 6,
   };
 
   /** Structure containing a single instruction and its arguments */
   struct CodeOp
   {
-    static CodeOp getSuccess(void* data);
+    template<class T> static CodeOp getSuccess(T* ptr)
+    {
+      ASS(ptr); //data has to be a non-zero pointer
+      CodeOp res;
+      res.setAlternative(0);
+      res._setData(ptr);
+      ASS(res.isSuccess());
+      return res;
+    }
     static CodeOp getLitEnd(ILStruct* ils);
-    static CodeOp getTermOp(InstructionSuffix i, unsigned num);
+    static CodeOp getTermOp(Instruction i, unsigned num);
     static CodeOp getGroundTermCheck(const Term* trm);
 
     bool equalsForOpMatching(const CodeOp& o) const;
@@ -188,65 +191,76 @@ public:
      * on some architectures, pointers are only 4-byte aligned and
      * the instruction is stored in first three bits.
      */
-    inline bool isSuccess() const { return instrPrefix()==SUCCESS_OR_FAIL && data(); }
-    inline bool isFail() const { return !data(); }
-    inline bool isLitEnd() const { return instrPrefix()==LIT_END; }
-    inline bool isSearchStruct() const { return instrPrefix()==SUFFIX_INSTR && instrSuffix()==SEARCH_STRUCT; }
-    inline bool isCheckFun() const { return instrPrefix()==SUFFIX_INSTR && instrSuffix()==CHECK_FUN; }
-    inline bool isCheckGroundTerm() const { return instrPrefix()==CHECK_GROUND_TERM; }
+    inline bool isSuccess() const { return _instruction()==SUCCESS_OR_FAIL && _data<void>(); }
+    inline bool isFail() const { return !_data<void>(); }
+    inline bool isLitEnd() const { return _instruction()==LIT_END; }
+    inline bool isSearchStruct() const { return _instruction()==SEARCH_STRUCT; }
+    inline bool isCheckFun() const { return _instruction()==CHECK_FUN; }
+    inline bool isCheckGroundTerm() const { return _instruction()==CHECK_GROUND_TERM; }
 
     inline Term* getTargetTerm() const
     {
       ASS(isCheckGroundTerm());
-      return reinterpret_cast<Term*>(data()&~static_cast<size_t>(CHECK_GROUND_TERM));
+      return _data<Term>();
     }
 
-    inline void* getSuccessResult() { ASS(isSuccess()); return _result; }
+    template<class T> inline T* getSuccessResult() { ASS(isSuccess()); return _data<T>(); }
 
     inline ILStruct* getILS()
     {
       ASS(isLitEnd());
-      return reinterpret_cast<ILStruct*>(data()&~static_cast<size_t>(LIT_END));
+      return _data<ILStruct>();
     }
     inline const ILStruct* getILS() const
     {
-      return const_cast<CodeOp*>(this)->getILS();
+      return _data<ILStruct>();
     }
 
     SearchStruct* getSearchStruct() const;
 
-    inline InstructionPrefix instrPrefix() const { return static_cast<InstructionPrefix>(_info.prefix); }
-    inline InstructionSuffix instrSuffix() const
-    {
-      ASS_EQ(instrPrefix(), SUFFIX_INSTR);
-      return static_cast<InstructionSuffix>(_info.suffix);
-    }
-
-    inline unsigned arg() const { return _info.arg; }
     inline CodeOp* alternative() const { return _alternative; }
     inline CodeOp*& alternative() { return _alternative; }
 
     inline void setAlternative(CodeOp* op) { ASS_NEQ(op, this); _alternative=op; }
-    inline void setLongInstr(InstructionSuffix i) { _info.prefix=SUFFIX_INSTR; _info.suffix=i; }
 
-    void makeFail() { _data=0; }
+    void makeFail() { _setData<void>(0); }
 
     friend std::ostream& operator<<(std::ostream& out, const CodeOp& op);
 
+    static constexpr unsigned
+      INSTRUCTION_BITS_START = 0,
+      INSTRUCTION_BITS_END = INSTRUCTION_BITS_START + 3,
+      ARG_BITS_START = INSTRUCTION_BITS_END,
+      ARG_BITS_END = CHAR_BIT * sizeof(uint64_t),
+      DATA_BITS_START = 0,
+      DATA_BITS_END = CHAR_BIT * sizeof(void *);
+
+    static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
+    static_assert(SEARCH_STRUCT < 8, "must be able to squash instructions into 3 bits");
+    static_assert(alignof(Term) == 8);
+
+    template<unsigned lower, unsigned upper, class T> friend uint64_t BitUtils::getBits(const T&);
+    template<unsigned lower, unsigned upper, class T> friend void BitUtils::setBits(T&, uint64_t);
+    // getters and setters
+#define GET_AND_SET(type, name, Name, NAME) \
+    type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(*this); }\
+    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(*this, val); }
+    GET_AND_SET(unsigned, instruction, Instruction, INSTRUCTION)
+    GET_AND_SET(unsigned, arg, Arg, ARG)
+#undef GET_AND_SET
+    template<class T> T* _data() const {
+      // static_assert(alignof(T)==8);
+      return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(*this));
+    }
+    template<class T> void _setData(T* data) {
+      // static_assert(alignof(T)==8);
+      BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(*this, reinterpret_cast<uint64_t>(data));
+    }
+    // end bitfield
+
   private:
-    inline size_t data() const { return _data; }
+    uint64_t _content;
 
-    inline void setArg(unsigned arg) { ASS_L(arg,1<<28); _info.arg=arg; }
-
-    union {
-      struct {
-        unsigned prefix : 2;
-        unsigned suffix : 2;
-        unsigned arg : 28;
-      } _info;
-      void* _result;
-      size_t _data;
-    };
     /**
      * Pointer to an alternative operation
      *

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -51,7 +51,7 @@ public:
   // TODO: get rid of NOT_IMPLEMENTED
   VirtualIterator<QueryRes<AbstractingUnifier*, TermLiteralClause>> getUwa(TypedTermList t, Options::UnificationWithAbstraction, bool fixedPointIteration) override { NOT_IMPLEMENTED; }
 
-  virtual void output(std::ostream& out) const final override { out << "CodeTree"; }
+  virtual void output(std::ostream& out) const final override { out << _ct; }
 
 private:
   void _insert(TypedTermList t, Literal* lit, Clause* cls);

--- a/Indexing/TermCodeTree.cpp
+++ b/Indexing/TermCodeTree.cpp
@@ -34,8 +34,8 @@ using namespace Kernel;
 
 void TermCodeTree::onCodeOpDestroying(CodeOp* op)
 {
-  if (op->isSuccess()) {    
-    delete static_cast<TermInfo*>(op->getSuccessResult());
+  if (op->isSuccess()) {
+    delete op->getSuccessResult<TermInfo>();
   }
 }
 
@@ -88,7 +88,7 @@ void TermCodeTree::remove(const TermInfo& ti)
       INVALID_OPERATION("term being removed was not found");
     }
     ASS(rtm.op->isSuccess());
-    rti=static_cast<TermInfo*>(rtm.op->getSuccessResult());
+    rti=rtm.op->getSuccessResult<TermInfo>();
     if (*rti==ti) {
       break;
     }
@@ -178,7 +178,7 @@ TermCodeTree::TermInfo* TermCodeTree::TermMatcher::next()
   }
 
   ASS(op->isSuccess());
-  return static_cast<TermInfo*>(op->getSuccessResult());
+  return op->getSuccessResult<TermInfo>();
 }
 
 };

--- a/Indexing/TermCodeTree.cpp
+++ b/Indexing/TermCodeTree.cpp
@@ -151,7 +151,7 @@ void TermCodeTree::TermMatcher::init(CodeTree* tree, TermList t)
   linfoCnt=0;
 
   ASS(!ft);
-  ft=FlatTerm::create(t);
+  ft = FlatTerm::createUnexpanded(t);
 
   op=entry;
   tp=0;

--- a/Kernel/FlatTerm.cpp
+++ b/Kernel/FlatTerm.cpp
@@ -62,8 +62,8 @@ FlatTerm::FlatTerm(size_t length)
 
 size_t FlatTerm::getEntryCount(Term* t)
 {
-  //functionEntryCount entries per function and one per variable
-  return t->weight()*functionEntryCount-(functionEntryCount-1)*t->numVarOccs();
+  //FUNCTION_ENTRY_COUNT entries per function and one per variable
+  return t->weight()*FUNCTION_ENTRY_COUNT-(FUNCTION_ENTRY_COUNT-1)*t->numVarOccs();
 }
 
 FlatTerm* FlatTerm::create(Term* t)
@@ -148,29 +148,29 @@ FlatTerm* FlatTerm::copy(const FlatTerm* ft)
 
 void FlatTerm::swapCommutativePredicateArguments()
 {
-  ASS_EQ((*this)[0].tag(), FUN);
-  ASS_EQ((*this)[0].number()|1, 1); //as for now, the only commutative predicate is equality
+  ASS_EQ((*this)[0]._tag(), FUN);
+  ASS_EQ((*this)[0]._number()|1, 1); //as for now, the only commutative predicate is equality
 
   size_t firstStart=3;
   size_t firstLen;
-  if((*this)[firstStart].tag()==FUN) {
-    ASS_EQ((*this)[firstStart+2].tag(), FUN_RIGHT_OFS);
-    firstLen=(*this)[firstStart+2].number();
+  if((*this)[firstStart]._tag()==FUN) {
+    ASS_EQ((*this)[firstStart+2]._tag(), FUN_RIGHT_OFS);
+    firstLen=(*this)[firstStart+2]._number();
   }
   else {
-    ASS_EQ((*this)[firstStart].tag(), VAR);
+    ASS_EQ((*this)[firstStart]._tag(), VAR);
     firstLen=1;
   }
 
   size_t secStart=firstStart+firstLen;
   size_t secLen;
 
-  if((*this)[secStart].tag()==FUN) {
-    ASS_EQ((*this)[secStart+2].tag(), FUN_RIGHT_OFS);
-    secLen=(*this)[secStart+2].number();
+  if((*this)[secStart]._tag()==FUN) {
+    ASS_EQ((*this)[secStart+2]._tag(), FUN_RIGHT_OFS);
+    secLen=(*this)[secStart+2]._number();
   }
   else {
-    ASS_EQ((*this)[secStart].tag(), VAR);
+    ASS_EQ((*this)[secStart]._tag(), VAR);
     secLen=1;
   }
   ASS_EQ(secStart+secLen,_length);
@@ -192,14 +192,14 @@ void FlatTerm::swapCommutativePredicateArguments()
 
 void FlatTerm::Entry::expand()
 {
-  if (tag()==FUN) {
+  if (_tag()==FUN) {
     return;
   }
-  ASS(tag()==FUN_UNEXPANDED);
-  ASS(this[1].tag()==FUN_TERM_PTR);
-  ASS(this[2].tag()==FUN_RIGHT_OFS);
-  Term* t = this[1].ptr();
-  size_t p = FlatTerm::functionEntryCount;
+  ASS(_tag()==FUN_UNEXPANDED);
+  ASS(this[1]._tag()==FUN_TERM_PTR);
+  ASS(this[2]._tag()==FUN_RIGHT_OFS);
+  Term* t = this[1]._term();
+  size_t p = FlatTerm::FUNCTION_ENTRY_COUNT;
   for (unsigned i = 0; i < t->arity(); i++) {
     auto arg = t->nthArgument(i);
     if (arg->isVar()) {
@@ -211,11 +211,11 @@ void FlatTerm::Entry::expand()
       this[p] = Entry(FUN_UNEXPANDED, arg->term()->functor());
       this[p+1] = Entry(arg->term());
       this[p+2] = Entry(FUN_RIGHT_OFS, getEntryCount(arg->term()));
-      p += this[p+2].number();
+      p += this[p+2]._number();
     }
   }
-  ASS_EQ(p,this[2].number());
-  _info.tag = FUN;
+  ASS_EQ(p,this[2]._number());
+  _setTag(FUN);
 }
 
 };

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -83,7 +83,7 @@ public:
     static_assert(TAG_BITS_START == 0, "tag must be the least significant bits");
     static_assert(TERM_BITS_START == 0, "term must be the least significant bits");
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
-    static_assert(FUN_UNEXPANDED < 8, "must be able to squash orderings into 3 bits");
+    static_assert(FUN_UNEXPANDED < 8, "must be able to squash tags into 3 bits");
 
   // getters and setters
 #define GET_AND_SET(type, name, Name, NAME) \

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -37,7 +37,7 @@ public:
 
   static FlatTerm* copy(const FlatTerm* ft);
 
-  static const size_t functionEntryCount=3;
+  static constexpr size_t FUNCTION_ENTRY_COUNT=3;
 
   enum EntryTag {
     FUN_TERM_PTR = 0,
@@ -55,16 +55,13 @@ public:
   struct Entry
   {
     Entry() = default;
-    Entry(EntryTag tag, unsigned num) { _info.tag=tag; _info.number=num; }
-    Entry(Term* ptr) : _ptr(ptr) { ASS_EQ(tag(), FUN_TERM_PTR); }
+    Entry(EntryTag tag, unsigned num) { _setTag(tag); _setNumber(num); }
+    Entry(Term* term) { _setTerm(term); ASS_EQ(_tag(), FUN_TERM_PTR); }
 
-    inline EntryTag tag() const { return static_cast<EntryTag>(_info.tag); }
-    inline unsigned number() const { return _info.number; }
-    inline Term* ptr() const { return _ptr; }
-    inline bool isVar() const { return tag()==VAR; }
-    inline bool isVar(unsigned num) const { return isVar() && number()==num; }
-    inline bool isFun() const { return tag()==FUN || tag()==FUN_UNEXPANDED; }
-    inline bool isFun(unsigned num) const { return isFun() && number()==num; }
+    inline bool isVar() const { return _tag()==VAR; }
+    inline bool isVar(unsigned num) const { return isVar() && _number()==num; }
+    inline bool isFun() const { return _tag()==FUN || _tag()==FUN_UNEXPANDED; }
+    inline bool isFun(unsigned num) const { return isFun() && _number()==num; }
     /**
      * Should be called when @b isFun() is true.
      * If @b tag()==FUN_UNEXPANDED, it fills out entries for the functions
@@ -72,13 +69,34 @@ public:
      */
     void expand();
 
-    union {
-      Term* _ptr;
-      struct {
-	unsigned tag : 4;
-	unsigned number : 28;
-      } _info;
-    };
+    uint64_t _content;
+
+    static constexpr unsigned
+      TAG_BITS_START = 0,
+      TAG_BITS_END = TAG_BITS_START + 3,
+      NUMBER_BITS_START = TAG_BITS_END,
+      NUMBER_BITS_END = NUMBER_BITS_START + 27,
+      TERM_BITS_START = 0,
+      TERM_BITS_END = CHAR_BIT * sizeof(Term *);
+
+    // various properties we want to check
+    static_assert(TAG_BITS_START == 0, "tag must be the least significant bits");
+    static_assert(TERM_BITS_START == 0, "term must be the least significant bits");
+    static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
+    static_assert(FUN_UNEXPANDED < 8, "must be able to squash orderings into 3 bits");
+
+  // getters and setters
+#define GET_AND_SET(type, name, Name, NAME) \
+    type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(*this); }\
+    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(*this, val); }
+    GET_AND_SET(unsigned, tag, Tag, TAG)
+    GET_AND_SET(unsigned, number, Number, NUMBER)
+#undef GET_AND_SET
+    Term *_term() const
+    { return reinterpret_cast<Term *>(BitUtils::getBits<TERM_BITS_START, TERM_BITS_END>(*this)); }
+    void _setTerm(Term *term)
+    { BitUtils::setBits<TERM_BITS_START, TERM_BITS_END>(*this, reinterpret_cast<uint64_t>(term)); }
+    // end bitfield
   };
 
   inline Entry& operator[](size_t i) { ASS_L(i,_length); return _data[i]; }
@@ -86,7 +104,7 @@ public:
 
   void swapCommutativePredicateArguments();
   void changeLiteralPolarity()
-  { _data[0]._info.number^=1; }
+  { _data[0]._setNumber(_data[0]._number()^1); }
 
 private:
   static size_t getEntryCount(Term* t);

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -85,17 +85,13 @@ public:
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
     static_assert(FUN_UNEXPANDED < 8, "must be able to squash tags into 3 bits");
 
-  // getters and setters
-#define GET_AND_SET(type, name, Name, NAME) \
-    type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(*this); }\
-    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(*this, val); }
-    GET_AND_SET(unsigned, tag, Tag, TAG)
-    GET_AND_SET(unsigned, number, Number, NUMBER)
-#undef GET_AND_SET
-    Term *_term() const
-    { return reinterpret_cast<Term *>(BitUtils::getBits<TERM_BITS_START, TERM_BITS_END>(*this)); }
-    void _setTerm(Term *term)
-    { BitUtils::setBits<TERM_BITS_START, TERM_BITS_END>(*this, reinterpret_cast<uint64_t>(term)); }
+    // getters and setters
+    BITFIELD64_GET_AND_SET(unsigned, tag, Tag, TAG)
+    BITFIELD64_GET_AND_SET(unsigned, number, Number, NUMBER)
+    Term* _term() const
+    { return reinterpret_cast<Term*>(BitUtils::getBits<TERM_BITS_START, TERM_BITS_END>(_content)); }
+    void _setTerm(Term* term)
+    { BitUtils::setBits<TERM_BITS_START, TERM_BITS_END>(_content, reinterpret_cast<uint64_t>(term)); }
     // end bitfield
   };
 

--- a/Kernel/Substitution.cpp
+++ b/Kernel/Substitution.cpp
@@ -76,7 +76,7 @@ void Substitution::reset()
  * This function is to allow use of the @c Substitution class in the
  * methods of the @c SubstHelper class for applying substitutions.
  */
-TermList Substitution::apply(unsigned var)
+TermList Substitution::apply(unsigned var) const
 {
   TermList res;
   if(!findBinding(var, res)) {

--- a/Kernel/Substitution.hpp
+++ b/Kernel/Substitution.hpp
@@ -47,7 +47,7 @@ public:
   void rebind(int v, Term* t);
   void rebind(int v, TermList t);
   bool findBinding(int var, TermList& res) const;
-  TermList apply(unsigned var);
+  TermList apply(unsigned var) const;
   void unbind(int var);
   void reset();
   bool isEmpty() const { return _map.isEmpty(); }

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -322,27 +322,21 @@ private:
   static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
   static_assert(AO_INCOMPARABLE < 8, "must be able to squash orderings into 3 bits");
 
-  template<unsigned lower, unsigned upper, class T> friend uint64_t BitUtils::getBits(const T&);
-  template<unsigned lower, unsigned upper, class T> friend void BitUtils::setBits(T&, uint64_t);
   // getters and setters
-#define GET_AND_SET(type, name, Name, NAME) \
-  type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(*this); }\
-  void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(*this, val); }
-  GET_AND_SET(unsigned, tag, Tag, TAG)
-  GET_AND_SET(bool, polarity, Polarity, POLARITY)
-  GET_AND_SET(bool, commutative, Commutative, COMMUTATIVE)
-  GET_AND_SET(bool, shared, Shared, SHARED)
-  GET_AND_SET(bool, literal, Literal, LITERAL)
-  GET_AND_SET(bool, sort, Sort, SORT)
-  GET_AND_SET(bool, hasTermVar, HasTermVar, HAS_TERM_VAR)
-  GET_AND_SET(unsigned, order, Order, ORDER)
-  GET_AND_SET(uint32_t, distinctVars, DistinctVars, DISTINCT_VAR)
-  GET_AND_SET(uint32_t, id, Id, ID)
-#undef GET_AND_SET
+  BITFIELD64_GET_AND_SET(unsigned, tag, Tag, TAG)
+  BITFIELD64_GET_AND_SET(bool, polarity, Polarity, POLARITY)
+  BITFIELD64_GET_AND_SET(bool, commutative, Commutative, COMMUTATIVE)
+  BITFIELD64_GET_AND_SET(bool, shared, Shared, SHARED)
+  BITFIELD64_GET_AND_SET(bool, literal, Literal, LITERAL)
+  BITFIELD64_GET_AND_SET(bool, sort, Sort, SORT)
+  BITFIELD64_GET_AND_SET(bool, hasTermVar, HasTermVar, HAS_TERM_VAR)
+  BITFIELD64_GET_AND_SET(unsigned, order, Order, ORDER)
+  BITFIELD64_GET_AND_SET(uint32_t, distinctVars, DistinctVars, DISTINCT_VAR)
+  BITFIELD64_GET_AND_SET(uint32_t, id, Id, ID)
   Term *_term() const
-  { return reinterpret_cast<Term *>(BitUtils::getBits<TERM_BITS_START, TERM_BITS_END>(*this)); }
+  { return reinterpret_cast<Term *>(BitUtils::getBits<TERM_BITS_START, TERM_BITS_END>(this->_content)); }
   void _setTerm(Term *term)
-  { BitUtils::setBits<TERM_BITS_START, TERM_BITS_END>(*this, reinterpret_cast<uint64_t>(term)); }
+  { BitUtils::setBits<TERM_BITS_START, TERM_BITS_END>(this->_content, reinterpret_cast<uint64_t>(term)); }
   // end bitfield
 
   friend class Indexing::TermSharing;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -369,7 +369,7 @@ std::ostream& operator<<(std::ostream& out, SpecialFunctor const& self);
  * Class to represent terms and lists of terms.
  * @since 19/02/2008 Manchester, changed to use class TermList
  */
-class Term
+class alignas(8) Term
 {
 public:
 

--- a/Lib/BitUtils.hpp
+++ b/Lib/BitUtils.hpp
@@ -85,16 +85,21 @@ public:
       return mask;
   }
 
-  // get the bits of `_content` between `lower` and `upper`
-  template<unsigned lower, unsigned upper, class T>
-  static uint64_t getBits(const T& t) {
+  /**
+   * The functions below help set up classes containing bitfields
+   * and unions in a portable way. For an example @see TermList.
+   */
+
+  // get the bits of `bits` between `lower` and `upper`
+  template<unsigned lower, unsigned upper>
+  static uint64_t getBits(const uint64_t& bits) {
     auto mask = bitmask64<lower, upper>();
-    return (t._content & mask) >> lower;
+    return (bits & mask) >> lower;
   }
 
-  // set the bits of `_content` between `lower` and `upper` to corresponding bits of `data`
-  template<unsigned lower, unsigned upper, class T>
-  static void setBits(T& t, uint64_t data) {
+  // set `bits` between `lower` and `upper` to corresponding bits of `data`
+  template<unsigned lower, unsigned upper>
+  static void setBits(uint64_t& bits, uint64_t data) {
     auto mask = bitmask64<lower, upper>();
 
     // shift `data` into position
@@ -106,10 +111,13 @@ public:
     data &= mask;
 
     // actually set the bits
-    t._content &= ~mask;
-    t._content |= data;
+    bits &= ~mask;
+    bits |= data;
   }
 
+  #define BITFIELD64_GET_AND_SET(type, name, Name, NAME) \
+    type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content); } \
+    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content, val); }
 };
 
 };

--- a/Lib/BitUtils.hpp
+++ b/Lib/BitUtils.hpp
@@ -16,6 +16,7 @@
 #ifndef __BitUtils__
 #define __BitUtils__
 
+#include <cstdint>
 #include <cstring>
 
 #include "Lib/Portability.hpp"

--- a/Lib/BitUtils.hpp
+++ b/Lib/BitUtils.hpp
@@ -70,6 +70,45 @@ public:
     return bits;
 #endif
   }
+
+  // compute a 64-bit mask starting at `lower` and ending just before `upper`
+  template<unsigned lower, unsigned upper>
+  static constexpr uint64_t bitmask64() {
+      static_assert(lower < upper, "empty range");
+      static_assert(upper - lower <= 64, "too many bits");
+      uint64_t mask = ~0;
+      mask >>= lower;
+      mask <<= lower;
+      mask <<= 64 - upper;
+      mask >>= 64 - upper;
+      return mask;
+  }
+
+  // get the bits of `_content` between `lower` and `upper`
+  template<unsigned lower, unsigned upper, class T>
+  static uint64_t getBits(const T& t) {
+    auto mask = bitmask64<lower, upper>();
+    return (t._content & mask) >> lower;
+  }
+
+  // set the bits of `_content` between `lower` and `upper` to corresponding bits of `data`
+  template<unsigned lower, unsigned upper, class T>
+  static void setBits(T& t, uint64_t data) {
+    auto mask = bitmask64<lower, upper>();
+
+    // shift `data` into position
+    data <<= lower;
+
+    // mask out upper bits of `data`
+    // *probably* not strictly necessary if `data` always zero at `upper` and `above`,
+    // but doesn't cost us much (~2 instructions) to put this sanity check here
+    data &= mask;
+
+    // actually set the bits
+    t._content &= ~mask;
+    t._content |= data;
+  }
+
 };
 
 };


### PR DESCRIPTION
Two main changes in this pull request:
- `CodeTree::SearchStruct` is refactored avoiding duplication of subclasses. Raw array containing value-target pairs is replaced with STL containers for better and easier handling.
- Added new tag `FUN_UNEXPANDED` to `FlatTerm` in which case only the tag, term pointer and number of subentries is filled out first. A call on `FlatTerm::Entry::expand` fills out the same entries for the arguments. The point is that we expand tha flat term lazily which in some cases would be a bottleneck when the `FlatTerm` is not even used.

Additionally, added some basic printing for code trees.