### PR TITLE
parser fixes, thanks to Joe

### DIFF
--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1191,7 +1191,7 @@ TermList AtomicSort::arraySort(TermList indexSort, TermList innerSort)
 }
 
 TermList AtomicSort::tupleSort(unsigned arity, TermList* sorts)
-{ return TermList(Term::create(env.signature->getTupleConstructor(arity), arity, sorts)); }
+{ return TermList(AtomicSort::create(env.signature->getTupleConstructor(arity), arity, sorts)); }
 
 unsigned Term::computeDistinctVars() const
 {

--- a/Lib/Exception.cpp
+++ b/Lib/Exception.cpp
@@ -42,7 +42,10 @@ void Exception::cry (ostream& str) const
  */
 void UserErrorException::cry (ostream& str) const
 {
-  str << "User error: " << _message << endl;
+  str << "User error: " << _message;
+  if(line)
+    str << " (detected at or around line " << line << ")";
+  str << endl;
 } // UserErrorException::cry
 
 /**

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -99,6 +99,8 @@ class UserErrorException
  public:
   using ParsingRelatedException::ParsingRelatedException;
 
+  // input line related to the error: non-zero if set
+  unsigned line = 0;
   void cry (std::ostream&) const;
 }; // UserErrorException
 

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -105,7 +105,12 @@ TPTP::~TPTP()
 
 void TPTP::parse()
 {
-  parseImpl();
+  try {
+    parseImpl();
+  } catch (UserErrorException &e) {
+    e.line = lineNumber();
+    throw;
+  }
 }
 
 /**

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -69,13 +69,7 @@ const int TPTP::SIGMA = 103u;
 UnitList* TPTP::parse(istream& input)
 {
   Parse::TPTP parser(input);
-  try{
-    parser.parse();
-  }
-  catch (UserErrorException& exception) {
-    vstring msg = exception.msg();
-    throw ParseErrorException(msg,parser.lineNumber());
-  }
+  parser.parse();
   return parser.units();
 }
 
@@ -111,11 +105,7 @@ TPTP::~TPTP()
 
 void TPTP::parse()
 {
-  try{
-    parseImpl();
-  } catch (UserErrorException& exception) {
-    throw ParseErrorException(exception.msg(),lineNumber());
-  }
+  parseImpl();
 }
 
 /**
@@ -1345,7 +1335,7 @@ void TPTP::fof(bool fo)
   }
   else if (tp == "assumption" || tp == "unknown") {
     // MS: we were silently dropping these until now. I wonder why...
-    PARSE_ERROR((vstring)"Unsupported unit type '" + tp + "' found",start);
+    USER_ERROR("Unsupported unit type '", tp, "' found");
   }
   else {
     PARSE_ERROR((vstring)"unit type, such as axiom or definition expected but " + tp + " found",
@@ -1469,7 +1459,7 @@ void TPTP::tff()
   }
   else if (tp == "assumption" || tp == "unknown") {
     // MS: we were silently dropping these until now. I wonder why...
-    PARSE_ERROR((vstring)"Unsupported unit type '" + tp + "' found",start);
+    USER_ERROR("Unsupported unit type '", tp);
   }
   else if (tp == "claim") {
     _lastInputType = UnitInputType::CLAIM;
@@ -3180,7 +3170,7 @@ Formula* TPTP::createPredicateApplication(vstring name, unsigned arity)
     } else {
       _substScratchpad.reset();
       if(!_substScratchpad.match(sort, 0, tsSort, 1)) {
-        USER_ERROR("Failed to create predicate application for ", name, " of type ", type, "\n",
+        USER_ERROR("Failed to create predicate application for ", name, " of type ", type->toString(), "\n",
                    "The sort ", tsSort, " of the intended term argument ", ts, " (at index ", i, ") "
                    "is not an instance of sort ", sort);
       }

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -312,7 +312,7 @@ public:
     ~ParseErrorException() {}
   protected:
     vstring _message;
-    unsigned _ln;
+    unsigned _ln = 0;
   }; // TPTP::ParseErrorException
 
 #define PARSE_ERROR(msg,tok) \


### PR DESCRIPTION
See #542. Fix some of the crashes reported there.
1. When creating a tuple sort, we should call `AtomicSort::create`, not `Term::create`. I think it was probably fine data-wise, but we fail an assertion.
2. We catch `USER_ERRORS` and wrap them as `PARSE_ERRORS` with a line number. I'm not sure how useful this is and it means we can't distinguish between "we parsed this but can't do anything with it" (e.g. HOL + theories), and "syntax error". Don't do that.
3. Some `PARSE_ERRORS` should be `USER_ERRORS`.