### PR TITLE
remove `splPrefix`, not necessary

### DIFF
--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -512,7 +512,6 @@ struct InferenceStore::TPTPProofPrinter
 {
   TPTPProofPrinter(ostream& out, InferenceStore* is)
   : ProofPrinter(out, is) {
-    splitPrefix = Saturation::Splitter::splPrefix; 
     // Don't delay printing in TPTP proof mode
     delayPrinting = false;
   }
@@ -526,8 +525,6 @@ struct InferenceStore::TPTPProofPrinter
   }
 
 protected:
-  vstring splitPrefix;
-
   vstring getRole(InferenceRule rule, UnitInputType origin)
   {
     switch(rule) {

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -616,17 +616,10 @@ void SplittingBranchSelector::recomputeModel(SplitLevelStack& addedComps, SplitL
 // Splitter
 //////////////
 
-vstring Splitter::splPrefix = "";
-
 Splitter::Splitter()
 : _deleteDeactivated(Options::SplittingDeleteDeactivated::ON), _branchSelector(*this),
   _clausesAdded(false), _haveBranchRefutation(false)
-{
-  if(env.options->proof()==Options::Proof::TPTP){
-    unsigned spl = env.signature->addFreshFunction(0,"spl");
-    splPrefix = env.signature->functionName(spl)+"_";
-  }
-}
+{}
 
 Splitter::~Splitter()
 {
@@ -727,17 +720,20 @@ SATLiteral Splitter::getLiteralFromName(SplitLevel compName)
   bool polarity = (compName&1)==0;
   return SATLiteral(var, polarity);
 }
+
 vstring Splitter::getFormulaStringFromName(SplitLevel compName, bool negated)
 {
   SATLiteral lit = getLiteralFromName(compName);
   if (negated) {
     lit = lit.opposite();
   }
-  if (lit.isPositive()) {
-    return splPrefix+Lib::Int::toString(lit.var());
-  } else {
-    return "~"+splPrefix+Lib::Int::toString(lit.var());
-  }
+
+  vstringstream result;
+  if(lit.isNegative())
+    result << '~';
+  // TPTP convention for new symbol names: this is a defined predicate
+  result << "sP" << lit.var() << "_split";
+  return result.str();
 }
 
 Unit* Splitter::getDefinitionFromName(SplitLevel compName) const

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -314,8 +314,6 @@ private:
   Set<SATClause *, DerefPtrHash<DefaultHash>> _already_added;
 
 public:
-  static vstring splPrefix;
-
   // for observing the current model
   SplitLevel splitLevelBound() { return _db.size(); }
   bool splitLevelActive(SplitLevel lev) {


### PR DESCRIPTION
There's a static `splPrefix` floating around in `Splitter`, which is mirrored as `splitPrefix` in `InferenceStore`. It doesn't seem to do much and does not conform with the [convention](https://tptp.cs.miami.edu/TSTP/NewSymbolNames.html).

Just compute this thing on-demand and conform to the convention.