### PR TITLE
disable optimisation for Clang and GCC on tricky translation units

### DIFF
--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -14,6 +14,15 @@
  * @author Martin Suda
  */
 
+/* this translation unit causes the optimiser to take a very long time,
+ * but it's not really performance-critical code:
+ * disable optimisation for this file with various compilers */
+#if defined(__clang__)
+#pragma clang optimize off
+#elif defined(__GNUC__)
+#pragma GCC optimize 0
+#endif
+
 #include "Schedules.hpp"
 
 #include "Shell/Options.hpp"

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -19,6 +19,16 @@
  * IMPORTANT --> see .hpp file for instructions on how to add an option
  */
 
+/* this translation unit causes the optimiser to take a very long time,
+ * but it's not really performance-critical code:
+ * disable optimisation for this file with various compilers */
+#if defined(__clang__)
+#pragma clang optimize off
+#elif defined(__GNUC__)
+#pragma GCC optimize 0
+#endif
+
+
 // Visual does not know the round function
 #include <cmath>
 #include <filesystem>


### PR DESCRIPTION
`CASC/Schedules.cpp` and `Shell/Options.cpp` both take upwards of a minute to compile with optimsations enabled on my machine, but they're not really the hot parts of Vampire. Disable optimisations for Clang and GCC at least on these files.

Ideally eventually we'd fix the code, but for now this seems like a low priority.