### PR TITLE
Demodulation redundancy check cannot be turned off

### DIFF
--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -34,6 +34,10 @@ DemodulationHelper::DemodulationHelper(const Options& opts, const Ordering* ord)
 
 bool DemodulationHelper::redundancyCheckNeededForPremise(Clause* rwCl, Literal* rwLit, TermList rwTerm) const
 {
+  if (!_redundancyCheck) {
+    return false;
+  }
+
   if (!rwLit->isEquality() || (rwTerm!=*rwLit->nthArgument(0) && rwTerm!=*rwLit->nthArgument(1))) {
     return false;
   }


### PR DESCRIPTION
During the latest refactor, I forgot to actually use the flag which checks `drc=off`.

I wonder what effects this had on our CASC schedules.