### PR TITLE
ERD as simplifier

### DIFF
--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -100,6 +100,7 @@
 #include "Shell/Statistics.hpp"
 #include "Shell/UIHelper.hpp"
 #include "Shell/Shuffling.hpp"
+#include "Shell/EqResWithDeletion.hpp"
 
 #include "Splitter.hpp"
 
@@ -1730,6 +1731,10 @@ SaturationAlgorithm* SaturationAlgorithm::createFromOptions(Problem& prb, const 
 ImmediateSimplificationEngine* SaturationAlgorithm::createISE(Problem& prb, const Options& opt, Ordering& ordering)
 {
   CompositeISE* res=new CompositeISE();
+
+  if(prb.hasEquality() && opt.equalityResolutionWithDeletion() == Options::RuleActivity::SIMPLIF) {
+    res->addFront(new EqResWithDeletion());
+  }
 
   if(prb.hasEquality() && opt.equationalTautologyRemoval()) {
     res->addFront(new EquationalTautologyRemoval());

--- a/Shell/EqResWithDeletion.hpp
+++ b/Shell/EqResWithDeletion.hpp
@@ -22,12 +22,14 @@
 
 #include "Kernel/Term.hpp"
 
+#include "Inferences/InferenceEngine.hpp"
+
 namespace Shell {
 
 using namespace Lib;
 using namespace Kernel;
 
-class EqResWithDeletion
+class EqResWithDeletion : public Inferences::ImmediateSimplificationEngine
 {
 public:
   void apply(Problem& prb);
@@ -35,10 +37,10 @@ public:
 
   TermList apply(unsigned var);
   Clause* apply(Clause* cl);
+
+  Clause* simplify(Clause* cl) override { return apply(cl); }
 private:
   bool scan(Literal* lit);
-
-
 
   /** The substitution induced by resolved inequalities
    * (It is reset with each clause). */

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -486,9 +486,9 @@ public:
 
   /** Possible values for activity of some inference rules */
   enum class RuleActivity : unsigned int {
-    INPUT_ONLY = 0,
-    OFF = 1,
-    ON = 2
+    OFF,
+    ON,
+    SIMPLIF
   };
 
   enum class QuestionAnsweringMode : unsigned int {
@@ -2159,7 +2159,7 @@ public:
   bool superpositionFromVariables() const { return _superpositionFromVariables.actualValue; }
   EqualityProxy equalityProxy() const { return _equalityProxy.actualValue; }
   bool useMonoEqualityProxy() const { return _useMonoEqualityProxy.actualValue; }
-  bool equalityResolutionWithDeletion() const { return _equalityResolutionWithDeletion.actualValue; }
+  RuleActivity equalityResolutionWithDeletion() const { return _equalityResolutionWithDeletion.actualValue; }
   ExtensionalityResolution extensionalityResolution() const { return _extensionalityResolution.actualValue; }
   bool FOOLParamodulation() const { return _FOOLParamodulation.actualValue; }
   bool termAlgebraInferences() const { return _termAlgebraInferences.actualValue; }
@@ -2457,7 +2457,7 @@ private:
 
   ChoiceOptionValue<EqualityProxy> _equalityProxy;
   BoolOptionValue _useMonoEqualityProxy;
-  BoolOptionValue _equalityResolutionWithDeletion;
+  ChoiceOptionValue<RuleActivity> _equalityResolutionWithDeletion;
   BoolOptionValue _equivalentVariableRemoval;
   ChoiceOptionValue<ExtensionalityResolution> _extensionalityResolution;
   UnsignedOptionValue _extensionalityMaxLength;

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -361,7 +361,8 @@ void Preprocess::preprocess(Problem& prb)
 //     }
 //   }
 
-   if (_options.equalityResolutionWithDeletion() && prb.mayHaveInequalityResolvableWithDeletion() ) {
+   if (_options.equalityResolutionWithDeletion() != Options::RuleActivity::OFF
+         && prb.mayHaveInequalityResolvableWithDeletion() ) {
      env.statistics->phase=Statistics::EQUALITY_RESOLUTION_WITH_DELETION;
      if (env.options->showPreprocessing())
       std::cout << "equality resolution with deletion" << std::endl;

--- a/samplers/samplerFOL.txt
+++ b/samplers/samplerFOL.txt
@@ -9,7 +9,7 @@
 ep!=off > mep ~cat on:10,off:1
 
 # equality_resolution_with_deletion
-> erd ~cat on:10,off:1
+> erd ~cat on:10,off:1,simplif:5
 
 # function_definition_elimination
 > fde ~cat all:5,none:1,unused:1

--- a/samplers/samplerIND.txt
+++ b/samplers/samplerIND.txt
@@ -9,7 +9,7 @@
 ep!=off > mep ~cat on:10,off:1
 
 # equality_resolution_with_deletion
-> erd ~cat on:10,off:1
+> erd ~cat on:10,off:1,simplif:5
 
 # function_definition_elimination
 > fde ~cat all:5,none:1,unused:1

--- a/samplers/samplerSMT.txt
+++ b/samplers/samplerSMT.txt
@@ -12,7 +12,7 @@
 ep!=off > mep ~cat on:10,off:1
 
 # equality_resolution_with_deletion
-> erd ~cat on:10,off:1
+> erd ~cat on:10,off:1,simplif:5
 
 # function_definition_elimination
 > fde ~cat all:5,none:1,unused:1

--- a/samplers/samplerUEQ.txt
+++ b/samplers/samplerUEQ.txt
@@ -9,7 +9,7 @@
 ep!=off > mep ~cat on:10,off:1
 
 # equality_resolution_with_deletion
-> erd ~cat on:10,off:1
+> erd ~cat on:10,off:1,simplif:5
 
 # function_definition_elimination
 > fde ~cat all:5,none:1,unused:1


### PR DESCRIPTION
I hacked this up during Uwe's talk at IJCAR. 

Not sure if we want it, but it's a small change and seems to help (for UNS) a tiny bit:
```
Sort by UNS
7567 ['problemsSTD_rel_erds7706_dis5_sims-off_i5000.pkl']
7577 ['problemsSTD_rel_erds7706_dis5_i5000.pkl']
7585 ['problemsSTD_rel_erds7706_dis5_erd-simplif_i5000.pkl']
```

(coincidentally, the change improvement is in a similar ballpark to what we lose if we turn off simultaneous superposition).

For SAT, we consider erd=simplif an incomplete strategy, so we get:
```
Sort by SAT
517 ['problemsSTD_rel_erds7706_dis5_erd-simplif_i5000.pkl']
986 ['problemsSTD_rel_erds7706_dis5_i5000.pkl']
986 ['problemsSTD_rel_erds7706_dis5_sims-off_i5000.pkl']
```
