### PR TITLE
GREATER_EQ and LESS_EQ have to go

### DIFF
--- a/Indexing/LiteralIndex.cpp
+++ b/Indexing/LiteralIndex.cpp
@@ -275,7 +275,6 @@ void RewriteRuleIndex::handleEquivalence(Clause* c, Literal* cgr, Clause* d, Lit
   }
   switch(cmpRes) {
   case Ordering::GREATER:
-  case Ordering::GREATER_EQ:
     if(cgr->containsAllVariablesOf(csm)) {
       if(cgr->isPositive()) {
         handle(LiteralClause{cgr, c}, adding);
@@ -286,7 +285,6 @@ void RewriteRuleIndex::handleEquivalence(Clause* c, Literal* cgr, Clause* d, Lit
     }
     break;
   case Ordering::LESS:
-  case Ordering::LESS_EQ:
     if(csm->containsAllVariablesOf(cgr)) {
       if(csm->isPositive()) {
         handle(LiteralClause{csm, c}, adding);

--- a/Inferences/ArithmeticSubtermGeneralization.cpp
+++ b/Inferences/ArithmeticSubtermGeneralization.cpp
@@ -117,11 +117,9 @@ SimplifyingGeneratingInference1::Result generalizeBottomUp(Clause* cl, EvalFn ev
             case Ordering::LESS:
               oneLess = true;
               break;
-            case Ordering::LESS_EQ:
             case Ordering::EQUAL:
               break;
             case Ordering::GREATER:
-            case Ordering::GREATER_EQ:
             case Ordering::INCOMPARABLE:
               allLessEq = false;
               DEBUG("ordering violation: ", cmp)

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -415,12 +415,10 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
         RSTAT_MCTR_INC("BSD, lhsVector.size() when INCOMPARABLE", lhsVector.size());
         break;
       case Ordering::GREATER:
-      case Ordering::GREATER_EQ:
         ASS(termContainsAllVariablesOfOtherUnderSubst(t0, t1, applicator));
         lhsVector.push_back(t0);
         break;
       case Ordering::LESS:
-      case Ordering::LESS_EQ:
         ASS(termContainsAllVariablesOfOtherUnderSubst(t1, t0, applicator));
         lhsVector.push_back(t1);
         break;
@@ -567,7 +565,6 @@ bool BackwardSubsumptionDemodulation::rewriteCandidate(Clause* sideCl, Clause* m
             }
           }
           Ordering::Result r_cmp_t = ordering.compare(rhsS, t);
-          ASS_NEQ(r_cmp_t, Ordering::LESS_EQ);  // NOTE: LESS_EQ doesn't seem to occur in the code currently. It is unclear why the ordering is not simplified to LESS, EQUAL and GREATER.
           if (r_cmp_t == Ordering::LESS) {
             // rhsS < t implies eqLitS < dlit
             ASS_EQ(ordering.compare(binder.applyTo(eqLit), dlit), Ordering::LESS);

--- a/Inferences/BinaryResolution.cpp
+++ b/Inferences/BinaryResolution.cpp
@@ -177,7 +177,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, Cla
 
         if (o == Ordering::GREATER ||
             (ls->isPositiveForSelection(newLit)    // strict maximimality for positive literals
-                && (o == Ordering::GREATER_EQ || o == Ordering::EQUAL))) { // where is GREATER_EQ ever coming from?
+                && o == Ordering::EQUAL)) {
           env.statistics->inferencesBlockedForOrderingAftercheck++;
           res->destroy();
           return 0;
@@ -215,7 +215,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, Cla
 
         if (o == Ordering::GREATER ||
             (ls->isPositiveForSelection(newLit)   // strict maximimality for positive literals
-                && (o == Ordering::GREATER_EQ || o == Ordering::EQUAL))) { // where is GREATER_EQ ever coming from?
+                && o == Ordering::EQUAL)) {
           env.statistics->inferencesBlockedForOrderingAftercheck++;
           res->destroy();
           return 0;

--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -80,7 +80,7 @@ bool DemodulationHelper::isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermLi
 
   TermList other=EqHelper::getOtherEqualitySide(rwLit, rwTerm);
   Ordering::Result tord = _ord->compare(tgtTerm, other);
-  if (tord == Ordering::LESS || tord == Ordering::LESS_EQ) {
+  if (tord == Ordering::LESS) {
     return true;
   }
 

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -127,11 +127,11 @@ struct EqualityFactoring::ResultFn
     TermList srtS = absUnif.subs().apply(srt,0);
     TermList sLHSS = absUnif.subs().apply(sLHS,0);
     TermList sRHSS = absUnif.subs().apply(sRHS,0);
-    if(Ordering::isGorGEorE(_ordering.compare(sRHSS,sLHSS))) {
+    if(Ordering::isGorE(_ordering.compare(sRHSS,sLHSS))) {
       return 0;
     }
     TermList fRHSS = absUnif.subs().apply(fRHS,0);
-    if(Ordering::isGorGEorE(_ordering.compare(fRHSS,sLHSS))) {
+    if(Ordering::isGorE(_ordering.compare(fRHSS,sLHSS))) {
       return 0;
     }
     auto constraints = absUnif.computeConstraintLiterals();

--- a/Inferences/ForwardSubsumptionDemodulation.cpp
+++ b/Inferences/ForwardSubsumptionDemodulation.cpp
@@ -364,12 +364,10 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
               RSTAT_MCTR_INC("FSD, lhsVector.size() when INCOMPARABLE", lhsVector.size());
               break;
             case Ordering::GREATER:
-            case Ordering::GREATER_EQ:
               ASS(termContainsAllVariablesOfOtherUnderSubst(t0, t1, applicator));
               lhsVector.push_back(t0);
               break;
             case Ordering::LESS:
-            case Ordering::LESS_EQ:
               ASS(termContainsAllVariablesOfOtherUnderSubst(t1, t0, applicator));
               lhsVector.push_back(t1);
               break;
@@ -548,7 +546,6 @@ bool ForwardSubsumptionDemodulation::perform(Clause* cl, Clause*& replacement, C
                   }
                 }
                 Ordering::Result r_cmp_t = ordering.compare(rhsS, t);
-                ASS_NEQ(r_cmp_t, Ordering::LESS_EQ);  // NOTE: LESS_EQ doesn't seem to occur in the code currently. It is unclear why the ordering is not simplified to LESS, EQUAL and GREATER.
                 if (r_cmp_t == Ordering::LESS) {
                   // rhsS < t implies eqLitS < dlit
                   ASS_EQ(ordering.compare(binder.applyTo(eqLit), dlit), Ordering::LESS);

--- a/Inferences/FunctionDefinitionRewriting.cpp
+++ b/Inferences/FunctionDefinitionRewriting.cpp
@@ -179,7 +179,7 @@ bool FunctionDefinitionDemodulation::perform(Clause* cl, Clause*& replacement, C
         }
         auto rhs = EqHelper::getOtherEqualitySide(qr.data->literal, qr.data->term);
         // TODO shouldn't allow demodulation with incomparables in the non-ground case
-        if (Ordering::isGorGEorE(ordering.compare(rhs,qr.data->term))) {
+        if (Ordering::isGorE(ordering.compare(rhs,qr.data->term))) {
           continue;
         }
         bool isEqTautology = false;

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -599,13 +599,11 @@ SimplifyingGeneratingInference1::Result SimplifyingGeneratingLiteralSimplificati
             case Ordering::Result::LESS:
               oneLess = true;
               break;
-            case Ordering::Result::LESS_EQ:
             case Ordering::Result::EQUAL:
               ASSERTION_VIOLATION
               break;
             case Ordering::Result::INCOMPARABLE:
             case Ordering::Result::GREATER:
-            case Ordering::Result::GREATER_EQ:
               if (cmp == Ordering::Result::INCOMPARABLE) {
                 env.statistics->evaluationIncomp++;
               } else {

--- a/Inferences/Narrow.cpp
+++ b/Inferences/Narrow.cpp
@@ -175,11 +175,11 @@ Clause* Narrow::performNarrow(
   TermList arg1=*nLiteralS->nthArgument(1);
 
   if(!arg0.containsSubterm(nTermS)) {
-    if(Ordering::isGorGEorE(ordering.getEqualityArgumentOrder(nLiteralS))) {
+    if(Ordering::isGorE(ordering.getEqualityArgumentOrder(nLiteralS))) {
       return 0;
     }
   } else if(!arg1.containsSubterm(nTermS)) {
-    if(Ordering::isGorGEorE(Ordering::reverse(ordering.getEqualityArgumentOrder(nLiteralS)))) {
+    if(Ordering::isGorE(Ordering::reverse(ordering.getEqualityArgumentOrder(nLiteralS)))) {
       return 0;
     }
   }

--- a/Inferences/SubVarSup.cpp
+++ b/Inferences/SubVarSup.cpp
@@ -244,11 +244,11 @@ Clause* SubVarSup::performSubVarSup(
     TermList arg1=*rwLitS->nthArgument(1);
 
     if(!arg0.containsSubterm(rwTermS)) {
-      if(Ordering::isGorGEorE(ordering.getEqualityArgumentOrder(rwLitS))) {
+      if(Ordering::isGorE(ordering.getEqualityArgumentOrder(rwLitS))) {
         return 0;
       }
     } else if(!arg1.containsSubterm(rwTermS)) {
-      if(Ordering::isGorGEorE(Ordering::reverse(ordering.getEqualityArgumentOrder(rwLitS)))) {
+      if(Ordering::isGorE(Ordering::reverse(ordering.getEqualityArgumentOrder(rwLitS)))) {
         return 0;
       }
     }

--- a/Inferences/SubsumptionDemodulationHelper.cpp
+++ b/Inferences/SubsumptionDemodulationHelper.cpp
@@ -244,10 +244,6 @@ SDHelper::ClauseComparisonResult SDHelper::clauseCompare(Literal* const lits1[],
         case Ordering::EQUAL:
           // should not happen due to first part where we remove equal literals
           ASSERTION_VIOLATION;
-        case Ordering::LESS_EQ:
-        case Ordering::GREATER_EQ:
-          // those don't appear
-          ASSERTION_VIOLATION;
         default:
           ASSERTION_VIOLATION;
       }

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -368,7 +368,7 @@ Clause* Superposition::performSuperposition(
 
   //check that we're not rewriting smaller subterm with larger
   auto comp = ordering.compare(tgtTermS,rwTermS);
-  if(Ordering::isGorGEorE(comp)) {
+  if(Ordering::isGorE(comp)) {
     return 0;
   }
 
@@ -378,11 +378,11 @@ Clause* Superposition::performSuperposition(
     TermList arg1=*rwLitS->nthArgument(1);
 
     if(!arg0.containsSubterm(rwTermS)) {
-      if(Ordering::isGorGEorE(ordering.getEqualityArgumentOrder(rwLitS))) {
+      if(Ordering::isGorE(ordering.getEqualityArgumentOrder(rwLitS))) {
         return 0;
       }
     } else if(!arg1.containsSubterm(rwTermS)) {
-      if(Ordering::isGorGEorE(Ordering::reverse(ordering.getEqualityArgumentOrder(rwLitS)))) {
+      if(Ordering::isGorE(Ordering::reverse(ordering.getEqualityArgumentOrder(rwLitS)))) {
         return 0;
       }
     }
@@ -478,7 +478,7 @@ Clause* Superposition::performSuperposition(
 
           Ordering::Result o = ordering.compare(currAfter,eqLitS);
 
-          if (o == Ordering::GREATER || o == Ordering::GREATER_EQ || o == Ordering::EQUAL) { // where is GREATER_EQ ever coming from?
+          if (o == Ordering::GREATER || o == Ordering::EQUAL) {
             env.statistics->inferencesBlockedForOrderingAftercheck++;
             return nullptr;
           }

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -67,12 +67,10 @@ bool EqHelper::hasGreaterEqualitySide(Literal* eq, const Ordering& ord, TermList
     case Ordering::INCOMPARABLE:
       return false;
     case Ordering::GREATER:
-    case Ordering::GREATER_EQ:
       lhs = *eq->nthArgument(0);
       rhs = *eq->nthArgument(1);
       return true;
     case Ordering::LESS:
-    case Ordering::LESS_EQ:
       lhs = *eq->nthArgument(1);
       rhs = *eq->nthArgument(0);
       return true;
@@ -218,11 +216,9 @@ VirtualIterator<TypedTermList> EqHelper::getRewritableVarsIterator(DHSet<unsigne
   }
   case Ordering::EQUAL:
   case Ordering::GREATER:
-  case Ordering::GREATER_EQ:
     sel=*lit->nthArgument(0);
     break;
   case Ordering::LESS:
-  case Ordering::LESS_EQ:
     sel=*lit->nthArgument(1);
     break;
 #if VDEBUG
@@ -253,11 +249,9 @@ VirtualIterator<ELEMENT_TYPE(SubtermIterator)> EqHelper::getRewritableSubtermIte
     }
     case Ordering::EQUAL:
     case Ordering::GREATER:
-    case Ordering::GREATER_EQ:
       sel=*lit->nthArgument(0);
       break;
     case Ordering::LESS:
-    case Ordering::LESS_EQ:
       sel=*lit->nthArgument(1);
       break;
 #if VDEBUG
@@ -296,10 +290,8 @@ VirtualIterator<TypedTermList> EqHelper::getLHSIterator(Literal* lit, const Orde
     case Ordering::INCOMPARABLE:
       return withEqualitySort(lit, iterItems(t0, t1) );
     case Ordering::GREATER:
-    case Ordering::GREATER_EQ:
       return withEqualitySort(lit, iterItems(t0) );
     case Ordering::LESS:
-    case Ordering::LESS_EQ:
       return withEqualitySort(lit, getSingletonIterator(t1) );
     //there should be no equality literals of equal terms
     case Ordering::EQUAL:
@@ -368,13 +360,11 @@ VirtualIterator<TypedTermList> EqHelper::getSubVarSupLHSIterator(Literal* lit, c
       }
       break;
     case Ordering::GREATER:
-    case Ordering::GREATER_EQ:
       if(t1hisVarOrComb){
         return pvi(getSingletonIterator(TypedTermList(t0,eqSort)));
       }
       break;
     case Ordering::LESS:
-    case Ordering::LESS_EQ:
       if(t0hisVarOrComb){
         return pvi(getSingletonIterator(TypedTermList(t1,eqSort)));
       }
@@ -432,12 +422,10 @@ std::pair<VirtualIterator<TypedTermList>,bool> EqHelper::getDemodulationLHSItera
       }
       break;
     case Ordering::GREATER:
-    case Ordering::GREATER_EQ:
       ASS(t0.containsAllVariablesOf(t1));
       isPreordered = true;
       return { withEqualitySort(lit, getSingletonIterator(t0) ), isPreordered };
     case Ordering::LESS:
-    case Ordering::LESS_EQ:
       ASS(t1.containsAllVariablesOf(t0));
       isPreordered = true;
       return { withEqualitySort(lit, getSingletonIterator(t1) ), isPreordered };

--- a/Kernel/KBO.cpp
+++ b/Kernel/KBO.cpp
@@ -93,9 +93,9 @@ protected:
   Result innerResult(TermList t1, TermList t2);
   Result applyVariableCondition(Result res)
   {
-    if(_posNum>0 && (res==LESS || res==LESS_EQ || res==EQUAL)) {
+    if(_posNum>0 && (res==LESS || res==EQUAL)) {
       res=INCOMPARABLE;
-    } else if(_negNum>0 && (res==GREATER || res==GREATER_EQ || res==EQUAL)) {
+    } else if(_negNum>0 && (res==GREATER || res==EQUAL)) {
       res=INCOMPARABLE;
     }
     return res;
@@ -307,8 +307,6 @@ Ordering::Result KBO::State::traverseLexBidir(AppliedTerm tl1, AppliedTerm tl2)
         _lexResult=innerResult(s.term, t.term);
         lexValidDepth=depth;
         ASS(_lexResult!=EQUAL);
-        ASS(_lexResult!=GREATER_EQ);
-        ASS(_lexResult!=LESS_EQ);
       }
     }
   }
@@ -382,12 +380,10 @@ Ordering::Result KBO::State::traverseLexUnidir(AppliedTerm tl1, AppliedTerm tl2)
         : _kbo.compareFunctionPrecedences(s.term.term()->functor(),t.term.term()->functor());
       switch (comp)
       {
-        case Ordering::LESS:
-        case Ordering::LESS_EQ: {
+        case Ordering::LESS: {
           return INCOMPARABLE;
         }
-        case Ordering::GREATER:
-        case Ordering::GREATER_EQ: {
+        case Ordering::GREATER: {
           traverse<1,/*unidirectional=*/true>(s);
           traverse<-1,/*unidirectional=*/true>(t);
           if (!checkVars()) {
@@ -933,13 +929,11 @@ Ordering::Result KBO::isGreaterOrEq(AppliedTerm tl1, AppliedTerm tl2) const
     : compareFunctionPrecedences(t1->functor(),t2->functor());
   switch (comp)
   {
-    case Ordering::LESS:
-    case Ordering::LESS_EQ: {
+    case Ordering::LESS: {
       res = INCOMPARABLE;
       break;
     }
-    case Ordering::GREATER:
-    case Ordering::GREATER_EQ: {
+    case Ordering::GREATER: {
       res = state->traverseNonLex</*unidirectional=*/true>(tl1,tl2);
       break;
     }

--- a/Kernel/KBOComparator.cpp
+++ b/Kernel/KBOComparator.cpp
@@ -34,13 +34,11 @@ KBOComparator::KBOComparator(TermList tl1, TermList tl2, const KBO& kbo)
 
     auto comp = kbo.compare(lhs,rhs);
     switch (comp) {
-      case Ordering::LESS:
-      case Ordering::LESS_EQ: {
+      case Ordering::LESS: {
         // at this point the execution will fail, no further instructions
         return;
       }
-      case Ordering::GREATER:
-      case Ordering::GREATER_EQ: {
+      case Ordering::GREATER: {
         // at this point the execution will succeed, push SUCCESS
         _instructions.push(Instruction::uintUint(InstructionTag::SUCCESS));
         return;
@@ -130,13 +128,11 @@ KBOComparator::KBOComparator(TermList tl1, TermList tl2, const KBO& kbo)
       : kbo.compareFunctionPrecedences(lhst->functor(),rhst->functor());
     switch (prec)
     {
-      case Ordering::LESS:
-      case Ordering::LESS_EQ: {
+      case Ordering::LESS: {
         // again, this means the execution failed
         return;
       }
-      case Ordering::GREATER:
-      case Ordering::GREATER_EQ: {
+      case Ordering::GREATER: {
         // and this means the execution succeeded
         _instructions.push(Instruction::uintUint(InstructionTag::SUCCESS));
         return;

--- a/Kernel/LPOComparator.cpp
+++ b/Kernel/LPOComparator.cpp
@@ -285,7 +285,6 @@ pair<Stack<Instruction>,BranchTag>* LPOComparator::createHelper(TermList tl1, Te
   // Use compare here to filter out as many
   // precomputable comparisons as possible.
   auto comp = lpo.compare(tl1,tl2);
-  ASS(comp != Ordering::LESS_EQ && comp != Ordering::GREATER_EQ);
   if (comp != Ordering::INCOMPARABLE) {
     if (comp == Ordering::LESS) {
       (*ptr)->second = BranchTag::T_INCOMPARABLE;

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -162,12 +162,8 @@ const char* Ordering::resultToString(Result r)
   switch(r) {
   case GREATER:
     return "GREATER";
-  case GREATER_EQ:
-    return "GREATER_EQ";
   case LESS:
     return "LESS";
-  case LESS_EQ:
-    return "LESS_EQ";
   case EQUAL:
     return "EQUAL";
   case INCOMPARABLE:
@@ -190,11 +186,10 @@ void Ordering::removeNonMaximal(LiteralList*& lits) const
     while (*ptr2 && *ptr1) {
       Ordering::Result res = compare((*ptr1)->head(), (*ptr2)->head());
 
-      if (res == Ordering::GREATER || res == Ordering::GREATER_EQ
-          || res == Ordering::EQUAL) {
+      if (res == Ordering::GREATER || res == Ordering::EQUAL) {
         LiteralList::pop(*ptr2);
         continue;
-      } else if (res == Ordering::LESS || res == Ordering::LESS_EQ) {
+      } else if (res == Ordering::LESS) {
         LiteralList::pop(*ptr1);
         goto topLevelContinue;
       }

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -62,10 +62,8 @@ public:
   enum [[nodiscard]] Result {
     GREATER=1,
     LESS=2,
-    GREATER_EQ=3,
-    LESS_EQ=4,
-    EQUAL=5,
-    INCOMPARABLE=6
+    EQUAL=3,
+    INCOMPARABLE=4
   };
 
   Ordering();
@@ -95,7 +93,7 @@ public:
 
   virtual void show(std::ostream& out) const = 0;
 
-  static bool isGorGEorE(Result r) { return (r == GREATER || r == GREATER_EQ || r == EQUAL); }
+  static bool isGorE(Result r) { return (r == GREATER || r == EQUAL); }
 
   void removeNonMaximal(LiteralList*& lits) const;
 
@@ -107,12 +105,8 @@ public:
     switch(r) {
     case GREATER:
       return LESS;
-    case GREATER_EQ:
-      return LESS_EQ;
     case LESS:
       return GREATER;
-    case LESS_EQ:
-      return GREATER_EQ;
     case EQUAL:
     case INCOMPARABLE:
       return r;
@@ -202,8 +196,6 @@ inline std::ostream& operator<<(std::ostream& out, Ordering::Result const& r)
   switch (r) {
     case Ordering::Result::GREATER: return out << "GREATER";
     case Ordering::Result::LESS: return out << "LESS";
-    case Ordering::Result::GREATER_EQ: return out << "GREATER_EQ";
-    case Ordering::Result::LESS_EQ: return out << "LESS_EQ";
     case Ordering::Result::EQUAL: return out << "EQUAL";
     case Ordering::Result::INCOMPARABLE: return out << "INCOMPARABLE";
     default:

--- a/Kernel/Ordering_Equality.cpp
+++ b/Kernel/Ordering_Equality.cpp
@@ -45,21 +45,11 @@ private:
   }
 
   Result compare_s1Gt1(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1GEt1(TermList s1,TermList s2,TermList t1,TermList t2) const;
   Result compare_s1It1(TermList s1,TermList s2,TermList t1,TermList t2) const;
   Result compare_s1It1_s2It2(TermList s1,TermList s2,TermList t1,TermList t2) const;
   Result compare_s1Gt1_s2It2(TermList s1,TermList s2,TermList t1,TermList t2) const;
   Result compare_s1Gt1_s2Lt2(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1Gt1_s2LEt2(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1GEt1_s2It2(TermList s1,TermList s2,TermList t1,TermList t2) const;
   Result compare_s1Gt1_s1It2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1Gt1_s1GEt2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1Gt1_s1GEt2_s2It2(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1GEt1_s1GEt2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1GEt1_s1It2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1GEt1_s2LEt2(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1Gt1_s1GEt2_s2Lt2(TermList s1,TermList s2,TermList t1,TermList t2) const;
-  Result compare_s1GEt1_s1GEt2_s2LEt1(TermList s1,TermList s2,TermList t1,TermList t2) const;
 
   mutable TermList s1,s2,t1,t2;
 
@@ -126,12 +116,8 @@ Ordering::Result Ordering::EqCmp::compareEqualities(Literal* eq1, Literal* eq2) 
   switch(compare(s1,t1)) {
   case GREATER:
     return compare_s1Gt1(s1,s2,t1,t2);
-  case GREATER_EQ:
-    return compare_s1GEt1(s1,s2,t1,t2);
   case INCOMPARABLE:
     return compare_s1It1(s1,s2,t1,t2);
-  case LESS_EQ:
-    return reverse(compare_s1GEt1(t1,t2,s1,s2));
   case LESS:
     return reverse(compare_s1Gt1(t1,t2,s1,s2));
   default:
@@ -148,37 +134,11 @@ Ordering::Result Ordering::EqCmp::compare_s1Gt1(TermList s1,TermList s2,TermList
 
   switch(compare(s2,t2)) {
   case GREATER:
-  case GREATER_EQ:
     return GREATER;
   case INCOMPARABLE:
     return compare_s1Gt1_s2It2(s1,s2,t1,t2);
-  case LESS_EQ:
-    return compare_s1Gt1_s2LEt2(s1,s2,t1,t2);
   case LESS:
     return compare_s1Gt1_s2Lt2(s1,s2,t1,t2);
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 >= t1
- */
-Ordering::Result Ordering::EqCmp::compare_s1GEt1(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER_EQ);
-
-  switch(compare(s2,t2)) {
-  case GREATER:
-    return GREATER;
-  case GREATER_EQ:
-    return GREATER_EQ;
-  case INCOMPARABLE:
-    return compare_s1GEt1_s2It2(s1,s2,t1,t2);
-  case LESS_EQ:
-    return compare_s1GEt1_s2LEt2(s1,s2,t1,t2);
-  case LESS:
-    return reverse(compare_s1Gt1_s2LEt2(t2,t1,s2,s1));
   default:
     ASSERTION_VIOLATION;
   }
@@ -194,12 +154,8 @@ Ordering::Result Ordering::EqCmp::compare_s1It1(TermList s1,TermList s2,TermList
   switch(compare(s2,t2)) {
   case GREATER:
     return compare_s1Gt1_s2It2(s2,s1,t2,t1);
-  case GREATER_EQ:
-    return compare_s1GEt1_s2It2(s2,s1,t2,t1);
   case INCOMPARABLE:
     return compare_s1It1_s2It2(s1,s2,t1,t2);
-  case LESS_EQ:
-    return reverse(compare_s1GEt1_s2It2(t2,t1,s2,s1));
   case LESS:
     return reverse(compare_s1Gt1_s2It2(t2,t1,s2,s1));
   default:
@@ -218,12 +174,8 @@ Ordering::Result Ordering::EqCmp::compare_s1It1_s2It2(TermList s1,TermList s2,Te
   switch(compare(s1,t2)) {
   case GREATER:
     return compare_s1Gt1_s1It2_s2It1(s1,s2,t2,t1);
-  case GREATER_EQ:
-    return compare_s1GEt1_s1It2_s2It1(s1,s2,t2,t1);
   case INCOMPARABLE:
     return INCOMPARABLE;
-  case LESS_EQ:
-    return reverse(compare_s1GEt1_s1It2_s2It1(t2,t1,s1,s2));
   case LESS:
     return reverse(compare_s1Gt1_s1It2_s2It1(t2,t1,s1,s2));
   default:
@@ -242,14 +194,10 @@ Ordering::Result Ordering::EqCmp::compare_s1Gt1_s2It2(TermList s1,TermList s2,Te
   switch(compare(s1,t2)) {
   case GREATER:
     return GREATER;
-  case GREATER_EQ:
-    return compare_s1Gt1_s1GEt2_s2It2(s1,s2,t1,t2);
   case INCOMPARABLE:
     return INCOMPARABLE;
-  case LESS_EQ:
   case LESS:
     ASS_NEQ(compare(s2,t1), LESS); //would cause s2<t2 by transitivity t2>s1>t1>s2 or t2>=s1>t1>s2
-    ASS_NEQ(compare(s2,t1), LESS_EQ); //would cause s2<t2 by transitivity t2>s1>t1>=s2 or t2>=s1>t1>=s2
     ASS_EQ(compare(t1,t2), LESS); //transitivity through s1
     return INCOMPARABLE;
   default:
@@ -269,75 +217,11 @@ Ordering::Result Ordering::EqCmp::compare_s1Gt1_s2Lt2(TermList s1,TermList s2,Te
   case GREATER:
     ASS_EQ(compare(s1,s2), GREATER); //transitivity through t2
     return GREATER;
-  case GREATER_EQ:
-    ASS_NEQ(compare(t1,t2), GREATER); //transitivity would make s1>t2 and not just s1>=t2
-    ASS_EQ(compare(s1,s2), GREATER); //transitivity through t2
-    return compare_s1Gt1_s1GEt2_s2Lt2(s1,s2,t1,t2);
-
   case INCOMPARABLE:
     return INCOMPARABLE;
-  case LESS_EQ:
-    ASS_NEQ(compare(s1,s2), LESS); //transitivity would make s1<t2 and not just s1<=t2
-    ASS_EQ(compare(t1,t2), LESS); //transitivity through t2
-    return reverse(compare_s1Gt1_s1GEt2_s2Lt2(t2,t1,s2,s1));
-
   case LESS:
     ASS_EQ(compare(t1,t2), LESS); //transitivity through t2
     return LESS;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 > t1 and s2 <= t2
- */
-Ordering::Result Ordering::EqCmp::compare_s1Gt1_s2LEt2(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER);
-  ASS_EQ(compare(s2,t2), LESS_EQ);
-
-  switch(compare(s1,t2)) {
-  case GREATER:
-    ASS_EQ(compare(s1,s2), GREATER); //transitivity through t2
-    return GREATER;
-  case GREATER_EQ:
-    ASS_NEQ(compare(t1,t2), GREATER); //transitivity would make s1>t2 and not just s1>=t2
-    ASS(compare(s1,s2)==LESS || compare(s1,s2)==LESS_EQ); //transitivity through t2
-    return INCOMPARABLE;
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-  case LESS:
-    ASS_EQ(compare(t1,t2), LESS); //transitivity through s1
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 >= t1 and s2 inc t2
- */
-Ordering::Result Ordering::EqCmp::compare_s1GEt1_s2It2(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER_EQ);
-  ASS_EQ(compare(s2,t2), INCOMPARABLE);
-
-  switch(compare(s1,t2)) {
-  case GREATER:
-    return compare_s1Gt1_s1GEt2_s2It1(s1,s2,t2,t1);
-  case GREATER_EQ:
-    return compare_s1GEt1_s1GEt2_s2It1(s1,s2,t2,t1);
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-    ASS(compare(t1,t2)==LESS || compare(t1,t2)==LESS_EQ); //transitivity through s1
-    ASS(compare(s2,t1) != LESS && compare(s2,t1) != LESS_EQ);
-    return INCOMPARABLE;
-  case LESS:
-    ASS_EQ(compare(t1,t2), LESS); //transitivity through s1
-    return INCOMPARABLE;
   default:
     ASSERTION_VIOLATION;
   }
@@ -354,230 +238,13 @@ Ordering::Result Ordering::EqCmp::compare_s1Gt1_s1It2_s2It1(TermList s1,TermList
 
   switch(compare(s2,t2)) {
   case GREATER:
-  case GREATER_EQ:
     return GREATER;
   case INCOMPARABLE:
-  case LESS_EQ:
   case LESS:
     return INCOMPARABLE;
   default:
     ASSERTION_VIOLATION;
   }
 }
-
-/**
- * Return the result of literal comparison assuming s1 > t1, s1 >= t2, s2 inc t1
- */
-Ordering::Result Ordering::EqCmp::compare_s1Gt1_s1GEt2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER);
-  ASS_EQ(compare(s1,t2), GREATER_EQ);
-  ASS_EQ(compare(s2,t1), INCOMPARABLE);
-
-  switch(compare(s2,t2)) {
-  case GREATER:
-  case GREATER_EQ:
-    return GREATER;
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-    ASS(compare(s1,s2)==GREATER || compare(s1,s2)==GREATER_EQ); //transitivity through t2
-    return INCOMPARABLE;
-  case LESS:
-    ASS_EQ(compare(s1,s2), GREATER); //transitivity through t2
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 > t1, s1 >= t2, s2 inc t2
- */
-Ordering::Result Ordering::EqCmp::compare_s1Gt1_s1GEt2_s2It2(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER);
-  ASS_EQ(compare(s1,t2), GREATER_EQ);
-  ASS_EQ(compare(s2,t2), INCOMPARABLE);
-
-  switch(compare(s2,t1)) {
-  case GREATER:
-    return GREATER;
-  case GREATER_EQ:
-    return GREATER_EQ;
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-  case LESS:
-    ASS_EQ(compare(s1,s2), GREATER); //transitivity through t1
-    ASS_NEQ(compare(t1,t2), LESS); //otherwise it would hold s1<t2 by transitivity
-    ASS_NEQ(compare(t1,t2), LESS_EQ); //otherwise it would hold s1<t2 or s1<=t2 by transitivity
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 >= t1, s1 >= t2, s2 inc t1
- */
-Ordering::Result Ordering::EqCmp::compare_s1GEt1_s1GEt2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER_EQ);
-  ASS_EQ(compare(s1,t2), GREATER_EQ);
-  ASS_EQ(compare(s2,t1), INCOMPARABLE);
-
-  switch(compare(s2,t2)) {
-  case GREATER:
-    return GREATER;
-  case GREATER_EQ:
-    return GREATER_EQ;
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-    ASS(compare(s1,s2)==GREATER || compare(s1,s2)==GREATER_EQ); //transitivity through t2
-    return INCOMPARABLE;
-  case LESS:
-    ASS_EQ(compare(s1,s2), GREATER); //transitivity through t2
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 >= t1, s1 inc t2, s2 inc t1
- */
-Ordering::Result Ordering::EqCmp::compare_s1GEt1_s1It2_s2It1(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER_EQ);
-  ASS_EQ(compare(s1,t2), INCOMPARABLE);
-  ASS_EQ(compare(s2,t1), INCOMPARABLE);
-
-  ASS_NEQ(compare(t1,t2), GREATER); //otherwise it would hold s1>t2 by transitivity
-  ASS_NEQ(compare(t1,t2), GREATER_EQ); //otherwise it would hold s1>=t2 by transitivity
-  ASS_NEQ(compare(s1,s2), LESS); //otherwise it would hold s2>t1 by transitivity
-  ASS_NEQ(compare(s1,s2), LESS_EQ); //otherwise it would hold s2>=t1 by transitivity
-
-  switch(compare(s2,t2)) {
-  case GREATER:
-    ASS_NEQ(compare(s1,s2), GREATER); //otherwise it would hold s1>t2 by transitivity
-    ASS_NEQ(compare(s1,s2), GREATER_EQ); //otherwise it would hold s1>t2 by transitivity
-    ASS_NEQ(compare(t1,t2), LESS); //otherwise it would hold s2>t1 by transitivity
-    ASS_NEQ(compare(t1,t2), LESS_EQ); //otherwise it would hold s2>t1 by transitivity
-    return GREATER;
-  case GREATER_EQ:
-    ASS_NEQ(compare(s1,s2), GREATER); //otherwise it would hold s1>=t2 by transitivity
-    ASS_NEQ(compare(s1,s2), GREATER_EQ); //otherwise it would hold s1>=t2 by transitivity
-    ASS_NEQ(compare(t1,t2), LESS); //otherwise it would hold s2>=t1 by transitivity
-    ASS_NEQ(compare(t1,t2), LESS_EQ); //otherwise it would hold s2>=t1 by transitivity
-    return GREATER_EQ;
-  case INCOMPARABLE:
-  case LESS_EQ:
-  case LESS:
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 >= t1, s2 <= t2
- */
-Ordering::Result Ordering::EqCmp::compare_s1GEt1_s2LEt2(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER_EQ);
-  ASS_EQ(compare(s2,t2), LESS_EQ);
-
-  switch(compare(s1,t2)) {
-  case GREATER:
-    ASS_EQ(compare(s1,s2),GREATER); //transitivity through t2
-    ASS_NEQ(compare(t2,t1), GREATER);
-    ASS_NEQ(compare(t2,t1), GREATER_EQ);
-    ASS_NEQ(compare(s2,t1), GREATER_EQ);
-    ASS_NEQ(compare(s2,t1), GREATER);
-    return INCOMPARABLE;
-
-  case GREATER_EQ:
-    ASS(compare(s1,s2)==GREATER || compare(s1,s2)==GREATER_EQ); //transitivity through t2
-    return compare_s1GEt1_s1GEt2_s2LEt1(s1,s2,t2,t1);
-
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-    ASS(compare(t2,t1)==GREATER || compare(t2,t1)==GREATER_EQ); //transitivity through s1
-    return reverse(compare_s1GEt1_s1GEt2_s2LEt1(t2,t1,s1,s2));
-
-  case LESS:
-    ASS_EQ(compare(t2,t1),GREATER); //transitivity through s1
-    ASS_NEQ(compare(s2,s1), GREATER);
-    ASS_NEQ(compare(s2,s1), GREATER_EQ);
-    ASS_NEQ(compare(t2,s1), GREATER_EQ);
-    ASS_NEQ(compare(t2,s1), GREATER);
-    return INCOMPARABLE;
-
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-
-/**
- * Return the result of literal comparison assuming s1 > t1, s1 >= t2, s2 < t2
- */
-Ordering::Result Ordering::EqCmp::compare_s1Gt1_s1GEt2_s2Lt2(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER);
-  ASS_EQ(compare(s1,t2), GREATER_EQ);
-  ASS_EQ(compare(s2,t2), LESS);
-
-  ASS_EQ(compare(s1,s2), GREATER); //transitivity through t2
-  ASS_NEQ(compare(t1,t2), GREATER);
-  ASS_NEQ(compare(t1,t2), GREATER_EQ);
-
-  switch(compare(s2,t1)) {
-  case GREATER:
-    ASS_EQ(compare(t2,t1),GREATER); //transitivity through s2
-    return GREATER;
-  case GREATER_EQ:
-    ASS_EQ(compare(t2,t1),GREATER); //transitivity through s2
-    return GREATER_EQ;
-  case INCOMPARABLE:
-  case LESS_EQ:
-  case LESS:
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
-/**
- * Return the result of literal comparison assuming s1 >= t1, s1 >= t2, s2 <= t1
- */
-Ordering::Result Ordering::EqCmp::compare_s1GEt1_s1GEt2_s2LEt1(TermList s1,TermList s2,TermList t1,TermList t2) const
-{
-  ASS_EQ(compare(s1,t1), GREATER_EQ);
-  ASS_EQ(compare(s1,t2), GREATER_EQ);
-  ASS_EQ(compare(s2,t1), LESS_EQ);
-
-  switch(compare(s2,t2)) {
-  case GREATER:
-    ASSERTION_VIOLATION;
-  case GREATER_EQ:
-    ASS(compare(t1,t2)==GREATER || compare(t1,t2)==GREATER_EQ); //transitivity through s2
-    return GREATER_EQ;
-  case INCOMPARABLE:
-    return INCOMPARABLE;
-  case LESS_EQ:
-    ASS(compare(s1,s2)==GREATER || compare(s1,s2)==GREATER_EQ); //transitivity through s2
-    return INCOMPARABLE;
-  case LESS:
-    ASS_EQ(compare(s1,s2),GREATER); //transitivity through t2
-    return INCOMPARABLE;
-  default:
-    ASSERTION_VIOLATION;
-  }
-}
-
 
 }

--- a/Kernel/SKIKBO.cpp
+++ b/Kernel/SKIKBO.cpp
@@ -66,9 +66,9 @@ private:
   Result innerResult(ArgsIt_ptr aai1, ArgsIt_ptr aai2);
   Result applyVariableCondition(Result res)
   {
-    if(_posNum>0 && (res==LESS || res==LESS_EQ || res==EQUAL)) {
+    if(_posNum>0 && (res==LESS || res==EQUAL)) {
       res=INCOMPARABLE;
-    } else if(_negNum>0 && (res==GREATER || res==GREATER_EQ || res==EQUAL)) {
+    } else if(_negNum>0 && (res==GREATER || res==EQUAL)) {
       res=INCOMPARABLE;
     }
     return res;
@@ -275,8 +275,6 @@ void SKIKBO::State::traverse(ArgsIt_ptr aat1, ArgsIt_ptr aat2)
         _lexResult=innerResult(aai1, aai2);
         lexValidDepth=depth;
         ASS(_lexResult!=EQUAL);
-        ASS(_lexResult!=GREATER_EQ);
-        ASS(_lexResult!=LESS_EQ);
       }
     }
   }

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -88,10 +88,8 @@ enum ArgumentOrderVals {
   AO_UNKNOWN=0,
   AO_GREATER=1,
   AO_LESS=2,
-  AO_GREATER_EQ=3,
-  AO_LESS_EQ=4,
-  AO_EQUAL=5,
-  AO_INCOMPARABLE=6,
+  AO_EQUAL=3,
+  AO_INCOMPARABLE=4,
 };
 
 /**


### PR DESCRIPTION
I have finally got annoyed enough to remove the two enum values that annoyed many Vampire developers before me (based on comments in the code).

There were probably earlier `Ordering` implementations which used these values but now nothing returns them on the term level, and literal-level comparisons like `Ordering_Equality` only used them when they were returned from the term level. Removing them gives a cleaner code and will hopefully allow more optimisations down the road.

I know only of `ArgumentOrderVals` which relies on the exact layout of `Ordering`, please let me know if there are more of these somewhere.