### PR TITLE
Fixes several model printing bugs (and more)

### DIFF
--- a/Debug/Assertion.hpp
+++ b/Debug/Assertion.hpp
@@ -164,6 +164,7 @@ template <typename T>
   catch (Exception& e) { e.cry(std::cout); ASSERTION_VIOLATION } \
   catch (...)          {                   ASSERTION_VIOLATION } \
 
+#define RELEASE_CODE(X) {}
 #define DEBUG_CODE(X) X
 #define ALWAYS(Cond) ASS(Cond)
 #define NEVER(Cond) ASS(!(Cond))
@@ -192,6 +193,7 @@ template <typename T>
   }
 #endif
 
+#define RELEASE_CODE(X) X
 #define DEBUG_CODE(X) {}
 
 #define ASS(Cond)  {}

--- a/Debug/RuntimeStatistics.cpp
+++ b/Debug/RuntimeStatistics.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 void RSMultiCounter::print(ostream& out)
 {
-  out << name() << ":"<< endl;
+  out << "% " << name() << ":"<< endl;
   for(size_t i=0;i<_counters.size();i++) {
     if(_counters[i]) {
       out << "  " << i << ": " << _counters[i] <<endl;
@@ -45,7 +45,7 @@ RSMultiStatistic::~RSMultiStatistic()
 
 void RSMultiStatistic::print(ostream& out)
 {
-  out << name() << ":"<< endl;
+  out << "% " << name() << ":"<< endl;
   for(size_t i=0;i<_values.size();i++) {
     if(_values[i]) {
 
@@ -67,8 +67,7 @@ void RSMultiStatistic::print(ostream& out)
 	  max=val;
 	}
       }
-      
-      out << "  " << i << ": " << 
+      out << "  " << i << ": " <<
               "cnt: "+Int::toString(cnt)+
               ", avg: "+Int::toString(static_cast<float>(sum)/cnt)+
               ", min: "+Int::toString(min)+
@@ -98,14 +97,14 @@ RuntimeStatistics::~RuntimeStatistics()
 
 void RuntimeStatistics::print(ostream& out)
 {
-  out<<"----  Runtime statistics ----"<<endl;
+  out<<"% ----  Runtime statistics ----"<<endl;
 
   ObjSkipList::Iterator it(_objs);
   while(it.hasNext()) {
     it.next()->print(out);
   }
 
-  out<<"-----------------------------"<<endl;
+  out<<"% -----------------------------"<<endl;
 }
 
 

--- a/Debug/RuntimeStatistics.hpp
+++ b/Debug/RuntimeStatistics.hpp
@@ -111,7 +111,7 @@ class RSCounter
 public:
   RSCounter(const char* name) : RSObject(name), _counter(0) {}
 
-  void print(std::ostream& out) { out << name() << ": " << _counter << std::endl; }
+  void print(std::ostream& out) { out << "% " << name() << ": " << _counter << std::endl; }
   void inc() { _counter++; }
   void inc(size_t num) { _counter+=num; }
 private:

--- a/FMB/FiniteModel.cpp
+++ b/FMB/FiniteModel.cpp
@@ -427,7 +427,7 @@ bool FiniteModel::evaluate(Unit* unit)
     formula = fu->getFormula();
   }
 
-  formula = partialEvaluate(formula);
+  formula = partialEvaluate(formula,0);
   formula = SimplifyFalseTrue::simplify(formula);
   return evaluate(formula);
 }
@@ -549,7 +549,7 @@ bool FiniteModel::evaluate(Formula* formula,unsigned depth)
      * TODO: This is recursive, which could be problematic in the long run
      *
      */
-    Formula* FiniteModel::partialEvaluate(Formula* formula)
+    Formula* FiniteModel::partialEvaluate(Formula* formula,unsigned depth)
     {
 #if DEBUG_MODEL
         for(unsigned i=0;i<depth;i++){ cout << "."; }
@@ -572,7 +572,7 @@ bool FiniteModel::evaluate(Formula* formula,unsigned depth)
                     return formula;
                 case NOT:
                 {
-                  Formula* inner = partialEvaluate(formula->uarg());
+                  Formula* inner = partialEvaluate(formula->uarg(),depth+1);
                   return new NegatedFormula(inner);
                 }
                 case AND:
@@ -582,7 +582,7 @@ bool FiniteModel::evaluate(Formula* formula,unsigned depth)
                 FormulaList* newArgs = 0;
                 FormulaList::Iterator fit(args);
                 while(fit.hasNext()){
-                    Formula* newArg = partialEvaluate(fit.next());
+                    Formula* newArg = partialEvaluate(fit.next(),depth+1);
                     FormulaList::push(newArg,newArgs);
                 }
                 return new JunctionFormula(formula->connective(),newArgs); 
@@ -594,8 +594,8 @@ bool FiniteModel::evaluate(Formula* formula,unsigned depth)
             {
                 Formula* left = formula->left();
                 Formula* right = formula->right();
-                Formula* newLeft = partialEvaluate(left);
-                Formula* newRight = partialEvaluate(right);
+                Formula* newLeft = partialEvaluate(left,depth+1);
+                Formula* newRight = partialEvaluate(right,depth+1);
                 
                 return new BinaryFormula(formula->connective(),newLeft,newRight); 
             }
@@ -605,7 +605,7 @@ bool FiniteModel::evaluate(Formula* formula,unsigned depth)
             {
                 VList* vs = formula->vars();
                 Formula* inner  = formula->qarg();
-                Formula* newInner = partialEvaluate(inner);
+                Formula* newInner = partialEvaluate(inner,depth+1);
                 return new QuantifiedFormula(formula->connective(),vs,0,newInner);
             }
             default:

--- a/FMB/FiniteModel.hpp
+++ b/FMB/FiniteModel.hpp
@@ -58,7 +58,7 @@ public:
 
 private:
 
- Formula* partialEvaluate(Formula* formula);
+ Formula* partialEvaluate(Formula* formula,unsigned depth);
  // currently private as requires formula to be rectified
  bool evaluate(Formula* formula,unsigned depth=0);
 

--- a/FMB/FiniteModel.hpp
+++ b/FMB/FiniteModel.hpp
@@ -82,6 +82,8 @@ public:
    if(_domainConstants.find(c,t)) return t;
    std::string name = "domainConstant";//+Lib::Int::toString(c);
    unsigned f = env.signature->addFreshFunction(0,name.c_str()); 
+   Signature::Symbol* fSym = env.signature->getFunction(f);
+   fSym->setType(OperatorType::getConstantsType(AtomicSort::defaultSort()));
    t = Term::createConstant(f);
    _domainConstants.insert(c,t);
    _domainConstantsRev.insert(t,c);

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -445,7 +445,7 @@ void FiniteModelBuilder::init()
     ClauseList::pushFromIterator(_prb.clauseIterator(),clist);
     Monotonicity::addSortPredicates(true, clist,deleted_functions);
   }
-  if(env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::FUNCTION){ 
+  if(env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::FUNCTION){
     ClauseList::pushFromIterator(_prb.clauseIterator(),clist);
     Monotonicity::addSortFunctions(true,clist);
   }
@@ -505,7 +505,7 @@ void FiniteModelBuilder::init()
               map->insert(rnum,set);
             }
             set->insert(lnum);
-          } 
+          }
         }
       }
     }

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -790,7 +790,7 @@ void FiniteModelBuilder::init()
   for(unsigned f=0;f<env.signature->functions();f++){
     if(del_f[f]) continue;
 
-    if(env.signature->functionArity(f)==0){ 
+    if(env.signature->functionArity(f)==0){
       TermList vsrtT = env.signature->getFunction(f)->fnType()->result();
       if(!vsrtT.isBoolSort()){
         unsigned vsrt = vsrtT.term()->functor();

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -579,10 +579,14 @@ void FiniteModelBuilder::init()
     if(del_f[f]) cout << "Mark " << env.signature->functionName(f)  << " as deleted" << endl;
 #endif
   }
-  for(unsigned p=0;p<env.signature->predicates();p++){
-    del_p[p] = ((bool)_prb.getEliminatedPredicates().findPtr(p) || (bool)_prb.getPartiallyEliminatedPredicates().findPtr(p));
+  for(unsigned p=1;p<env.signature->predicates();p++){ // skipping equality
+    del_p[p] = ((bool)_prb.getEliminatedPredicates().findPtr(p) || env.signature->getPredicate(p)->usageCnt()==0);
 #if VTRACE_FMB
-    if(del_p[p]) cout << "Mark " << env.signature->predicateName(p) << " as deleted" << endl;
+    if(del_p[p]) {
+      cout << "Mark " << env.signature->predicateName(p) << " as deleted" << endl;
+      cout << "  since (bool)_prb.getEliminatedPredicates().findPtr(p) = " << (bool)_prb.getEliminatedPredicates().findPtr(p) << endl;
+      cout << "  since env.signature->getPredicate(p)->usageCnt() = " << env.signature->getPredicate(p)->usageCnt() << endl;
+    }
 #endif
   }
 

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -432,9 +432,9 @@ void FiniteModelBuilder::init()
 
   ClauseList* clist = 0;
   if(env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::PREDICATE){
-    DArray<unsigned> deleted_functions(env.signature->functions());
+    DArray<bool> deleted_functions(env.signature->functions());
     for(unsigned f=0;f<env.signature->functions();f++){
-      deleted_functions[f] =  _prb.getEliminatedFunctions().find(f) || env.signature->getFunction(f)->usageCnt()==0;
+      deleted_functions[f] =  (bool)_prb.getEliminatedFunctions().findPtr(f) || env.signature->getFunction(f)->usageCnt()==0;
      }
     ClauseList::pushFromIterator(_prb.clauseIterator(),clist);
     Monotonicity::addSortPredicates(true,clist,deleted_functions,_monotonic_vampire_sorts);
@@ -574,13 +574,13 @@ void FiniteModelBuilder::init()
   del_p.ensure(env.signature->predicates());
 
   for(unsigned f=0;f<env.signature->functions();f++){
-    del_f[f] = _prb.getEliminatedFunctions().find(f) || env.signature->getFunction(f)->usageCnt()==0;
+    del_f[f] = (bool)_prb.getEliminatedFunctions().findPtr(f) || env.signature->getFunction(f)->usageCnt()==0;
 #if VTRACE_FMB
     if(del_f[f]) cout << "Mark " << env.signature->functionName(f)  << " as deleted" << endl;
 #endif
   }
   for(unsigned p=0;p<env.signature->predicates();p++){
-    del_p[p] = (_prb.getEliminatedPredicates().find(p) || _prb.getPartiallyEliminatedPredicates().find(p));
+    del_p[p] = ((bool)_prb.getEliminatedPredicates().findPtr(p) || (bool)_prb.getPartiallyEliminatedPredicates().findPtr(p));
 #if VTRACE_FMB
     if(del_p[p]) cout << "Mark " << env.signature->predicateName(p) << " as deleted" << endl;
 #endif

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -532,7 +532,7 @@ void FiniteModelBuilder::init()
   }
   if(!_clauses){
     if(outputAllowed()){
-      cout << "The problem is propositional so there are no sorts!" << endl;
+      cout << "% The problem is propositional so there are no sorts!" << endl;
     }
   }
 
@@ -561,11 +561,15 @@ void FiniteModelBuilder::init()
 
   }
 
-  // TODO: consider updating usage count by rescanning property
-  // in particular, terms replaced by definitions have disappeared!
+  { // An ugly hack to cause a recomputation of usageCnts!
+    // (it's already ugly the usageCnts are stored with Symbols)
 
-  // TODO: consider updating usage count by rescanning property as we have had to
-  //       OR ensure that usage count is updated for any introduced symbols e.g. in Monotonicity
+    UnitList* units = 0; // we create a list just because ClauseList is not a UnitList in C++
+    UnitList::pushFromIterator(IterTraits(ClauseList::Iterator(_groundClauses)).map([](Clause* c) { return (Unit*)c; }),units);
+    UnitList::pushFromIterator(IterTraits(ClauseList::Iterator(_clauses)).map([](Clause* c) { return (Unit*)c; }),units);
+    ScopedPtr<Property> dummy_property(Property::scan(units));
+    UnitList::destroy(units);
+  }
 
   // record the deleted functions and predicates
   // we do this here so that there are slots for symbols introduce in previous

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1568,8 +1568,8 @@ MainLoopResult FiniteModelBuilder::runImpl()
         if(s+1 < _sortedSignature->distinctSorts){ max_res+=","; min_res+=",";}
       }
       if(doPrinting){
-        cout << "Detected minimum model sizes of " << min_res << "]" << endl;
-        cout << "Detected maximum model sizes of " << max_res << "]" << endl;
+        cout << "% Detected minimum model sizes of " << min_res << "]" << endl;
+        cout << "% Detected maximum model sizes of " << max_res << "]" << endl;
       }
   }
 

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -172,7 +172,7 @@ bool FiniteModelBuilder::reset(){
     DArray<unsigned> f_signature = _sortedSignature->functionSignatures[f];
     ASS(f_signature.size() == env.signature->functionArity(f)+1);
 
-    unsigned add = _sortModelSizes[f_signature[0]]; 
+    unsigned add = _sortModelSizes[f_signature[0]];
     for(unsigned i=1;i<f_signature.size();i++){
       unsigned n_add = add * _sortModelSizes[f_signature[i]];
       if (n_add < add) { // additional overflow check - we multiply by positive integers!
@@ -644,18 +644,18 @@ void FiniteModelBuilder::init()
   cout << "Finding Min and Max Sort Sizes" << endl;
 #endif
 
-    // Record the maximum sort sizes detected during sort inference 
+    // Record the maximum sort sizes detected during sort inference
     _distinctSortMaxs.ensure(_sortedSignature->distinctSorts);
     _distinctSortMins.ensure(_sortedSignature->distinctSorts);
-    for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){ 
-      _distinctSortMaxs[s]=UINT_MAX; 
+    for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){
+      _distinctSortMaxs[s]=UINT_MAX;
       _distinctSortMins[s]=1;
     }
 
     DArray<unsigned> bfromSI(_sortedSignature->distinctSorts);
     DArray<unsigned> dConstants(_sortedSignature->distinctSorts);
     DArray<unsigned> dFunctions(_sortedSignature->distinctSorts);
-    for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){ 
+    for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){
       bfromSI[s]=0;
       dConstants[s]=0;
       dFunctions[s]=0;
@@ -668,17 +668,17 @@ void FiniteModelBuilder::init()
       dConstants[parent] += (_sortedSignature->sortedConstants[s]).size();
       dFunctions[parent] += (_sortedSignature->sortedFunctions[s]).size();
     }
-    for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){ 
-      _distinctSortMaxs[s] = min(_distinctSortMaxs[s],bfromSI[s]); 
+    for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){
+      _distinctSortMaxs[s] = min(_distinctSortMaxs[s],bfromSI[s]);
     }
 
 
     for(unsigned s=0;s<_sortedSignature->distinctSorts;s++){
       bool epr = env.getMainProblem()->getProperty()->category()==Property::EPR
                  // if we have no functions we are epr in this sort
-                 || dFunctions[s]==0; 
+                 || dFunctions[s]==0;
       if(epr){
-        unsigned c = dConstants[s]; 
+        unsigned c = dConstants[s];
         if(c==0) continue; //size of 0 does not make sense... maybe we should set it to 1 here? TODO
         // TODO not sure about this second condition, if c < current max what would happen?
         // why are we looking for the 'biggest' max?
@@ -694,7 +694,7 @@ void FiniteModelBuilder::init()
       if((env.getMainProblem()->getProperty()->usesSort(s) || env.signature->isNonDefaultCon(s)) && _sortedSignature->vampireToDistinct.find(s)){
         Stack<unsigned>* dmembers = _sortedSignature->vampireToDistinct.get(s);
         ASS(dmembers);
-        if(dmembers->size() > 1){ 
+        if(dmembers->size() > 1){
           unsigned parent = _sortedSignature->vampireToDistinctParent.get(s);
           Stack<unsigned>::Iterator children(*dmembers);
           while(children.hasNext()){
@@ -1548,7 +1548,6 @@ MainLoopResult FiniteModelBuilder::runImpl()
 
   env.statistics->phase = Statistics::FMB_CONSTRAINT_GEN;
 
-
   if(outputAllowed()){
       bool doPrinting = false;
 #if VTRACE_FMB
@@ -1577,6 +1576,12 @@ MainLoopResult FiniteModelBuilder::runImpl()
   _distinctSortSizes.ensure(_sortedSignature->distinctSorts);
   for(unsigned i=0;i<_distinctSortSizes.size();i++){
      _distinctSortSizes[i]=max(_startModelSize,_distinctSortMins[i]);
+     if (_startModelSize > _distinctSortMaxs[i]) {
+      if(outputAllowed()){
+        cout << "% fmb_start_size (= " << _startModelSize << ") larger than a detected sort maximum size!" << endl;
+      }
+      return MainLoopResult(Statistics::REFUTATION_NOT_FOUND);
+     }
   }
   for(unsigned s=0;s<_sortedSignature->sorts;s++) {
     _sortModelSizes[s] = _distinctSortSizes[_sortedSignature->parents[s]];
@@ -2487,7 +2492,7 @@ bool FiniteModelBuilder::HackyDSAE::increaseModelSizes(DArray<unsigned>& newSort
       delete _constraints_generators.pop();
 #if VTRACE_DOMAINS
       cout << "Deleted" << endl;
-#endif    
+#endif
     }
   }
 

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -434,9 +434,8 @@ void FiniteModelBuilder::init()
     FunctionRelationshipInference inf;
     inf.findFunctionRelationships(
       _prb.clauseIterator(),
-      equivalent_vampire_sorts,
       vampire_sort_constraints_nonstrict,
-      vampire_sort_constraints_strict); 
+      vampire_sort_constraints_strict);
   }
 
   ClauseList* clist = 0;

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -426,8 +426,6 @@ void FiniteModelBuilder::init()
 
   env.statistics->phase = Statistics::FMB_PREPROCESSING;
 
-  
-  Stack<DHSet<unsigned>*> equivalent_vampire_sorts; 
   DHSet<std::pair<unsigned,unsigned>> vampire_sort_constraints_nonstrict;
   DHSet<std::pair<unsigned,unsigned>> vampire_sort_constraints_strict;
   if(env.options->fmbDetectSortBounds()){
@@ -603,7 +601,7 @@ void FiniteModelBuilder::init()
   {
     TIME_TRACE("fmb sort inference");
     //ClauseList* both = ClauseList::concat(_clauses,_groundClauses);
-    SortInference inference(_clauses,del_f,del_p,equivalent_vampire_sorts,_distinct_sort_constraints);
+    SortInference inference(_clauses,del_f,del_p,_distinct_sort_constraints);
     inference.doInference();
     _sortedSignature = inference.getSignature();
     ASS(_sortedSignature);

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1916,6 +1916,9 @@ void FiniteModelBuilder::onModelFound()
   for(unsigned f=0;f<env.signature->functions();f++){
     if(del_f[f]) continue;
 
+    Signature::Symbol* sym = env.signature->getFunction(f);
+    if (sym->introduced()) continue;
+
     //cout << "For " << env.signature->getFunction(f)->name() << endl;
     unsigned arity = env.signature->functionArity(f);
 
@@ -1923,7 +1926,7 @@ void FiniteModelBuilder::onModelFound()
     static DArray<unsigned> maxVarSizeBig;
     maxVarSizeBig.ensure(arity);
 
-    OperatorType* tp = env.signature->getFunction(f)->fnType();
+    OperatorType* tp = sym->fnType();
     ASS_EQ(tp->numTypeArguments(),0) // no polymorphic business in FMB
     for(unsigned var=0;var<arity;var++){
       unsigned vamp_srt = tp->arg(var).term()->functor();
@@ -1992,6 +1995,9 @@ void FiniteModelBuilder::onModelFound()
   for(unsigned p=1;p<env.signature->predicates();p++){
     if(del_p[p]) continue;
 
+    Signature::Symbol* sym = env.signature->getPredicate(p);
+    if (sym->introduced()) continue;
+
     unsigned arity = env.signature->predicateArity(p);
     //cout << "Record for " << env.signature->getPredicate(p)->name() << "/" << arity << endl;
 
@@ -1999,7 +2005,7 @@ void FiniteModelBuilder::onModelFound()
     static DArray<unsigned> maxVarSizeBig;
     maxVarSizeBig.ensure(arity);
 
-    OperatorType* tp = env.signature->getPredicate(p)->fnType();
+    OperatorType* tp = sym->fnType();
     ASS_EQ(tp->numTypeArguments(),0) // no polymorphic business in FMB
     for(unsigned var=0;var<arity;var++){
       unsigned vamp_srt = tp->arg(var).term()->functor();

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1910,36 +1910,13 @@ void FiniteModelBuilder::onModelFound()
 
   FiniteModelMultiSorted model(vampireSortSizes);
 
-  //Record interpretation of constants
+  //Record interpretation of constants and functions
   for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->functionArity(f)>0) continue;
-    if(del_f[f]) continue;
-
-    DEBUG_CODE(bool found=false;)
-    unsigned retSrt = _sortedSignature->functionSignatures[f][0];
-    unsigned maxRtSrtSize = min(_sortedSignature->sortBounds[retSrt],_sortModelSizes[retSrt]);
-    for(unsigned c=1;c<=maxRtSrtSize;c++){
-      static DArray<unsigned> grounding(1);
-      grounding[0]=c;
-      SATLiteral slit = getSATLiteral(f,grounding,true,true);
-      if(_solver->trueInAssignment(slit)){
-        //if(found){ cout << "Error: multiple interpretations of " << name << endl;}
-        ASS(!found);
-        DEBUG_CODE(found=true;)
-        model.addConstantDefinition(f,c);
-      }
-    }
-    ASS(found);
-  }
-
-  //Record interpretation of functions
-  for(unsigned f=0;f<env.signature->functions();f++){
-    unsigned arity = env.signature->functionArity(f);
-    if(arity==0) continue;
     if(del_f[f]) continue;
 
     //cout << "For " << env.signature->getFunction(f)->name() << endl;
 
+    unsigned arity = env.signature->functionArity(f);
     static DArray<unsigned> grounding;
     grounding.ensure(arity+1); // leave the last uninitialized until later in the loop
     for(unsigned i=0;i<arity;i++){
@@ -1973,7 +1950,7 @@ fModelLabel:
           if(_solver->trueInAssignment(slit)){
             ASS(!found);
             found=true;
-            model.addFunctionDefinition(f,grounding,c);
+            model.addFunctionDefinition(f,grounding);
             RELEASE_CODE(break);
           }
         }

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1988,8 +1988,8 @@ fModelLabel:
              // This means that there is no result for this input
              // This is a result of the finite sort bounding and the argument
              // says that we can equate this domain element to a smaller one below the bound
-             //TODO fix this 
-             //cout << "NOT FOUND for " << env.signature->functionName(f) << endl; 
+             //TODO fix this
+             //cout << "NOT FOUND for " << env.signature->functionName(f) << endl;
           }
 
           goto fModelLabel;
@@ -1998,7 +1998,7 @@ fModelLabel:
   }
 
 
-  //Record interpretation of prop symbols 
+  //Record interpretation of prop symbols
   static const DArray<unsigned> emptyG(0);
   for(unsigned f=1;f<env.signature->predicates();f++){
     if(env.signature->predicateArity(f)>0) continue;
@@ -2006,14 +2006,14 @@ fModelLabel:
     if(_partiallyDeletedPredicates.find(f)) continue;
 
     bool res;
-    if(!_trivialPredicates.find(f,res)){ 
+    if(!_trivialPredicates.find(f,res)){
       SATLiteral slit = getSATLiteral(f,emptyG,true,false);
-      res=_solver->trueInAssignment(slit); 
+      res=_solver->trueInAssignment(slit);
     }
     model.addPropositionalDefinition(f,res);
   }
 
-  //Record interpretation of predicates 
+  //Record interpretation of predicates
   for(unsigned f=1;f<env.signature->predicates();f++){
     unsigned arity = env.signature->predicateArity(f);
     if(arity==0) continue;
@@ -2040,7 +2040,7 @@ fModelLabel:
 
 pModelLabel:
       for(unsigned i=arity-1;i+1!=0;i--){
-    
+
         if(args[i]==_sortModelSizes[f_signature[i]]){
           grounding[i]=1;
           args[i]=1;

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -601,7 +601,7 @@ void FiniteModelBuilder::init()
   {
     TIME_TRACE("fmb sort inference");
     //ClauseList* both = ClauseList::concat(_clauses,_groundClauses);
-    SortInference inference(_clauses,del_f,del_p,_distinct_sort_constraints);
+    SortInference inference(_clauses,del_f,del_p,_distinct_sort_constraints,_monotonic_vampire_sorts);
     inference.doInference();
     _sortedSignature = inference.getSignature();
     ASS(_sortedSignature);

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1583,7 +1583,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
   if (reset()) {
   while(true){
     if(outputAllowed()) {
-      cout << "TRYING " << "["; 
+      cout << "% TRYING " << "[";
       for(unsigned i=0;i<_distinctSortSizes.size();i++){
         cout << _distinctSortSizes[i];
         if(i+1 < _distinctSortSizes.size()) cout << ",";
@@ -1879,7 +1879,7 @@ void FiniteModelBuilder::onModelFound()
 
   reportSpiderStatus('-');
   if(outputAllowed()){
-    cout << "Finite Model Found!" << endl;
+    cout << "% Finite Model Found!" << endl;
   }
 
   //we need to print this early because model generating can take some time

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -2064,7 +2064,8 @@ void FiniteModelBuilder::onModelFound()
         } else {
           grounding[i] = 1;
 
-          ASS_EQ(extension_mode,0) // it should be fine to delete this, but Martin would like to know the counter-example to this ASS
+          // ASS_EQ(extension_mode,0) // it should be fine to delete this, but Martin would like to know the counter-example to this ASS
+          // these really occur (just uncomment above a search a bit over TPTP)
           extension_mode = sort_extension_modes[i];
         }
       }

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -443,11 +443,11 @@ void FiniteModelBuilder::init()
       deleted_functions[f] = _deletedFunctions.find(f) || env.signature->getFunction(f)->usageCnt()==0;
      }
     ClauseList::pushFromIterator(_prb.clauseIterator(),clist);
-    Monotonicity::addSortPredicates(true, clist,deleted_functions);
+    Monotonicity::addSortPredicates(true,clist,deleted_functions,_monotonic_vampire_sorts);
   }
   if(env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::FUNCTION){
     ClauseList::pushFromIterator(_prb.clauseIterator(),clist);
-    Monotonicity::addSortFunctions(true,clist);
+    Monotonicity::addSortFunctions(true,clist,_monotonic_vampire_sorts);
   }
 
 

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -69,7 +69,7 @@
 
 #define LOG(X) // cout << #X <<  X << endl;
 
-namespace FMB 
+namespace FMB
 {
 
 using namespace std;
@@ -572,8 +572,8 @@ void FiniteModelBuilder::init()
 
   // TODO: consider updating usage count by rescanning property
   // in particular, terms replaced by definitions have disappeared!
-  
-  // TODO: consider updating usage count by rescanning property as we have had to 
+
+  // TODO: consider updating usage count by rescanning property as we have had to
   //       OR ensure that usage count is updated for any introduced symbols e.g. in Monotonicity
 
   // record the deleted functions and predicates
@@ -606,7 +606,7 @@ void FiniteModelBuilder::init()
     //ClauseList* both = ClauseList::concat(_clauses,_groundClauses);
     SortInference inference(_clauses,del_f,del_p,equivalent_vampire_sorts,_distinct_sort_constraints);
     inference.doInference();
-    _sortedSignature = inference.getSignature(); 
+    _sortedSignature = inference.getSignature();
     ASS(_sortedSignature);
 #if VTRACE_FMB
     cout << "Done sort inference" << endl;
@@ -615,7 +615,7 @@ void FiniteModelBuilder::init()
     // now we have a mapping between vampire sorts and distinct sorts we can translate
     // the sort constraints, if any
     {
-      DHSet<std::pair<unsigned,unsigned>>::Iterator it(vampire_sort_constraints_nonstrict); 
+      DHSet<std::pair<unsigned,unsigned>>::Iterator it(vampire_sort_constraints_nonstrict);
       while(it.hasNext()){
         std::pair<unsigned,unsigned> vconstraint = it.next();
         ASS(_sortedSignature->vampireToDistinctParent.find(vconstraint.first));
@@ -1191,8 +1191,8 @@ unsigned FiniteModelBuilder::estimateFunctionalDefCount()
 
 void FiniteModelBuilder::addNewFunctionalDefs()
 {
-  // For each function f of arity n we add the constraint 
-  // f(x1,...,xn) != y | f(x1,...,xn) != z 
+  // For each function f of arity n we add the constraint
+  // f(x1,...,xn) != y | f(x1,...,xn) != z
   // they should be instantiated with groundings where y!=z
 
   for(unsigned f=0;f<env.signature->functions();f++){
@@ -1207,10 +1207,9 @@ void FiniteModelBuilder::addNewFunctionalDefs()
     static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(arity+2);
 
-    // find max size of y and z 
+    // find max size of y and z
     unsigned returnSrt = f_signature[arity];
-    maxVarSize[0] = min(_sortedSignature->sortBounds[returnSrt],_sortModelSizes[returnSrt]);
-    maxVarSize[1] = min(_sortedSignature->sortBounds[returnSrt],_sortModelSizes[returnSrt]);
+    maxVarSize[0] = maxVarSize[1] = min(_sortedSignature->sortBounds[returnSrt],_sortModelSizes[returnSrt]);
 
     // we skip 0 and 1 as these are y and z
     for(unsigned var=2;var<arity+2;var++){
@@ -1251,9 +1250,9 @@ newFuncLabel:
           use.ensure(arity+1);
           for(unsigned k=0;k<arity;k++) use[k]=grounding[k+2];
           use[arity]=grounding[0];
-          satClauseLits.push(getSATLiteral(f,use,false,true)); 
+          satClauseLits.push(getSATLiteral(f,use,false,true));
           use[arity]=grounding[1];
-          satClauseLits.push(getSATLiteral(f,use,false,true)); 
+          satClauseLits.push(getSATLiteral(f,use,false,true));
 
           SATClause* satCl = SATClause::fromStack(satClauseLits);
           addSATClause(satCl);
@@ -1266,7 +1265,7 @@ newFuncLabel:
 void FiniteModelBuilder::addNewSymmetryOrderingAxioms(unsigned size,
                        Stack<GroundedTerm>& groundedTerms)
 {
-  // Add restricted totality 
+  // Add restricted totality
   // i.e. for constant a1 add { a1=1 } and for a2 add { a2=1, a2=2 } and so on
   if(groundedTerms.length() < size) return;
 
@@ -1280,7 +1279,7 @@ void FiniteModelBuilder::addNewSymmetryOrderingAxioms(unsigned size,
   //cout << "Add symmetry ordering for " << gt.toString() << endl;
 
   static SATLiteralStack satClauseLits;
-  satClauseLits.reset(); 
+  satClauseLits.reset();
   for(unsigned i=1;i<=size;i++){
     grounding[arity]=i;
     SATLiteral sl = getSATLiteral(gt.f,grounding,true,true);
@@ -1297,7 +1296,7 @@ void FiniteModelBuilder::addNewSymmetryCanonicityAxioms(unsigned size,
 {
   if(size<=1) return;
 
-  unsigned w = _symmetryRatio * maxSize; 
+  unsigned w = _symmetryRatio * maxSize;
   if(w > groundedTerms.length()){
      w = groundedTerms.length();
   }
@@ -1305,7 +1304,7 @@ void FiniteModelBuilder::addNewSymmetryCanonicityAxioms(unsigned size,
   for(unsigned i=1;i<w;i++){
       static SATLiteralStack satClauseLits;
       satClauseLits.reset();
-   
+
       GroundedTerm gti = groundedTerms[i];
       unsigned arityi = env.signature->functionArity(gti.f);
 
@@ -1316,7 +1315,6 @@ void FiniteModelBuilder::addNewSymmetryCanonicityAxioms(unsigned size,
       for(unsigned a=0;a<arityi;a++){ grounding_i[a]=gti.grounding[a];}
       grounding_i[arityi]=size;
       satClauseLits.push(getSATLiteral(gti.f,grounding_i,false,true));
- 
       //cout << "Adding cannon for " << gti.toString() << endl;
 
       for(unsigned j=0;j<i;j++){
@@ -1883,36 +1881,35 @@ MainLoopResult FiniteModelBuilder::runImpl()
 
 void FiniteModelBuilder::onModelFound()
 {
- // Don't do any output if proof is off
- if(_opt.proof()==Options::Proof::OFF){ 
-   return; 
- }
+  // Don't do any output if proof is off
+  if(_opt.proof()==Options::Proof::OFF){
+    return;
+  }
 
- reportSpiderStatus('-');
- if(outputAllowed()){
-   cout << "Finite Model Found!" << endl;
- }
+  reportSpiderStatus('-');
+  if(outputAllowed()){
+    cout << "Finite Model Found!" << endl;
+  }
 
- //we need to print this early because model generating can take some time
- if(szsOutputMode()) {
-   std::cout << "% SZS status "<<( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
-       << " for " << _opt.problemName() << endl << flush;
-   UIHelper::satisfiableStatusWasAlreadyOutput = true;
- }
+  //we need to print this early because model generating can take some time
+  if(szsOutputMode()) {
+    std::cout << "% SZS status "<<( UIHelper::haveConjecture() ? "CounterSatisfiable" : "Satisfiable" )
+        << " for " << _opt.problemName() << endl << flush;
+    UIHelper::satisfiableStatusWasAlreadyOutput = true;
+  }
   // Prevent timing out whilst the model is being printed
   Timer::setLimitEnforcement(false);
 
-
- DHMap<unsigned,unsigned> vampireSortSizes;
- for(unsigned vSort=0;vSort<env.signature->typeCons();vSort++){
-   unsigned size = 1;
-   if(env.signature->isInterpretedNonDefault(vSort) && !env.signature->isBoolCon(vSort)){ size=0;}
-   unsigned dsort;
-   if(_sortedSignature->vampireToDistinctParent.find(vSort,dsort)){
-     size = _distinctSortSizes[dsort];
-   }
-   vampireSortSizes.insert(vSort,size);
- }
+  DHMap<unsigned,unsigned> vampireSortSizes;
+  for(unsigned vSort=0;vSort<env.signature->typeCons();vSort++){
+    unsigned size = 1;
+    if(env.signature->isInterpretedNonDefault(vSort) && !env.signature->isBoolCon(vSort)){ size=0;}
+    unsigned dsort;
+    if(_sortedSignature->vampireToDistinctParent.find(vSort,dsort)){
+      size = _distinctSortSizes[dsort];
+    }
+    vampireSortSizes.insert(vSort,size);
+  }
 
   FiniteModelMultiSorted model(vampireSortSizes);
 
@@ -1922,7 +1919,9 @@ void FiniteModelBuilder::onModelFound()
     if(del_f[f]) continue;
 
     DEBUG_CODE(bool found=false;)
-    for(unsigned c=1;c<=_sortModelSizes[_sortedSignature->functionSignatures[f][0]];c++){
+    unsigned retSrt = _sortedSignature->functionSignatures[f][0];
+    unsigned maxRtSrtSize = min(_sortedSignature->sortBounds[retSrt],_sortModelSizes[retSrt]);
+    for(unsigned c=1;c<=maxRtSrtSize;c++){
       static DArray<unsigned> grounding(1);
       grounding[0]=c;
       SATLiteral slit = getSATLiteral(f,grounding,true,true);
@@ -1936,7 +1935,7 @@ void FiniteModelBuilder::onModelFound()
     ASS(found);
   }
 
-  //Record interpretation of functions 
+  //Record interpretation of functions
   for(unsigned f=0;f<env.signature->functions();f++){
     unsigned arity = env.signature->functionArity(f);
     if(arity==0) continue;
@@ -1954,7 +1953,7 @@ void FiniteModelBuilder::onModelFound()
     const DArray<unsigned>& f_signature = _sortedSignature->functionSignatures[f];
     static DArray<unsigned> maxVarSize;
     maxVarSize.ensure(arity);
-    for(unsigned var=0;var<arity;var++){ 
+    for(unsigned var=0;var<arity;var++){
       unsigned srt = f_signature[var];
       maxVarSize[var] = min(_sortedSignature->sortBounds[srt],_sortModelSizes[srt]);
     }

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -1626,7 +1626,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
 #endif
     //TODO consider adding clauses directly to SAT solver in new interface?
     // pass clauses and assumption to SAT Solver
-    SATSolver::Status satResult = SATSolver::UNKNOWN;
+    SATSolver::Status satResult = SATSolver::Status::UNKNOWN;
     {
       if (_opt.randomTraversals()) {
         TIME_TRACE(TimeTrace::SHUFFLING);
@@ -1662,7 +1662,7 @@ MainLoopResult FiniteModelBuilder::runImpl()
     }
 
     // if the clauses are satisfiable then we have found a finite model
-    if(satResult == SATSolver::SATISFIABLE){
+    if(satResult == SATSolver::Status::SATISFIABLE){
 
       if (_xmass) { // for CONTOUR
         // before printing possibly retract _distinctSortSizes (and the corresponding _sortModelSizes) according to the set assumptions

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -169,7 +169,7 @@ bool FiniteModelBuilder::reset(){
   // Start from 1 as SAT solver variables are 1-based
   unsigned offsets=1;
   for(unsigned f=0; f<env.signature->functions();f++){
-    if(del_f[f]) continue; 
+    if(del_f[f]) continue;
     f_offsets[f]=offsets;
 #if VTRACE_FMB
     cout << "offset for " << f << " is " << offsets << " (arity is " << env.signature->functionArity(f) << ") " << endl;
@@ -2041,17 +2041,18 @@ pModelLabel:
     }
   }
 
+#if 0
   //Evaluate removed functions and constants
   unsigned maxf = env.signature->functions(); // model evaluation can add new constants
   //bool unfinished=true;
   //while(unfinished){
   //unfinished=false;
   unsigned f=maxf;
-  while(f > 0){ 
+  while(f > 0){
     f--;
     //cout << "Consider " << f << endl;
     unsigned arity = env.signature->functionArity(f);
-    if(!del_f[f]) continue; 
+    if(!del_f[f]) continue;
     // For now, just skip unused functions!
     if(env.signature->getFunction(f)->usageCnt()==0) continue;
     //del_f[f]=false;
@@ -2063,7 +2064,7 @@ pModelLabel:
     //cout << def->toString() << endl;
 
     ASS(def->isEquality());
-    Term* funApp = 0; 
+    Term* funApp = 0;
     Term* funDef = 0;
 
     if(def->nthArgument(0)->term()->functor()==f){
@@ -2111,7 +2112,7 @@ ffModelLabel:
 
           Substitution subst;
           for(unsigned j=0;j<arity;j++){
-            TermList vs = env.signature->getFunction(f)->fnType()->arg(j); 
+            TermList vs = env.signature->getFunction(f)->fnType()->arg(j);
             unsigned vampireSrt = vs.term()->functor();
             //cout << grounding[j] << " is " << model.getDomainConstant(grounding[j],vampireSrt)->toString() << endl;
             subst.bind(vars[j],model.getDomainConstant(grounding[j],vampireSrt));
@@ -2139,7 +2140,7 @@ ffModelLabel:
       }
       catch(UserErrorException& exception){
         //cout << "Setting unfinished" << endl;
-        //unfinished=true;  
+        //unfinished=true;
         //del_f[f]=true;
       }
     }
@@ -2147,7 +2148,6 @@ ffModelLabel:
   //}
 
   //Evaluate removed propositions and predicates
-#if 0
   f=env.signature->predicates()-1;
   while(f>0){
     f--;
@@ -2163,7 +2163,7 @@ ffModelLabel:
       //cout << "For " << env.signature->getPredicate(f)->name() << endl;
       //cout << udef->toString() << endl;
     //}
-    Formula* def = udef->getFormula();   
+    Formula* def = udef->getFormula();
     Literal* predApp = 0;
     Formula* predDef = 0;
     bool polarity = true;
@@ -2175,7 +2175,7 @@ ffModelLabel:
         Formula* inner = def->qarg();
         ASS(inner->connective()==Connective::IFF);
         Formula* left = inner->left();
-        Formula* right = inner->right(); 
+        Formula* right = inner->right();
 
         if(left->connective()==Connective::NOT){
           polarity=!polarity;
@@ -2231,7 +2231,7 @@ ffModelLabel:
       grounding[i]=1;
       TermList vs = env.signature->getPredicate(f)->predType()->arg(i);
       unsigned vampireSrt = vs.term()->functor();
-      unsigned dsrt = _sortedSignature->vampireToDistinctParent.get(vampireSrt); 
+      unsigned dsrt = _sortedSignature->vampireToDistinctParent.get(vampireSrt);
       p_signature_distinct[i] = dsrt;
     }
     grounding[arity-1]=0;
@@ -2251,9 +2251,9 @@ ppModelLabel:
           }
           else{
             Substitution subst;
-            for(unsigned j=0;j<arity;j++){ 
+            for(unsigned j=0;j<arity;j++){
               //cout << grounding[j] << " is " << model.getDomainConstant(grounding[j])->toString() << endl;
-              TermList vs = env.signature->getPredicate(f)->predType()->arg(j); 
+              TermList vs = env.signature->getPredicate(f)->predType()->arg(j);
               unsigned vampireSrt = vs.term()->functor();
               subst.bind(vars[j],model.getDomainConstant(grounding[j],vampireSrt));
             }
@@ -2265,7 +2265,7 @@ ppModelLabel:
               if(!polarity) res=!res;
               model.addPredicateDefinition(f,grounding,res);
             }
-            catch(UserErrorException& exception){ 
+            catch(UserErrorException& exception){
               // TODO order symbols for partial evaluation
             }
           }

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -135,7 +135,7 @@ private:
   // are used to give the interpretation of the function/predicate if a model is found
   DHMap<unsigned,Literal*> _deletedFunctions;
   DHMap<unsigned,Unit*> _deletedPredicates;
-  DHMap<unsigned,Unit*> _partiallyDeletedPredicates; 
+  DHMap<unsigned,Unit*> _partiallyDeletedPredicates;
   DHMap<unsigned,bool> _trivialPredicates;
   // if del_f[i] (resp del_p[i]) is true then that function (resp predicate) should be ignored
   DArray<unsigned> del_f;

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -131,8 +131,8 @@ private:
   ScopedPtr<SATSolverWithAssumptions> _solver;
 
   // if del_f[i] (resp del_p[i]) is true then that function (resp predicate) should be ignored
-  DArray<unsigned> del_f;
-  DArray<unsigned> del_p;
+  DArray<bool> del_f;
+  DArray<bool> del_p;
 
   // Store monotonicity_info (see Monotonicity::check) for every sort detected (or made) monotonic
   DHMap<unsigned,DArray<signed char>*> _monotonic_vampire_sorts;

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -136,6 +136,8 @@ private:
 
   // Store monotonicity_info (see Monotonicity::check) for every sort detected (or made) monotonic
   DHMap<unsigned,DArray<signed char>*> _monotonic_vampire_sorts;
+  Stack<unsigned> _sortFunctions; // sort functions to remember - need to be eliminated from the model in the end
+  Stack<unsigned> _sortPredicates; // sort predicates to remember - need to be eliminated from the model in the end
 
   // Add a SATClause to the SAT solver
   void addSATClause(SATClause* cl);

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -212,7 +212,7 @@ private:
 
   // Currently an experimental option allows you to start at larger model sizes
   // TODO in the future we could use this for a cheap way to 'pause' and 'restart' fmb
-  unsigned _startModelSize; 
+  unsigned _startModelSize;
   // If we detect that FMB is not an approprate sa at init we then terminate immediately at runImpl
   bool _isAppropriate;
   // Option used in symmetry breaking

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -97,7 +97,7 @@ private:
   // For each model size up to the maximum add both ordering and canonicity constraints for each (inferred) sort
   void addNewSymmetryAxioms(){
       ASS(_sortedSignature);
-    
+
     for(unsigned s=0;s<_sortedSignature->sorts;s++){
       //std::cout << "SORT " << s << std::endl;
       unsigned modelSize = _sortModelSizes[s];
@@ -141,6 +141,9 @@ private:
   DArray<unsigned> del_f;
   DArray<unsigned> del_p;
 
+  // Store monotonicity_info (see Monotonicity::check) for every sort detected (or made) monotonic
+  DHMap<unsigned,DArray<signed char>*> _monotonic_vampire_sorts;
+
   // Add a SATClause to the SAT solver
   void addSATClause(SATClause* cl);
   // Add a singleton SATClause in the form of a SATLiteral to the SAT solver
@@ -159,9 +162,9 @@ private:
   ClauseList* _groundClauses;
   ClauseList* _clauses;
 
-  // Record for function symbol the minimum bound of the return sort or any parameter sorts 
+  // Record for function symbol the minimum bound of the return sort or any parameter sorts
   DArray<unsigned> _fminbound;
-  // Record for each clause the sorts of the variables 
+  // Record for each clause the sorts of the variables
   // As clauses are normalized variables will be numbered 0,1,...
   DHMap<Clause*,DArray<unsigned>*> _clauseVariableSorts;
 

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -130,13 +130,6 @@ private:
   // SAT solver used to solve constraints (a new one is used for each model size)
   ScopedPtr<SATSolverWithAssumptions> _solver;
 
-  // Structures to record symbols removed during preprocessing i.e. via definition elimination
-  // These are ignored throughout finite model building and then the definitions (recorded here)
-  // are used to give the interpretation of the function/predicate if a model is found
-  DHMap<unsigned,Literal*> _deletedFunctions;
-  DHMap<unsigned,Unit*> _deletedPredicates;
-  DHMap<unsigned,Unit*> _partiallyDeletedPredicates;
-  DHMap<unsigned,bool> _trivialPredicates;
   // if del_f[i] (resp del_p[i]) is true then that function (resp predicate) should be ignored
   DArray<unsigned> del_f;
   DArray<unsigned> del_p;

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -103,12 +103,11 @@ FiniteModelMultiSorted::FiniteModelMultiSorted(const DHMap<unsigned,unsigned>& s
   }
 }
 
-void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsigned>& args_and_res)
+void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res)
 {
-  ASS_EQ(env.signature->functionArity(f)+1,args_and_res.size());
+  ASS_EQ(env.signature->functionArity(f),args.size());
 
-  unsigned arity = args_and_res.size()-1;
-  unsigned res = args_and_res[arity];
+  unsigned arity = args.size();
 
   if(arity==0 && !env.signature->getFunction(f)->introduced()){
     TermList srt = env.signature->getFunction(f)->fnType()->result();
@@ -124,7 +123,7 @@ void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsi
   unsigned mult = 1;
   OperatorType* sig = env.signature->getFunction(f)->fnType();
   for(unsigned i=0;i<arity;i++){
-    var += mult*(args_and_res[i]-1);
+    var += mult*(args[i]-1);
     unsigned s = sig->arg(i).term()->functor();
     mult *= _sizes.get(s);
   }
@@ -143,7 +142,7 @@ void FiniteModelMultiSorted::addPredicateDefinition(unsigned p, const DArray<uns
 {
   ASS_EQ(env.signature->predicateArity(p),args.size());
 
-  cout << "addPredicateDefinition for " << p << "(" << env.signature->predicateName(p) << ")" << endl;
+  //cout << "addPredicateDefinition for " << p << "(" << env.signature->predicateName(p) << ")" << endl;
 
   unsigned var = p_offsets[p];
   unsigned mult = 1;

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -64,7 +64,12 @@ void FiniteModelMultiSorted::initTables()
       add *= _sizes[sig->arg(i).term()->functor()];
     }
 
-    ASS(UINT_MAX - add > offsets);
+    if (UINT_MAX - add <= offsets) {
+      // the SAT solver skipped some functions as they are eliminated
+      // (the model, on the other hand, should be prepared to hold their values later too)
+      INVALID_OPERATION("Model too large to represent!");
+    }
+
     offsets += add;
   }
   _f_interpretation.expand(offsets,0);
@@ -82,7 +87,12 @@ void FiniteModelMultiSorted::initTables()
       add *= (mult>0 ? mult : 1);
     }
 
-    ASS(UINT_MAX - add > offsets);
+    if (UINT_MAX - add <= offsets) {
+      // the SAT solver skipped some functions as they are eliminated
+      // (the model, on the other hand, should be prepared to hold their values later too)
+      INVALID_OPERATION("Model too large to represent!");
+    }
+
     offsets += add;
   }
   _p_interpretation.expand(offsets,0);

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -45,7 +45,7 @@ using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 
-FiniteModelMultiSorted::FiniteModelMultiSorted(DHMap<unsigned,unsigned> sizes) : 
+FiniteModelMultiSorted::FiniteModelMultiSorted(DHMap<unsigned,unsigned> sizes) :
    _sizes(sizes), _isPartial(false)
 {
   (void)_isPartial; // to suppress unused warning
@@ -64,11 +64,11 @@ FiniteModelMultiSorted::FiniteModelMultiSorted(DHMap<unsigned,unsigned> sizes) :
     OperatorType* sig = env.signature->getFunction(f)->fnType();
     unsigned s = sig->result().term()->functor();
     unsigned add = _sizes.get(s);
-    for(unsigned i=0;i<arity;i++){ 
+    for(unsigned i=0;i<arity;i++){
       s = sig->arg(i).term()->functor();
-      add*= _sizes.get(s); 
+      add*= _sizes.get(s);
     }
-    
+
     ASS(UINT_MAX - add > offsets);
     offsets += add;
   }
@@ -82,9 +82,9 @@ FiniteModelMultiSorted::FiniteModelMultiSorted(DHMap<unsigned,unsigned> sizes) :
     OperatorType* sig = env.signature->getPredicate(p)->predType();
     unsigned add = 1;
 
-    for(unsigned i=0;i<arity;i++){ 
+    for(unsigned i=0;i<arity;i++){
       unsigned s = sig->arg(i).term()->functor();
-      int mult = _sizes.get(s); 
+      int mult = _sizes.get(s);
       ASS(mult>0);
       add*= (mult>0 ? mult : 1);
     }
@@ -96,6 +96,8 @@ FiniteModelMultiSorted::FiniteModelMultiSorted(DHMap<unsigned,unsigned> sizes) :
 
   sortRepr.ensure(env.signature->typeCons());
   for(unsigned s=0;s<env.signature->typeCons();s++){
+    if(env.signature->isInterpretedNonDefault(s))
+      continue;
     sortRepr[s].ensure(_sizes.get(s)+1);
     for(unsigned i=0;i<=_sizes.get(s);i++){
       sortRepr[s][i] = -1;

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -218,7 +218,7 @@ std::string FiniteModelMultiSorted::toString()
       if(frep >= 0){
         cname = env.signature->functionName(frep);
       }
-      cnames[s][i]=cname; 
+      cnames[s][i]=cname;
       modelStm << cname << ":" << sortName << ")." << endl;
     }
 
@@ -227,7 +227,7 @@ std::string FiniteModelMultiSorted::toString()
     modelStm << "      ! [X:" << sortName << "] : (" << endl;
     modelStm << "         ";
     for(unsigned i=1;i<=size;i++){
-      modelStm << "X = " << cnames[s][i]; 
+      modelStm << "X = " << cnames[s][i];
       if(i<size) modelStm << " | ";
       if(i==size) modelStm << endl;
       else if(i%5==0) modelStm << endl << "         ";
@@ -383,7 +383,7 @@ fModelLabel:
     modelStm << "tff("<<prepend("declare_", name)<<",type,"<<name<<": (";
     for(unsigned i=0;i<arity;i++){
       TermList argST = sig->arg(i);
-      unsigned argS = argST.term()->functor();      
+      unsigned argS = argST.term()->functor();
       modelStm << env.signature->typeConName(argS);
       if(i+1 < arity) modelStm << " * ";
     }
@@ -408,7 +408,7 @@ pModelLabel:
         else{
           args[i]++;
 
-          //TODO could probably compute this directly, instead of via args 
+          //TODO could probably compute this directly, instead of via args
           // my mind isn't in the right place to do that now though!
           unsigned var = offset;
           unsigned mult=1;
@@ -432,7 +432,7 @@ pModelLabel:
             if(j!=0) modelStm << ",";
             TermList argSortT = sig->arg(j);
             unsigned argSort = argSortT.term()->functor();
-            modelStm << cnames[argSort][args[j]]; 
+            modelStm << cnames[argSort][args[j]];
           }
           modelStm << ")";
           if(res==0){
@@ -445,8 +445,6 @@ pModelLabel:
       modelStm << endl << ")." << endl << endl;
   }
 
-
-
   return modelStm.str();
 }
 
@@ -457,7 +455,7 @@ unsigned FiniteModelMultiSorted::evaluateGroundTerm(Term* term)
 #if DEBUG_MODEL
   cout << "evaluating ground term " << term->toString() << endl;
   cout << "domain constant status " << isDomainConstant(term) << endl;
-#endif  
+#endif
   if(isDomainConstant(term)) return getDomainConstant(term).first;
 
   unsigned arity = env.signature->functionArity(term->functor());
@@ -518,7 +516,7 @@ bool FiniteModelMultiSorted::evaluateGroundLiteral(Literal* lit)
     var += mult*(args[i]-1);
     unsigned s = sig->arg(i).term()->functor();
     mult *=_sizes.get(s);
-  }  
+  }
 
 #if VDEBUG
   if((lit->functor()+1)<p_offsets.size()) ASS_L(var,p_offsets[lit->functor()+1]);
@@ -527,14 +525,14 @@ bool FiniteModelMultiSorted::evaluateGroundLiteral(Literal* lit)
 
   unsigned res = p_interpretation[var];
 #if DEBUG_MODEL
-    cout << "res is " << res << " and polarity is " << lit->polarity() << endl; 
+    cout << "res is " << res << " and polarity is " << lit->polarity() << endl;
 #endif
 
-  if(res==0) 
+  if(res==0)
     USER_ERROR("Could not evaluate "+lit->toString()+", probably a partial model");
 
   if(lit->polarity()) return (res==2);
-  else return (res==1); 
+  else return (res==1);
 }
 
 bool FiniteModelMultiSorted::evaluate(Unit* unit)
@@ -560,13 +558,13 @@ bool FiniteModelMultiSorted::evaluate(Unit* unit)
 /**
  *
  * TODO: This is recursive, which could be problematic in the long run
- * 
+ *
  */
 bool FiniteModelMultiSorted::evaluate(Formula* formula,unsigned depth)
 {
 #if DEBUG_MODEL
   for(unsigned i=0;i<depth;i++){ cout << "."; }
-  cout << "Evaluating..." << formula->toString() << endl; 
+  cout << "Evaluating..." << formula->toString() << endl;
 #endif
 
   bool isAnd = false;

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -113,7 +113,7 @@ void FiniteModelMultiSorted::addConstantDefinition(unsigned f, unsigned res)
 
 void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res)
 {
-  ASS_EQ(env.signature->functionArity(f),args.size());
+  ASS_LE(env.signature->functionArity(f),args.size());
 
   if(env.signature->functionArity(f)==0 && !env.signature->getFunction(f)->introduced()){
     TermList srt = env.signature->getFunction(f)->fnType()->result();
@@ -156,7 +156,7 @@ void FiniteModelMultiSorted::addPredicateDefinition(unsigned p, const DArray<uns
 {
   ASS_EQ(env.signature->predicateArity(p),args.size());
 
-  //cout << "addPredicateDefinition for " << p << "(" << env.signature->predicateName(p) << ")" << endl;
+  cout << "addPredicateDefinition for " << p << "(" << env.signature->predicateName(p) << ")" << endl;
 
   unsigned var = p_offsets[p];
   unsigned mult = 1;

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -132,12 +132,6 @@ void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsi
   f_interpretation[var] = res;
 }
 
-void FiniteModelMultiSorted::addPropositionalDefinition(unsigned p, bool res)
-{
-  static const DArray<unsigned> empty(0);
-  addPredicateDefinition(p,empty,res);
-}
-
 void FiniteModelMultiSorted::addPredicateDefinition(unsigned p, const DArray<unsigned>& args, bool res)
 {
   ASS_EQ(env.signature->predicateArity(p),args.size());

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -226,13 +226,14 @@ std::string FiniteModelMultiSorted::toString()
 
   //Constants
   for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->getFunction(f)->usageCnt()==0) continue;
-    unsigned arity = env.signature->functionArity(f);
+    Signature::Symbol* symb = env.signature->getFunction(f);
+    if(symb->usageCnt()==0) continue;
+    unsigned arity = symb->arity();
     if(arity>0) continue;
-    if(!printIntroduced && env.signature->getFunction(f)->introduced()) continue;
-    std::string name = env.signature->functionName(f);
+    if(!printIntroduced && symb->introduced()) continue;
+    std::string name = symb->name();
     unsigned res = f_interpretation[f_offsets[f]];
-    TermList srtT = env.signature->getFunction(f)->fnType()->result();
+    TermList srtT = symb->fnType()->result();
     unsigned srt = srtT.term()->functor();
     std::string cname = cnames[srt][res];
     if(name == cname) continue;
@@ -243,25 +244,25 @@ std::string FiniteModelMultiSorted::toString()
       modelStm << "tff("<<append(name,"_definition")<<",axiom,"<<name<<" = " << cname << ")."<<endl;
     }
     else{
-      modelStm << "% " << name << " undefined in model" << endl; 
+      modelStm << "% " << name << " undefined in model" << endl;
     }
   }
 
   //Functions
   for(unsigned f=0;f<env.signature->functions();f++){
-    if(env.signature->getFunction(f)->usageCnt()==0) continue;
-    unsigned arity = env.signature->functionArity(f);
+    Signature::Symbol* symb = env.signature->getFunction(f);
+    if(symb->usageCnt()==0) continue;
+    unsigned arity = symb->arity();
     if(arity==0) continue;
-    if(!printIntroduced && env.signature->getFunction(f)->introduced()) continue;
-    std::string name = env.signature->functionName(f);
-
-    OperatorType* sig = env.signature->getFunction(f)->fnType();
+    if(!printIntroduced && symb->introduced()) continue;
+    std::string name = symb->name();
+    OperatorType* sig = symb->fnType();
     modelStm << "tff("<<prepend("declare_", name)<<",type,"<<name<<": (";
     for(unsigned i=0;i<arity;i++){
       modelStm << sig->arg(i).toString();
       if(i+1 < arity) modelStm << " * ";
     }
-    modelStm << ") > " << sig->result().toString() << ")." << endl; 
+    modelStm << ") > " << sig->result().toString() << ")." << endl;
 
     modelStm << "tff("<<prepend("function_", name)<<",axiom,"<<endl;
 
@@ -327,8 +328,10 @@ fModelLabel:
   for(unsigned f=1;f<env.signature->predicates();f++){
     unsigned arity = env.signature->predicateArity(f);
     if(arity>0) continue;
-    if(!printIntroduced && env.signature->getPredicate(f)->introduced()) continue;
-    std::string name = env.signature->predicateName(f);
+    Signature::Symbol* symb = env.signature->getPredicate(f);
+    if(!printIntroduced && symb->introduced()) continue;
+    if(symb->usageCnt() == 0) continue;
+    std::string name = symb->name();
     modelStm << "tff("<<prepend("declare_", name)<<",type,"<<name<<": $o)."<<endl;
     unsigned res = p_interpretation[p_offsets[f]];
     if(res==2){
@@ -344,12 +347,13 @@ fModelLabel:
 
 //Predicates
   for(unsigned f=1;f<env.signature->predicates();f++){
-    unsigned arity = env.signature->predicateArity(f);
+    Signature::Symbol* symb = env.signature->getPredicate(f);
+    unsigned arity = symb->arity();
     if(arity==0) continue;
-    if(!printIntroduced && env.signature->getPredicate(f)->introduced()) continue;
-    std::string name = env.signature->predicateName(f);
-
-    OperatorType* sig = env.signature->getPredicate(f)->predType();
+    if(!printIntroduced && symb->introduced()) continue;
+    if(symb->usageCnt() == 0) continue;
+    std::string name = symb->name();
+    OperatorType* sig = symb->predType();
     modelStm << "tff("<<prepend("declare_", name)<<",type,"<<name<<": (";
     for(unsigned i=0;i<arity;i++){
       TermList argST = sig->arg(i);

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -184,7 +184,7 @@ std::string FiniteModelMultiSorted::toString()
     for(unsigned i=1;i<=size;i++){
       modelStm << "tff(" << append(prepend("declare_", sortNameLabel), Int::toString(i).c_str()) << ",type,";
       int frep = sortRepr[s][i];
-      std::string cname = prepend("fmb_", sortNameLabel+"_"+Lib::Int::toString(i));
+      std::string cname = append(prepend("fmb_", sortNameLabel),(std::string("_")+Lib::Int::toString(i)).c_str());
       if(frep >= 0){
         cname = env.signature->functionName(frep);
       }

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -123,7 +123,7 @@ void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsi
       //cout << env.sorts->sortName(srt) << " and " << res << endl;
       sortRepr[srtU][res]=f;
     }
-  } 
+  }
 
   unsigned var = f_offsets[f];
   unsigned mult = 1;
@@ -136,7 +136,7 @@ void FiniteModelMultiSorted::addFunctionDefinition(unsigned f, const DArray<unsi
 
   //TODO should be a zero array, should check if previously assigned
   //     check consistency and only update coverage if not defined already
-  
+
   ASS_L(var, f_interpretation.size());
   f_interpretation[var] = res;
 
@@ -242,7 +242,7 @@ std::string FiniteModelMultiSorted::toString()
     for(unsigned i=1;i<=size;i++){
       for(unsigned j=i+1;j<=size;j++){
         c++;
-        modelStm << cnames[s][i] <<" != " << cnames[s][j]; 
+        modelStm << cnames[s][i] <<" != " << cnames[s][j];
         if(!(i==size-1 && j==size)){
            modelStm << " & ";
            if(c%5==0){ modelStm << endl << "         "; }
@@ -269,7 +269,7 @@ std::string FiniteModelMultiSorted::toString()
 
     std::string sortName = env.signature->typeConName(srt);
     modelStm << "tff("<<prepend("declare_", name)<<",type,"<<name<<":"<<sortName<<")."<<endl;
-    if(res>0){ 
+    if(res>0){
       modelStm << "tff("<<append(name,"_definition")<<",axiom,"<<name<<" = " << cname << ")."<<endl;
     }
     else{

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -35,103 +35,92 @@ using namespace Kernel;
  *
  */
 class FiniteModelMultiSorted {
- DHMap<unsigned,unsigned> _sizes;
+  const DHMap<unsigned,unsigned>& _sizes;
 
 public:
 
- // sortSizes is a map from vampire sorts (defined in Kernel/Sorts) to the size of that sort
- FiniteModelMultiSorted(DHMap<unsigned,unsigned> sortSizes);
+  // sortSizes is a map from vampire sorts (defined in Kernel/Sorts) to the size of that sort
+  FiniteModelMultiSorted(const DHMap<unsigned,unsigned>& sortSizes);
 
- // Assume def is an equality literal with a
- // function application on lhs and constant on rhs
- void addConstantDefinition(unsigned f, unsigned res);
- void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res);
- // Assume def is non-equality ground literal
- void addPropositionalDefinition(unsigned f, bool res);
- void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res);
+  // Assume def is an equality literal with a
+  // function application on lhs and constant on rhs
+  void addFunctionDefinition(unsigned f, const DArray<unsigned>& args_and_res);
+  // Assume def is non-equality ground literal
+  void addPropositionalDefinition(unsigned f, bool res);
+  void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res);
 
- bool isPartial();
+  bool evaluate(Unit* unit);
+  unsigned evaluateGroundTerm(Term* term);
+  bool evaluateGroundLiteral(Literal* literal);
 
- bool evaluate(Unit* unit);
- unsigned evaluateGroundTerm(Term* term);
- bool evaluateGroundLiteral(Literal* literal);
-
- std::string toString();
+  std::string toString();
 
 private:
+  Formula* partialEvaluate(Formula* formula);
+  // currently private as requires formula to be rectified
+  bool evaluate(Formula* formula,unsigned depth=0);
 
- Formula* partialEvaluate(Formula* formula);
- // currently private as requires formula to be rectified
- bool evaluate(Formula* formula,unsigned depth=0);
+  DArray<DArray<int>> sortRepr;
 
- // The model is partial if there is a operation with arity n that does not have
- // coverage size^n in its related coverage map
- bool _isPartial;
- DHMap<unsigned,unsigned> _functionCoverage;
- DHMap<unsigned,unsigned> _predicateCoverage;
+  DArray<unsigned> f_offsets;
+  DArray<unsigned> p_offsets;
+  DArray<unsigned> f_interpretation;
+  DArray<unsigned> p_interpretation; // 0 is undef, 1 false, 2 true
 
- DArray<DArray<int>> sortRepr;
-
- DArray<unsigned> f_offsets;
- DArray<unsigned> p_offsets;
- DArray<unsigned> f_interpretation;
- DArray<unsigned> p_interpretation; // 0 is undef, 1 false, 2 true
-
- // the pairs of <constant number, sort>
- DHMap<std::pair<unsigned,unsigned>,Term*> _domainConstants;
- DHMap<Term*,std::pair<unsigned,unsigned>> _domainConstantsRev;
+  // the pairs of <constant number, sort>
+  DHMap<std::pair<unsigned,unsigned>,Term*> _domainConstants;
+  DHMap<Term*,std::pair<unsigned,unsigned>> _domainConstantsRev;
 public:
- Term* getDomainConstant(unsigned c, unsigned srt)
- {
-   Term* t;
-   std::pair<unsigned,unsigned> pair = std::make_pair(c,srt);
-   if(_domainConstants.find(pair,t)) return t;
-   std::string name = "domCon_"+env.signature->typeConName(srt)+"_"+Lib::Int::toString(c);
-   unsigned f = env.signature->addFreshFunction(0,name.c_str());
-   TermList srtT = TermList(AtomicSort::createConstant(srt));
-   env.signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
-   t = Term::createConstant(f);
-   _domainConstants.insert(pair,t);
-   _domainConstantsRev.insert(t,pair);
+  Term* getDomainConstant(unsigned c, unsigned srt)
+  {
+    Term* t;
+    std::pair<unsigned,unsigned> pair = std::make_pair(c,srt);
+    if(_domainConstants.find(pair,t)) return t;
+    std::string name = "domCon_"+env.signature->typeConName(srt)+"_"+Lib::Int::toString(c);
+    unsigned f = env.signature->addFreshFunction(0,name.c_str());
+    TermList srtT = TermList(AtomicSort::createConstant(srt));
+    env.signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
+    t = Term::createConstant(f);
+    _domainConstants.insert(pair,t);
+    _domainConstantsRev.insert(t,pair);
 
-   return t;
- }
- std::pair<unsigned,unsigned> getDomainConstant(Term* t)
- {
-   std::pair<unsigned,unsigned> pair;
-   if(_domainConstantsRev.find(t,pair)) return pair;
-   USER_ERROR("Evaluated to "+t->toString()+" when expected a domain constant, probably a partial model");
- }
- bool isDomainConstant(Term* t)
- {
-   return _domainConstantsRev.find(t);
- }
- std::string prepend(const char* prefix, std::string name) {
-   if (name.empty()) {
-     return std::string(prefix);
-   } else if(name[0] == '$') {
-     return std::string("'") + prefix + name + "'";
-   } else if (name[0] == '\'') {
-     std::string dequoted = name.substr(1, name.length() - 1);
-     return std::string("'") + prefix + dequoted;
-   } else {
-     return prefix + name;
-   }
- }
- std::string append(std::string name, const char* suffix) {
-   if (name.empty()) {
-     return std::string(suffix);
-   } else if(name[0] == '$') {
-     return std::string("'") + name + suffix + "'";
-   } else if (name[0] == '\'') {
-     std::string dequoted = name.substr(0, name.length() - 1);
-     return dequoted + suffix + "'";
-   } else {
-     return name + suffix;
-   }
- }
+    return t;
+  }
+  std::pair<unsigned,unsigned> getDomainConstant(Term* t)
+  {
+    std::pair<unsigned,unsigned> pair;
+    if(_domainConstantsRev.find(t,pair)) return pair;
+    USER_ERROR("Evaluated to "+t->toString()+" when expected a domain constant, probably a partial model");
+  }
+  bool isDomainConstant(Term* t)
+  {
+    return _domainConstantsRev.find(t);
+  }
+  std::string prepend(const char* prefix, std::string name) {
+    if (name.empty()) {
+      return std::string(prefix);
+    } else if(name[0] == '$') {
+      return std::string("'") + prefix + name + "'";
+    } else if (name[0] == '\'') {
+      std::string dequoted = name.substr(1, name.length() - 1);
+      return std::string("'") + prefix + dequoted;
+    } else {
+      return prefix + name;
+    }
+  }
+  std::string append(std::string name, const char* suffix) {
+    if (name.empty()) {
+      return std::string(suffix);
+    } else if(name[0] == '$') {
+      return std::string("'") + name + suffix + "'";
+    } else if (name[0] == '\'') {
+      std::string dequoted = name.substr(0, name.length() - 1);
+      return dequoted + suffix + "'";
+    } else {
+      return name + suffix;
+    }
+  }
 };
-
 
 } // namespace FMB
 #endif

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -46,7 +46,6 @@ public:
   // function application on lhs and constant on rhs
   void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res);
   // Assume def is non-equality ground literal
-  void addPropositionalDefinition(unsigned f, bool res);
   void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res);
 
   bool evaluate(Unit* unit);

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -44,7 +44,7 @@ public:
 
   // Assume def is an equality literal with a
   // function application on lhs and constant on rhs
-  void addFunctionDefinition(unsigned f, const DArray<unsigned>& args_and_res);
+  void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res);
   // Assume def is non-equality ground literal
   void addPropositionalDefinition(unsigned f, bool res);
   void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res);

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -37,11 +37,15 @@ using namespace Kernel;
 class FiniteModelMultiSorted {
   DArray<unsigned> _sizes;
 
+  static const char INTP_UNDEF = 0;
+  static const char INTP_FALSE = 1;
+  static const char INTP_TRUE = 2;
+
   // two big tables waiting to be filled with the intrepreations (of functions and predicates)
   DArray<unsigned> _f_offsets;
   DArray<unsigned> _p_offsets;
   DArray<unsigned> _f_interpretation;
-  DArray<unsigned> _p_interpretation; // 0 is undef, 1 false, 2 true
+  DArray<char> _p_interpretation; // 0 is undef, 1 false, 2 true
 
   // candidates for the domain constants in the model printed (we use existing constants of the respective sort, but introduce a new symbol, if there is none)
   // this is not the same thing (although, maybe, these could be unified?) as _domainConstants, which are used for evaluation

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -45,10 +45,10 @@ public:
  // Assume def is an equality literal with a
  // function application on lhs and constant on rhs
  void addConstantDefinition(unsigned f, unsigned res);
- void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res); 
+ void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res);
  // Assume def is non-equality ground literal
  void addPropositionalDefinition(unsigned f, bool res);
- void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res); 
+ void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res);
 
  bool isPartial();
 
@@ -87,7 +87,7 @@ public:
    std::pair<unsigned,unsigned> pair = std::make_pair(c,srt);
    if(_domainConstants.find(pair,t)) return t;
    std::string name = "domCon_"+env.signature->typeConName(srt)+"_"+Lib::Int::toString(c);
-   unsigned f = env.signature->addFreshFunction(0,name.c_str()); 
+   unsigned f = env.signature->addFreshFunction(0,name.c_str());
    TermList srtT = TermList(AtomicSort::createConstant(srt));
    env.signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
    t = Term::createConstant(f);

--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -50,8 +50,7 @@ namespace FMB
 using namespace std;
 using namespace Shell;
 
-void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator clauses, 
-                 Stack<DHSet<unsigned>*>& eq_classes, 
+void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator clauses,
                  DHSet<std::pair<unsigned,unsigned>>& nonstrict_cons,
                  DHSet<std::pair<unsigned,unsigned>>& strict_cons)
 {
@@ -109,50 +108,6 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
     }
   }
 
-  // Find equalities
-/*
-  Stop this for now... broken (need to check no strict) and very uncommon 
-
-  IntUnionFind uf(env.sorts->sorts());
-  {
-    DHSet<std::pair<unsigned,unsigned>>::Iterator it1(nonstrict_constraints);
-    while(it1.hasNext()){
-      std::pair<unsigned,unsigned> con1 = it1.next();
-      if(con1.first==con1.second) continue;
-      DHSet<std::pair<unsigned,unsigned>>::Iterator it2(nonstrict_constraints);
-      while(it2.hasNext()){
-        std::pair<unsigned,unsigned> con2 = it2.next();
-        if(con1.second == con2.first && con1.first == con2.second){
-          uf.doUnion(con1.first,con1.second);
-        }
-      }
-    }
-  }
-  uf.evalComponents();
-
-  bool header_printed = false;
-  {
-    for(unsigned s=0;s<env.sorts->sorts();s++){
-      DHSet<unsigned>* cls = new DHSet<unsigned>();
-      for(unsigned t=0;t<env.sorts->sorts();t++){
-        if(uf.root(t)==s) cls->insert(t);
-      }
-      if(cls->size()>1){
-        if(print){
-           if(!header_printed){
-             cout << "Equalities:" << endl;
-             header_printed=true;
-           }
-           cout << "= ";
-           DHSet<unsigned>::Iterator it(*cls);
-           while(it.hasNext()) cout << it.next() << " ";
-           cout << endl;
-         }
-         eq_classes.push(cls);   
-      }
-    }
-  }
-*/
   // Normalise constraints
   unsigned constraint_count = 0;
   {

--- a/FMB/FunctionRelationshipInference.hpp
+++ b/FMB/FunctionRelationshipInference.hpp
@@ -35,10 +35,9 @@ class FunctionRelationshipInference {
 
 public:
 
-void findFunctionRelationships(ClauseIterator clauses, 
-                               Stack<DHSet<unsigned>*>& eq_classes, 
+void findFunctionRelationships(ClauseIterator clauses,
                                DHSet<std::pair<unsigned,unsigned>>& nonstrict_cons,
-                               DHSet<std::pair<unsigned,unsigned>>& strict_cons); 
+                               DHSet<std::pair<unsigned,unsigned>>& strict_cons);
 
 private:
 

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -247,17 +247,15 @@ static void addDefinition(FiniteModelMultiSorted& model,Literal* lit,bool negate
     // Defining a predicate or proposition
     unsigned p = lit->functor();
     unsigned arity = env.signature->predicateArity(p);
-    if(arity==0) model.addPropositionalDefinition(p,!negated);
-    else{
-      DArray<unsigned> args(arity);
-      for(unsigned i=0;i<arity;i++){
-        TermList* arg = lit->nthArgument(i);
-        if(arg->isVar() || !domainConstants.contains(arg->term()))
-          USER_ERROR("Expect term on left of definition to be grounded with domain constants");
-        args[i] = domainConstantNumber.get(arg->term());
-      }
-      model.addPredicateDefinition(p,args,!negated);
+
+    DArray<unsigned> args(arity);
+    for(unsigned i=0;i<arity;i++){
+      TermList* arg = lit->nthArgument(i);
+      if(arg->isVar() || !domainConstants.contains(arg->term()))
+        USER_ERROR("Expect term on left of definition to be grounded with domain constants");
+      args[i] = domainConstantNumber.get(arg->term());
     }
+    model.addPredicateDefinition(p,args,!negated);
   }
 }
 

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -100,7 +100,15 @@ static void doCheck(UnitList* units)
   }
 
   std::cout << "Loading model..." << std::endl;
-  FiniteModelMultiSorted model(sortSizes);
+  DArray<unsigned> sortSizesArray(env.signature->typeCons());
+  {
+    auto it = sortSizes.items();
+    while (it.hasNext()) {
+      auto [sort,curModelSize] = it.next();
+      sortSizesArray[sort] = curModelSize;
+    }
+  }
+  FiniteModelMultiSorted model(sortSizesArray);
 
   Set<Term*> domainConstants; // union of all the perSort ones
   DHMap<Term*,unsigned> domainConstantNumber;

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -117,15 +117,14 @@ static void doCheck(UnitList* units)
 
     // number the domain constants
     Set<Term*>::Iterator dit(curDomainConstants);
-    static DArray<unsigned> cval(1);
-    cval[0]=1;
+    unsigned count=1;
     while(dit.hasNext()){
       Term* con = dit.next();
       std::cout << "    " << con->toString() << std::endl;
       domainConstants.insert(con);
-      domainConstantNumber.insert(con,cval[0]);
-      model.addFunctionDefinition(con->functor(),cval);
-      cval[0]++;
+      domainConstantNumber.insert(con,count);
+      model.addFunctionDefinition(con->functor(),DArray<unsigned>(0),count);
+      count++;
     }
   }
 
@@ -234,15 +233,14 @@ static void addDefinition(FiniteModelMultiSorted& model,Literal* lit,bool negate
     Term* fun = left->term();
     unsigned f = fun->functor();
     unsigned arity = env.signature->functionArity(f);
-    DArray<unsigned> args_and_val(arity+1);
+    DArray<unsigned> args(arity);
     for(unsigned i=0;i<arity;i++){
       TermList* arg = fun->nthArgument(i);
       if(arg->isVar() || !domainConstants.contains(arg->term()))
         USER_ERROR("Expect term on left of definition to be grounded with domain constants");
-      args_and_val[i] = domainConstantNumber.get(arg->term());
+      args[i] = domainConstantNumber.get(arg->term());
     }
-    args_and_val[arity] = res;
-    model.addFunctionDefinition(f,args_and_val);
+    model.addFunctionDefinition(f,args,res);
   }else{
     // not sure this makes sense but...
     if(!lit->polarity()) negated=!negated;

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -21,6 +21,7 @@
 #include "Lib/DHMap.hpp"
 #include "Lib/Set.hpp"
 #include "Lib/Environment.hpp"
+#include "Lib/StringUtils.hpp"
 
 #include "Kernel/Problem.hpp"
 #include "Kernel/Unit.hpp"
@@ -29,11 +30,13 @@
 
 #include "FiniteModel.hpp"
 
-
 namespace FMB{
 
 using namespace Lib;
 using namespace Kernel;
+
+using std::cout;
+using std::endl;
 
 class ModelCheck{
 
@@ -46,6 +49,7 @@ static void doCheck(UnitList* units)
   // TODO search for something of the right shape
   unsigned modelSize = 0;
   Set<Term*> domainConstants;
+  // first just search for finite_domain axiom (TODO: do this for every sort!)
   {
     UnitList::Iterator uit(units);
     while(uit.hasNext()){
@@ -53,8 +57,8 @@ static void doCheck(UnitList* units)
       if(u->inputType()!= UnitInputType::MODEL_DEFINITION) continue;
       std::string name;
       ALWAYS(Parse::TPTP::findAxiomName(u,name));
-      if(name == "finite_domain"){
-        //std::cout << "Finite domain axiom found:" << std::endl << u->toString() << std::endl;
+      if(StringUtils::starts_with(name,"finite_domain")){
+        // std::cout << "Finite domain axiom found:" << std::endl << u->toString() << std::endl;
         // Set model size and domainConstants
         // And check it is a finite domain axiom
         if(u->isClause()){
@@ -108,11 +112,11 @@ static void doCheck(UnitList* units)
       if(u->inputType()!= UnitInputType::MODEL_DEFINITION) continue;
       std::string name;
       ALWAYS(Parse::TPTP::findAxiomName(u,name));
-      if(name == "finite_domain" || name == "distinct_domain") continue;
+      if(StringUtils::starts_with(name,"finite_domain") || StringUtils::starts_with(name,"distinct_domain")) continue;
 
       // All model formulas should be conjunctions of definitions
       // TODO allow for unit clause definitions in the future
-      if(u->isClause()) USER_ERROR("Expecting model to use formulas i.e. fof");
+      if(u->isClause()) USER_ERROR("Expecting model to use formulas i.e. fof/tff");
       Formula* formula = u->getFormula();
 
       if(formula->connective()==Connective::NOT){
@@ -184,8 +188,6 @@ static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domain
             if(domainConstants.contains(constant)) USER_ERROR("finite_domain is not a domain axiom");
 
             domainConstants.insert(constant);
-
-
 }
 
 static void addDefinition(FiniteModel& model,Literal* lit,bool negated,

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -92,18 +92,20 @@ static void doCheck(UnitList* units)
   std::cout << "Detected model of size " << modelSize << std::endl;
   std::cout << "Distinct domain assumed, domain elements are:" << std::endl;
 
+  std::cout << "Loading model..." << std::endl;
+  FiniteModel model(modelSize);
+
   // number the domain constants
   DHMap<Term*,unsigned> domainConstantNumber;
   Set<Term*>::Iterator dit(domainConstants);
   unsigned count=1;
-  while(dit.hasNext()){ 
+  while(dit.hasNext()){
     Term* con = dit.next();
-    std::cout << con->toString() << std::endl; 
-    domainConstantNumber.insert(con,count++); 
+    std::cout << con->toString() << std::endl;
+    domainConstantNumber.insert(con,count);
+    model.addConstantDefinition(con->functor(),count);
+    count++;
   }
-
-  std::cout << "Loading model..." << std::endl;
-  FiniteModel model(modelSize);
 
   {
     UnitList::Iterator uit(units);

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -173,6 +173,7 @@ static void doCheck(UnitList* units)
     std::cout << "Model loaded" << std::endl;
     std::cout << "Checking formulas..." << std::endl;
     {
+      bool allTrue = true;
       UnitList::Iterator uit(units);
       while(uit.hasNext()){
         Unit* u = uit.next();
@@ -180,7 +181,13 @@ static void doCheck(UnitList* units)
 
         std::cout << "Checking " << u->toString() << "..." << std::endl;
         bool res = model.evaluate(u);
+        allTrue &= res;
         std::cout << "Evaluates to " << (res ? "True" : "False") << std::endl;
+      }
+      if (allTrue) {
+        std::cout << "All formulas evaluated to True!" << std::endl;
+      } else {
+        std::cout << "There was a false formula!" << std::endl;
       }
     }
   }

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -169,7 +169,7 @@ bool Monotonicity::guards(Literal* l, unsigned var, Stack<SATLiteral>& slits)
 
 
 void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<bool>& del_f,
-  DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts) // may write into this
+  DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_predicates) // may write into these
 {
   // First compute the monotonic sorts
   DArray<bool> isMonotonic(env.signature->typeCons());
@@ -197,6 +197,7 @@ void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const D
       unsigned p = env.signature->addFreshPredicate(1,name.c_str());
       env.signature->getPredicate(p)->setType(OperatorType::getPredicateType({TermList(AtomicSort::createConstant(s))}));
       sortPredicates[s] = p;
+      sort_predicates.push(p);
 
       auto monot_info = new DArray<signed char>(env.signature->predicates());
       // when adding sort predicate, we assume all predicates false-extended
@@ -329,7 +330,7 @@ public:
 };
 
 void Monotonicity::addSortFunctions(bool withMon, ClauseList*& clauses,
-  DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts) // may write into this
+  DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_functions) // may write into these
 {
   // First compute the monotonic sorts
   DArray<bool> isMonotonic(env.signature->typeCons());
@@ -360,6 +361,7 @@ void Monotonicity::addSortFunctions(bool withMon, ClauseList*& clauses,
       // increment usage count so not treated as deleted
       env.signature->getFunction(f)->incUsageCnt();
       sortFunctions[s] = f;
+      sort_functions.push(f);
 
       auto monot_info = new DArray<signed char>(env.signature->predicates());
       // when adding sort functions, we assume all predicates copy-extended

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -168,7 +168,7 @@ bool Monotonicity::guards(Literal* l, unsigned var, Stack<SATLiteral>& slits)
 }
 
 
-void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f,
+void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<bool>& del_f,
   DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts) // may write into this
 {
   // First compute the monotonic sorts

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -74,8 +74,8 @@ DArray<signed char>* Monotonicity::check() {
   DArray<signed char>* res = new DArray<signed char>(env.signature->predicates());
   (*res)[0] = 0; // pick a value for the 0-th = predicate (we don't really care here)
   for(unsigned p=1;p<env.signature->predicates();p++){
-    bool trueExt = _solver->getAssignment(_pT.get(p).var());
-    bool falseExt = _solver->getAssignment(_pF.get(p).var());
+    bool trueExt = _solver->trueInAssignment(_pT.get(p));
+    bool falseExt = _solver->trueInAssignment(_pF.get(p));
     ASS(!trueExt || !falseExt)
     (*res)[p] = trueExt ? 1 : (falseExt ? -1 : 0);
   }

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -154,7 +154,7 @@ bool Monotonicity::guards(Literal* l, unsigned var, Stack<SATLiteral>& slits)
 }
 
 
-void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, DArray<unsigned>& del_f)
+void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f)
 {
   // First compute the monotonic sorts
   DArray<bool> isMonotonic(env.signature->typeCons());

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -132,8 +132,8 @@ void Monotonicity::safe(Clause* c, Literal* parent, TermList* t,Stack<SATLiteral
           // if guards returns true it means true will be added to the clause
           // so don't bother creating it
           return;
-        } 
-      } 
+        }
+      }
       _solver->addClause(SATClause::fromStack(slits));
     }
   }
@@ -178,8 +178,9 @@ void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const D
        if(withMon){
          Monotonicity m(clauses,s);
          auto monot_info = m.check();
-         isMonotonic[s] = (bool)monot_info;
-         ALWAYS(monotonic_vampire_sorts.insert(s,monot_info));
+         if ((isMonotonic[s] = (bool)monot_info)) {
+           ALWAYS(monotonic_vampire_sorts.insert(s,monot_info));
+         }
        }
        else{
         isMonotonic[s] = false;
@@ -337,8 +338,9 @@ void Monotonicity::addSortFunctions(bool withMon, ClauseList*& clauses,
        if(withMon){
          Monotonicity m(clauses,s);
          auto monot_info = m.check();
-         isMonotonic[s] = (bool)monot_info;
-         ALWAYS(monotonic_vampire_sorts.insert(s,monot_info));
+         if ((isMonotonic[s] = (bool)monot_info)) {
+           ALWAYS(monotonic_vampire_sorts.insert(s,monot_info));
+         }
        }
        else{
         isMonotonic[s] = false;

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -54,9 +54,9 @@ public:
   DArray<signed char>* check();
 
   static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<bool>& del_f,
-    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts);
+    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_predicates);
   static void addSortFunctions(bool withMon, ClauseList*& clauses,
-    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts);
+    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_functions);
 
 private:
   void monotone(Clause* c, Literal* l);

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -49,12 +49,14 @@ public:
    *
    * If the answer is positive, it will allocate a DArray to store
    * for every predicate symbol whether it should be treated (in sort srt)
-   * as false-extened (-1), copy-extended (0), or true-extended (+1).
+   * as false-extended (-1), copy-extended (0), or true-extended (+1).
    */
   DArray<signed char>* check();
 
-  static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f);
-  static void addSortFunctions(bool withMon, ClauseList*& clauses);
+  static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f,
+    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts);
+  static void addSortFunctions(bool withMon, ClauseList*& clauses,
+    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts);
 
 private:
   void monotone(Clause* c, Literal* l);

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -44,26 +44,31 @@ public:
   // Assumes clauses are flattened
   Monotonicity(ClauseList* clauses, unsigned srt);
 
-  bool check(){ return _result;}
+  /**
+   * Returns nullptr if not monotone.
+   *
+   * If the answer is positive, it will allocate a DArray to store
+   * for every predicate symbol whether it should be treated (in sort srt)
+   * as false-extened (-1), copy-extended (0), or true-extended (+1).
+   */
+  DArray<signed char>* check();
 
   static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f);
   static void addSortFunctions(bool withMon, ClauseList*& clauses);
 
 private:
-  
-  void monotone(Clause* c, Literal* l); 
-  
-  void safe(Clause* c, Literal* l, TermList* t); 
-  void safe(Clause* c, Literal* l, TermList* t, SATLiteral add); 
+  void monotone(Clause* c, Literal* l);
+
+  void safe(Clause* c, Literal* l, TermList* t);
+  void safe(Clause* c, Literal* l, TermList* t, SATLiteral add);
   void safe(Clause* c, Literal* l, TermList* t, Stack<SATLiteral>& slits);
 
   // returns true if the true literal should be added to slits
   // returns false otherwise (if false should be added or something else has been added)
   bool guards(Literal* l, unsigned var, Stack<SATLiteral>& slits);
 
- 
-  unsigned _srt; 
-  
+  unsigned _srt;
+
   // the constructor computes the result
   bool _result;
 
@@ -71,7 +76,6 @@ private:
   DHMap<unsigned,SATLiteral> _pT;
 
   ScopedPtr<SATSolver> _solver;
-
 };
 
 }

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -53,7 +53,7 @@ public:
    */
   DArray<signed char>* check();
 
-  static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f,
+  static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<bool>& del_f,
     DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts);
   static void addSortFunctions(bool withMon, ClauseList*& clauses,
     DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts);

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -46,7 +46,7 @@ public:
 
   bool check(){ return _result;}
 
-  static void addSortPredicates(bool withMon, ClauseList*& clauses, DArray<unsigned>& del_f);
+  static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<unsigned>& del_f);
   static void addSortFunctions(bool withMon, ClauseList*& clauses);
 
 private:

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -51,8 +51,6 @@ using namespace std;
  */
 void SortInference::doInference()
 {
-  bool _print = env.options->showFMBsortInfo();
-
   if(_ignoreInference){
 #if DEBUG_SORT_INFERENCE
    cout << "Ignoring sort inference..." << endl;

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -180,11 +180,13 @@ void SortInference::doInference()
         bool monotonic = _assumeMonotonic;
         if(!monotonic){
           Monotonicity m(_clauses,s);
-          monotonic = m.check();
+          auto monot_info = m.check();
+          if (monot_info) {
+            _monotonic_vampire_sorts.insert(s,monot_info);
+          }
         }
-        if(monotonic){
-          _monotonicVampireSorts.insert(s);
-        }
+        // if we didn't just add the monot_info, it should have been there already from the _assumeMonotonic branch
+        ASS(!monotonic || _monotonic_vampire_sorts.findPtr(s))
         if(_print){
           if(monotonic && !_assumeMonotonic){
             cout << "Input sort " << env.signature->typeConName(s) << " is monotonic" << endl;
@@ -831,7 +833,7 @@ unsigned SortInference::getDistinctSort(unsigned subsort, unsigned realVampireSo
   //cout << "CREATE " << subsort << "," << env.sorts->sortName(realVampireSort) << endl;
   ASS(createNew);
 
-  if(_monotonicVampireSorts.contains(vampireSort)){
+  if(_monotonic_vampire_sorts.findPtr(vampireSort)){
     if(_collapsingMonotonicSorts){
       _collapsed++;
       if(firstMonotonicSortSeen){

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -39,7 +39,7 @@
 #define DEBUG_SORT_INFERENCE 0
 
 
-namespace FMB 
+namespace FMB
 {
 
 using namespace std;
@@ -147,10 +147,10 @@ void SortInference::doInference()
       unsigned arity = env.signature->functionArity(f);
       OperatorType* ftype = env.signature->getFunction(f)->fnType();
       _sig->functionSignatures[f].ensure(arity+1);
-      for(unsigned i=0;i<arity;i++){ 
+      for(unsigned i=0;i<arity;i++){
         TermList argTypeT = ftype->arg(i);
         unsigned argType = argTypeT.term()->functor();
-        _sig->functionSignatures[f][i]=(*_sig->vampireToDistinct.get(argType))[0]; 
+        _sig->functionSignatures[f][i]=(*_sig->vampireToDistinct.get(argType))[0];
       }
       TermList resTypeT = ftype->result();
       unsigned resType = resTypeT.term()->functor();
@@ -162,27 +162,13 @@ void SortInference::doInference()
       unsigned arity = env.signature->predicateArity(p);
       OperatorType* ptype = env.signature->getPredicate(p)->predType();
       _sig->predicateSignatures[p].ensure(arity);
-      for(unsigned i=0;i<arity;i++){ 
+      for(unsigned i=0;i<arity;i++){
         TermList argTypeT = ptype->arg(i);
         unsigned argType = argTypeT.term()->functor();
-        _sig->predicateSignatures[p][i]=(*_sig->vampireToDistinct.get(argType))[0]; 
+        _sig->predicateSignatures[p][i]=(*_sig->vampireToDistinct.get(argType))[0];
       }
     }
     return;
-  }
-
-
-  // Add _equiv_v_sorts to a useful structure
-  {
-    Stack<DHSet<unsigned>*>::Iterator it(_equiv_v_sorts);
-    while(it.hasNext()){
-      DHSet<unsigned>* cls = it.next();
-      unsigned el = cls->getOneKey();
-      DHSet<unsigned>::Iterator els(*cls);
-      while(els.hasNext()){
-        _equiv_vs.doUnion(el,els.next());
-      } 
-    }
   }
 
   // Monotoniticy Detection
@@ -246,7 +232,7 @@ void SortInference::doInference()
 
   while(cit.hasNext()){
    Clause* c = cit.next();
-  
+
 #if DEBUG_SORT_INFERENCE
    cout << "CLAUSE " << c->toString() << endl;
 #endif
@@ -254,14 +240,14 @@ void SortInference::doInference()
   Array<Stack<unsigned>> varPositions(c->varCnt());
   ZIArray<unsigned> varsWithPosEq(c->varCnt());
   IntUnionFind localUF(c->varCnt()+1); // +1 to avoid it being 0.. last pos will not be used
-   
+
   // When scanning the clause, keep info about whether it could be of the form C : X = t_1 | ... | X = t_n , where t_i may be a variable as well
   // (however, we can't have X \in \Vars(t_i): think of the unit clause X = f(X) which does not restrict the domain size to 1)
   // If the first literal is X = Y we remember X in v[0] and Y in v[1], subsequent literals will be different and only at most one candidate for "X" will remain
   // Any literal of the form X = nonvar reduces the num_vars_consdired to 1 or 0 (depending on whether X is possibly one of the two vars we keep track of)
   unsigned v[2];
   short unsigned num_vars_always_in_equalities = 3; // 3 means we are still open to the possibility of assigning both v1 and v2, but they are uninitialized at the moment
-   
+
   for(unsigned i=0;i<c->length();i++){
     Literal* l = (*c)[i];
     if(l->isEquality()) {
@@ -280,18 +266,18 @@ void SortInference::doInference()
             if (l->nthArgument(i)->isVar() && !l->nthArgument(1-i)->containsSubterm(*l->nthArgument(i))) {
               unsigned var = l->nthArgument(i)->var();
               if (v[0] == var) {
-                num_vars_always_in_equalities = 1; 
+                num_vars_always_in_equalities = 1;
                 break; // and we are done
-              } 
+              }
               if (v[1] == var) {
                 v[0] = var;
-                num_vars_always_in_equalities = 1; 
+                num_vars_always_in_equalities = 1;
                 break; // and we are done
-              } 
+              }
               // this side is a completely different var (than v[0] or v[1])
             }
           }
-          if (num_vars_always_in_equalities == 2) { 
+          if (num_vars_always_in_equalities == 2) {
             // we didn't succeed for either side, so it's over for this clause
             num_vars_always_in_equalities = 0;
           }
@@ -301,8 +287,8 @@ void SortInference::doInference()
             if (l->nthArgument(i)->isVar() && !l->nthArgument(1-i)->containsSubterm(*l->nthArgument(i))) {
               if (v[0] == l->nthArgument(i)->var()) {
                 found = true;
-                break; 
-              } 
+                break;
+              }
               // this side is a different var than v[0]
             }
           }
@@ -311,7 +297,7 @@ void SortInference::doInference()
           }
         }
       } else {
-        num_vars_always_in_equalities = 0; 
+        num_vars_always_in_equalities = 0;
       }
 
       if(l->isTwoVarEquality()) {
@@ -327,7 +313,7 @@ void SortInference::doInference()
           cout << "varsWithPosEq X" << l->nthArgument(0)->var() << endl;
           cout << "varsWithPosEq X" << l->nthArgument(1)->var() << endl;
 #endif
-        }         
+        }
       } else {
         ASS(!l->nthArgument(0)->isVar());
         ASS(l->nthArgument(1)->isVar());
@@ -375,7 +361,7 @@ void SortInference::doInference()
      // If so, the first literal can be used to find the sort of X
      //  - if it is a two var equality we take the sort
      //  - otherwise, it will be of the form X = t and we get the sort of t
-     unsigned sort = SortHelper::getEqualityArgumentSort((*c)[0]).term()->functor();     
+     unsigned sort = SortHelper::getEqualityArgumentSort((*c)[0]).term()->functor();
      unsigned max = c->length();
      unsigned old;
      // set the new max if it is smaller than an existing max
@@ -459,7 +445,7 @@ void SortInference::doInference()
     if(f < _del_f.size() && _del_f[f]) continue;
 
     unsigned offset = offset_f[f];
-    unsigned arity = env.signature->functionArity(f); 
+    unsigned arity = env.signature->functionArity(f);
     int root = unionFind.root(offset);
     unsigned rangeSort;
     if(!translate.find(root,rangeSort)){
@@ -577,7 +563,7 @@ void SortInference::doInference()
 #endif
     // fresh constants are introduced for sorts with no constants
     // but that have function symbols, therefore these sorts cannot
-    // be bounded 
+    // be bounded
     // We need to treat them specially as they are functions that are added
     // after we do sort inference (so offsets/positions do not apply)
     if(f >= firstFreshConstant){
@@ -712,7 +698,7 @@ void SortInference::doInference()
 #if DEBUG_SORT_INFERENCE
       cout << argSort << " ";
 #endif
-    }    
+    }
 #if DEBUG_SORT_INFERENCE
    cout << "("<< offset_p[p] << ")"<< endl;
 #endif
@@ -734,7 +720,7 @@ void SortInference::doInference()
       _sig->vampireToDistinct.insert(vsort,stack);
       _sig->vampireToDistinctParent.insert(vsort,dsort);
     }
-  } 
+  }
   // allocate an extra sort per disinct sort for variable equalities
   _sig->varEqSorts.ensure(_distinctSorts);
   _sig->sortBounds.expand(_sig->sorts+_distinctSorts);
@@ -756,17 +742,17 @@ void SortInference::doInference()
     for(unsigned s=0;s<_sig->distinctSorts;s++){
       unsigned children =0;
       std::string res="";
-      for(unsigned i=0;i<_sig->sorts;i++){ 
+      for(unsigned i=0;i<_sig->sorts;i++){
         if(_sig->parents[i]==s){
           if(children>0) res+=",";
           res+=Lib::Int::toString(i);
-          children++; 
+          children++;
         }
       }
       cout << s << " has " << children << " inferred subsorts as members [" << res << "]" << endl;
     }
     cout << "Vampire to distinct sort mapping:" << endl;
-    cout << "["; 
+    cout << "[";
     for(unsigned i=0;i<_sig->distinctSorts;i++){
 
       Stack<unsigned>* vs = _sig->distinctToVampire.get(i);
@@ -784,7 +770,7 @@ void SortInference::doInference()
       if(!_sig->vampireToDistinct.find(s)){ continue; }
 
       // make sure it has a parent
-      if(!_sig->vampireToDistinctParent.find(s)){ 
+      if(!_sig->vampireToDistinctParent.find(s)){
 
         ASS(!_sig->vampireToDistinct.get(s)->isEmpty());
 
@@ -794,14 +780,14 @@ void SortInference::doInference()
       }
       // add those constraints between children and parent
       unsigned parent = _sig->vampireToDistinctParent.get(s);
-#if DEBUG_SORT_INFERENCE 
+#if DEBUG_SORT_INFERENCE
       cout << "Parent " << parent << " for " << env.signature->typeConName(s) << endl;
 #endif
       Stack<unsigned>::Iterator children(*_sig->vampireToDistinct.get(s));
       while(children.hasNext()){
         unsigned child = children.next();
         if(child==parent) continue;
-#if DEBUG_SORT_INFERENCE 
+#if DEBUG_SORT_INFERENCE
         cout << "Child " << child << " for " << env.signature->typeConName(s) << endl;
 #endif
         _sort_constraints.push(make_pair(parent,child));

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -664,9 +664,9 @@ void SortInference::doInference()
 #if DEBUG_SORT_INFERENCE
     cout << env.signature->predicateName(p) << " : ";
 #endif
-    //cout << env.signature->predicateName(p) <<" : "; 
+    //cout << env.signature->predicateName(p) <<" : ";
     unsigned arity = env.signature->predicateArity(p);
-    // Now set _signatures 
+    // Now set _signatures
     _sig->predicateSignatures[p].ensure(arity);
 
     Signature::Symbol* prSym = env.signature->getPredicate(p);

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -855,21 +855,6 @@ unsigned SortInference::getDistinctSort(unsigned subsort, unsigned realVampireSo
       }
       _sig->monotonicSorts[ourSort]=true;
     }
-    else if(!_expandSubsorts && (unsigned)_equiv_vs.root(vampireSort)!=vampireSort){
-      unsigned rootSort = _equiv_vs.root(vampireSort);
-      if(!ourDistinctSorts.find(rootSort,ourSort)){
-          ourSort = _distinctSorts++;
-          if(!_sig->distinctToVampire.find(ourSort)){
-            _sig->distinctToVampire.insert(ourSort,new Stack<unsigned>());
-          }
-          ourDistinctSorts.insert(rootSort,ourSort);
-          _sig->distinctToVampire.get(ourSort)->push(rootSort);
-          if(!_sig->vampireToDistinct.find(rootSort)){
-            _sig->vampireToDistinct.insert(rootSort,new Stack<unsigned>());
-          }
-          _sig->vampireToDistinct.get(rootSort)->push(ourSort);
-      }
-    }
    else ourSort = _distinctSorts++;
 
    ourDistinctSorts.insert(vampireSort,ourSort);

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -76,8 +76,8 @@ struct SortedSignature{
 class SortInference {
 public:
   SortInference(ClauseList* clauses,
-                const DArray<unsigned>& del_f,
-                const DArray<unsigned>& del_p,
+                const DArray<bool>& del_f,
+                const DArray<bool>& del_p,
                 Stack<std::pair<unsigned,unsigned>>& distinct_sort_constraints,
                 DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
@@ -126,8 +126,8 @@ private:
 
   SortedSignature* _sig;
   ClauseList* _clauses;
-  const DArray<unsigned>& _del_f;
-  const DArray<unsigned>& _del_p;
+  const DArray<bool>& _del_f;
+  const DArray<bool>& _del_p;
 
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
   DHMap<unsigned,DArray<signed char>*>& _monotonic_vampire_sorts;

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -76,8 +76,8 @@ struct SortedSignature{
 class SortInference {
 public:
   SortInference(ClauseList* clauses,
-                DArray<unsigned> del_f,
-                DArray<unsigned> del_p,
+                const DArray<unsigned>& del_f,
+                const DArray<unsigned>& del_p,
                 Stack<std::pair<unsigned,unsigned>>& cons) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
                 _sort_constraints(cons) {
@@ -124,8 +124,8 @@ private:
 
   SortedSignature* _sig;
   ClauseList* _clauses;
-  DArray<unsigned> _del_f;
-  DArray<unsigned> _del_p;
+  const DArray<unsigned>& _del_f;
+  const DArray<unsigned>& _del_p;
 
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
 };

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -78,9 +78,9 @@ public:
   SortInference(ClauseList* clauses,
                 const DArray<unsigned>& del_f,
                 const DArray<unsigned>& del_p,
-                Stack<std::pair<unsigned,unsigned>>& cons) :
+                Stack<std::pair<unsigned,unsigned>>& distinct_sort_constraints) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
-                _sort_constraints(cons) {
+                _sort_constraints(distinct_sort_constraints) { // this is essentially an output argument; TODO: what's the spec?
 
                   _sig = new SortedSignature();
                   _print = env.options->showFMBsortInfo();

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -43,7 +43,7 @@ struct SortedSignature{
 
     // gives the maximum size of a sort
     DArray<unsigned> sortBounds;
-    
+
     // the number of distinct sorts that might have different sizes
     unsigned distinctSorts;
 
@@ -88,25 +88,25 @@ public:
                   _print = env.options->showFMBsortInfo();
 
                    // ignore inference if there are no clauses
-                  _ignoreInference = !clauses; 
+                  _ignoreInference = !clauses;
                   _expandSubsorts = env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::EXPAND;
 
                   _usingMonotonicity = true;
-                  _collapsingMonotonicSorts = (env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::OFF && 
+                  _collapsingMonotonicSorts = (env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::OFF &&
                                                env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::EXPAND);
-                  _assumeMonotonic = _collapsingMonotonicSorts && 
+                  _assumeMonotonic = _collapsingMonotonicSorts &&
                                      env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::GROUP;
 
                   _distinctSorts=0;
                   _collapsed=0;
 
                   ASS(! (_expandSubsorts && _collapsingMonotonicSorts) );
-                  ASS( _collapsingMonotonicSorts || !_assumeMonotonic); 
+                  ASS( _collapsingMonotonicSorts || !_assumeMonotonic);
                 }
 
-   void doInference();                
+   void doInference();
 
-   SortedSignature* getSignature(){ return _sig; } 
+   SortedSignature* getSignature(){ return _sig; }
 
 private:
 

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -129,6 +129,8 @@ private:
   const DArray<bool>& _del_f;
   const DArray<bool>& _del_p;
 
+  // these two actually live in FiniteModelBuilder and serve as output arguments of this sort inference
+  // (see more explanations there)
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
   DHMap<unsigned,DArray<signed char>*>& _monotonic_vampire_sorts;
 };

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -13,7 +13,7 @@
  *
  *
  * NOTE: An important convention to remember is that when we have a DArray representing
- *       the signature or grounding of a function the lastt argument is the return
+ *       the signature or grounding of a function the last argument is the return
  *       so array[arity] is return and array[i] is the ith argument of the function
  */
 
@@ -78,10 +78,9 @@ public:
   SortInference(ClauseList* clauses,
                 DArray<unsigned> del_f,
                 DArray<unsigned> del_p,
-                Stack<DHSet<unsigned>*> equiv_v_sorts,
                 Stack<std::pair<unsigned,unsigned>>& cons) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
-                _equiv_v_sorts(equiv_v_sorts), _equiv_vs(env.signature->typeCons()),
+                _equiv_vs(env.signature->typeCons()),
                 _sort_constraints(cons) {
 
                   _sig = new SortedSignature();
@@ -128,11 +127,9 @@ private:
   ClauseList* _clauses;
   DArray<unsigned> _del_f;
   DArray<unsigned> _del_p;
-  Stack<DHSet<unsigned>*> _equiv_v_sorts;
   IntUnionFind _equiv_vs;
 
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
-
 };
 
 }

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -119,8 +119,8 @@ private:
 
   unsigned _distinctSorts;
   unsigned _collapsed;
-  DHSet<unsigned> monotonicVampireSorts;
-  ZIArray<unsigned> posEqualitiesOnSort;
+  DHSet<unsigned> _monotonicVampireSorts;
+  ZIArray<unsigned> _posEqualitiesOnSort;  // grows as needed, as new sorts are named
 
   SortedSignature* _sig;
   ClauseList* _clauses;

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -80,7 +80,6 @@ public:
                 DArray<unsigned> del_p,
                 Stack<std::pair<unsigned,unsigned>>& cons) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
-                _equiv_vs(env.signature->typeCons()),
                 _sort_constraints(cons) {
 
                   _sig = new SortedSignature();
@@ -127,7 +126,6 @@ private:
   ClauseList* _clauses;
   DArray<unsigned> _del_f;
   DArray<unsigned> _del_p;
-  IntUnionFind _equiv_vs;
 
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
 };

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -78,10 +78,13 @@ public:
   SortInference(ClauseList* clauses,
                 const DArray<unsigned>& del_f,
                 const DArray<unsigned>& del_p,
-                Stack<std::pair<unsigned,unsigned>>& distinct_sort_constraints) :
+                Stack<std::pair<unsigned,unsigned>>& distinct_sort_constraints,
+                DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
-                _sort_constraints(distinct_sort_constraints) { // this is essentially an output argument; TODO: what's the spec?
-
+                // these two are essentially output arguments
+                _sort_constraints(distinct_sort_constraints),
+                _monotonic_vampire_sorts(monotonic_vampire_sorts)
+                {
                   _sig = new SortedSignature();
                   _print = env.options->showFMBsortInfo();
 
@@ -119,7 +122,6 @@ private:
 
   unsigned _distinctSorts;
   unsigned _collapsed;
-  DHSet<unsigned> _monotonicVampireSorts;
   ZIArray<unsigned> _posEqualitiesOnSort;  // grows as needed, as new sorts are named
 
   SortedSignature* _sig;
@@ -128,6 +130,7 @@ private:
   const DArray<unsigned>& _del_p;
 
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
+  DHMap<unsigned,DArray<signed char>*>& _monotonic_vampire_sorts;
 };
 
 }

--- a/Inferences/GlobalSubsumption.cpp
+++ b/Inferences/GlobalSubsumption.cpp
@@ -161,7 +161,7 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
   // check for subsuming clause by looking for a proper subset of used assumptions
   SATSolver::Status res = solver.solveUnderAssumptions(assumps, _uprOnly, true /* only proper subsets */);
 
-  if (res == SATSolver::UNSATISFIABLE) {
+  if (res == SATSolver::Status::UNSATISFIABLE) {
     // it should always be UNSAT with full assumps,
     // but we may not get that far with limited solving power (_uprOnly)
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -563,13 +563,13 @@ Option<Substitution> TheoryInstAndSimp::instantiateGeneralised(
     }
 
     DEBUG_CODE(auto res =) _solver->solveUnderAssumptions(theoryLits, 0, false);
-    ASS_EQ(res, SATSolver::UNSATISFIABLE)
+    ASS_EQ(res, SATSolver::Status::UNSATISFIABLE)
 
     Set<TermList> usedDefs;
     for (auto& x : _solver->failedAssumptions()) {
       definitionLiterals
         .tryGet(x)
-        .andThen([&](TermList t) 
+        .andThen([&](TermList t)
             { usedDefs.insert(t); });
     }
 
@@ -650,13 +650,13 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*> const&
   // now we can call the solver
   SATSolver::Status status = _solver->solveUnderAssumptions(skolemized.lits, 0, false);
 
-  if(status == SATSolver::UNSATISFIABLE) {
+  if(status == SATSolver::Status::UNSATISFIABLE) {
     DEBUG("unsat")
     return pvi(getSingletonIterator(Solution::unsat()));
 
-  } else if(status == SATSolver::SATISFIABLE) {
+  } else if(status == SATSolver::Status::SATISFIABLE) {
     DEBUG("found model: ", _solver->getModel())
-    auto subst = _generalisation ? instantiateGeneralised(skolemized, freshVar) 
+    auto subst = _generalisation ? instantiateGeneralised(skolemized, freshVar)
                                  : instantiateWithModel(skolemized);
     if (subst.isSome()) {
       return pvi(getSingletonIterator(Solution(std::move(subst).unwrap())));
@@ -720,7 +720,7 @@ struct InstanceFn
         auto skolem = parent->skolemize(iterTraits(invertedLits.iterFifo() /* without guards !! */));
         auto status = parent->_solver->solveUnderAssumptions(skolem.lits, 0, false);
         // we have an unsat solution without guards
-        redundant = status == SATSolver::UNSATISFIABLE;
+        redundant = status == SATSolver::Status::UNSATISFIABLE;
       }
 
       if (redundant) {

--- a/Kernel/OperatorType.hpp
+++ b/Kernel/OperatorType.hpp
@@ -31,25 +31,25 @@
 namespace Kernel {
 
 /**
- * The OperatorType class represents the predicate and function types 
+ * The OperatorType class represents the predicate and function types
  * the only difference between the two is that a predicate type has return type
  * $o whilst a function type has any other return type.
  *
  * The class can be used to store polymorphic types which are of the form:
- * !>[alpha_0, ..., alpha_m](sort1 * ... * sortn) > return_sort where sorts can only contain variables 
+ * !>[alpha_0, ..., alpha_m](sort1 * ... * sortn) > return_sort where sorts can only contain variables
  * from  in {alpha_0,...,alpha_m}. View "A Polymorphic Vampire" for more details:
  *
  * https://link.springer.com/chapter/10.1007/978-3-030-51054-1_21
  *
- * The class stores data in a Vector<TermList>*, of length 
+ * The class stores data in a Vector<TermList>*, of length
  * num_of_arg_sorts + 1. The number of bound variables is stored in
  * a field _typeArgsArity. It is assumed that the bound variables range from
  * 0 to _typeArgsArity - 1. In order for this assumption to be valid all sorts must
- * normalised (view SortHelper::normaliseArgSorts) before being passed to a type forming 
+ * normalised (view SortHelper::normaliseArgSorts) before being passed to a type forming
  * function.
  *
  * The objects of this class are perfectly shared (so that equal predicate / function types correspond to equal pointers)
- * and are obtained via static methods (to guarantee the sharing). 
+ * and are obtained via static methods (to guarantee the sharing).
  */
 class OperatorType
 {
@@ -60,7 +60,7 @@ public:
     { return (*t1) == (*t2); }
 
     static unsigned hash(OperatorType* ot)
-    { 
+    {
       OperatorKey& key = *ot->key();
       unsigned typeArgsArity = ot->numTypeArguments();
       return HashUtils::combine(
@@ -74,7 +74,7 @@ private:
   typedef Vector<TermList> OperatorKey; // Vector of argument sorts together with "0" appended for predicates and resultSort appended for functions
   OperatorKey* _key;
   unsigned _typeArgsArity; /** number of quantified variables of this type */
- 
+
   // constructors kept private
   OperatorType(OperatorKey* key, unsigned vLength) : _key(key), _typeArgsArity(vLength) {}
 
@@ -94,7 +94,7 @@ public:
   ~OperatorType() { _key->deallocate(); }
 
   inline bool operator==(const OperatorType& t) const
-  { return  *_key==*t._key && 
+  { return  *_key==*t._key &&
              _typeArgsArity==t._typeArgsArity; }
 
   static OperatorType* getPredicateType(unsigned arity, const TermList* sorts=0, unsigned taArity = 0) {
@@ -138,14 +138,14 @@ public:
    * Constants are function symbols of 0 arity, so just provide the result sort.
    */
   static OperatorType* getConstantsType(TermList resultSort, unsigned taArity = 0) {
-    return getFunctionType(0,nullptr,resultSort, taArity); 
+    return getFunctionType(0,nullptr,resultSort, taArity);
   }
 
   /**
    * Convenience function for creating OperatorType for type constructors.
    */
   static OperatorType* getTypeConType(unsigned arity) {
-    return getFunctionTypeUniformRange(arity, AtomicSort::superSort(), AtomicSort::superSort()); 
+    return getFunctionTypeUniformRange(arity, AtomicSort::superSort(), AtomicSort::superSort());
   }
 
   OperatorKey* key() const { return _key; }
@@ -172,7 +172,7 @@ public:
   {
     if(idx < _typeArgsArity){
       return AtomicSort::superSort();
-    } 
+    }
     return (*_key)[idx - _typeArgsArity];
   }
 
@@ -188,8 +188,8 @@ public:
   TermList result() const {
     return (*_key)[arity() - numTypeArguments()];
   }
-  
-  std::string toString() const;  
+
+  std::string toString() const;
 
   bool isSingleSortType(TermList sort) const;
   bool isAllDefault() const { return isSingleSortType(AtomicSort::defaultSort()); }

--- a/Kernel/Problem.hpp
+++ b/Kernel/Problem.hpp
@@ -191,7 +191,7 @@ private:
   UnitList* _units;
   DHMap<unsigned,Literal*> _deletedFunctions;
   DHMap<unsigned,Unit*> _deletedPredicates;
-  DHMap<unsigned,Unit*> _partiallyDeletedPredicates; 
+  DHMap<unsigned,Unit*> _partiallyDeletedPredicates;
   ScopedPtr<FunctionDefinitionHandler> _fnDefHandler;
 
   bool _hadIncompleteTransformation;

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -991,7 +991,7 @@ private:
    * If the term algebra is polymorphic, it contains the general type, ctors, dtors, etc.
    * For a term algebra instance, this map gives the general term algebra based on the top-level
    * functor of its sort, the ctors and dtors still have to be instantiated to the right instances.
-   */ 
+   */
   DHMap<unsigned, Shell::TermAlgebra*> _termAlgebras;
 
   //TODO Why are these here? They are not used anywhere. AYB

--- a/Lib/DArray.hpp
+++ b/Lib/DArray.hpp
@@ -122,7 +122,7 @@ public:
 
     _size = s;
   }
-  
+
   inline bool operator==(const DArray& o) const
   {
     if(size()!=o.size()) { return false; }
@@ -141,8 +141,6 @@ public:
 
   inline C* begin() { return _array; }
   inline C* end() { return _array+_size; }
-
-
 
   /**
    * Set array's size to @b s and that its capacity is at least @b s.

--- a/Lib/StringUtils.hpp
+++ b/Lib/StringUtils.hpp
@@ -31,6 +31,9 @@ public:
   static bool isPositiveDecimal(std::string str);
   static void replaceAll(std::string& where, const std::string& from, const std::string& to);
 
+  static bool starts_with(const std::string& str, const std::string& what) {
+    return str.rfind(what,0) == 0;
+  }
   static void splitStr(const char* str, char delimiter, Stack<std::string>& strings);
   static void dropEmpty(Stack<std::string>& strings);
   static bool readEquality(const char* str, char eqChar, std::string& lhs, std::string& rhs);

--- a/Minisat/utils/System.cc
+++ b/Minisat/utils/System.cc
@@ -46,7 +46,7 @@ static inline int memReadStat(int field)
 
     for (; field >= 0; field--)
         if (fscanf(in, "%d", &value) != 1)
-            printf("ERROR! Failed to parse memory statistics from \"/proc\".\n"), exit(1);
+            printf("%% ERROR! Failed to parse memory statistics from \"/proc\".\n"), exit(1);
     fclose(in);
     return value;
 }
@@ -72,7 +72,7 @@ static inline int memReadPeak(void)
 }
 
 double Minisat::memUsed() { return (double)memReadStat(0) * (double)getpagesize() / (1024*1024); }
-double Minisat::memUsedPeak(bool strictlyPeak) { 
+double Minisat::memUsedPeak(bool strictlyPeak) {
     double peak = memReadPeak() / (double)1024;
     return peak == 0 && !strictlyPeak ? memUsed() : peak; }
 
@@ -96,8 +96,8 @@ double Minisat::memUsedPeak(bool) { return memUsed(); }
 
 #else
 double Minisat::memUsed()     { return 0; }
-double Minisat::memUsedPeak(bool) { 
-  return 0; 
+double Minisat::memUsedPeak(bool) {
+  return 0;
 }
 #endif
 
@@ -108,7 +108,7 @@ void Minisat::setX86FPUPrecision()
     // Only correct FPU precision on Linux architectures that needs and supports it:
     fpu_control_t oldcw, newcw;
     _FPU_GETCW(oldcw); newcw = (oldcw & ~_FPU_EXTENDED) | _FPU_DOUBLE; _FPU_SETCW(newcw);
-    printf("WARNING: for repeatability, setting FPU to use double precision\n");
+    printf("%% WARNING: for repeatability, setting FPU to use double precision\n");
 #endif
 }
 
@@ -129,7 +129,7 @@ void Minisat::limitMemory(uint64_t max_mem_mb)
         if (rl.rlim_max == RLIM_INFINITY || new_mem_lim < rl.rlim_max){
             rl.rlim_cur = new_mem_lim;
             if (setrlimit(RLIMIT_AS, &rl) == -1)
-                printf("WARNING! Could not set resource limit: Virtual memory.\n");
+                printf("%% WARNING! Could not set resource limit: Virtual memory.\n");
         }
     }
 
@@ -140,7 +140,7 @@ void Minisat::limitMemory(uint64_t max_mem_mb)
 #else
 void Minisat::limitMemory(uint64_t /*max_mem_mb*/)
 {
-    printf("WARNING! Memory limit not supported on this architecture.\n");
+    printf("%% WARNING! Memory limit not supported on this architecture.\n");
 }
 #endif
 
@@ -154,14 +154,14 @@ void Minisat::limitTime(uint32_t max_cpu_time)
         if (rl.rlim_max == RLIM_INFINITY || (rlim_t)max_cpu_time < rl.rlim_max){
             rl.rlim_cur = max_cpu_time;
             if (setrlimit(RLIMIT_CPU, &rl) == -1)
-                printf("WARNING! Could not set resource limit: CPU-time.\n");
+                printf("%% WARNING! Could not set resource limit: CPU-time.\n");
         }
     }
 }
 #else
 void Minisat::limitTime(uint32_t /*max_cpu_time*/)
 {
-    printf("WARNING! CPU-time limit not supported on this architecture.\n");
+    printf("%% WARNING! CPU-time limit not supported on this architecture.\n");
 }
 #endif
 

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -1451,7 +1451,10 @@ void TPTP::tff()
 
   _bools.push(true); // to denote that it is an FOF formula
   _isQuestion = false;
-  if (tp == "axiom" || tp == "plain") {
+  if(_modelDefinition){
+    _lastInputType = UnitInputType::MODEL_DEFINITION;
+  }
+  else if (tp == "axiom" || tp == "plain") {
     _lastInputType = UnitInputType::AXIOM;
   }
   else if (tp == "extensionality"){

--- a/SAT/BufferedSolver.cpp
+++ b/SAT/BufferedSolver.cpp
@@ -22,7 +22,7 @@ namespace SAT
 {
 
 BufferedSolver::BufferedSolver(SATSolver* inner)
- : _inner(inner), _checkedIdx(0), _lastStatus(SATISFIABLE), _varCnt(0), _varCntInnerOld(0)
+ : _inner(inner), _checkedIdx(0), _lastStatus(Status::SATISFIABLE), _varCnt(0), _varCntInnerOld(0)
 {
 }
 /**
@@ -116,11 +116,11 @@ SATSolver::Status BufferedSolver::solve(unsigned conflictCountLimit)
   // it needs _inner to have either a model or to be provably unsat
   ASS_EQ(conflictCountLimit, UINT_MAX);
   
-  if (_lastStatus == UNSATISFIABLE) {
-    return UNSATISFIABLE;
+  if (_lastStatus == Status::UNSATISFIABLE) {
+    return Status::UNSATISFIABLE;
   }
   
-  ASS_EQ(_lastStatus,SATISFIABLE);
+  ASS_EQ(_lastStatus,Status::SATISFIABLE);
   
   // check if clauses are implied by current ground model and buffered literals
   size_t sz = _unadded.size();
@@ -134,7 +134,7 @@ SATSolver::Status BufferedSolver::solve(unsigned conflictCountLimit)
   }
 
   RSTAT_CTR_INC("solver_buffer_hit");
-  return SATSolver::SATISFIABLE;
+  return Status::SATISFIABLE;
 }
 
 /**
@@ -149,14 +149,14 @@ SATSolver::VarAssignment BufferedSolver::getAssignment(unsigned var)
 
   // check buffer
   if(!_literalBuffer.isEmpty() && _literalBuffer.find(var)) {
-    return _literalBuffer.get(var) ? SATSolver::TRUE : SATSolver::FALSE;
+    return _literalBuffer.get(var) ? VarAssignment::TRUE : VarAssignment::FALSE;
   }
 
   // refer to inner if variable not new
   if (var <= _varCntInnerOld) {
     return _inner->getAssignment(var); 
   } else {
-    return SATSolver::DONT_CARE; // If it is new and not yet assigned in buffer
+    return VarAssignment::DONT_CARE; // If it is new and not yet assigned in buffer
   }
 }
 

--- a/SAT/MinimizingSolver.cpp
+++ b/SAT/MinimizingSolver.cpp
@@ -77,9 +77,9 @@ SATSolver::VarAssignment MinimizingSolver::getAssignment(unsigned var)
   }
 
   if(admitsDontcare(var)) {
-    return SATSolver::DONT_CARE;
+    return VarAssignment::DONT_CARE;
   }
-  return _asgn[var] ? SATSolver::TRUE : SATSolver::FALSE;
+  return _asgn[var] ? VarAssignment::TRUE : VarAssignment::FALSE;
 }
 
 bool MinimizingSolver::isZeroImplied(unsigned var)
@@ -87,7 +87,7 @@ bool MinimizingSolver::isZeroImplied(unsigned var)
   ASS_G(var,0); ASS_LE(var,_varCnt);
 
   bool res = _inner->isZeroImplied(var);
-  ASS(!res || getAssignment(var)!=DONT_CARE); //zero-implied variables will not become a don't care
+  ASS(!res || getAssignment(var)!=VarAssignment::DONT_CARE); //zero-implied variables will not become a don't care
   return res;
 }
 
@@ -184,18 +184,18 @@ void MinimizingSolver::processInnerAssignmentChanges()
     VarAssignment va = _inner->getAssignment(v);
     bool changed;
     switch(va) {
-    case DONT_CARE:
+    case VarAssignment::DONT_CARE:
       changed = false;
       break;
-    case TRUE:
+    case VarAssignment::TRUE:
       changed = !_asgn[v];
       _asgn[v] = true;
       break;
-    case FALSE:
+    case VarAssignment::FALSE:
       changed = _asgn[v];
       _asgn[v] = false;
       break;
-    case NOT_KNOWN:
+    case VarAssignment::NOT_KNOWN:
     default:
       ASSERTION_VIOLATION;
       break;

--- a/SAT/MinisatInterfacing.cpp
+++ b/SAT/MinisatInterfacing.cpp
@@ -27,7 +27,7 @@ using namespace Lib;
 using namespace Minisat;
   
 MinisatInterfacing::MinisatInterfacing(const Shell::Options& opts, bool generateProofs):
-  _status(SATISFIABLE)
+  _status(Status::SATISFIABLE)
 {
   // TODO: consider tuning minisat's options to be set for _solver
   // (or even forwarding them to vampire's options)  
@@ -61,7 +61,7 @@ SATSolver::Status MinisatInterfacing::solveUnderAssumptions(const SATLiteralStac
 
   solveModuloAssumptionsAndSetStatus(conflictCountLimit);
 
-  if (_status == SATSolver::UNSATISFIABLE) {
+  if (_status == Status::UNSATISFIABLE) {
     // unload minisat's internal conflict clause to _failedAssumptionBuffer
     _failedAssumptionBuffer.reset();
     Minisat::LSet& conflict = _solver.conflict;
@@ -79,19 +79,19 @@ SATSolver::Status MinisatInterfacing::solveUnderAssumptions(const SATLiteralStac
  * Solve modulo assumptions and set status.
  * @b conflictCountLimit as with addAssumption.
  */
-void MinisatInterfacing::solveModuloAssumptionsAndSetStatus(unsigned conflictCountLimit) 
+void MinisatInterfacing::solveModuloAssumptionsAndSetStatus(unsigned conflictCountLimit)
 {
   // TODO: consider calling simplify(); or only from time to time?
-    
+
   _solver.setConfBudget(conflictCountLimit); // treating UINT_MAX as \infty
   lbool res = _solver.solveLimited(_assumptions);
-  
+
   if (res == l_True) {
-    _status = SATISFIABLE;
+    _status = Status::SATISFIABLE;
   } else if (res == l_False) {
-    _status = UNSATISFIABLE;    
+    _status = Status::UNSATISFIABLE;
   } else {
-    _status = UNKNOWN;
+    _status = Status::UNKNOWN;
   }
 }
 
@@ -129,29 +129,29 @@ SATSolver::Status MinisatInterfacing::solve(unsigned conflictCountLimit)
   return _status;
 }
 
-void MinisatInterfacing::addAssumption(SATLiteral lit) 
+void MinisatInterfacing::addAssumption(SATLiteral lit)
 {
   _assumptions.push(vampireLit2Minisat(lit));
 }
 
-SATSolver::VarAssignment MinisatInterfacing::getAssignment(unsigned var) 
+SATSolver::VarAssignment MinisatInterfacing::getAssignment(unsigned var)
 {
-	ASS_EQ(_status, SATISFIABLE);  
+	ASS_EQ(_status, Status::SATISFIABLE);
 	ASS_G(var,0); ASS_LE(var,(unsigned)_solver.nVars());
   lbool res;
-    
-  Minisat::Var mvar = vampireVar2Minisat(var);  
-  if (mvar < _solver.model.size()) {  
+
+  Minisat::Var mvar = vampireVar2Minisat(var);
+  if (mvar < _solver.model.size()) {
     if ((res = _solver.modelValue(mvar)) == l_True) {
-      return TRUE;
-    } else if (res == l_False) {    
-      return FALSE;
-    } else {              
+      return VarAssignment::TRUE;
+    } else if (res == l_False) {
+      return VarAssignment::FALSE;
+    } else {
       ASSERTION_VIOLATION;
-      return NOT_KNOWN;
+      return VarAssignment::NOT_KNOWN;
     }
   } else { // new vars have been added but the model didn't grow yet
-    return DONT_CARE;
+    return VarAssignment::DONT_CARE;
   }
 }
 

--- a/SAT/MinisatInterfacing.hpp
+++ b/SAT/MinisatInterfacing.hpp
@@ -89,7 +89,7 @@ public:
   
   virtual void retractAllAssumptions() override {
     _assumptions.clear();
-    _status = UNKNOWN;
+    _status = Status::UNKNOWN;
   };
   
   virtual bool hasAssumptions() const override {

--- a/SAT/MinisatInterfacingNewSimp.cpp
+++ b/SAT/MinisatInterfacingNewSimp.cpp
@@ -38,7 +38,7 @@ using namespace Minisat;
 const unsigned MinisatInterfacingNewSimp::VAR_MAX = std::numeric_limits<Minisat::Var>::max() / 2;
   
 MinisatInterfacingNewSimp::MinisatInterfacingNewSimp(const Shell::Options& opts, bool generateProofs):
-  _status(SATISFIABLE)
+  _status(Status::SATISFIABLE)
 {
   // TODO: consider tuning minisat's options to be set for _solver
   // (or even forwarding them to vampire's options)  
@@ -88,7 +88,7 @@ SATSolver::Status MinisatInterfacingNewSimp::solveUnderAssumptions(const SATLite
 
   solveModuloAssumptionsAndSetStatus(conflictCountLimit);
 
-  if (_status == SATSolver::UNSATISFIABLE) {
+  if (_status == Status::UNSATISFIABLE) {
     // unload minisat's internal conflict clause to _failedAssumptionBuffer
     _failedAssumptionBuffer.reset();
     Minisat::LSet& conflict = _solver.conflict;
@@ -120,11 +120,11 @@ void MinisatInterfacingNewSimp::solveModuloAssumptionsAndSetStatus(unsigned conf
     //cout << "After: vars " << bef - _solver.eliminated_vars << ", non-unit clauses " << _solver.nClauses() << endl;
   
     if (res == l_True) {
-      _status = SATISFIABLE;
+      _status = Status::SATISFIABLE;
     } else if (res == l_False) {
-      _status = UNSATISFIABLE;
+      _status = Status::UNSATISFIABLE;
     } else {
-      _status = UNKNOWN;
+      _status = Status::UNKNOWN;
     }
   }catch(Minisat::OutOfMemoryException&){
     reportMinisatOutOfMemory();
@@ -172,22 +172,22 @@ void MinisatInterfacingNewSimp::addAssumption(SATLiteral lit)
 
 SATSolver::VarAssignment MinisatInterfacingNewSimp::getAssignment(unsigned var) 
 {
-	ASS_EQ(_status, SATISFIABLE);  
+	ASS_EQ(_status, Status::SATISFIABLE);
 	ASS_G(var,0); ASS_LE(var,(unsigned)_solver.nVars());
   lbool res;
-    
-  Minisat::Var mvar = vampireVar2Minisat(var);  
-  if (mvar < _solver.model.size()) {  
+
+  Minisat::Var mvar = vampireVar2Minisat(var);
+  if (mvar < _solver.model.size()) {
     if ((res = _solver.modelValue(mvar)) == l_True) {
-      return TRUE;
-    } else if (res == l_False) {    
-      return FALSE;
-    } else {              
+      return VarAssignment::TRUE;
+    } else if (res == l_False) {
+      return VarAssignment::FALSE;
+    } else {
       ASSERTION_VIOLATION;
-      return NOT_KNOWN;
+      return VarAssignment::NOT_KNOWN;
     }
   } else { // new vars have been added but the model didn't grow yet
-    return DONT_CARE;
+    return VarAssignment::DONT_CARE;
   }
 }
 

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -146,7 +146,7 @@ private:
           if (rl.rlim_max == RLIM_INFINITY || new_mem_lim < rl.rlim_max){
               rl.rlim_cur = new_mem_lim;
               if (setrlimit(RLIMIT_AS, &rl) == -1)
-                  printf("WARNING! Could not set resource limit: Virtual memory.\n");
+                  printf("%% WARNING! Could not set resource limit: Virtual memory.\n");
           }
       }
   }

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -96,7 +96,7 @@ public:
   
   virtual void retractAllAssumptions() override {
     _assumptions.clear();
-    _status = UNKNOWN;
+    _status = Status::UNKNOWN;
   };
   
   virtual bool hasAssumptions() const override {

--- a/SAT/SAT2FO.cpp
+++ b/SAT/SAT2FO.cpp
@@ -85,12 +85,12 @@ void SAT2FO::collectAssignment(SATSolver& solver, LiteralStack& res) const
   unsigned maxVar = maxSATVar();
   for (unsigned i = 1; i <= maxVar; i++) {
     SATSolver::VarAssignment asgn = solver.getAssignment(i);
-    if(asgn==SATSolver::DONT_CARE) {
+    if(asgn==SATSolver::VarAssignment::DONT_CARE) {
       //we don't add DONT_CARE literals into the assignment
       continue;
     }
-    ASS(asgn==SATSolver::TRUE || asgn==SATSolver::FALSE);
-    SATLiteral sl(i, asgn==SATSolver::TRUE);
+    ASS(asgn==SATSolver::VarAssignment::TRUE || asgn==SATSolver::VarAssignment::FALSE);
+    SATLiteral sl(i, asgn==SATSolver::VarAssignment::TRUE);
     ASS(solver.trueInAssignment(sl));
     Literal* lit = toFO(sl);
     if(!lit) {

--- a/SAT/SATLiteral.hpp
+++ b/SAT/SATLiteral.hpp
@@ -36,7 +36,7 @@ public:
    *
    * @b var must be greater than 0 and @b polarity either 1 or 0 (for positive or negative)
    */
-  inline SATLiteral(unsigned var, unsigned polarity) :_polarity(polarity), _var(var) 
+  inline SATLiteral(unsigned var, unsigned polarity) :_polarity(polarity), _var(var)
   { ASS_G(var,0); ASS_NEQ(var,0x7FFFFFFF); }
 
 

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -40,7 +40,7 @@ public:
   };
 
   virtual ~SATSolver() {}
-  
+
   /**
    * Add a clause to the solver.
    *

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -24,13 +24,13 @@ namespace SAT {
 
 class SATSolver {
 public:
-  enum VarAssignment {
+  enum class VarAssignment {
     TRUE,
     FALSE,
     DONT_CARE,  // to represent partial models
     NOT_KNOWN
   };
-  enum Status {
+  enum class Status {
     SATISFIABLE,
     UNSATISFIABLE,
     /**
@@ -62,14 +62,14 @@ public:
    * a partial model P computed must satisfy all the clauses added to the solver
    * via addClause and there must be a full model extending P which also
    * satisfies clauses added via addClauseIgnoredInPartialModel.
-   * 
+   *
    * This is a default implementation of addClauseIgnoredInPartialModel
    * for all the solvers which return total models
    * for which addClause and addClauseIgnoredInPartialModel
    * naturally coincide.
-   */  
+   */
   virtual void addClauseIgnoredInPartialModel(SATClause* cl) { addClause(cl); }
-  
+
   /**
    * Opportunity to perform in-processing of the clause database.
    */
@@ -77,7 +77,7 @@ public:
 
   /**
    * Establish Status of the clause set inserted so far.
-   * 
+   *
    * If conflictCountLimit==0,
    * do only unit propagation, if conflictCountLimit==UINT_MAX, do
    * full satisfiability check, and for values in between, restrict
@@ -85,9 +85,9 @@ public:
    * solving and assign the status to UNKNOWN.
    */
   virtual Status solve(unsigned conflictCountLimit) = 0;
-  
+
   Status solve(bool onlyPropagate=false) { return solve(onlyPropagate ? 0u : UINT_MAX); }
-    
+
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
@@ -117,20 +117,20 @@ public:
 
   /**
    * Ensure that clauses mentioning variables 1..newVarCnt can be handled.
-   * 
+   *
    * See also newVar for a different (and conceptually incompatible)
    * way for managing variables in the solver.
    */
   virtual void ensureVarCount(unsigned newVarCnt) {}
-  
+
   /**
    * Allocate a slot for a new (previosly unused) variable in the solver
-   * and return the variable. 
-   * 
+   * and return the variable.
+   *
    * Variables start from 1 and keep increasing by 1.
    */
   virtual unsigned newVar() = 0;
-  
+
   virtual void suggestPolarity(unsigned var, unsigned pol) = 0;
 
   /**
@@ -148,9 +148,9 @@ public:
    * Immediately after a call to solveXXX that returned UNSAT,
    * this method can be used to obtain the corresponding
    * empty SATClause as a root of a corresponding refutation tree.
-   * 
+   *
    * (However, the empty clause may be invalidated later on.)
-   */    
+   */
   virtual SATClause* getRefutation() = 0;
 
   /**
@@ -170,7 +170,7 @@ public:
   bool trueInAssignment(SATLiteral lit)
   {
     VarAssignment asgn = getAssignment(lit.var());
-    VarAssignment desired = lit.polarity() ? TRUE : FALSE;
+    VarAssignment desired = lit.polarity() ? VarAssignment::TRUE : VarAssignment::FALSE;
     return asgn==desired;
   }
 
@@ -180,22 +180,33 @@ public:
   bool falseInAssignment(SATLiteral lit)
   {
     VarAssignment asgn = getAssignment(lit.var());
-    VarAssignment desired = lit.polarity() ? FALSE: TRUE;
+    VarAssignment desired = lit.polarity() ? VarAssignment::FALSE: VarAssignment::TRUE;
     return asgn==desired;
-  }  
+  }
 };
 
 inline std::ostream& operator<<(std::ostream& out, SATSolver::Status const& s)
-{ 
+{
   switch (s)  {
-    case SATSolver::SATISFIABLE: return out << "SATISFIABLE";
-    case SATSolver::UNSATISFIABLE: return out << "UNSATISFIABLE";
-    case SATSolver::UNKNOWN: return out << "UNKNOWN";
+    case SATSolver::Status::SATISFIABLE: return out << "SATISFIABLE";
+    case SATSolver::Status::UNSATISFIABLE: return out << "UNSATISFIABLE";
+    case SATSolver::Status::UNKNOWN: return out << "UNKNOWN";
     default: ASSERTION_VIOLATION; return  out << "INVALID STATUS";
   }
 }
 
-class SATSolverWithAssumptions: 
+inline std::ostream& operator<<(std::ostream& out, SATSolver::VarAssignment const& a)
+{
+  switch (a)  {
+    case SATSolver::VarAssignment::TRUE: return out << "TRUE";
+    case SATSolver::VarAssignment::FALSE: return out << "FALSE";
+    case SATSolver::VarAssignment::DONT_CARE: return out << "DONT_CARE";
+    case SATSolver::VarAssignment::NOT_KNOWN: return out << "NOT_KNOWN";
+    default: ASSERTION_VIOLATION; return  out << "INVALID STATUS";
+  }
+}
+
+class SATSolverWithAssumptions:
       public SATSolver {
 public:
 
@@ -238,7 +249,7 @@ public:
     _failedAssumptionBuffer.reset();
 
     Status res = solve(conflictCountLimit);
-    if (res == UNSATISFIABLE) {
+    if (res == Status::UNSATISFIABLE) {
       return res;
     }
 
@@ -249,7 +260,7 @@ public:
       _failedAssumptionBuffer.push(lit);
 
       res = solve(conflictCountLimit);
-      if (res == UNSATISFIABLE) {
+      if (res == Status::UNSATISFIABLE) {
         break;
       }
     }
@@ -322,7 +333,7 @@ public:
         }
       }
 
-      if (solve(conflictCountLimit) == UNSATISFIABLE) {
+      if (solve(conflictCountLimit) == Status::UNSATISFIABLE) {
         // leave out forever by overwriting by the last one (buffer shrinks implicitly)
         _failedAssumptionBuffer[i] = _failedAssumptionBuffer[--sz];
       } else {
@@ -344,33 +355,33 @@ protected:
 /**
  * A convenience class for solvers which do not track actual refutations
  * and so return the whole set of clauses added so far as refutations.
- * 
+ *
  * This need not necessarily inherit from SATSolverWithAssumptions,
- * but why bother with multiple inheritance if we know the only 
+ * but why bother with multiple inheritance if we know the only
  * two descendants of this class will need it...
  */
 class PrimitiveProofRecordingSATSolver : public SATSolverWithAssumptions {
 public:
-  PrimitiveProofRecordingSATSolver() :  
+  PrimitiveProofRecordingSATSolver() :
     _addedClauses(0), _refutation(new(0) SATClause(0)), _refutationInference(new PropInference(SATClauseList::empty()))
     {
-      _refutation->setInference(_refutationInference);    
+      _refutation->setInference(_refutationInference);
     }
-  
+
   virtual ~PrimitiveProofRecordingSATSolver() {
     // cannot clear the list - some inferences may be keeping its suffices till proof printing phase ...
     // _addedClauses->destroy(); // we clear the list but not its content
   }
 
-  virtual void addClause(SATClause* cl) override 
+  virtual void addClause(SATClause* cl) override
   {
     SATClauseList::push(cl,_addedClauses);
   }
-  
+
   virtual SATClause* getRefutation() override
   {
-    // connect the added clauses ... 
-    SATClauseList* prems = _addedClauses;  
+    // connect the added clauses ...
+    SATClauseList* prems = _addedClauses;
 
     // ... with the current assumptions
 
@@ -391,9 +402,9 @@ public:
 
     _refutationInference->setPremises(prems);
 
-    return _refutation; 
+    return _refutation;
   }
-  
+
   virtual SATClauseList* getRefutationPremiseList() override {
     return _addedClauses;
   }
@@ -401,7 +412,7 @@ public:
 private:
   // to be used for the premises of a refutation
   SATClauseList* _addedClauses;
-  
+
   /**
    * Empty clause to be returned by the getRefutation call.
    * Recycled between consecutive getRefutation calls.
@@ -410,7 +421,7 @@ private:
   /**
    * The inference inside _refutation.
    */
-  PropInference* _refutationInference;  
+  PropInference* _refutationInference;
 };
 
 

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -109,7 +109,7 @@ Z3Interfacing::Z3Interfacing(SAT2FO& s2f, bool showZ3, bool unsatCoresForAssumpt
   _hasSeenArrays(false),
   _varCnt(0),
   _sat2fo(s2f),
-  _status(SATISFIABLE),
+  _status(Status::SATISFIABLE),
   _config(),
   _context(_config),
   _solver(_context),
@@ -282,15 +282,15 @@ SATSolver::Status Z3Interfacing::solve()
 
   switch (result) {
     case z3::check_result::unsat:
-      _status = UNSATISFIABLE;
+      _status = Status::UNSATISFIABLE;
       break;
     case z3::check_result::sat:
-      _status = SATISFIABLE;
+      _status = Status::SATISFIABLE;
       _model = _solver.get_model();
       outputln("(get-model)");
       break;
     case z3::check_result::unknown:
-      _status = UNKNOWN;
+      _status = Status::UNKNOWN;
       break;
     default: ASSERTION_VIOLATION;
   }
@@ -316,22 +316,22 @@ SATSolver::Status Z3Interfacing::solveUnderAssumptions(const SATLiteralStack& as
 
 SATSolver::VarAssignment Z3Interfacing::getAssignment(unsigned var)
 {
-  ASS_EQ(_status,SATISFIABLE);
+  ASS_EQ(_status,Status::SATISFIABLE);
   bool named = isNamedExpr(var);
   z3::expr rep = named ? getNameExpr(var) : getRepresentation(SATLiteral(var,1)).expr;
   outputln("(get-value (", rep, "))");
   z3::expr assignment = _model.eval(rep, true /*model_completion*/);
 
   if(assignment.bool_value()==Z3_L_TRUE){
-    return TRUE;
+    return VarAssignment::TRUE;
   } else if(assignment.bool_value()==Z3_L_FALSE){
-    return FALSE;
+    return VarAssignment::FALSE;
   } else {
 #if VDEBUG
     std::cout << rep << std::endl;
     ASSERTION_VIOLATION_REP(assignment);
 #endif
-    return NOT_KNOWN;
+    return VarAssignment::NOT_KNOWN;
   }
 }
 

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -57,7 +57,6 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
-
 /////////////////////////////
 // SplittingBranchSelector
 //
@@ -70,7 +69,7 @@ void SplittingBranchSelector::init()
   switch(_parent.getOptions().satSolver()){
     case Options::SatSolver::MINISAT:
       _solver = new MinisatInterfacing(_parent.getOptions(),true);
-      break;      
+      break;
 #if VZ3
     case Options::SatSolver::Z3:
       {
@@ -327,10 +326,10 @@ SATSolver::VarAssignment SplittingBranchSelector::getSolverAssimentConsideringCC
 
     if (lit && lit->isEquality() && lit->ground()) {
       if (_trueInCCModel.find(var)) {
-        ASS(_solver->getAssignment(var) != SATSolver::FALSE || var > lastCheckedVar);
+        ASS(_solver->getAssignment(var) != SATSolver::VarAssignment::FALSE || var > lastCheckedVar);
         // only a newly introduced variable can be false in the SATSolver for no good reason
 
-        return SATSolver::TRUE;
+        return SATSolver::VarAssignment::TRUE;
       }
       // else we can force neither FALSE not DONT_CARE here, because
       // the former could introduce a disequality that shouldn't be in FO anymore
@@ -353,10 +352,10 @@ int SplittingBranchSelector::assertedGroundPositiveEqualityCompomentMaxAge()
   unsigned maxSatVar = _parent.maxSatVar();
   for(unsigned i=1; i<=maxSatVar; i++) {
     SATSolver::VarAssignment asgn = _solver->getAssignment(i);
-    if(asgn==SATSolver::DONT_CARE) {
+    if(asgn==SATSolver::VarAssignment::DONT_CARE) {
       continue;
     }
-    SATLiteral sl(i, asgn==SATSolver::TRUE);
+    SATLiteral sl(i, asgn==SATSolver::VarAssignment::TRUE);
     SplitLevel name = _parent.getNameFromLiteral(sl);
     if (!_parent.isUsedName(name)) {
       continue;
@@ -383,7 +382,7 @@ SATSolver::Status SplittingBranchSelector::processDPConflicts()
   // ASS(_solver->getStatus()==SATSolver::SATISFIABLE);
 
   if(!_dp) {
-    return SATSolver::SATISFIABLE;
+    return SATSolver::Status::SATISFIABLE;
   }
   
   SAT2FO& s2f = _parent.satNaming();
@@ -427,8 +426,8 @@ SATSolver::Status SplittingBranchSelector::processDPConflicts()
     {
       TIME_TRACE(TimeTrace::AVATAR_SAT_SOLVER);
       
-      if (_solver->solve() == SATSolver::UNSATISFIABLE) {
-        return SATSolver::UNSATISFIABLE;
+      if (_solver->solve() == SATSolver::Status::UNSATISFIABLE) {
+        return SATSolver::Status::UNSATISFIABLE;
       }
     }
   }
@@ -502,19 +501,19 @@ SATSolver::Status SplittingBranchSelector::processDPConflicts()
     }
   }
   
-  return SATSolver::SATISFIABLE;
+  return SATSolver::Status::SATISFIABLE;
 }
 
 void SplittingBranchSelector::updateSelection(unsigned satVar, SATSolver::VarAssignment asgn,
     SplitLevelStack& addedComps, SplitLevelStack& removedComps)
 {
-  ASS_NEQ(asgn, SATSolver::NOT_KNOWN); //we always do full SAT solving, so there shouldn't be unknown variables
+  ASS_NEQ(asgn, SATSolver::VarAssignment::NOT_KNOWN); //we always do full SAT solving, so there shouldn't be unknown variables
 
   SplitLevel posLvl = _parent.getNameFromLiteral(SATLiteral(satVar, true));
   SplitLevel negLvl = _parent.getNameFromLiteral(SATLiteral(satVar, false));
 
   switch(asgn) {
-  case SATSolver::TRUE: 
+  case SATSolver::VarAssignment::TRUE:
     if(!_selected.find(posLvl) && _parent.isUsedName(posLvl)) {
       _selected.insert(posLvl);
       addedComps.push(posLvl);
@@ -524,7 +523,7 @@ void SplittingBranchSelector::updateSelection(unsigned satVar, SATSolver::VarAss
       removedComps.push(negLvl);
     }
     break;
-  case SATSolver::FALSE:    
+  case SATSolver::VarAssignment::FALSE:
     if(!_selected.find(negLvl) && _parent.isUsedName(negLvl)) {
       _selected.insert(negLvl);
       addedComps.push(negLvl);
@@ -534,7 +533,7 @@ void SplittingBranchSelector::updateSelection(unsigned satVar, SATSolver::VarAss
       removedComps.push(posLvl);
     }
     break;
-  case SATSolver::DONT_CARE:
+  case SATSolver::VarAssignment::DONT_CARE:
     if(_eagerRemoval) {
       if(_selected.find(posLvl)) {
         _selected.remove(posLvl);
@@ -583,17 +582,17 @@ void SplittingBranchSelector::recomputeModel(SplitLevelStack& addedComps, SplitL
     }
     stat = _solver->solve();
   }
-  if (stat == SATSolver::SATISFIABLE) {
+  if (stat == SATSolver::Status::SATISFIABLE) {
     stat = processDPConflicts();
   }
-  if(stat == SATSolver::UNSATISFIABLE) {
+  if(stat == SATSolver::Status::UNSATISFIABLE) {
     handleSatRefutation(); // noreturn!
   }
-  if(stat == SATSolver::UNKNOWN){
+  if(stat == SATSolver::Status::UNKNOWN){
     env.statistics->smtReturnedUnknown=true;
     throw MainLoop::MainLoopFinishedException(Statistics::REFUTATION_NOT_FOUND);
   }
-  ASS_EQ(stat,SATSolver::SATISFIABLE);
+  ASS_EQ(stat,SATSolver::Status::SATISFIABLE);
 
   for(unsigned i=1; i<=maxSatVar; i++) {
     SATSolver::VarAssignment asgn = getSolverAssimentConsideringCCModel(i);
@@ -603,7 +602,7 @@ void SplittingBranchSelector::recomputeModel(SplitLevelStack& addedComps, SplitL
      * A bug report / feature request has been sent to the z3 people, but this will make us stay sound in release mode.
      * (While violating an assertion in debug - see getAssignment in Z3Interfacing).
      */
-    if (asgn == SATSolver::NOT_KNOWN) {
+    if (asgn == SATSolver::VarAssignment::NOT_KNOWN) {
       env.statistics->smtDidNotEvaluate=true;
       throw MainLoop::MainLoopFinishedException(Statistics::REFUTATION_NOT_FOUND);
     }

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2423,7 +2423,7 @@ void Options::set(const char* name,const char* value, bool longOpt)
       case IgnoreMissing::WARN:
         if (outputAllowed()) {
           addCommentSignForSZS(std::cout);
-          std::cout << "WARNING: invalid value "<< value << " for option " << name << endl;
+          std::cout << "% WARNING: invalid value "<< value << " for option " << name << endl;
         }
         break;
       case IgnoreMissing::ON:
@@ -2437,7 +2437,7 @@ void Options::set(const char* name,const char* value, bool longOpt)
       if (_ignoreMissing.actualValue == IgnoreMissing::WARN) {
         if (outputAllowed()) {
           addCommentSignForSZS(std::cout);
-          std::cout << "WARNING: " << msg << endl;
+          std::cout << "% WARNING: " << msg << endl;
         }
         return;
       } // else:
@@ -2688,13 +2688,13 @@ bool Options::OptionValue<T>::checkProblemConstraints(Property* prop){
 
          if (env.options->mode() == Mode::SPIDER){
            reportSpiderFail();
-           USER_ERROR("WARNING: " + longName + con->msg());
+           USER_ERROR("% WARNING: " + longName + con->msg());
          }
 
          switch(env.options->getBadOptionChoice()){
          case BadOption::OFF: break;
          default:
-           cout << "WARNING: " << longName << con->msg() << endl;
+           cout << "% WARNING: " << longName << con->msg() << endl;
          }
          return false;
       }
@@ -3191,7 +3191,7 @@ void Options::sampleStrategy(const std::string& strategySamplerFilename)
     */
   }
 
-  cout << "Random strategy: " + generateEncodedOptions() << endl;
+  cout << "% Random strategy: " + generateEncodedOptions() << endl;
 }
 
 /**
@@ -3233,7 +3233,7 @@ void Options::readOptionsString(std::string optionsString,bool assign)
               case IgnoreMissing::WARN:
                 if (outputAllowed()) {
                   addCommentSignForSZS(std::cout);
-                  std::cout << "WARNING: value " << value << " for option "<< param <<" not known" << endl;
+                  std::cout << "% WARNING: value " << value << " for option "<< param <<" not known" << endl;
                 }
                 break;
               case IgnoreMissing::ON:
@@ -3256,7 +3256,7 @@ void Options::readOptionsString(std::string optionsString,bool assign)
       case IgnoreMissing::WARN:
         if (outputAllowed()) {
           addCommentSignForSZS(std::cout);
-          std::cout << "WARNING: option "<< param << " not known." << endl;
+          std::cout << "% WARNING: option "<< param << " not known." << endl;
         }
         break;
       case IgnoreMissing::ON:

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -225,7 +225,7 @@ void PredicateDefinition::eliminatePredicateDefinition(unsigned pred, ReplMap& r
     repl = makeImplFromDef(def, pred, fwd);
 
     if(!repl) {
-      //the definition formula was simplified by other transformation to the      
+      //the definition formula was simplified by other transformation to the
       //point it is no longer definition that can be eliminated
       if (env.options->showPreprocessing()) {
         std::cout << "[PP] Formula " << (*def)

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -482,13 +482,13 @@ void Property::scanSort(TermList sort)
   }
 
   if(!higherOrder() && !hasPolymorphicSym()){
-    //used sorts is for FMB which is not compatible with 
+    //used sorts is for FMB which is not compatible with
     //higher-order or polymorphism
     unsigned sortU = sort.term()->functor();
     if(!_usesSort.get(sortU)){
       _sortsUsed++;
       _usesSort[sortU]=true;
-    } 
+    }
   }
 
   if (sort==AtomicSort::defaultSort()) {

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -231,9 +231,9 @@ public:
   bool higherOrder() const { return hasCombs() || hasApp() || hasLogicalProxy() ||
                                     hasArrowSort() || _hasLambda; }
   bool quantifiesOverPolymorphicVar() const { return _quantifiesOverPolymorphicVar; }
-  bool usesSort(unsigned sort) const { 
+  bool usesSort(unsigned sort) const {
     if(_usesSort.size() <= sort) return false;
-    return _usesSort[sort]; 
+    return _usesSort[sort];
   } //TODO only utilised by FMB which should eventually update to use the new sorts (as TermLists)
   bool usesSingleSort() const { return _sortsUsed==1; }
   unsigned sortsUsed() const { return _sortsUsed; }

--- a/UnitTests/tSATSolver.cpp
+++ b/UnitTests/tSATSolver.cpp
@@ -110,7 +110,7 @@ void testProofWithAssumptions(SATSolver& s)
   s.addClause(getClause("a"));
   s.addClause(getClause("A"));
 
-  ASS_EQ(s.solve(),SATSolver::UNSATISFIABLE);
+  ASS_EQ(s.solve(),SATSolver::Status::UNSATISFIABLE);
 
   SATClause* refutation = s.getRefutation();
   PropInference* inf = static_cast<PropInference*>(refutation->inference());
@@ -120,7 +120,7 @@ void testProofWithAssumptions(SATSolver& s)
   List<SATClause*>* prems = inf->getPremises();
 
   // cout << "Inference length: " << prems->length() << endl;
-  
+
   while(prems){
     // cout << prems->head()->toString() << endl;
     prems = prems->tail();
@@ -131,19 +131,19 @@ void testProofWithAssumptions(SATSolver& s)
 TEST_FUN(testProofWithAssums)
 {
   MinisatInterfacing s(*env.options,true);
-  testProofWithAssumptions(s);    
+  testProofWithAssumptions(s);
 }
 
 void testInterface(SATSolverWithAssumptions &s) {
   ensurePrepared(s);
-      
-  ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
-  
+
+  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
+
   unsigned a = getLit('a').var();
   unsigned b = getLit('b').var();
   unsigned c = getLit('c').var();
   unsigned d = getLit('d').var();
-  
+
   /*
   s.suggestPolarity(a,0);
   ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
@@ -151,7 +151,7 @@ void testInterface(SATSolverWithAssumptions &s) {
   s.suggestPolarity(a,1);
   ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
   ASS(!s.trueInAssignment(getLit('a')));
-  
+
   s.forcePolarity(a,0);
   ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
   ASS(s.trueInAssignment(getLit('a')));
@@ -159,71 +159,71 @@ void testInterface(SATSolverWithAssumptions &s) {
   ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
   ASS(!s.trueInAssignment(getLit('a')));
   */
-  
+
   s.addClause(getClause("ab"));
-  ASS_EQ(s.solve(true),SATSolver::UNKNOWN);
+  ASS_EQ(s.solve(true),SATSolver::Status::UNKNOWN);
   s.addClause(getClause("aB"));
-  ASS_EQ(s.solve(true),SATSolver::UNKNOWN);
+  ASS_EQ(s.solve(true),SATSolver::Status::UNKNOWN);
   s.addClause(getClause("Ab"));
-  ASS_EQ(s.solve(true),SATSolver::UNKNOWN);
+  ASS_EQ(s.solve(true),SATSolver::Status::UNKNOWN);
   s.addClause(getClause("C"));
-  ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
-  
+  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
+
   ASS(s.trueInAssignment(getLit('a')));
   ASS(s.trueInAssignment(getLit('b')));
   ASS(s.falseInAssignment(getLit('c')));
 
   // for a and b depends on learned clauses, which depend on decide polarity
   // but should be both at the same time, or none of the two
-  ASS(s.isZeroImplied(a) == s.isZeroImplied(b));   
-  
+  ASS(s.isZeroImplied(a) == s.isZeroImplied(b));
+
   ASS(s.isZeroImplied(c));
   ASS(!s.isZeroImplied(d));
 
   cout << " Random: ";
-  for (int i = 0; i < 10; i++) {    
+  for (int i = 0; i < 10; i++) {
     s.randomizeForNextAssignment(27);
     s.solve();
     cout << s.trueInAssignment(getLit('d'));
   }
-  cout << "  Fixed: ";      
-  for (int i = 0; i < 10; i++) {        
+  cout << "  Fixed: ";
+  for (int i = 0; i < 10; i++) {
     cout << s.trueInAssignment(getLit('d'));
   }
-  cout << endl;  
-  
+  cout << endl;
+
   s.addAssumption(getLit('d'));
   s.addAssumption(getLit('a'));
   ASS(s.hasAssumptions());
-  ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
-  s.retractAllAssumptions();
-  ASS(!s.hasAssumptions());
-  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
-  
-  ASS(!s.hasAssumptions());
-  s.addAssumption(getLit('A'));
-  ASS(s.hasAssumptions());
-  ASS_EQ(s.solve(),SATSolver::UNSATISFIABLE);
-  s.retractAllAssumptions();
-  ASS(!s.hasAssumptions());
-  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
-    
-  s.addAssumption(getLit('a'));
-  ASS(s.hasAssumptions());
-  ASS_EQ(s.solve(),SATSolver::SATISFIABLE);
+  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
   s.retractAllAssumptions();
   ASS(!s.hasAssumptions());
   // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
 
-  ASS_EQ(s.solve(),SATSolver::SATISFIABLE);    
+  ASS(!s.hasAssumptions());
+  s.addAssumption(getLit('A'));
+  ASS(s.hasAssumptions());
+  ASS_EQ(s.solve(),SATSolver::Status::UNSATISFIABLE);
+  s.retractAllAssumptions();
+  ASS(!s.hasAssumptions());
+  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
+
+  s.addAssumption(getLit('a'));
+  ASS(s.hasAssumptions());
+  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
+  s.retractAllAssumptions();
+  ASS(!s.hasAssumptions());
+  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
+
+  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
 }
 
 TEST_FUN(testSATSolverInterface)
 { 
-  cout << endl << "Minisat" << endl;  
+  cout << endl << "Minisat" << endl;
   MinisatInterfacing sMini(*env.options,true);
   testInterface(sMini);
-    
+
   /* Not fully conforming - does not support zeroImplied and resource-limited solving
   cout << endl << "Z3" << endl;
   {
@@ -251,7 +251,7 @@ void testAssumptions(SATSolverWithAssumptions &s) {
   assumps.push(getLit('E'));
   assumps.push(getLit('Y'));
 
-  ASS_EQ(s.solveUnderAssumptions(assumps),SATSolver::UNSATISFIABLE);
+  ASS_EQ(s.solveUnderAssumptions(assumps),SATSolver::Status::UNSATISFIABLE);
 
   const SATLiteralStack& failed = s.failedAssumptions();
   for (unsigned i = 0; i < failed.size(); i++) {

--- a/UnitTests/tZ3Interfacing.cpp
+++ b/UnitTests/tZ3Interfacing.cpp
@@ -7,7 +7,7 @@
  * https://vprover.github.io/license.html
  * and in the source directory
  */
-  
+
 #include "Test/UnitTesting.hpp"
 #include "Test/SyntaxSugar.hpp"
 #include "Test/SyntaxSugar.hpp"
@@ -51,7 +51,7 @@ void checkStatus(SAT::Z3Interfacing& z3, SAT2FO& s2f, SATSolver::Status expected
     }
     cout << "[ expected ] " <<  expected << endl;
     cout << "[ is       ] " <<  status << endl;
-    if (status == Z3Interfacing::SATISFIABLE) {
+    if (status == SATSolver::Status::SATISFIABLE) {
       cout << "[ model    ] " <<  z3.getModel() << endl;
 
     }
@@ -60,7 +60,7 @@ void checkStatus(SAT::Z3Interfacing& z3, SAT2FO& s2f, SATSolver::Status expected
   z3.retractAllAssumptions();
 }
 
-void checkStatus(SATSolver::Status expected, Stack<Literal*> assumptions) 
+void checkStatus(SATSolver::Status expected, Stack<Literal*> assumptions)
 {
   SAT2FO s2f;
   SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "");
@@ -75,7 +75,7 @@ void checkStatus(SATSolver::Status expected, Stack<Literal*> assumptions)
 TEST_FUN(solve__real__simple_01) {
   NUMBER_SUGAR(Real)
   checkStatus(
-      SATSolver::UNSATISFIABLE, 
+      SATSolver::Status::UNSATISFIABLE,
       { num(3) == num(0) });
 }
 
@@ -83,7 +83,7 @@ TEST_FUN(solve__real__simple_02) {
   NUMBER_SUGAR(Real)
   DECL_CONST(a, Real)
   checkStatus(
-      SATSolver::SATISFIABLE, 
+      SATSolver::Status::SATISFIABLE,
       { num(3) == a });
 }
 
@@ -91,14 +91,14 @@ TEST_FUN(solve__real__simple_02) {
 TEST_FUN(solve__rat__simple_03) {
   NUMBER_SUGAR(Real)
   checkStatus(
-      SATSolver::UNSATISFIABLE, 
+      SATSolver::Status::UNSATISFIABLE,
       { num(3) == num(3) + 2 * num(7) });
 }
 
 TEST_FUN(solve__rat__simple_04) {
   NUMBER_SUGAR(Real)
   checkStatus(
-      SATSolver::UNSATISFIABLE, 
+      SATSolver::Status::UNSATISFIABLE,
       { num(17) != num(3) + 2 * num(7) });
 }
 
@@ -109,21 +109,21 @@ TEST_FUN(solve__rat__simple_04) {
 TEST_FUN(solve__fool__simple_01) {
   DECL_VAR(x, 0);
   checkStatus(
-      SATSolver::SATISFIABLE, 
+      SATSolver::Status::SATISFIABLE,
       { fool(false) == x });
 }
 
 TEST_FUN(solve__fool__simple_02) {
   DECL_VAR(x, 0);
   checkStatus(
-      SATSolver::SATISFIABLE, 
+      SATSolver::Status::SATISFIABLE,
       { fool(true) == x });
 }
 
 
 TEST_FUN(solve__fool__simple_03) {
   checkStatus(
-      SATSolver::UNSATISFIABLE, 
+      SATSolver::Status::UNSATISFIABLE,
       { fool(true) == fool(false) });
 }
 
@@ -152,8 +152,8 @@ TEST_FUN(solve__dty__01) {
   DECL_CONST(a0, alpha)
   DECL_CONST(a1, alpha)
 
-  checkStatus(SATSolver::UNSATISFIABLE, { cons(a0, nil) == nil });
-  checkStatus(SATSolver::UNSATISFIABLE, { cons(a0, nil) == cons(a1, nil), a0 != a1 });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { cons(a0, nil) == nil });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { cons(a0, nil) == cons(a1, nil), a0 != a1 });
 }
 
 
@@ -174,7 +174,7 @@ TEST_FUN(solve__dty__01) {
 
 TEST_FUN(solve__dty__02) {
   DECL_EVEN_ODD
-  checkStatus(SATSolver::UNSATISFIABLE, { succEven(succOdd(zero)) == zero });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { succEven(succOdd(zero)) == zero });
 }
 
 
@@ -183,7 +183,7 @@ TEST_FUN(solve__dty__03_01) {
   DECL_EVEN_ODD
   DECL_LIST(even)
   // request non-mutual first
-  checkStatus(SATSolver::UNSATISFIABLE, { cons(succEven(succOdd(zero)), nil) == cons(zero, nil) });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { cons(succEven(succOdd(zero)), nil) == cons(zero, nil) });
 }
 
 TEST_FUN(solve__dty__03_02) {
@@ -191,7 +191,7 @@ TEST_FUN(solve__dty__03_02) {
   DECL_EVEN_ODD
   DECL_LIST(even)
   // request mutual only
-  checkStatus(SATSolver::UNSATISFIABLE, { succEven(succOdd(zero)) == zero });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { succEven(succOdd(zero)) == zero });
 }
 
 TEST_FUN(solve__dty__03_03) {
@@ -199,8 +199,8 @@ TEST_FUN(solve__dty__03_03) {
   DECL_EVEN_ODD
   DECL_LIST(even)
   // request mutual first
-  checkStatus(SATSolver::UNSATISFIABLE, { succEven(succOdd(zero)) == zero });
-  checkStatus(SATSolver::UNSATISFIABLE, { cons(succEven(succOdd(zero)), nil) == cons(zero, nil) });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { succEven(succOdd(zero)) == zero });
+  checkStatus(SATSolver::Status::UNSATISFIABLE, { cons(succEven(succOdd(zero)), nil) == cons(zero, nil) });
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
@@ -214,7 +214,7 @@ void checkInstantiation(SAT::Z3Interfacing& z3, SAT2FO& s2f, Stack<Literal*> ass
   }
 
   auto status = z3.solve();
-  ASS_EQ(status, Z3Interfacing::SATISFIABLE);
+  ASS_EQ(status, SATSolver::Status::SATISFIABLE);
   auto result = z3.evaluateInModel(toInstantiate.term());
   if (result != expected.term()) {
     cout << "[ input    ] " << endl;
@@ -231,7 +231,7 @@ void checkInstantiation(SAT::Z3Interfacing& z3, SAT2FO& s2f, Stack<Literal*> ass
 }
 
 
-/** 
+/**
  * Runs z3 on a bunch of vampire literals as assumptions, that need to be satisfyable. 
  * Then  the term toInstantiate will be instantiated with the model. The instantiated 
  * term will be checked to be equal to the term expected.
@@ -301,8 +301,6 @@ TEST_FUN(instantiate__list_02) {
 }
 
 TEST_FUN(segfault01) {
-
-
   Z3_config config = Z3_mk_config();
   Z3_context context = Z3_mk_context(config);
 
@@ -311,8 +309,8 @@ TEST_FUN(segfault01) {
 
   Z3_func_decl enumCtor;
   Z3_func_decl enumDiscr;
-  Z3_sort sorts = Z3_mk_enumeration_sort(context, 
-      sortNames, 1, 
+  Z3_sort sorts = Z3_mk_enumeration_sort(context,
+      sortNames, 1,
       &consName, &enumCtor, &enumDiscr);
 
   Z3_symbol c1_sym = Z3_mk_string_symbol(context, "c1");
@@ -351,7 +349,7 @@ TEST_FUN(segfault02) {
   SAT2FO s2f;
   SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "");
 
-  checkStatus(z3, s2f, SATSolver::SATISFIABLE, { inst159 == inst160 });
+  checkStatus(z3, s2f, SATSolver::Status::SATISFIABLE, { inst159 == inst160 });
   z3.solve();
 }
 

--- a/samplers/samplerFNT.txt
+++ b/samplers/samplerFNT.txt
@@ -348,8 +348,8 @@ sa=fmb fmbes=sbeam > fmbksg ~cat off:2,on:1
 
 # fmb_start_size - setting this to values > 1 is making things "finite model incomplete" (but could save time for some problems)
 sa=fmb > $fmbss ~cat 1:5,666:1
-$fmbss=1 > fmbss ~cat 1:1
-$fmbss=666 > fmbss ~sgd 0.1,1
+sa=fmb $fmbss=1 > fmbss ~cat 1:1
+sa=fmb $fmbss=666 > fmbss ~sgd 0.1,1
 
 # fmb_symmetry_symbol_order
 sa=fmb > fmbsso ~cat occurence:22,input_usage:1,preprocessed_usage:1

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -301,8 +301,7 @@ void preprocessMode(Problem* problem, bool theory)
 void modelCheckMode(Problem* problem)
 {
   ScopedPtr<Problem> prb(problem);
-  env.options->setOutputAxiomNames(true);
-
+  
   if(env.getMainProblem()->hasPolymorphicSym() || env.getMainProblem()->isHigherOrder()){
     USER_ERROR("Polymorphic Vampire is not yet compatible with theory reasoning");
   }

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -766,6 +766,10 @@ int main(int argc, char* argv[])
 
     Lib::setMemoryLimit(env.options->memoryLimit() * 1048576ul);
 
+    if (opts.mode() == Options::Mode::MODEL_CHECK) {
+      opts.setOutputAxiomNames(true);
+    }
+
     if (opts.interactive()) {
       interactiveMetamode();
     } else {

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -446,6 +446,10 @@ void clausifyMode(Problem* problem, bool theory)
   simplifier.addFront(new TautologyDeletionISE());
   simplifier.addFront(new DuplicateLiteralRemovalISE());
 
+  if (!env.options->strategySamplerFilename().empty()) {
+    env.options->sampleStrategy(env.options->strategySamplerFilename());
+  }
+
   ScopedPtr<Problem> prb(preprocessProblem(problem));
 
   //outputSymbolDeclarations deals with sorts as well for now


### PR DESCRIPTION
Quite a few changes in FiniteModelBuilder and around with the ultimate aim of Vampire being able to correctly model-check all finite models it generates. 

This PR achieves this goal for inputs in CNF and under `fde=none:erd=off:updr=off:bce=off` - (This means we verify models we output, but so far only for strategies which don't manipulate the signature or eliminate things.)

The next step will be to support undoing these elimination operations and making the model work for the original input (and to do the corresponding operations also for saturations, where we will simply dump the definitions of the eliminated symbols to document how one could recover a model, if they had one.)