### PR TITLE
Fix `latex_output` for ⊤ and ⊥

### DIFF
--- a/Shell/LaTeX.cpp
+++ b/Shell/LaTeX.cpp
@@ -191,7 +191,7 @@ std::string LaTeX::toString (Formula* f) const
 {
   static std::string names [] =
   { "", " \\Vand ", " \\Vor ", " \\Vimp ", " \\Viff ", " \\Vxor ",
-	  "\\neg ", "\\forall ", "\\exists ", "\bot", "\top", "", ""};
+    "\\neg ", "\\forall ", "\\exists ", "", "\\bot", "\\top", "", ""};
 
   Connective c = f->connective();
   std::string con = names[(int)c];


### PR DESCRIPTION
Given `not-true.smt2`:

```lisp
(set-info :smt-lib-version 2.6)
(set-logic QF_UF)

(assert (not true))

(check-sat)
(exit)
```

and:

```bash
 vampire --latex_output tex/not-true.tex not-true.smt2
```

this PR fixes the following:

![before-not-true](https://github.com/user-attachments/assets/5eeb25b2-2783-4f70-89cb-2485cea2ff26)

so that it becomes:

![after-not-true](https://github.com/user-attachments/assets/53e2d323-4292-4122-bb7b-225a1aabfefd)

