### PR TITLE
Remove `using namespace Lib` from hpp files.

### DIFF
--- a/CASC/PortfolioMode.hpp
+++ b/CASC/PortfolioMode.hpp
@@ -30,7 +30,6 @@
 namespace CASC
 {
 
-using namespace Lib;
 using namespace Shell;
 
 class PortfolioMode {
@@ -54,7 +53,7 @@ private:
   [[noreturn]] void runSlice(Options& strategyOpt);
 
 #if VDEBUG
-  DHSet<pid_t> childIds;
+  Lib::DHSet<pid_t> childIds;
 #endif
   unsigned _numWorkers;
   // file that will contain a proof
@@ -66,7 +65,7 @@ private:
    * Note that in the current process this child object is the only one that
    * will be using the problem object.
    */
-  ScopedPtr<Problem> _prb;
+  Lib::ScopedPtr<Problem> _prb;
   float _slowness;
 };
 

--- a/DP/DecisionProcedure.hpp
+++ b/DP/DecisionProcedure.hpp
@@ -19,7 +19,6 @@
 
 namespace DP {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**

--- a/DP/ShortConflictMetaDP.cpp
+++ b/DP/ShortConflictMetaDP.cpp
@@ -18,6 +18,7 @@ namespace DP
 {
 
 using namespace std;
+using namespace Lib;
 
 /**
  * Computes number of literals in core not implied at the zero level

--- a/DP/ShortConflictMetaDP.hpp
+++ b/DP/ShortConflictMetaDP.hpp
@@ -28,7 +28,6 @@
 
 namespace DP {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace SAT;
 
@@ -70,9 +69,9 @@ private:
   unsigned getCoreSize(const LiteralStack& core);
 
 
-  Stack<LiteralStack> _unsatCores;
+  Lib::Stack<LiteralStack> _unsatCores;
 
-  ScopedPtr<DecisionProcedure> _inner;
+  Lib::ScopedPtr<DecisionProcedure> _inner;
   SAT2FO& _sat2fo;
   SATSolver& _solver;
 };

--- a/DP/SimpleCongruenceClosure.cpp
+++ b/DP/SimpleCongruenceClosure.cpp
@@ -32,6 +32,7 @@ namespace DP
 {
 
 using namespace std;
+using namespace Lib;
 
 const unsigned SimpleCongruenceClosure::NO_SIG_SYMBOL = 0xFFFFFFFF;
 

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -29,7 +29,6 @@
 
 namespace DP {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -163,7 +162,7 @@ private:
   void propagate();
 
   unsigned getProofDepth(unsigned c);
-  void collectUnifyingPath(unsigned c1, unsigned c2, Stack<unsigned>& path);
+  void collectUnifyingPath(unsigned c1, unsigned c2, Lib::Stack<unsigned>& path);
 
   static const unsigned NO_SIG_SYMBOL;
   struct ConstInfo
@@ -202,14 +201,14 @@ private:
 
     /** If reprConst==0, contains other constants whose representative
      * this constant is */
-    Stack<unsigned> classList;
+    Lib::Stack<unsigned> classList;
     /**
      * If reprConst==0, contains list of pair names in whose pairs this
      * constant appears as a representative of one of the arguments.
      * Irregardless of the value of reprConst, also contains representatives
      * of all pairs that have this very constant as one of arguments.
      */
-    Stack<unsigned> useList;
+    Lib::Stack<unsigned> useList;
         
     // needed for getModel:    
     /**
@@ -219,7 +218,7 @@ private:
     /**
      * Meaningful for representatives. A list of edges leaving the class "upwards".
      */
-    Stack<unsigned> upEdges;
+    Lib::Stack<unsigned> upEdges;
     /**
      * Meaningful for namedPairs. 
      * 
@@ -239,7 +238,7 @@ private:
   };
 
   struct ConstOrderingComparator;  
-  typedef DHMap<unsigned,TermList> NFMap;
+  typedef Lib::DHMap<unsigned,TermList> NFMap;
   void computeConstsNormalForm(unsigned c, NFMap& normalForms);
   
 #if VDEBUG
@@ -253,7 +252,7 @@ private:
    * of constants in special cases, such as to indicate that there is
    * no constant.
    */
-  DArray<ConstInfo> _cInfos;
+  Lib::DArray<ConstInfo> _cInfos;
 
   /** Positive literals are made equivalent to this constant */
   unsigned _posLitConst;
@@ -263,31 +262,31 @@ private:
   /**
    * Map from signature symbols to the local constant numbers.
    */
-  DHMap<std::pair<unsigned,SignatureKind>,unsigned> _sigConsts;
+  Lib::DHMap<std::pair<unsigned,SignatureKind>,unsigned> _sigConsts;
 
-  typedef DHMap<CPair,unsigned> PairMap;
+  typedef Lib::DHMap<CPair,unsigned> PairMap;
   /** Names of constant pairs (modulo the congruence!)*/
   PairMap _pairNames;
 
   /** Constants corresponding to terms */
-  DHMap<TermList,unsigned> _termNames;
+  Lib::DHMap<TermList,unsigned> _termNames;
   /** Constants corresponding to literals */
-  DHMap<Literal*,unsigned> _litNames;
+  Lib::DHMap<Literal*,unsigned> _litNames;
 
   /**
    * Equality that caused unsatisfiability; if CEq::isInvalid(), there isn't such.
    */
-  Stack<CEq> _unsatEqs;
-  Deque<CEq> _pendingEqualities;
-  Stack<CEq> _negEqualities;
+  Lib::Stack<CEq> _unsatEqs;
+  Lib::Deque<CEq> _pendingEqualities;
+  Lib::Stack<CEq> _negEqualities;
 
   struct DistinctEntry
   {
     DistinctEntry(Literal* l) : _lit(l) {}
     Literal* _lit;
-    Stack<unsigned> _consts;
+    Lib::Stack<unsigned> _consts;
   };
-  typedef Stack<DistinctEntry> DistinctStack;
+  typedef Lib::Stack<DistinctEntry> DistinctStack;
   DistinctStack _distinctConstraints;
   /** Negated distinct constraints, these can lead to an UNKNOWN satisfiability result 
    * 

--- a/Debug/RuntimeStatistics.cpp
+++ b/Debug/RuntimeStatistics.cpp
@@ -25,6 +25,7 @@ namespace Debug
 {
 
 using namespace std;
+using namespace Lib;
 
 void RSMultiCounter::print(ostream& out)
 {

--- a/Debug/RuntimeStatistics.hpp
+++ b/Debug/RuntimeStatistics.hpp
@@ -87,7 +87,6 @@ square's last digit:
 
 namespace Debug {
 
-using namespace Lib;
 
 class RSObject
 {
@@ -127,13 +126,13 @@ public:
   void print(std::ostream& out);
   void inc(size_t index) { _counters[index]++; }
 private:
-  ZIArray<size_t> _counters;
+  Lib::ZIArray<size_t> _counters;
 };
 
 class RSMultiStatistic
 : public RSObject
 {
-  typedef List<int> ValList;
+  typedef Lib::List<int> ValList;
 public:
   RSMultiStatistic(const char* name) : RSObject(name) {}
   ~RSMultiStatistic();
@@ -141,7 +140,7 @@ public:
   void print(std::ostream& out);
   void addRecord(size_t index, int value) { ValList::push(value, _values[index]); }
 private:
-  ZIArray<ValList* > _values;
+  Lib::ZIArray<ValList* > _values;
 };
 
 class RuntimeStatistics
@@ -151,8 +150,9 @@ public:
 
   struct RSObjComparator
   {
-    static Comparison compare(const char* name, RSObject* o2)
+    static Lib::Comparison compare(const char* name, RSObject* o2)
     {
+      using namespace Lib;
       int res=strcmp(name, o2->name());
       return (res>0) ? GREATER : ((res==0) ? EQUAL : LESS);
     }
@@ -175,7 +175,7 @@ private:
   RuntimeStatistics();
   ~RuntimeStatistics();
 
-  typedef SkipList<RSObject*,RSObjComparator> ObjSkipList;
+  typedef Lib::SkipList<RSObject*,RSObjComparator> ObjSkipList;
   ObjSkipList _objs;
 };
 

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -54,7 +54,7 @@ void Debug::Tracer::printStack(std::ostream& str) {
     str << ' ' << call_stack[sz - (i + 1)];
   str << std::endl;
 
-  if (env.options->traceback()) {
+  if (Lib::env.options->traceback()) {
 // UNIX-like systems, including BSD and Linux but not MacOS
 #if defined(__unix__)
   str << "invoking addr2line(1) ..." << std::endl;

--- a/FMB/ClauseFlattening.cpp
+++ b/FMB/ClauseFlattening.cpp
@@ -29,6 +29,7 @@
 namespace FMB{
 
 using namespace std;
+using namespace Lib;
 
 bool ClauseFlattening::isShallow(Literal* lit)
 {

--- a/FMB/CliqueFinder.hpp
+++ b/FMB/CliqueFinder.hpp
@@ -21,23 +21,23 @@ namespace FMB {
 
   class CliqueFinder {
   public:
-    static unsigned findMaxCliqueSize(DHMap<unsigned,DHSet<unsigned>*>* Ngraph)
+    static unsigned findMaxCliqueSize(Lib::DHMap<unsigned,Lib::DHSet<unsigned>*>* Ngraph)
     {
       //std::cout << "findMaxCliqueSize with " << Ngraph->size() << std::endl;
 
       // at least stores the number of nodes with at least index neighbours
-      DArray<Stack<unsigned>> atleast;
+      Lib::DArray<Lib::Stack<unsigned>> atleast;
       atleast.ensure(Ngraph->size()+1); // the +1 is to protect against a self-loop sneaking in
 
-      DHMap<unsigned,DHSet<unsigned>*>::Iterator miter(*Ngraph);
+      Lib::DHMap<unsigned,Lib::DHSet<unsigned>*>::Iterator miter(*Ngraph);
       while(miter.hasNext()){
         unsigned c;
-        DHSet<unsigned>* nbs;
+        Lib::DHSet<unsigned>* nbs;
         miter.next(c,nbs);
         unsigned size = nbs->size();
         //std::cout << ">> " << c << ": " << size << std::endl;
 
-        //DHSet<unsigned>::Iterator dit(*nbs);
+        //Lib::DHSet<unsigned>::Iterator dit(*nbs);
         //while(dit.hasNext()){ std::cout << dit.next() << std::endl; }
 
         for(;size>0;size--){
@@ -61,13 +61,13 @@ namespace FMB {
         else if (atleast[i].size() > i+1){
           //std::cout << "CASE 2" << std::endl;
           unsigned left = atleast[i].size();
-          Stack<unsigned>::Iterator niter(atleast[i]);
+          Lib::Stack<unsigned>::Iterator niter(atleast[i]);
           while(niter.hasNext() && left >= i+1){
             unsigned c = niter.next();
             //std::cout << ">> " << c << std::endl;
             auto ns = Ngraph->get(c);
             if(ns->size()==i){
-              Stack<unsigned> clique;
+              Lib::Stack<unsigned> clique;
               clique.loadFromIterator(ns->iterator());
               clique.push(c);
               if(checkClique(Ngraph,clique)){
@@ -89,7 +89,7 @@ namespace FMB {
   private:
 
     // check if a clique is a clique
-    static bool checkClique(DHMap<unsigned,DHSet<unsigned>*>* Ngraph, Stack<unsigned>& clique)
+    static bool checkClique(Lib::DHMap<unsigned,Lib::DHSet<unsigned>*>* Ngraph, Lib::Stack<unsigned>& clique)
     {
       //std::cout << "CHECK "; for(unsigned j=0;j<clique.size();j++){ std::cout << clique[j] << " ";}; std::cout << std::endl;
 
@@ -97,7 +97,7 @@ namespace FMB {
         unsigned c1 = clique[i];
         auto ns = Ngraph->get(c1);
         //std::cout << c1 << " neighbours: "; 
-        //DHSet<unsigned>::Iterator pit(*ns);while(pit.hasNext()){std::cout << pit.next() << " ";};std::cout<<std::endl;
+        //Lib::DHSet<unsigned>::Iterator pit(*ns);while(pit.hasNext()){std::cout << pit.next() << " ";};std::cout<<std::endl;
         for(unsigned j=i+1;j<clique.size();j++){
           unsigned c2 = clique[j];
           //std::cout << "checking " << c2 << " is a neighbour of " << c1 << std::endl;

--- a/FMB/DefinitionIntroduction.hpp
+++ b/FMB/DefinitionIntroduction.hpp
@@ -31,7 +31,7 @@ namespace FMB {
   class DefinitionIntroduction{
   public:
     DefinitionIntroduction(ClauseIterator cit) : _cit(cit) {
-      //_ng = env.options->fmbNonGroundDefs();
+      //_ng = Lib::env.options->fmbNonGroundDefs();
     }
 
 
@@ -59,7 +59,7 @@ namespace FMB {
     void process(Clause* c){
       //std::cout << "Process " << c->toString() << std::endl;
 
-      static Stack<Literal*> lits; // to rebuild the clause
+      static Lib::Stack<Literal*> lits; // to rebuild the clause
       lits.reset();
 
       bool anyUpdated = false;
@@ -70,7 +70,7 @@ namespace FMB {
 
         //std::cout << " process " << l->toString() << std::endl;
 
-        Stack<TermList> args; 
+        Lib::Stack<TermList> args; 
         for(TermList* ts = l->args(); ts->isNonEmpty(); ts = ts->next()){
           // do not add definitions for variables or constants
           if(ts->isVar() ||  ts->term()->arity()==0 || !ts->term()->ground()){
@@ -116,9 +116,9 @@ namespace FMB {
         //std::cout << "Considering " << t->toString() << std::endl;
         if(t->arity()==0) continue;
         if(!_introduced.find(t)){
-          unsigned newConstant = env.signature->addFreshFunction(0,"fmbdef");
+          unsigned newConstant = Lib::env.signature->addFreshFunction(0,"fmbdef");
           TermList srt = SortHelper::getResultSort(t);
-          Signature::Symbol* newConstantSymb = env.signature->getFunction(newConstant);
+          Signature::Symbol* newConstantSymb = Lib::env.signature->getFunction(newConstant);
           newConstantSymb->setType(OperatorType::getConstantsType(srt));
           newConstantSymb->incUsageCnt();
           Term* c = Term::createConstant(newConstant); 
@@ -127,7 +127,7 @@ namespace FMB {
 
           //Now apply definitions to t
           bool updated = false;
-          Stack<TermList> args;
+          Lib::Stack<TermList> args;
           for(TermList* ts = t->args(); ts->isNonEmpty(); ts = ts->next()){
             ASS(ts->term()->ground());
             // do not add definitions for constants
@@ -143,7 +143,7 @@ namespace FMB {
           }
           TermList sort = SortHelper::getResultSort(t); //TODO set sort of c as this
           Literal* l = Literal::createEquality(true,TermList(t),TermList(c),sort);
-          static Stack<Literal*> lstack;
+          static Lib::Stack<Literal*> lstack;
           lstack.reset();
           lstack.push(l);
           Clause* def = Clause::fromStack(lstack,NonspecificInference1(InferenceRule::FMB_DEF_INTRO,from));
@@ -184,13 +184,13 @@ namespace FMB {
         unsigned vars = t->vars();
 
         // then create a fresh function symbol for the definition
-        newf = env.signature->addFreshFunction(vars,"fmbdef");
+        newf = Lib::env.signature->addFreshFunction(vars,"fmbdef");
         // and save it
         _introducedNG.insert(t,newf);
         
 
         // next create the definition clause
-        Stack<TermList> varTerms;
+        Lib::Stack<TermList> varTerms;
         for(unsigned v=0;v<vars;v++){
           TermList vt(v,false);
           varTerms.push(vt);
@@ -200,7 +200,7 @@ namespace FMB {
         unsigned sort = SortHelper::getResultSort(t); //TODO set sort of newf
         Literal* l = Literal::createEquality(true,TermList(t),TermList(nt),sort);
 
-        static Stack<Literal*> lstack;
+        static Lib::Stack<Literal*> lstack;
         lstack.reset();
         lstack.push(l);
         Clause* def = Clause::fromStack(lstack,from->inputType(),
@@ -219,10 +219,10 @@ namespace FMB {
     bool _ng;
 */
     ClauseIterator _cit;
-    Stack<Clause*> _processed;
+    Lib::Stack<Clause*> _processed;
 
-    DHMap<Term*,Term*> _introduced;
-    DHMap<Term*,unsigned> _introducedNG;
+    Lib::DHMap<Term*,Term*> _introduced;
+    Lib::DHMap<Term*,unsigned> _introducedNG;
 
   };
 

--- a/FMB/FiniteModel.hpp
+++ b/FMB/FiniteModel.hpp
@@ -27,7 +27,6 @@
 
 namespace FMB {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -43,10 +42,10 @@ public:
  // Assume def is an equality literal with a
  // function application on lhs and constant on rhs
  void addConstantDefinition(unsigned f, unsigned res);
- void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res); 
+ void addFunctionDefinition(unsigned f, const Lib::DArray<unsigned>& args, unsigned res); 
  // Assume def is non-equality ground literal
  void addPropositionalDefinition(unsigned f, bool res);
- void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res); 
+ void addPredicateDefinition(unsigned f, const Lib::DArray<unsigned>& args, bool res); 
 
  bool isPartial();
 
@@ -65,23 +64,23 @@ private:
  // The model is partial if there is a operation with arity n that does not have
  // coverage size^n in its related coverage map
  bool _isPartial;
- DHMap<unsigned,unsigned> _functionCoverage;
- DHMap<unsigned,unsigned> _predicateCoverage;
+ Lib::DHMap<unsigned,unsigned> _functionCoverage;
+ Lib::DHMap<unsigned,unsigned> _predicateCoverage;
 
- DArray<unsigned> f_offsets;
- DArray<unsigned> p_offsets;
- DArray<unsigned> f_interpretation;
- DArray<unsigned> p_interpretation; // 0 is undef, 1 false, 2 true
+ Lib::DArray<unsigned> f_offsets;
+ Lib::DArray<unsigned> p_offsets;
+ Lib::DArray<unsigned> f_interpretation;
+ Lib::DArray<unsigned> p_interpretation; // 0 is undef, 1 false, 2 true
 
- DHMap<unsigned,Term*> _domainConstants;
- DHMap<Term*,unsigned> _domainConstantsRev;
+ Lib::DHMap<unsigned,Term*> _domainConstants;
+ Lib::DHMap<Term*,unsigned> _domainConstantsRev;
 public:
  Term* getDomainConstant(unsigned c)
  {
    Term* t;
    if(_domainConstants.find(c,t)) return t;
    std::string name = "domainConstant";//+Lib::Int::toString(c);
-   unsigned f = env.signature->addFreshFunction(0,name.c_str()); 
+   unsigned f = Lib::env.signature->addFreshFunction(0,name.c_str()); 
    t = Term::createConstant(f);
    _domainConstants.insert(c,t);
    _domainConstantsRev.insert(t,c);

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -73,6 +73,7 @@ namespace FMB
 {
 
 using namespace std;
+using namespace Lib;
 
 FiniteModelBuilder::FiniteModelBuilder(Problem& prb, const Options& opt)
 : MainLoop(prb, opt), _sortedSignature(0), _groundClauses(0), _clauses(0),

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -29,7 +29,6 @@
 #include "Lib/BinaryHeap.hpp"
 
 namespace FMB {
-using namespace Lib;
 using namespace Kernel;
 using namespace Inferences;
 using namespace Shell;
@@ -42,7 +41,7 @@ using namespace SAT;
    */
   struct GroundedTerm{
     unsigned f;
-    DArray<unsigned> grounding;
+    Lib::DArray<unsigned> grounding;
 
     std::string toString(){
       std::string ret = Lib::Int::toString(f)+"[";
@@ -89,9 +88,9 @@ private:
   void addNewTotalityDefs();
 
   // Add constraints for symmetry ordering i.e. the first modelSize groundedTerms are ordered
-  void addNewSymmetryOrderingAxioms(unsigned modelSize,Stack<GroundedTerm>& groundedTerms); 
+  void addNewSymmetryOrderingAxioms(unsigned modelSize,Lib::Stack<GroundedTerm>& groundedTerms); 
   // Add constraints for canonicity of symmetry order i.e. if a groundedTerm uses a constant smaller terms use smaller constants
-  void addNewSymmetryCanonicityAxioms(unsigned modelSize,Stack<GroundedTerm>& groundedTerms,unsigned maxModelSize);
+  void addNewSymmetryCanonicityAxioms(unsigned modelSize,Lib::Stack<GroundedTerm>& groundedTerms,unsigned maxModelSize);
 
   // Add all symmetry constraints
   // For each model size up to the maximum add both ordering and canonicity constraints for each (inferred) sort
@@ -115,7 +114,7 @@ private:
   // Converts a grounded term (literal) into a SATLiteral
   // The elements are the domain constants to use as parameters
   // polarity is used if isFunction is false
-  SATLiteral getSATLiteral(unsigned func, const DArray<unsigned>& elements,bool polarity,
+  SATLiteral getSATLiteral(unsigned func, const Lib::DArray<unsigned>& elements,bool polarity,
                            bool isFunction);
 
   // resets all structures and SAT solver using _sortModelSizes 
@@ -124,22 +123,22 @@ private:
   // make the symmetry orderings
   void createSymmetryOrdering();
   // The per-sort ordering of grounded terms used for symmetry breaking
-  DArray<Stack<GroundedTerm>> _sortedGroundedTerms;
+  Lib::DArray<Lib::Stack<GroundedTerm>> _sortedGroundedTerms;
 
   unsigned _curMaxVar;
   // SAT solver used to solve constraints (a new one is used for each model size)
-  ScopedPtr<SATSolverWithAssumptions> _solver;
+  Lib::ScopedPtr<SATSolverWithAssumptions> _solver;
 
   // Structures to record symbols removed during preprocessing i.e. via definition elimination
   // These are ignored throughout finite model building and then the definitions (recorded here)
   // are used to give the interpretation of the function/predicate if a model is found
-  DHMap<unsigned,Literal*> _deletedFunctions;
-  DHMap<unsigned,Unit*> _deletedPredicates;
-  DHMap<unsigned,Unit*> _partiallyDeletedPredicates; 
-  DHMap<unsigned,bool> _trivialPredicates;
+  Lib::DHMap<unsigned,Literal*> _deletedFunctions;
+  Lib::DHMap<unsigned,Unit*> _deletedPredicates;
+  Lib::DHMap<unsigned,Unit*> _partiallyDeletedPredicates; 
+  Lib::DHMap<unsigned,bool> _trivialPredicates;
   // if del_f[i] (resp del_p[i]) is true then that function (resp predicate) should be ignored
-  DArray<unsigned> del_f;
-  DArray<unsigned> del_p;
+  Lib::DArray<unsigned> del_f;
+  Lib::DArray<unsigned> del_p;
 
   // Add a SATClause to the SAT solver
   void addSATClause(SATClause* cl);
@@ -160,16 +159,16 @@ private:
   ClauseList* _clauses;
 
   // Record for function symbol the minimum bound of the return sort or any parameter sorts 
-  DArray<unsigned> _fminbound;
+  Lib::DArray<unsigned> _fminbound;
   // Record for each clause the sorts of the variables 
   // As clauses are normalized variables will be numbered 0,1,...
-  DHMap<Clause*,DArray<unsigned>*> _clauseVariableSorts;
+  Lib::DHMap<Clause*,Lib::DArray<unsigned>*> _clauseVariableSorts;
 
   // There is a implicit mapping from ground terms to SAT variables
   // These offsets give the SAT variable for the *first* grounding of each function or predicate symbol
   // Then the SAT variables for other groundings can be computed from this
-  DArray<unsigned> f_offsets;
-  DArray<unsigned> p_offsets;
+  Lib::DArray<unsigned> f_offsets;
+  Lib::DArray<unsigned> p_offsets;
 
   // do contour encoding instead of point-wise
   bool _xmass;
@@ -179,7 +178,7 @@ private:
   /* Each distinctSort has as many markers as is its current size.
    * Their offsets are stored on per sort basis.
    */
-  DArray<unsigned> marker_offsets;
+  Lib::DArray<unsigned> marker_offsets;
 
   // } else {
 
@@ -224,8 +223,8 @@ private:
   unsigned _sizeWeightRatio;
 
   // sizes to use for each sort
-  DArray<unsigned> _sortModelSizes;
-  DArray<unsigned> _distinctSortSizes;
+  Lib::DArray<unsigned> _sortModelSizes;
+  Lib::DArray<unsigned> _distinctSortSizes;
 
   enum ConstraintSign {
     EQ,     // the value has to matched
@@ -234,13 +233,13 @@ private:
     STAR    // we don't care about this value
   };
 
-  typedef DArray<std::pair<ConstraintSign,unsigned>> Constraint_Generator_Vals;
+  typedef Lib::DArray<std::pair<ConstraintSign,unsigned>> Constraint_Generator_Vals;
 
   class DSAEnumerator { // Domain Size Assignment Enumerator - for the point-wise encoding case
   public:
-    virtual bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>&, Stack<std::pair<unsigned,unsigned>>&) { return true; }
+    virtual bool init(unsigned, Lib::DArray<unsigned>&, Lib::Stack<std::pair<unsigned,unsigned>>&, Lib::Stack<std::pair<unsigned,unsigned>>&) { return true; }
     virtual void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) = 0;
-    virtual bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) = 0;
+    virtual bool increaseModelSizes(Lib::DArray<unsigned>& newSortSizes, Lib::DArray<unsigned>& sortMaxes) = 0;
     virtual bool isFmbComplete(unsigned noDomains) { return false; }
     virtual ~DSAEnumerator() {}
   };
@@ -259,14 +258,17 @@ private:
     };
 
     struct Constraint_Generator_Compare {
-      static Comparison compare (Constraint_Generator* c1, Constraint_Generator* c2)
-      { return c1->_weight < c2->_weight ? LESS : c1->_weight == c2->_weight ? EQUAL : GREATER; }
+      static Lib::Comparison compare (Constraint_Generator* c1, Constraint_Generator* c2)
+      {
+        using namespace Lib;
+        return c1->_weight < c2->_weight ? LESS : c1->_weight == c2->_weight ? EQUAL : GREATER;
+      }
     };
 
     typedef Lib::BinaryHeap<Constraint_Generator*,Constraint_Generator_Compare> Constraint_Generator_Heap;
 
-    Stack<std::pair<unsigned,unsigned>>* _distinct_sort_constraints;
-    Stack<std::pair<unsigned,unsigned>>* _strict_distinct_sort_constraints;
+    Lib::Stack<std::pair<unsigned,unsigned>>* _distinct_sort_constraints;
+    Lib::Stack<std::pair<unsigned,unsigned>>* _strict_distinct_sort_constraints;
 
     /**
      * Constraints are at the same time used as generators.
@@ -278,14 +280,14 @@ private:
     bool _skippedSomeSizes;
 
     bool _keepOldGenerators;
-    Stack<Constraint_Generator*> _old_generators; // keeping old generators degraded performance on average ...
+    Lib::Stack<Constraint_Generator*> _old_generators; // keeping old generators degraded performance on average ...
   protected:
-    bool checkConstriant(DArray<unsigned>& newSortSizes, Constraint_Generator_Vals& constraint);
+    bool checkConstriant(Lib::DArray<unsigned>& newSortSizes, Constraint_Generator_Vals& constraint);
 
   public:
     HackyDSAE(bool keepOldGenerators) : _maxWeightSoFar(0), _keepOldGenerators(keepOldGenerators) {}
 
-    bool init(unsigned _startSize, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>& dsc, Stack<std::pair<unsigned,unsigned>>& sdsc) override {
+    bool init(unsigned _startSize, Lib::DArray<unsigned>&, Lib::Stack<std::pair<unsigned,unsigned>>& dsc, Lib::Stack<std::pair<unsigned,unsigned>>& sdsc) override {
       _skippedSomeSizes = (_startSize > 1);
       _distinct_sort_constraints = &dsc;
       _strict_distinct_sort_constraints = &sdsc;
@@ -294,7 +296,7 @@ private:
 
     bool isFmbComplete(unsigned noDomains) override { return (noDomains <= 1) && !_skippedSomeSizes; }
     void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) override;
-    bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) override;
+    bool increaseModelSizes(Lib::DArray<unsigned>& newSortSizes, Lib::DArray<unsigned>& sortMaxes) override;
   };
 
 #if VZ3
@@ -302,32 +304,32 @@ private:
     z3::context _context;
     z3::solver  _smtSolver;
     unsigned _lastWeight;
-    DArray<z3::expr*> _sizeConstants;
+    Lib::DArray<z3::expr*> _sizeConstants;
     bool _skippedSomeSizes;
   protected:
-    unsigned loadSizesFromSmt(DArray<unsigned>& szs);
+    unsigned loadSizesFromSmt(Lib::DArray<unsigned>& szs);
     void reportZ3OutOfMemory();
   public:
     SmtBasedDSAE() : _smtSolver(_context) {}
 
-    bool init(unsigned, DArray<unsigned>&, Stack<std::pair<unsigned,unsigned>>&, Stack<std::pair<unsigned,unsigned>>&) override;
+    bool init(unsigned, Lib::DArray<unsigned>&, Lib::Stack<std::pair<unsigned,unsigned>>&, Lib::Stack<std::pair<unsigned,unsigned>>&) override;
     void learnNogood(Constraint_Generator_Vals& nogood, unsigned weight) override;
-    bool increaseModelSizes(DArray<unsigned>& newSortSizes, DArray<unsigned>& sortMaxes) override;
+    bool increaseModelSizes(Lib::DArray<unsigned>& newSortSizes, Lib::DArray<unsigned>& sortMaxes) override;
     bool isFmbComplete(unsigned) override { return !_skippedSomeSizes; }
   };
 #endif
 
   // the sort constraints from injectivity/surjectivity
   // pairs of distinct sorts where pair.first >= pair.second
-  Stack<std::pair<unsigned,unsigned>> _distinct_sort_constraints;
+  Lib::Stack<std::pair<unsigned,unsigned>> _distinct_sort_constraints;
   // pairs of distinct sorts where pair.first > pair.second
-  Stack<std::pair<unsigned,unsigned>> _strict_distinct_sort_constraints;
+  Lib::Stack<std::pair<unsigned,unsigned>> _strict_distinct_sort_constraints;
 
   // Record the number of constants in the problem per distinct sort
-  DArray<unsigned> _distinctSortConstantCount;
+  Lib::DArray<unsigned> _distinctSortConstantCount;
   // min and max sizes for distinct sorts
-  DArray<unsigned> _distinctSortMins;
-  DArray<unsigned> _distinctSortMaxs;
+  Lib::DArray<unsigned> _distinctSortMins;
+  Lib::DArray<unsigned> _distinctSortMaxs;
   //unsigned _maxModelSizeAllSorts;
 
 public: // debugging

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -27,7 +27,6 @@
 
 namespace FMB {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -35,20 +34,20 @@ using namespace Kernel;
  *
  */
 class FiniteModelMultiSorted {
- DHMap<unsigned,unsigned> _sizes;
+ Lib::DHMap<unsigned,unsigned> _sizes;
 
 public:
 
  // sortSizes is a map from vampire sorts (defined in Kernel/Sorts) to the size of that sort
- FiniteModelMultiSorted(DHMap<unsigned,unsigned> sortSizes);
+ FiniteModelMultiSorted(Lib::DHMap<unsigned,unsigned> sortSizes);
 
  // Assume def is an equality literal with a
  // function application on lhs and constant on rhs
  void addConstantDefinition(unsigned f, unsigned res);
- void addFunctionDefinition(unsigned f, const DArray<unsigned>& args, unsigned res); 
+ void addFunctionDefinition(unsigned f, const Lib::DArray<unsigned>& args, unsigned res); 
  // Assume def is non-equality ground literal
  void addPropositionalDefinition(unsigned f, bool res);
- void addPredicateDefinition(unsigned f, const DArray<unsigned>& args, bool res); 
+ void addPredicateDefinition(unsigned f, const Lib::DArray<unsigned>& args, bool res); 
 
  bool isPartial();
 
@@ -67,29 +66,29 @@ private:
  // The model is partial if there is a operation with arity n that does not have
  // coverage size^n in its related coverage map
  bool _isPartial;
- DHMap<unsigned,unsigned> _functionCoverage;
- DHMap<unsigned,unsigned> _predicateCoverage;
+ Lib::DHMap<unsigned,unsigned> _functionCoverage;
+ Lib::DHMap<unsigned,unsigned> _predicateCoverage;
 
- DArray<DArray<int>> sortRepr;
+ Lib::DArray<Lib::DArray<int>> sortRepr;
 
- DArray<unsigned> f_offsets;
- DArray<unsigned> p_offsets;
- DArray<unsigned> f_interpretation;
- DArray<unsigned> p_interpretation; // 0 is undef, 1 false, 2 true
+ Lib::DArray<unsigned> f_offsets;
+ Lib::DArray<unsigned> p_offsets;
+ Lib::DArray<unsigned> f_interpretation;
+ Lib::DArray<unsigned> p_interpretation; // 0 is undef, 1 false, 2 true
 
  // the pairs of <constant number, sort>
- DHMap<std::pair<unsigned,unsigned>,Term*> _domainConstants;
- DHMap<Term*,std::pair<unsigned,unsigned>> _domainConstantsRev;
+ Lib::DHMap<std::pair<unsigned,unsigned>,Term*> _domainConstants;
+ Lib::DHMap<Term*,std::pair<unsigned,unsigned>> _domainConstantsRev;
 public:
  Term* getDomainConstant(unsigned c, unsigned srt)
  {
    Term* t;
    std::pair<unsigned,unsigned> pair = std::make_pair(c,srt);
    if(_domainConstants.find(pair,t)) return t;
-   std::string name = "domCon_"+env.signature->typeConName(srt)+"_"+Lib::Int::toString(c);
-   unsigned f = env.signature->addFreshFunction(0,name.c_str()); 
+   std::string name = "domCon_"+Lib::env.signature->typeConName(srt)+"_"+Lib::Int::toString(c);
+   unsigned f = Lib::env.signature->addFreshFunction(0,name.c_str()); 
    TermList srtT = TermList(AtomicSort::createConstant(srt));
-   env.signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
+   Lib::env.signature->getFunction(f)->setType(OperatorType::getConstantsType(srtT));
    t = Term::createConstant(f);
    _domainConstants.insert(pair,t);
    _domainConstantsRev.insert(t,pair);

--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -48,6 +48,7 @@
 namespace FMB
 {
 using namespace std;
+using namespace Lib;
 using namespace Shell;
 
 void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator clauses, 

--- a/FMB/FunctionRelationshipInference.hpp
+++ b/FMB/FunctionRelationshipInference.hpp
@@ -24,7 +24,6 @@
 
 namespace FMB {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -36,9 +35,9 @@ class FunctionRelationshipInference {
 public:
 
 void findFunctionRelationships(ClauseIterator clauses, 
-                               Stack<DHSet<unsigned>*>& eq_classes, 
-                               DHSet<std::pair<unsigned,unsigned>>& nonstrict_cons,
-                               DHSet<std::pair<unsigned,unsigned>>& strict_cons); 
+                               Lib::Stack<Lib::DHSet<unsigned>*>& eq_classes, 
+                               Lib::DHSet<std::pair<unsigned,unsigned>>& nonstrict_cons,
+                               Lib::DHSet<std::pair<unsigned,unsigned>>& strict_cons); 
 
 private:
 
@@ -52,8 +51,8 @@ void addClaimForFunction(TermList x, TermList y, TermList fx, TermList fy,
 void addClaim(Formula* conjecture, ClauseList*& newClauses);
 Formula* getName(TermList fromSort, TermList toSort, bool strict);
 
-DHMap<unsigned,std::pair<unsigned,unsigned>> _labelMap_nonstrict;
-DHMap<unsigned,std::pair<unsigned,unsigned>> _labelMap_strict;
+Lib::DHMap<unsigned,std::pair<unsigned,unsigned>> _labelMap_nonstrict;
+Lib::DHMap<unsigned,std::pair<unsigned,unsigned>> _labelMap_strict;
 
 };
 

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -32,7 +32,6 @@
 
 namespace FMB{
 
-using namespace Lib;
 using namespace Kernel;
 
 class ModelCheck{
@@ -45,7 +44,7 @@ static void doCheck(UnitList* units)
   // Currently assume it is called 'finite_domain'
   // TODO search for something of the right shape
   unsigned modelSize = 0;
-  Set<Term*> domainConstants;
+  Lib::Set<Term*> domainConstants;
   {
     UnitList::Iterator uit(units);
     while(uit.hasNext()){
@@ -89,8 +88,8 @@ static void doCheck(UnitList* units)
   std::cout << "Distinct domain assumed, domain elements are:" << std::endl;
 
   // number the domain constants
-  DHMap<Term*,unsigned> domainConstantNumber;
-  Set<Term*>::Iterator dit(domainConstants);
+  Lib::DHMap<Term*,unsigned> domainConstantNumber;
+  Lib::Set<Term*>::Iterator dit(domainConstants);
   unsigned count=1;
   while(dit.hasNext()){ 
     Term* con = dit.next();
@@ -161,7 +160,7 @@ static void doCheck(UnitList* units)
 
 private:
 
-static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domainConstants)
+static void checkIsDomainLiteral(Literal* l, int& single_var, Lib::Set<Term*>& domainConstants)
 {
             if(!l->isEquality()) USER_ERROR("finite_domain is not a domain axiom");
 
@@ -180,7 +179,7 @@ static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domain
             // store and check the ground constant used
             Term* constant = right->term();
             unsigned f = constant->functor();
-            if(env.signature->functionArity(f)!=0) USER_ERROR("finite_domain is not a domain axiom");
+            if(Lib::env.signature->functionArity(f)!=0) USER_ERROR("finite_domain is not a domain axiom");
             if(domainConstants.contains(constant)) USER_ERROR("finite_domain is not a domain axiom");
 
             domainConstants.insert(constant);
@@ -189,8 +188,8 @@ static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domain
 }
 
 static void addDefinition(FiniteModel& model,Literal* lit,bool negated,
-                          Set<Term*>& domainConstants,
-                          DHMap<Term*,unsigned>& domainConstantNumber)
+                          Lib::Set<Term*>& domainConstants,
+                          Lib::DHMap<Term*,unsigned>& domainConstantNumber)
 {
   if(lit->isEquality()){
           if(!lit->polarity() || negated) USER_ERROR("Cannot have negated function definition");
@@ -207,10 +206,10 @@ static void addDefinition(FiniteModel& model,Literal* lit,bool negated,
           if(left->isVar()) USER_ERROR("Expect term on left of definition");
           Term* fun = left->term();
           unsigned f = fun->functor();
-          unsigned arity = env.signature->functionArity(f);
+          unsigned arity = Lib::env.signature->functionArity(f);
           if(arity==0) model.addConstantDefinition(f,res);
           else{
-            DArray<unsigned> args(arity);
+            Lib::DArray<unsigned> args(arity);
             for(unsigned i=0;i<arity;i++){
               TermList* arg = fun->nthArgument(i);
               if(arg->isVar() || !domainConstants.contains(arg->term()))
@@ -224,10 +223,10 @@ static void addDefinition(FiniteModel& model,Literal* lit,bool negated,
           if(!lit->polarity()) negated=!negated;
           // Defining a predicate or proposition
           unsigned p = lit->functor();
-          unsigned arity = env.signature->predicateArity(p);
+          unsigned arity = Lib::env.signature->predicateArity(p);
           if(arity==0) model.addPropositionalDefinition(p,!negated);
           else{
-            DArray<unsigned> args(arity);
+            Lib::DArray<unsigned> args(arity);
             for(unsigned i=0;i<arity;i++){
               TermList* arg = lit->nthArgument(i);
               if(arg->isVar() || !domainConstants.contains(arg->term()))

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -39,6 +39,7 @@ namespace FMB
 {
 
 using namespace std;
+using namespace Lib;
 
 Monotonicity::Monotonicity(ClauseList* clauses, unsigned srt) : _srt(srt)
 {

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -37,7 +37,6 @@
 namespace FMB {
   using namespace Kernel;
   using namespace SAT;
-  using namespace Lib;
 
 class Monotonicity{
 public:
@@ -46,7 +45,7 @@ public:
 
   bool check(){ return _result;}
 
-  static void addSortPredicates(bool withMon, ClauseList*& clauses, DArray<unsigned>& del_f);
+  static void addSortPredicates(bool withMon, ClauseList*& clauses, Lib::DArray<unsigned>& del_f);
   static void addSortFunctions(bool withMon, ClauseList*& clauses);
 
 private:
@@ -55,11 +54,11 @@ private:
   
   void safe(Clause* c, Literal* l, TermList* t); 
   void safe(Clause* c, Literal* l, TermList* t, SATLiteral add); 
-  void safe(Clause* c, Literal* l, TermList* t, Stack<SATLiteral>& slits);
+  void safe(Clause* c, Literal* l, TermList* t, Lib::Stack<SATLiteral>& slits);
 
   // returns true if the true literal should be added to slits
   // returns false otherwise (if false should be added or something else has been added)
-  bool guards(Literal* l, unsigned var, Stack<SATLiteral>& slits);
+  bool guards(Literal* l, unsigned var, Lib::Stack<SATLiteral>& slits);
 
  
   unsigned _srt; 
@@ -67,10 +66,10 @@ private:
   // the constructor computes the result
   bool _result;
 
-  DHMap<unsigned,SATLiteral> _pF;
-  DHMap<unsigned,SATLiteral> _pT;
+  Lib::DHMap<unsigned,SATLiteral> _pF;
+  Lib::DHMap<unsigned,SATLiteral> _pT;
 
-  ScopedPtr<SATSolver> _solver;
+  Lib::ScopedPtr<SATSolver> _solver;
 
 };
 

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -43,6 +43,7 @@ namespace FMB
 {
 
 using namespace std;
+using namespace Lib;
 
 
 /**

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -29,73 +29,72 @@
 namespace FMB {
 using namespace Kernel;
 using namespace Shell;
-using namespace Lib;
 
 struct SortedSignature{
     unsigned sorts;
-    DArray<Stack<unsigned>> sortedConstants;
-    DArray<Stack<unsigned>> sortedFunctions;
+    Lib::DArray<Lib::Stack<unsigned>> sortedConstants;
+    Lib::DArray<Lib::Stack<unsigned>> sortedFunctions;
 
     // for f(x,y) = z this will store sort(z),sort(x),sort(y)
-    DArray<DArray<unsigned>> functionSignatures;
+    Lib::DArray<Lib::DArray<unsigned>> functionSignatures;
     // for p(x,y) this will store sort(x),sort(y)
-    DArray<DArray<unsigned>> predicateSignatures;
+    Lib::DArray<Lib::DArray<unsigned>> predicateSignatures;
 
     // gives the maximum size of a sort
-    DArray<unsigned> sortBounds;
+    Lib::DArray<unsigned> sortBounds;
     
     // the number of distinct sorts that might have different sizes
     unsigned distinctSorts;
 
     // for each distinct sort gives a sort that can be used for variable equalities that are otherwise unsorted
     // some of these will not be used, we could detect these cases... but it is not interesting
-    DArray<unsigned> varEqSorts;
+    Lib::DArray<unsigned> varEqSorts;
 
     // the distinct parents of sorts
     // has length sorts with contents from distinctSorts
     // invariant: all monotonic sorts will have parent 0, the first non-monotonic sort
-    DArray<unsigned> parents;
+    Lib::DArray<unsigned> parents;
 
     // Map the distinct sorts back to their vampire parents
     // A distinct sort may merge multipe vampire sorts (due to monotonicity)
-    DHMap<unsigned,Stack<unsigned>*> distinctToVampire;
+    Lib::DHMap<unsigned,Lib::Stack<unsigned>*> distinctToVampire;
     // A vampire sort can only be mapped to more than one distinct sort under certain conditions i.e. when
     // (i) the option for fmbSortInference = expand
     // (ii) at most one sort has non-monotonic subsorts and that is called parent
     // (iii) additional constraints have been added making expanded <= parent
-    DHMap<unsigned,Stack<unsigned>*> vampireToDistinct;
+    Lib::DHMap<unsigned,Lib::Stack<unsigned>*> vampireToDistinct;
     // This maps to the distinct parent
     // invariant: domain of the two maps are the same and the second maps to something in the stack of the first
-    DHMap<unsigned,unsigned> vampireToDistinctParent;
+    Lib::DHMap<unsigned,unsigned> vampireToDistinctParent;
 
     // has size distinctSorts
     // is 1 if that distinct sort is monotonic
-    ZIArray<bool> monotonicSorts;
+    Lib::ZIArray<bool> monotonicSorts;
 };
 
 class SortInference {
 public:
   SortInference(ClauseList* clauses,
-                DArray<unsigned> del_f,
-                DArray<unsigned> del_p,
-                Stack<DHSet<unsigned>*> equiv_v_sorts,
-                Stack<std::pair<unsigned,unsigned>>& cons) :
+                Lib::DArray<unsigned> del_f,
+                Lib::DArray<unsigned> del_p,
+                Lib::Stack<Lib::DHSet<unsigned>*> equiv_v_sorts,
+                Lib::Stack<std::pair<unsigned,unsigned>>& cons) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
-                _equiv_v_sorts(equiv_v_sorts), _equiv_vs(env.signature->typeCons()),
+                _equiv_v_sorts(equiv_v_sorts), _equiv_vs(Lib::env.signature->typeCons()),
                 _sort_constraints(cons) {
 
                   _sig = new SortedSignature();
-                  _print = env.options->showFMBsortInfo();
+                  _print = Lib::env.options->showFMBsortInfo();
 
                    // ignore inference if there are no clauses
                   _ignoreInference = !clauses; 
-                  _expandSubsorts = env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::EXPAND;
+                  _expandSubsorts = Lib::env.options->fmbAdjustSorts() == Options::FMBAdjustSorts::EXPAND;
 
                   _usingMonotonicity = true;
-                  _collapsingMonotonicSorts = (env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::OFF && 
-                                               env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::EXPAND);
+                  _collapsingMonotonicSorts = (Lib::env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::OFF && 
+                                               Lib::env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::EXPAND);
                   _assumeMonotonic = _collapsingMonotonicSorts && 
-                                     env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::GROUP;
+                                     Lib::env.options->fmbAdjustSorts() != Options::FMBAdjustSorts::GROUP;
 
                   _distinctSorts=0;
                   _collapsed=0;
@@ -121,17 +120,17 @@ private:
 
   unsigned _distinctSorts;
   unsigned _collapsed;
-  DHSet<unsigned> monotonicVampireSorts;
-  ZIArray<unsigned> posEqualitiesOnSort;
+  Lib::DHSet<unsigned> monotonicVampireSorts;
+  Lib::ZIArray<unsigned> posEqualitiesOnSort;
 
   SortedSignature* _sig;
   ClauseList* _clauses;
-  DArray<unsigned> _del_f;
-  DArray<unsigned> _del_p;
-  Stack<DHSet<unsigned>*> _equiv_v_sorts;
-  IntUnionFind _equiv_vs;
+  Lib::DArray<unsigned> _del_f;
+  Lib::DArray<unsigned> _del_p;
+  Lib::Stack<Lib::DHSet<unsigned>*> _equiv_v_sorts;
+  Lib::IntUnionFind _equiv_vs;
 
-  Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
+  Lib::Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
 
 };
 

--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -35,9 +35,9 @@ template<class C> class Vector;
 template<typename T> class List;
 template<typename T> class SharedSet;
 
-typedef List<int> IntList;
-typedef Stack<std::string> StringStack;
-typedef List<VoidFunc> VoidFuncList;
+typedef Lib::List<int> IntList;
+typedef Lib::Stack<std::string> StringStack;
+typedef Lib::List<VoidFunc> VoidFuncList;
 
 class DefaultHash;
 class DefaultHash2;
@@ -53,46 +53,45 @@ class Timer;
 
 namespace Kernel
 {
-using namespace Lib;
 
 class Signature;
 
 class Term;
 class TermList;
-typedef VirtualIterator<TermList> TermIterator;
-typedef Stack<TermList> TermStack;
+typedef Lib::VirtualIterator<TermList> TermIterator;
+typedef Lib::Stack<TermList> TermStack;
 
 struct SubstApplicator;
 struct AppliedTerm;
 
-typedef List<unsigned> VList; // a list of variables (which are unsigned)
-typedef List<TermList> SList; // a list of sorts (which are now, with polymorphism, TermLists)
-typedef const SharedSet<unsigned> VarSet;
+typedef Lib::List<unsigned> VList; // a list of variables (which are unsigned)
+typedef Lib::List<TermList> SList; // a list of sorts (which are now, with polymorphism, TermLists)
+typedef const Lib::SharedSet<unsigned> VarSet;
 
 
 class Literal;
-typedef List<Literal*> LiteralList;
-typedef Stack<Literal*> LiteralStack;
-typedef VirtualIterator<Literal*> LiteralIterator;
+typedef Lib::List<Literal*> LiteralList;
+typedef Lib::Stack<Literal*> LiteralStack;
+typedef Lib::VirtualIterator<Literal*> LiteralIterator;
 
 class Inference;
 
 class Unit;
-typedef List<Unit*> UnitList;
-typedef Stack<Unit*> UnitStack;
-typedef VirtualIterator<Unit*> UnitIterator;
+typedef Lib::List<Unit*> UnitList;
+typedef Lib::Stack<Unit*> UnitStack;
+typedef Lib::VirtualIterator<Unit*> UnitIterator;
 
 class FormulaUnit;
 class Formula;
-typedef List<Formula*> FormulaList;
-typedef VirtualIterator<Formula*> FormulaIterator;
-typedef Stack<Formula*> FormulaStack;
+typedef Lib::List<Formula*> FormulaList;
+typedef Lib::VirtualIterator<Formula*> FormulaIterator;
+typedef Lib::Stack<Formula*> FormulaStack;
 
 class Clause;
-typedef VirtualIterator<Clause*> ClauseIterator;
-typedef SingleParamEvent<Clause*> ClauseEvent;
-typedef List<Clause*> ClauseList;
-typedef Stack<Clause*> ClauseStack;
+typedef Lib::VirtualIterator<Clause*> ClauseIterator;
+typedef Lib::SingleParamEvent<Clause*> ClauseEvent;
+typedef Lib::List<Clause*> ClauseList;
+typedef Lib::Stack<Clause*> ClauseStack;
 
 class Problem;
 
@@ -100,11 +99,11 @@ class Renaming;
 class Substitution;
 
 class RobSubstitution;
-typedef VirtualIterator<RobSubstitution*> SubstIterator;
+typedef Lib::VirtualIterator<RobSubstitution*> SubstIterator;
 typedef Lib::SmartPtr<RobSubstitution> RobSubstitutionSP;
 
 class Matcher;
-typedef VirtualIterator<Matcher*> MatchIterator;
+typedef Lib::VirtualIterator<Matcher*> MatchIterator;
 
 class LiteralSelector;
 
@@ -114,7 +113,7 @@ struct OrderingComparator;
 typedef std::unique_ptr<const OrderingComparator> OrderingComparatorUP;
 
 typedef unsigned SplitLevel;
-typedef const SharedSet<SplitLevel> SplitSet;
+typedef const Lib::SharedSet<SplitLevel> SplitSet;
 
 /**
  * Color of a term
@@ -176,17 +175,16 @@ class BackwardSimplificationEngine;
 
 namespace SAT
 {
-using namespace Lib;
 
 class SATClause;
 class SATLiteral;
 class SATInference;
 class SATSolver;
 
-typedef VirtualIterator<SATClause*> SATClauseIterator;
-typedef List<SATClause*> SATClauseList;
-typedef Stack<SATClause*> SATClauseStack;
-typedef Stack<SATLiteral> SATLiteralStack;
+typedef Lib::VirtualIterator<SATClause*> SATClauseIterator;
+typedef Lib::List<SATClause*> SATClauseList;
+typedef Lib::Stack<SATClause*> SATClauseStack;
+typedef Lib::Stack<SATLiteral> SATLiteralStack;
 }
 
 namespace Shell

--- a/Indexing/ClauseCodeTree.hpp
+++ b/Indexing/ClauseCodeTree.hpp
@@ -29,7 +29,6 @@
 
 namespace Indexing {
 
-using namespace Lib;
 using namespace Kernel;
 
 class ClauseCodeTree : public CodeTree
@@ -49,19 +48,19 @@ private:
 
   struct InitialLiteralOrderingComparator;
 
-  void optimizeLiteralOrder(DArray<Literal*>& lits);
+  void optimizeLiteralOrder(Lib::DArray<Literal*>& lits);
   void evalSharing(Literal* lit, CodeOp* startOp, size_t& sharedLen, size_t& unsharedLen, CodeOp*& nextOp);
   static void matchCode(CodeStack& code, CodeOp* startOp, size_t& matchedCnt, CodeOp*& nextOp);
 
   //////// removal //////////
 
-  bool removeOneOfAlternatives(CodeOp* op, Clause* cl, Stack<CodeOp*>* firstsInBlocks);
+  bool removeOneOfAlternatives(CodeOp* op, Clause* cl, Lib::Stack<CodeOp*>* firstsInBlocks);
 
   struct RemovingLiteralMatcher
   : public RemovingMatcher
   {
     void init(CodeOp* entry_, LitInfo* linfos_, size_t linfoCnt_,
-	ClauseCodeTree* tree_, Stack<CodeOp*>* firstsInBlocks_);
+	ClauseCodeTree* tree_, Lib::Stack<CodeOp*>* firstsInBlocks_);
 
     USE_ALLOCATOR(RemovingLiteralMatcher);
   };
@@ -87,7 +86,7 @@ private:
   private:
     bool _eagerlyMatched;
 
-    Stack<CodeOp*> eagerResults;
+    Lib::Stack<CodeOp*> eagerResults;
 
     void recordMatch();
   };
@@ -134,9 +133,9 @@ public:
      * [if sres] Ground literals negated
      * [if sres] Non-ground literals negated
      */
-    DArray<LitInfo> lInfos;
+    Lib::DArray<LitInfo> lInfos;
 
-    Stack<Recycled<LiteralMatcher, NoReset>> lms;
+    Lib::Stack<Lib::Recycled<LiteralMatcher, Lib::NoReset>> lms;
   };
 
 private:

--- a/Indexing/ClauseVariantIndex.hpp
+++ b/Indexing/ClauseVariantIndex.hpp
@@ -27,7 +27,6 @@
 
 namespace Indexing {
 
-using namespace Lib;
 using namespace Kernel;
 
 class ClauseVariantIndex
@@ -63,9 +62,9 @@ public:
 private:
   Literal* getMainLiteral(Literal* const * lits, unsigned length);
 
-  DHMap<Literal*, ClauseList*> _groundUnits;
+  Lib::DHMap<Literal*, ClauseList*> _groundUnits;
 
-  ZIArray<LiteralSubstitutionTree*> _strees;
+  Lib::ZIArray<LiteralSubstitutionTree*> _strees;
 
   ClauseList* _emptyClauses;
 };
@@ -82,12 +81,12 @@ public:
 private:
   struct VariableIgnoringComparator;
 
-  typedef DHMap<unsigned, unsigned char> VarCounts; // overflows allowed
+  typedef Lib::DHMap<unsigned, unsigned char> VarCounts; // overflows allowed
 
   unsigned termFunctorHash(Term* t, unsigned hash_begin) {
     unsigned func = t->functor();
     // std::cout << "will hash funtor " << func << std::endl;
-    return DefaultHash::hash(func, hash_begin);
+    return Lib::DefaultHash::hash(func, hash_begin);
   }
 
   unsigned computeHashAndCountVariables(unsigned var, VarCounts& varCnts, unsigned hash_begin) {
@@ -101,7 +100,7 @@ private:
     }
 
     // std::cout << "will hash variable" << std::endl;
-    return DefaultHash::hash(varHash, hash_begin);
+    return Lib::DefaultHash::hash(varHash, hash_begin);
   }
 
   unsigned computeHashAndCountVariables(TermList* tl, VarCounts& varCnts, unsigned hash_begin);
@@ -109,7 +108,7 @@ private:
 
   unsigned computeHash(Literal* const * lits, unsigned length);
 
-  DHMap<unsigned, ClauseList*> _entries;
+  Lib::DHMap<unsigned, ClauseList*> _entries;
 };
 
 };

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -38,7 +38,6 @@
 
 namespace Indexing {
 
-using namespace Lib;
 using namespace Kernel;
 
 class CodeTree
@@ -87,7 +86,7 @@ public:
     TermList bindings[1];
 
   private:
-    void init(ILStruct* ils, unsigned liIndex, DArray<TermList>& bindingArray);
+    void init(ILStruct* ils, unsigned liIndex, Lib::DArray<TermList>& bindingArray);
 
     static MatchInfo* alloc(unsigned bindCnt);
 
@@ -109,7 +108,7 @@ public:
    */
   struct alignas(8) ILStruct
   {
-    ILStruct(const Literal* lit, unsigned varCnt, Stack<unsigned>& gvnStack);
+    ILStruct(const Literal* lit, unsigned varCnt, Lib::Stack<unsigned>& gvnStack);
     ~ILStruct();
     void putIntoSequence(ILStruct* previous_);
 
@@ -140,7 +139,7 @@ public:
     unsigned timestamp;
     //from here on, the values are valid only if the timestamp is current
 
-    void addMatch(unsigned liIndex, DArray<TermList>& bindingArray);
+    void addMatch(unsigned liIndex, Lib::DArray<TermList>& bindingArray);
     void deleteMatch(unsigned matchIndex);
     MatchInfo*& getMatch(unsigned matchIndex);
 
@@ -151,7 +150,7 @@ public:
     bool finished;
     bool noNonOppositeMatches;
   private:
-    DArray<MatchInfo*> matches;
+    Lib::DArray<MatchInfo*> matches;
   };
 
   enum Instruction
@@ -244,9 +243,9 @@ public:
     BITFIELD64_GET_AND_SET(unsigned, instruction, Instruction, INSTRUCTION)
     BITFIELD64_GET_AND_SET(unsigned, arg, Arg, ARG)
     template<class T> T* _data() const
-    { return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(this->_content)); }
+    { return reinterpret_cast<T*>(Lib::BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(this->_content)); }
     template<class T> void _setData(T* data)
-    { BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(this->_content, reinterpret_cast<uint64_t>(data)); }
+    { Lib::BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(this->_content, reinterpret_cast<uint64_t>(data)); }
     // end bitfield
 
   private:
@@ -325,8 +324,8 @@ public:
   using FnSearchStruct = SearchStructImpl<SearchStruct::FN_STRUCT>;
   using GroundTermSearchStruct = SearchStructImpl<SearchStruct::GROUND_TERM_STRUCT>;
 
-  typedef Vector<CodeOp> CodeBlock;
-  typedef Stack<CodeOp> CodeStack;
+  typedef Lib::Vector<CodeOp> CodeBlock;
+  typedef Lib::Stack<CodeOp> CodeStack;
 
   struct BaseMatcher
   {
@@ -372,7 +371,7 @@ public:
 
   //////////// insertion //////////////
 
-  typedef DHMap<unsigned,unsigned> VarMap;
+  typedef Lib::DHMap<unsigned,unsigned> VarMap;
 
   /** Context for code compilation */
   struct CompileContext
@@ -398,7 +397,7 @@ public:
 
   //////////// removal //////////////
 
-  void optimizeMemoryAfterRemoval(Stack<CodeOp*>* firstsInBlocks, CodeOp* removedOp);
+  void optimizeMemoryAfterRemoval(Lib::Stack<CodeOp*>* firstsInBlocks, CodeOp* removedOp);
 
   struct RemovingMatcher
   : public BaseMatcher
@@ -413,7 +412,7 @@ public:
 
   protected:
     void init(CodeOp* entry_, LitInfo* linfos_, size_t linfoCnt_,
-	CodeTree* tree_, Stack<CodeOp*>* firstsInBlocks_);
+	CodeTree* tree_, Lib::Stack<CodeOp*>* firstsInBlocks_);
 
 
     bool prepareLiteral();
@@ -435,10 +434,10 @@ public:
     };
 
     /** Variable bindings */
-    DArray<unsigned> bindings;
+    Lib::DArray<unsigned> bindings;
 
-    Stack<BTPoint> btStack;
-    Stack<CodeOp*>* firstsInBlocks;
+    Lib::Stack<BTPoint> btStack;
+    Lib::Stack<CodeOp*>* firstsInBlocks;
     bool fresh;
     size_t curLInfo;
 
@@ -468,8 +467,8 @@ public:
     CodeOp* op;
   };
 
-  typedef Stack<BTPoint> BTStack;
-  typedef DArray<TermList> BindingArray;
+  typedef Lib::Stack<BTPoint> BTStack;
+  typedef Lib::DArray<TermList> BindingArray;
 
   /**
    * Context for finding matches of literals

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -30,7 +30,6 @@ namespace Indexing
 {
 
 using namespace Kernel;
-using namespace Lib;
 
 
 /**
@@ -52,11 +51,11 @@ public:
     }
   }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions = true) final override;
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions = true) final override;
   // TODO use TypedTermList here too
   bool generalizationExists(TermList t) final override;
   // TODO: get rid of NOT_IMPLEMENTED
-  VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(TypedTermList t, Options::UnificationWithAbstraction, bool fixedPointIteration) override { NOT_IMPLEMENTED; }
+  Lib::VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(TypedTermList t, Options::UnificationWithAbstraction, bool fixedPointIteration) override { NOT_IMPLEMENTED; }
 
   virtual void output(std::ostream& out) const final override { out << _ct; }
 

--- a/Indexing/GroundingIndex.hpp
+++ b/Indexing/GroundingIndex.hpp
@@ -40,8 +40,8 @@ protected:
   virtual void handleClause(Clause* c, bool adding);
 
 private:
-  ScopedPtr<SATSolverWithAssumptions> _solver;
-  ScopedPtr<GlobalSubsumptionGrounder> _grounder;
+  Lib::ScopedPtr<SATSolverWithAssumptions> _solver;
+  Lib::ScopedPtr<GlobalSubsumptionGrounder> _grounder;
 };
 
 }

--- a/Indexing/Index.hpp
+++ b/Indexing/Index.hpp
@@ -37,7 +37,6 @@
 namespace Indexing
 {
 using namespace Kernel;
-using namespace Lib;
 using namespace Saturation;
 
 struct LiteralClause 
@@ -200,8 +199,8 @@ protected:
   //TODO: postponing index modifications during iteration (methods isBeingIterated() etc...)
 
 private:
-  SubscriptionData _addedSD;
-  SubscriptionData _removedSD;
+  Lib::SubscriptionData _addedSD;
+  Lib::SubscriptionData _removedSD;
 };
 
 };

--- a/Indexing/IndexManager.hpp
+++ b/Indexing/IndexManager.hpp
@@ -27,7 +27,6 @@
 namespace Indexing
 {
 
-using namespace Lib;
 using namespace Saturation;
 
 enum IndexType {
@@ -93,7 +92,7 @@ private:
     int refCnt;
   };
   SaturationAlgorithm* _alg;
-  DHMap<IndexType,Entry> _store;
+  Lib::DHMap<IndexType,Entry> _store;
 
   Index* create(IndexType t);
   Shell::Options::UnificationWithAbstraction _uwa;

--- a/Indexing/InductionFormulaIndex.hpp
+++ b/Indexing/InductionFormulaIndex.hpp
@@ -31,9 +31,8 @@ namespace Inferences {
 
 namespace Indexing {
 
-using namespace Lib;
 using namespace Kernel;
-using Key = std::pair<Stack<LiteralStack>,std::pair<Literal*,Literal*>>;
+using Key = std::pair<Lib::Stack<LiteralStack>,std::pair<Literal*,Literal*>>;
 
 class InductionFormulaIndex
 {
@@ -56,18 +55,18 @@ public:
       }
       _st.push(std::make_pair(cls, subst));
     }
-    const Stack<std::pair<ClauseStack,Substitution>>& get() const {
+    const Lib::Stack<std::pair<ClauseStack,Substitution>>& get() const {
       return _st;
     }
   private:
-    Stack<std::pair<ClauseStack,Substitution>> _st;
+    Lib::Stack<std::pair<ClauseStack,Substitution>> _st;
   };
 
   static Key represent(const Inferences::InductionContext& context);
 
   bool findOrInsert(const Inferences::InductionContext& context, Entry*& e, Literal* bound1 = nullptr, Literal* bound2 = nullptr);
 private:
-  DHMap<Key,Entry> _map;
+  Lib::DHMap<Key,Entry> _map;
 };
 
 }

--- a/Indexing/LiteralIndex.hpp
+++ b/Indexing/LiteralIndex.hpp
@@ -30,19 +30,19 @@ class LiteralIndex
 : public Index
 {
 public:
-  VirtualIterator<LiteralClause> getAll()
+  Lib::VirtualIterator<LiteralClause> getAll()
   { return _is->getAll(); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LiteralClause>> getUnifications(Literal* lit, bool complementary, bool retrieveSubstitutions = true)
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LiteralClause>> getUnifications(Literal* lit, bool complementary, bool retrieveSubstitutions = true)
   { return _is->getUnifications(lit, complementary, retrieveSubstitutions); }
 
-  VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(Literal* lit, bool complementary, Options::UnificationWithAbstraction uwa, bool fixedPointIteration)
+  Lib::VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(Literal* lit, bool complementary, Options::UnificationWithAbstraction uwa, bool fixedPointIteration)
   { return _is->getUwa(lit, complementary, uwa, fixedPointIteration); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LiteralClause>> getGeneralizations(Literal* lit, bool complementary, bool retrieveSubstitutions = true)
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LiteralClause>> getGeneralizations(Literal* lit, bool complementary, bool retrieveSubstitutions = true)
   { return _is->getGeneralizations(lit, complementary, retrieveSubstitutions); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LiteralClause>> getInstances(Literal* lit, bool complementary, bool retrieveSubstitutions = true)
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LiteralClause>> getInstances(Literal* lit, bool complementary, bool retrieveSubstitutions = true)
   { return _is->getInstances(lit, complementary, retrieveSubstitutions); }
 
   size_t getUnificationCount(Literal* lit, bool complementary)
@@ -167,7 +167,7 @@ private:
   void handleEquivalence(Clause* c, Literal* cgr, Clause* d, Literal* dgr, bool adding);
 
   LiteralIndexingStructure<LiteralClause>* _partialIndex;
-  DHMap<Clause*,Clause*> _counterparts;
+  Lib::DHMap<Clause*,Clause*> _counterparts;
   Ordering& _ordering;
 };
 

--- a/Indexing/LiteralIndexingStructure.hpp
+++ b/Indexing/LiteralIndexingStructure.hpp
@@ -34,19 +34,19 @@ public:
   void insert(LeafData ld) { handle(std::move(ld), /* insert = */ true ); }
   void remove(LeafData ld) { handle(std::move(ld), /* insert = */ false); }
 
-  virtual VirtualIterator<LeafData> getAll() { NOT_IMPLEMENTED; }
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getUnifications(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
-  virtual VirtualIterator<QueryRes<AbstractingUnifier*, LeafData>> getUwa(Literal* lit, bool complementary, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) = 0;
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getGeneralizations(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getInstances(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getVariants(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<LeafData> getAll() { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getUnifications(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<AbstractingUnifier*, LeafData>> getUwa(Literal* lit, bool complementary, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) = 0;
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getGeneralizations(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getInstances(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getVariants(Literal* lit, bool complementary, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
 
   virtual size_t getUnificationCount(Literal* lit, bool complementary)
   {
     return countIteratorElements(getUnifications(lit, complementary, false));
   }
 
-  virtual void output(std::ostream& out, Option<unsigned> multilineIndent) const = 0;
+  virtual void output(std::ostream& out, Lib::Option<unsigned> multilineIndent) const = 0;
 
   friend std::ostream& operator<<(std::ostream& out,                 LiteralIndexingStructure const& self) {      self.output(out, {}               ); return out; }
   friend std::ostream& operator<<(std::ostream& out, OutputMultiline<LiteralIndexingStructure>const& self) { self.self.output(out, some(self.indent)); return out; }

--- a/Indexing/LiteralMiniIndex.hpp
+++ b/Indexing/LiteralMiniIndex.hpp
@@ -23,7 +23,6 @@
 
 namespace Indexing {
 
-using namespace Lib;
 using namespace Kernel;
 
 
@@ -54,7 +53,7 @@ private:
   static bool literalHeaderComparator(const Entry& e1, const Entry& e2);
 
   unsigned _cnt = 0;
-  DArray<Entry> _entries;
+  Lib::DArray<Entry> _entries;
 
   struct IteratorBase
   {

--- a/Indexing/LiteralSubstitutionTree.hpp
+++ b/Indexing/LiteralSubstitutionTree.hpp
@@ -43,13 +43,13 @@ class LiteralSubstitutionTree
 
 public:
   LiteralSubstitutionTree()
-    : _trees(env.signature->predicates() * 2)
+    : _trees(Lib::env.signature->predicates() * 2)
     { }
 
   void handle(LeafData ld, bool insert) final override
   { getTree(ld.key(), /* complementary */ false).handle(std::move(ld), insert); }
 
-  VirtualIterator<LeafData> getAll() final override
+  Lib::VirtualIterator<LeafData> getAll() final override
   {
     return pvi(
           iterTraits(getRangeIterator((unsigned long)0, _trees.size()))
@@ -60,16 +60,16 @@ public:
         );
   }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData_>> getUnifications(Literal* lit, bool complementary, bool retrieveSubstitutions) final override
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData_>> getUnifications(Literal* lit, bool complementary, bool retrieveSubstitutions) final override
   { return pvi(getResultIterator<typename SubstitutionTree::template Iterator<RetrievalAlgorithms::RobUnification>>(lit, complementary, retrieveSubstitutions)); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getGeneralizations(Literal* lit, bool complementary, bool retrieveSubstitutions) final override
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getGeneralizations(Literal* lit, bool complementary, bool retrieveSubstitutions) final override
   { return pvi(getResultIterator<FastGeneralizationsIterator>(lit, complementary, retrieveSubstitutions)); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getInstances(Literal* lit, bool complementary, bool retrieveSubstitutions) final override
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getInstances(Literal* lit, bool complementary, bool retrieveSubstitutions) final override
   { return pvi(getResultIterator<FastInstancesIterator>(lit, complementary, retrieveSubstitutions)); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getVariants(Literal* query, bool complementary, bool retrieveSubstitutions) final override
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getVariants(Literal* query, bool complementary, bool retrieveSubstitutions) final override
   {
     return pvi(iterTraits(getTree(query, complementary).getVariants(query, retrieveSubstitutions)));
   }
@@ -94,7 +94,7 @@ private:
       { return tree->template iterator<Iterator>(lit, retrieveSubstitutions, reversed, args...); };
 
     return ifElseIter(
-        tree->isEmpty(), [&]() { return VirtualIterator<ELEMENT_TYPE(Iterator)>::getEmpty(); }, 
+        tree->isEmpty(), [&]() { return Lib::VirtualIterator<ELEMENT_TYPE(Iterator)>::getEmpty(); }, 
                          [&]() { return ifElseIter(!lit->commutative(), 
                                  [&]() { return iter(/* reverse */ false); },
                                  [&]() { return concatIters(iter(/* reverse */ false), iter(/* reverse */ true)); }); }
@@ -115,7 +115,7 @@ private:
 
 public:
 
-  VirtualIterator<QueryRes<AbstractingUnifier*, LeafData>> getUwa(Literal* lit, bool complementary, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) final override
+  Lib::VirtualIterator<QueryRes<AbstractingUnifier*, LeafData>> getUwa(Literal* lit, bool complementary, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) final override
   { return pvi(getResultIterator<typename SubstitutionTree::template Iterator<RetrievalAlgorithms::UnificationWithAbstraction>>(lit, complementary, /* retrieveSubstitutions */ true, AbstractionOracle(uwa), fixedPointIteration)); }
 
   friend std::ostream& operator<<(std::ostream& out, LiteralSubstitutionTree const& self)
@@ -124,7 +124,7 @@ public:
     out << "{ ";
     for (auto& t : self._trees) {
       if (!t->isEmpty()) {
-        auto f = env.signature->getPredicate(idxToFunctor(i));
+        auto f = Lib::env.signature->getPredicate(idxToFunctor(i));
         if (idxIsNegative(i)) out << "~";
         out << *f << "(" << *t << "), "; 
       }
@@ -138,7 +138,7 @@ public:
     out << "{ " << std::endl;
     for (auto& t : self.self._trees) {
       if (!t->isEmpty()) {
-        auto f = env.signature->getPredicate(idxToFunctor(i));
+        auto f = Lib::env.signature->getPredicate(idxToFunctor(i));
         OutputMultiline<LiteralSubstitutionTree>::outputIndent(out, self.indent);
         out << (idxIsNegative(i) ? "~" : " ") << *f << "(" << multiline(*t, self.indent + 1) << ")" << std::endl; 
       }
@@ -147,7 +147,7 @@ public:
     return out << "} ";
   }
 
-  virtual void output(std::ostream& out, Option<unsigned> multilineIndent) const override {
+  virtual void output(std::ostream& out, Lib::Option<unsigned> multilineIndent) const override {
     if (multilineIndent) {
       out << multiline(*this, *multilineIndent);
     } else {
@@ -167,7 +167,7 @@ private:
     return *_trees[idx];
   }
 
-  Stack<std::unique_ptr<SubstitutionTree>> _trees;
+  Lib::Stack<std::unique_ptr<SubstitutionTree>> _trees;
 };
 
 };

--- a/Indexing/SubstitutionTree.cpp
+++ b/Indexing/SubstitutionTree.cpp
@@ -45,6 +45,9 @@
 #include "SubstitutionTree.hpp"
 
 namespace Indexing {
+
+using namespace Lib;
+
 struct UnresolvedSplitRecord
 {
   UnresolvedSplitRecord() {}

--- a/Indexing/TermCodeTree.hpp
+++ b/Indexing/TermCodeTree.hpp
@@ -35,7 +35,6 @@
 
 namespace Indexing {
 
-using namespace Lib;
 using namespace Kernel;
 
 template<class Data>
@@ -55,7 +54,7 @@ private:
   : public RemovingMatcher
   {
   public:
-    void init(FlatTerm* ft_, TermCodeTree* tree_, Stack<CodeOp*>* firstsInBlocks_);
+    void init(FlatTerm* ft_, TermCodeTree* tree_, Lib::Stack<CodeOp*>* firstsInBlocks_);
 
   };
 

--- a/Indexing/TermIndex.hpp
+++ b/Indexing/TermIndex.hpp
@@ -31,16 +31,16 @@ class TermIndex
 public:
   virtual ~TermIndex() {}
 
-  VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(TypedTermList t, Options::UnificationWithAbstraction uwa, bool fixedPointIteration)
+  Lib::VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(TypedTermList t, Options::UnificationWithAbstraction uwa, bool fixedPointIteration)
   { return _is->getUwa(t, uwa, fixedPointIteration); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getUnifications(TypedTermList t, bool retrieveSubstitutions = true)
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getUnifications(TypedTermList t, bool retrieveSubstitutions = true)
   { return _is->getUnifications(t, retrieveSubstitutions); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions = true)
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions = true)
   { return _is->getGeneralizations(t, retrieveSubstitutions); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getInstances(TypedTermList t, bool retrieveSubstitutions = true)
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getInstances(TypedTermList t, bool retrieveSubstitutions = true)
   { return _is->getInstances(t, retrieveSubstitutions); }
 
   friend std::ostream& operator<<(std::ostream& out, TermIndex const& self)

--- a/Indexing/TermIndexingStructure.hpp
+++ b/Indexing/TermIndexingStructure.hpp
@@ -29,11 +29,11 @@ public:
   void insert(Data data) { handle(std::move(data), /* insert */ true ); }
   void remove(Data data) { handle(std::move(data), /* insert */ false); }
 
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getUnifications(TypedTermList t, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
-  virtual VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(TypedTermList t, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) = 0;
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getUnificationsUsingSorts(TypedTermList tt, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }  
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
-  virtual VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getInstances(TypedTermList t, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getUnifications(TypedTermList t, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<AbstractingUnifier*, Data>> getUwa(TypedTermList t, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) = 0;
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getUnificationsUsingSorts(TypedTermList tt, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }  
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
+  virtual Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, Data>> getInstances(TypedTermList t, bool retrieveSubstitutions = true) { NOT_IMPLEMENTED; }
 
   virtual bool generalizationExists(TermList t) { NOT_IMPLEMENTED; }
 

--- a/Indexing/TermSharing.cpp
+++ b/Indexing/TermSharing.cpp
@@ -30,6 +30,7 @@
 #include "TermSharing.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Indexing;
 

--- a/Indexing/TermSharing.hpp
+++ b/Indexing/TermSharing.hpp
@@ -22,7 +22,6 @@
 
 #include "Lib/Allocator.hpp"
 
-using namespace Lib;
 using namespace Kernel;
 
 namespace Indexing {
@@ -59,9 +58,9 @@ public:
   static bool equals(const Literal* l1, const Literal* l2)
   { return Literal::literalEquals(l1, l2->functor(), l2->polarity() ^ opposite, 
         [&](auto i){ return *l2->nthArgument(i); }, 
-        l2->arity(), someIf(l2->isTwoVarEquality(), [&](){ return l2->twoVarEqSort(); }), l2->commutative()); }
+        l2->arity(), Lib::someIf(l2->isTwoVarEquality(), [&](){ return l2->twoVarEqSort(); }), l2->commutative()); }
 
-  DHSet<TermList>* getArraySorts(){
+  Lib::DHSet<TermList>* getArraySorts(){
     return &_arraySorts;
   }
 
@@ -100,15 +99,15 @@ private:
   static bool argNormGt(TermList t1, TermList t2);
 
   /** The set storing all terms */
-  Set<Term*,TermSharing> _terms;
+  Lib::Set<Term*,TermSharing> _terms;
   /** The set storing all literals */
-  Set<Literal*,TermSharing> _literals;
+  Lib::Set<Literal*,TermSharing> _literals;
   /** The set storing all sorts */
-  Set<AtomicSort*,TermSharing> _sorts;
+  Lib::Set<AtomicSort*,TermSharing> _sorts;
   /* Set containing all array sorts. 
    * Can be deleted once array axioms are made truly poltmorphic
    */  
-  DHSet<TermList> _arraySorts;
+  Lib::DHSet<TermList> _arraySorts;
 
   bool _poly;
   bool _wellSortednessCheckingDisabled;

--- a/Indexing/TermSubstitutionTree.hpp
+++ b/Indexing/TermSubstitutionTree.hpp
@@ -81,17 +81,17 @@ private:
   { return out << multiline(self.self._inner, self.indent); }
 
 public:
-  VirtualIterator<Indexing::QueryRes<ResultSubstitutionSP, LeafData_>> getInstances(TypedTermList t, bool retrieveSubstitutions) final override
+  Lib::VirtualIterator<Indexing::QueryRes<ResultSubstitutionSP, LeafData_>> getInstances(TypedTermList t, bool retrieveSubstitutions) final override
   { return pvi(getResultIterator<FastInstancesIterator>(t, retrieveSubstitutions)); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions) final override
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getGeneralizations(TypedTermList t, bool retrieveSubstitutions) final override
   { return pvi(getResultIterator<FastGeneralizationsIterator>(t, retrieveSubstitutions)); }
 
 
-  VirtualIterator<QueryRes<AbstractingUnifier*, LeafData>> getUwa(TypedTermList t, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) final override
+  Lib::VirtualIterator<QueryRes<AbstractingUnifier*, LeafData>> getUwa(TypedTermList t, Options::UnificationWithAbstraction uwa, bool fixedPointIteration) final override
   { return pvi(getResultIterator<typename SubstitutionTree::template Iterator<RetrievalAlgorithms::UnificationWithAbstraction>>(t, /* retrieveSubstitutions */ true, AbstractionOracle(uwa), fixedPointIteration)); }
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getUnifications(TypedTermList t, bool retrieveSubstitutions) override
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, LeafData>> getUnifications(TypedTermList t, bool retrieveSubstitutions) override
   { return pvi(getResultIterator<typename SubstitutionTree::template Iterator<RetrievalAlgorithms::RobUnification>>(t, retrieveSubstitutions)); }
 };
 

--- a/Inferences/ArithmeticSubtermGeneralization.cpp
+++ b/Inferences/ArithmeticSubtermGeneralization.cpp
@@ -23,6 +23,7 @@
 namespace Inferences {
 
 using namespace std;
+using namespace Lib;
 
 /** iterator over all subterms of a clause in polynomial normal form */
 static const auto iterTerms = [](Clause* cl) 

--- a/Inferences/ArithmeticSubtermGeneralization.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization.hpp
@@ -58,7 +58,7 @@ public:
   SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck);
 };
 
-Stack<SimplifyingGeneratingInference1*> allArithmeticSubtermGeneralizations();
+Lib::Stack<SimplifyingGeneratingInference1*> allArithmeticSubtermGeneralizations();
 
 
 } // namespace Inferences

--- a/Inferences/BoolSimp.cpp
+++ b/Inferences/BoolSimp.cpp
@@ -27,6 +27,8 @@
 
 namespace Inferences {
 
+using namespace Lib;
+
 Clause* BoolSimp::simplify(Clause* premise) {
   TermList subTerm;
   TermList simpedSubTerm;

--- a/Inferences/Cancellation.cpp
+++ b/Inferences/Cancellation.cpp
@@ -17,6 +17,7 @@
 
 namespace Inferences {
 
+using namespace Lib;
 
 Cancellation::~Cancellation() {}
 

--- a/Inferences/Cases.cpp
+++ b/Inferences/Cases.cpp
@@ -35,6 +35,7 @@
 namespace Inferences {
 
 using namespace std;
+using namespace Lib;
 
 Clause* Cases::performParamodulation(Clause* premise, Literal* lit, TermList t) {
   ASS(t.isTerm());

--- a/Inferences/CasesSimp.cpp
+++ b/Inferences/CasesSimp.cpp
@@ -35,7 +35,7 @@
 namespace Inferences {
 
 using namespace std;
-
+using namespace Lib;
 
 ClauseIterator CasesSimp::performSimplification(Clause* premise, Literal* lit, TermList t) {
   ASS(t.isTerm());

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -20,6 +20,8 @@
 namespace Inferences
 {
 
+using namespace Lib;
+
 struct IncompleteFunction {
   unsigned functor, arity, remaining;
 };

--- a/Inferences/DefinitionIntroduction.hpp
+++ b/Inferences/DefinitionIntroduction.hpp
@@ -48,9 +48,9 @@ private:
     Term *term;
     unsigned weight;
   };
-  DHSet<Term *> _defined;
-  Stack<Stack<Entry>> _entries;
-  Stack<Clause *> _definitions;
+  Lib::DHSet<Term *> _defined;
+  Lib::Stack<Lib::Stack<Entry>> _entries;
+  Lib::Stack<Clause *> _definitions;
 };
 
 }

--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -23,6 +23,7 @@
 
 namespace Inferences {
 
+using namespace Lib;
 using namespace Kernel;
 
 DemodulationHelper::DemodulationHelper(const Options& opts, const Ordering* ord)

--- a/Inferences/DistinctEqualitySimplifier.cpp
+++ b/Inferences/DistinctEqualitySimplifier.cpp
@@ -23,6 +23,8 @@
 namespace Inferences
 {
 
+using namespace Lib;
+
 Clause* DistinctEqualitySimplifier::simplify(Clause* cl)
 {
   if(!canSimplify(cl)) {

--- a/Inferences/EquationalTautologyRemoval.cpp
+++ b/Inferences/EquationalTautologyRemoval.cpp
@@ -23,6 +23,7 @@ namespace Inferences
 {
 
 using namespace std;
+using namespace Lib;
 
 Clause* EquationalTautologyRemoval::simplify(Clause* cl)
 {

--- a/Inferences/FOOLParamodulation.cpp
+++ b/Inferences/FOOLParamodulation.cpp
@@ -31,6 +31,8 @@
 
 namespace Inferences {
 
+using namespace Lib;
+
 ClauseIterator FOOLParamodulation::generateClauses(Clause* premise) {
   /**
    * We are going to implement the following inference rule, taken from the paper:

--- a/Inferences/ForwardLiteralRewriting.cpp
+++ b/Inferences/ForwardLiteralRewriting.cpp
@@ -27,6 +27,8 @@
 namespace Inferences
 {
 
+using namespace Lib;
+
 void ForwardLiteralRewriting::attach(SaturationAlgorithm* salg)
 {
   ForwardSimplificationEngine::attach(salg);

--- a/Inferences/GaussianVariableElimination.cpp
+++ b/Inferences/GaussianVariableElimination.cpp
@@ -21,6 +21,8 @@
 
 namespace Inferences {
 
+using namespace Lib;
+
 using Balancer = Kernel::Rebalancing::Balancer<Kernel::Rebalancing::Inverters::NumberTheoryInverter>;
 
 SimplifyingGeneratingInference1::Result GaussianVariableElimination::simplify(Clause* in, bool doCheckOrdering) 

--- a/Inferences/GlobalSubsumption.hpp
+++ b/Inferences/GlobalSubsumption.hpp
@@ -51,7 +51,7 @@ public:
   void detach() override;
   bool perform(Clause* cl, Clause*& replacement, ClauseIterator& premises) override;
   
-  Clause* perform(Clause* cl, Stack<Unit*>& prems);
+  Clause* perform(Clause* cl, Lib::Stack<Unit*>& prems);
  
 private:  
   struct Unit2ClFn;
@@ -90,12 +90,12 @@ private:
    * 
    * (Should this be rather a part of _index?)
    */
-  DHMap<unsigned, unsigned> _splits2vars;
+  Lib::DHMap<unsigned, unsigned> _splits2vars;
   
   /**
    * An inverse of the above map, for convenience.
    */  
-  DHMap<unsigned, unsigned> _vars2splits;
+  Lib::DHMap<unsigned, unsigned> _vars2splits;
       
 protected:  
   unsigned splitLevelToVar(SplitLevel lev) {        

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -48,7 +48,6 @@ namespace Inferences
 using namespace Kernel;
 using namespace Saturation;
 using namespace Shell;
-using namespace Lib;
 
 /**
  * This class is similar to @b NonVariableNonTypeIterator and is
@@ -58,7 +57,7 @@ using namespace Lib;
  * instance.
  */
 class ActiveOccurrenceIterator
-  : public IteratorCore<Term*>
+  : public Lib::IteratorCore<Term*>
 {
 public:
   ActiveOccurrenceIterator(Literal* lit, FunctionDefinitionHandler& fnDefHandler)
@@ -72,7 +71,7 @@ public:
   bool hasNext() override { return !_stack.isEmpty(); }
   Term* next() override;
 private:
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
   FunctionDefinitionHandler& _fnDefHandler;
 };
 
@@ -120,7 +119,7 @@ public:
   SkolemSquashingTermReplacement(const std::map<Term*, TermList>& m, unsigned& var)
     : TermReplacement(m), _v(var) {}
   TermList transformSubterm(TermList trm) override;
-  DHMap<Term*, unsigned, SharedTermHash> _tv; // maps terms to their variable replacement
+  Lib::DHMap<Term*, unsigned, SharedTermHash> _tv; // maps terms to their variable replacement
 private:
   unsigned& _v; // fresh variable counter supported by caller
 };
@@ -194,7 +193,7 @@ private:
  * induction terms replaced with placeholders.
  */
 class ContextReplacement
-  : public TermReplacement, public IteratorCore<InductionContext> {
+  : public TermReplacement, public Lib::IteratorCore<InductionContext> {
 public:
   ContextReplacement(const InductionContext& context);
 
@@ -273,7 +272,7 @@ public:
   ClauseIterator generateClauses(Clause* premise) override;
 
 #if VDEBUG
-  void setTestIndices(const Stack<Index*>& indices) override {
+  void setTestIndices(const Lib::Stack<Index*>& indices) override {
     _comparisonIndex = static_cast<LiteralIndex<LiteralClause>*>(indices[0]);
     _inductionTermIndex = static_cast<TermIndex*>(indices[1]);
     _structInductionTermIndex = static_cast<TermIndex*>(indices[2]);
@@ -327,7 +326,7 @@ private:
   void performInfIntInduction(const InductionContext& context, bool increasing, const TermLiteralClause& bound);
 
   struct DefaultBound { TypedTermList term; };
-  using Bound = Coproduct<TermLiteralClause, DefaultBound>;
+  using Bound = Lib::Coproduct<TermLiteralClause, DefaultBound>;
   void performIntInduction(const InductionContext& context, InductionFormulaIndex::Entry* e, bool increasing, Bound bound1, const TermLiteralClause* optionalBound2);
 
   void performIntInduction(const InductionContext& context, InductionFormulaIndex::Entry* e, bool increasing, TermLiteralClause const& bound1, const TermLiteralClause* optionalBound2)
@@ -361,7 +360,7 @@ private:
   bool isValidBound(const InductionContext& context, const TermLiteralClause& bound)
   { return isValidBound(context, Bound(bound)); }
 
-  Stack<Clause*> _clauses;
+  Lib::Stack<Clause*> _clauses;
   InductionHelper _helper;
   const Options& _opt;
   TermIndex* _structInductionTermIndex;

--- a/Inferences/InductionHelper.hpp
+++ b/Inferences/InductionHelper.hpp
@@ -35,10 +35,10 @@ public:
   InductionHelper(LiteralIndex<LiteralClause>* comparisonIndex, TermIndex* inductionTermIndex)
       : _comparisonIndex(comparisonIndex), _inductionTermIndex(inductionTermIndex) {}
 
-  VirtualIterator<TermLiteralClause> getLess(Term* t);
-  VirtualIterator<TermLiteralClause> getGreater(Term* t);
+  Lib::VirtualIterator<TermLiteralClause> getLess(Term* t);
+  Lib::VirtualIterator<TermLiteralClause> getGreater(Term* t);
 
-  VirtualIterator<QueryRes<ResultSubstitutionSP, TermLiteralClause>> getTQRsForInductionTerm(Term* inductionTerm);
+  Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, TermLiteralClause>> getTQRsForInductionTerm(Term* inductionTerm);
 
   static bool isIntegerComparison(Clause* c);
   static bool isIntInductionOn();
@@ -65,7 +65,7 @@ public:
   static Term* getOtherTermFromComparison(Literal* l, Term* t);
 
 private:
-  VirtualIterator<TermLiteralClause> getComparisonMatch(bool polarity, bool termIsLeft, Term* t);
+  Lib::VirtualIterator<TermLiteralClause> getComparisonMatch(bool polarity, bool termIsLeft, Term* t);
 
   // The following pointers can be null if splitting or integer induction is off.
   LiteralIndex<LiteralClause>* _comparisonIndex;  // not owned

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -36,7 +36,6 @@
 namespace Inferences
 {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Saturation;
 using namespace Shell;
@@ -82,7 +81,7 @@ public:
    * machinery for unit testing a single rule if that rule uses a term index. In order to circumvent this
    * issue we add this method in debug mode.
    * */
-  virtual void setTestIndices(Stack<Indexing::Index*> const&) {}
+  virtual void setTestIndices(Lib::Stack<Indexing::Index*> const&) {}
 #endif // VDEBUG
 protected:
   SaturationAlgorithm* _salg;
@@ -287,7 +286,7 @@ struct BwSimplificationRecord
   Clause* toRemove;
   Clause* replacement;
 };
-typedef VirtualIterator<BwSimplificationRecord> BwSimplificationRecordIterator;
+typedef Lib::VirtualIterator<BwSimplificationRecord> BwSimplificationRecordIterator;
 
 class BackwardSimplificationEngine
 : public InferenceEngine
@@ -351,7 +350,7 @@ public:
   void attach(SaturationAlgorithm* salg);
   void detach();
 private:
-  typedef List<ImmediateSimplificationEngine*> ISList;
+  typedef Lib::List<ImmediateSimplificationEngine*> ISList;
   ISList* _inners;
   ISList* _innersMany;
 };
@@ -367,7 +366,7 @@ private:
 //  void attach(SaturationAlgorithm* salg);
 //  void detach();
 //private:
-//  typedef List<ForwardSimplificationEngineSP> FSList;
+//  typedef Lib::List<ForwardSimplificationEngineSP> FSList;
 //  FSList* _inners;
 //};
 
@@ -382,7 +381,7 @@ public:
   void attach(SaturationAlgorithm* salg) override;
   void detach() override;
 private:
-  typedef List<GeneratingInferenceEngine*> GIList;
+  typedef Lib::List<GeneratingInferenceEngine*> GIList;
   GIList* _inners;
 };
 
@@ -399,8 +398,8 @@ public:
   void attach(SaturationAlgorithm* salg) override;
   void detach() override;
 private:
-  Stack<SimplifyingGeneratingInference*> _simplifiers;
-  Stack<GeneratingInferenceEngine*> _generators;
+  Lib::Stack<SimplifyingGeneratingInference*> _simplifiers;
+  Lib::Stack<GeneratingInferenceEngine*> _generators;
 };
 
 //removes clauses which define choice operators

--- a/Inferences/Injectivity.cpp
+++ b/Inferences/Injectivity.cpp
@@ -29,6 +29,8 @@
 
 namespace Inferences {
 
+using namespace Lib;
+
 ClauseIterator Injectivity::generateClauses(Clause* premise) {
   if(premise->length() != 2){
     return ClauseIterator::getEmpty();

--- a/Inferences/Instantiation.hpp
+++ b/Inferences/Instantiation.hpp
@@ -42,15 +42,15 @@ public:
   void registerClause(Clause* cl);
 
 private:
-  VirtualIterator<Term*> getCandidateTerms(Clause* cl, unsigned var,TermList sort);
+  Lib::VirtualIterator<Term*> getCandidateTerms(Clause* cl, unsigned var,TermList sort);
   class AllSubstitutionsIterator;
   struct ResultFn;
 
-  void tryMakeLiteralFalse(Literal*, Stack<Substitution>& subs);
+  void tryMakeLiteralFalse(Literal*, Lib::Stack<Substitution>& subs);
   Term* tryGetDifferentValue(Term* t); 
 
-  DHMap<TermList,Lib::Set<Term*>*> sorted_candidates_check;
-  DHMap<TermList,Lib::Stack<Term*>*> sorted_candidates;
+  Lib::DHMap<TermList,Lib::Set<Term*>*> sorted_candidates_check;
+  Lib::DHMap<TermList,Lib::Stack<Term*>*> sorted_candidates;
 
 };
 

--- a/Inferences/PolynomialEvaluation.hpp
+++ b/Inferences/PolynomialEvaluation.hpp
@@ -37,12 +37,12 @@ private:
 
   Result simplifyLiteral(Literal*) override;
 
-  Option<PolyNf> evaluate(TermList in, SortId sortNumber) const;
-  Option<PolyNf> evaluate(Term* in) const;
-  Option<PolyNf> evaluate(PolyNf in) const;
-  Option<PolyNf> evaluate(TypedTermList in) const;
+  Lib::Option<PolyNf> evaluate(TermList in, SortId sortNumber) const;
+  Lib::Option<PolyNf> evaluate(Term* in) const;
+  Lib::Option<PolyNf> evaluate(PolyNf in) const;
+  Lib::Option<PolyNf> evaluate(TypedTermList in) const;
 
-  Option<Result> tryEvalPredicate(Literal* orig, PolyNf* evaluatedArgs) const;
+  Lib::Option<Result> tryEvalPredicate(Literal* orig, PolyNf* evaluatedArgs) const;
 
   PolyNf evaluateStep(Term* orig, PolyNf* evaluatedArgs) const;
 };

--- a/Inferences/PushUnaryMinus.cpp
+++ b/Inferences/PushUnaryMinus.cpp
@@ -15,6 +15,7 @@
 namespace Inferences {
 
 using namespace std;
+using namespace Lib;
 
 enum class UMinus {
   Int,

--- a/Inferences/SubsumptionDemodulationHelper.hpp
+++ b/Inferences/SubsumptionDemodulationHelper.hpp
@@ -39,7 +39,6 @@ namespace Inferences {
 
 using namespace Indexing;
 using namespace Kernel;
-using namespace Lib;
 
 
 

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -49,7 +49,7 @@ class TheoryInstAndSimp
 public:
   using SortId = SAT::Z3Interfacing::SortId;
   ~TheoryInstAndSimp();
-  TheoryInstAndSimp() : TheoryInstAndSimp(*env.options) {}
+  TheoryInstAndSimp() : TheoryInstAndSimp(*Lib::env.options) {}
 
   TheoryInstAndSimp(Options& opts);
   TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, std::string const& exportSmtlib);
@@ -60,26 +60,26 @@ public:
 
 private:
   struct SkolemizedLiterals {
-    Stack<SATLiteral> lits;
-    Stack<unsigned> vars;
+    Lib::Stack<SATLiteral> lits;
+    Lib::Stack<unsigned> vars;
     Substitution subst;
   };
   template<class IterLits> SkolemizedLiterals skolemize(IterLits lits);
-  VirtualIterator<Solution> getSolutions(Stack<Literal*> const& theoryLiterals, Stack<Literal*> const& guards, unsigned freshVar);
+  Lib::VirtualIterator<Solution> getSolutions(Lib::Stack<Literal*> const& theoryLiterals, Lib::Stack<Literal*> const& guards, unsigned freshVar);
 
 
-  Option<Substitution> instantiateWithModel(SkolemizedLiterals skolemized);
-  Option<Substitution> instantiateGeneralised(SkolemizedLiterals skolemized, unsigned freshVar);
+  Lib::Option<Substitution> instantiateWithModel(SkolemizedLiterals skolemized);
+  Lib::Option<Substitution> instantiateGeneralised(SkolemizedLiterals skolemized, unsigned freshVar);
 
-  Stack<Literal*> selectTheoryLiterals(Clause* cl);
+  Lib::Stack<Literal*> selectTheoryLiterals(Clause* cl);
 
-  void originalSelectTheoryLiterals(Clause* cl, Stack<Literal*>& theoryLits,bool forZ3);
+  void originalSelectTheoryLiterals(Clause* cl, Lib::Stack<Literal*>& theoryLits,bool forZ3);
 
-  Stack<Literal*> applyFilters(Stack<Literal*> theoryLits);
-  void filterUninterpretedPartialFunctionDeep(Stack<Literal*>& theoryLits, Stack<Literal*>& filteredLits);
+  Lib::Stack<Literal*> applyFilters(Lib::Stack<Literal*> theoryLits);
+  void filterUninterpretedPartialFunctionDeep(Lib::Stack<Literal*>& theoryLits, Lib::Stack<Literal*>& filteredLits);
   
   /** returns the set of literals trivial in cl */
-  Stack<Literal*> selectTrivialLiterals(Clause* cl );
+  Lib::Stack<Literal*> selectTrivialLiterals(Clause* cl );
   bool isPure(Literal* lit);
 
   /**
@@ -113,7 +113,7 @@ private:
   {
     class SortedConstantCache {
       unsigned _used;
-      Stack<Term*> _constants;
+      Lib::Stack<Term*> _constants;
     public:
       SortedConstantCache() : _used(0), _constants() {}
       void reset();
@@ -121,7 +121,7 @@ private:
     };
 
     const char* _prefix;
-    Map<SortId, SortedConstantCache> _inner;
+    Lib::Map<SortId, SortedConstantCache> _inner;
 
   public:
     ConstantCache(const char* prefix) : _prefix(prefix), _inner() {}
@@ -138,7 +138,7 @@ private:
   volatile char padding00[1024];
   Z3Interfacing* _solver;
   volatile char padding01[1024];
-  Map<SortId, bool> _supportedSorts;
+  Lib::Map<SortId, bool> _supportedSorts;
   bool _generalisation;
   ConstantCache _instantiationConstants;
   ConstantCache _generalizationConstants;

--- a/Inferences/URResolution.hpp
+++ b/Inferences/URResolution.hpp
@@ -41,7 +41,7 @@ public:
 
 private:
   struct Item;
-  typedef List<Item*> ItemList;
+  typedef Lib::List<Item*> ItemList;
 
   void processAndGetClauses(Item* itm, unsigned startIdx, ClauseList*& acc);
 

--- a/Kernel/ApplicativeHelper.hpp
+++ b/Kernel/ApplicativeHelper.hpp
@@ -63,7 +63,7 @@ public:
   static void getHeadAndAllArgs(TermList term, TermList& head, TermStack& args); 
   static void getHeadAndArgs(TermList term, TermList& head, TermStack& args); 
   static void getHeadAndArgs(Term* term, TermList& head, TermStack& args);  
-  static void getHeadAndArgs(const Term* term, TermList& head, Deque<TermList>& args); 
+  static void getHeadAndArgs(const Term* term, TermList& head, Lib::Deque<TermList>& args); 
   static void getHeadSortAndArgs(TermList term, TermList& head, TermList& headSort, TermStack& args); 
   static bool isComb(const TermList t);
   static Signature::Combinator getComb(const TermList t);

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -37,7 +37,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * A literal selector class template that selects the best literal
@@ -63,6 +62,7 @@ class BestLiteralSelector
 protected:
   void doSelection(Clause* c, unsigned eligible) override
   {
+    using namespace Lib;
     unsigned besti=0;
     Literal* best=(*c)[0];
     for(unsigned i=1;i<eligible;i++) {
@@ -124,10 +124,10 @@ protected:
   {
     ASS_G(eligible, 1); //trivial cases should be taken care of by the base LiteralSelector
 
-    static bool combSup = env.options->combinatorySup();
+    static bool combSup = Lib::env.options->combinatorySup();
 
-    static DArray<Literal*> litArr(64);
-    static Set<unsigned> maxTermHeads;
+    static Lib::DArray<Literal*> litArr(64);
+    static Lib::Set<unsigned> maxTermHeads;
     maxTermHeads.reset();
     litArr.initFromArray(eligible,*c);
     litArr.sortInversed(_comp);
@@ -190,8 +190,8 @@ protected:
       c->setSelected(eligible);
     } else if(!singleSelected) {
       //select multiple maximal literals
-      static Stack<Literal*> replaced(16);
-      Set<Literal*> maxSet;
+      static Lib::Stack<Literal*> replaced(16);
+      Lib::Set<Literal*> maxSet;
       unsigned selCnt=0;
 
       for(LiteralList* mit=maximals; mit; mit=mit->tail()) {
@@ -231,9 +231,9 @@ protected:
     ensureSomeColoredSelected(c, eligible);
   }
 
-  void fillMaximals(LiteralList*& maximals, DArray<Literal*>& litArr)
+  void fillMaximals(LiteralList*& maximals, Lib::DArray<Literal*>& litArr)
   {
-    DArray<Literal*>::ReversedIterator rlit(litArr);
+    Lib::DArray<Literal*>::ReversedIterator rlit(litArr);
     while(rlit.hasNext()) {
       Literal* lit=rlit.next();
       LiteralList::push(lit,maximals);

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -33,7 +33,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * Class to represent clauses.
@@ -54,7 +53,7 @@ private:
   void operator delete(void* ptr) { ASSERTION_VIOLATION; }
 
   template<class VarIt>
-  void collectVars2(DHSet<unsigned>& acc);
+  void collectVars2(Lib::DHSet<unsigned>& acc);
 public:
   DECL_ELEMENT_TYPE(Literal*);
 
@@ -90,13 +89,13 @@ public:
   { return fromLiterals({}, inf); }
 
 
-  static Clause* fromStack(const Stack<Literal*>& lits, Inference inf)
+  static Clause* fromStack(const Lib::Stack<Literal*>& lits, Inference inf)
   { return new(lits.size()) Clause(lits.begin(), lits.size(), std::move(inf)); }
 
   template<class Iter>
   static Clause* fromIterator(Iter litit, const Inference& inf)
   {
-    static Stack<Literal*> st;
+    static Lib::Stack<Literal*> st;
     st.reset();
     st.loadFromIterator(litit);
     return fromStack(st, inf);
@@ -234,17 +233,17 @@ public:
     return savedTimestamp == _reductionTimestamp;
   }
 
-  auto getSelectedLiteralIterator() { return arrayIter(*this,numSelected()); }
-  auto iterLits()                   { return arrayIter(*this,size()); }
-  auto iterLits() const             { return arrayIter(*this,size()); }
+  auto getSelectedLiteralIterator() { return Lib::arrayIter(*this,numSelected()); }
+  auto iterLits()                   { return Lib::arrayIter(*this,size()); }
+  auto iterLits() const             { return Lib::arrayIter(*this,size()); }
   // TODO remove this
-  auto getLiteralIterator()         { return arrayIter(*this,size()); }
+  auto getLiteralIterator()         { return Lib::arrayIter(*this,size()); }
 
   bool isGround();
   bool isPropositional();
   bool isHorn();
 
-  VirtualIterator<unsigned> getVariableIterator();
+  Lib::VirtualIterator<unsigned> getVariableIterator();
 
   bool contains(Literal* lit);
 #if VDEBUG
@@ -271,7 +270,7 @@ public:
   void incNumActiveSplits() { _numActiveSplits++; }
   void decNumActiveSplits() { _numActiveSplits--; }
 
-  VirtualIterator<std::string> toSimpleClauseStrings();
+  Lib::VirtualIterator<std::string> toSimpleClauseStrings();
 
   void setAux()
   {
@@ -345,8 +344,8 @@ public:
   unsigned splitWeight() const;
   unsigned getNumeralWeight() const;
 
-  void collectVars(DHSet<unsigned>& acc);
-  void collectUnstableVars(DHSet<unsigned>& acc);
+  void collectVars(Lib::DHSet<unsigned>& acc);
+  void collectUnstableVars(Lib::DHSet<unsigned>& acc);
 
 
   unsigned varCnt();
@@ -391,7 +390,7 @@ protected:
   /** for splitting: timestamp marking when has the clause been reduced or restored by splitting */
   unsigned _reductionTimestamp;
   /** a map that translates Literal* to its index in the clause */
-  InverseLookup<Literal>* _literalPositions;
+  Lib::InverseLookup<Literal>* _literalPositions;
 
   int _numActiveSplits;
 

--- a/Kernel/ColorHelper.cpp
+++ b/Kernel/ColorHelper.cpp
@@ -33,6 +33,7 @@ namespace Kernel
 {
 
 using namespace std;
+using namespace Lib;
 
 /**
  * Return true if symbol number @c functor is transparent. If @c predicate

--- a/Kernel/ColorHelper.hpp
+++ b/Kernel/ColorHelper.hpp
@@ -24,7 +24,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace Saturation;
 
 class ColorHelper {
@@ -35,7 +34,7 @@ public:
    */
   static Color combine(Color c1, Color c2)
   {
-    ASS(env.colorUsed || (c1|c2)!=COLOR_INVALID);
+    ASS(Lib::env.colorUsed || (c1|c2)!=COLOR_INVALID);
     return static_cast<Color>(c1|c2);
   }
 
@@ -58,13 +57,13 @@ public:
   static void tryUnblock(Clause* c, SaturationAlgorithm* salg);
 
 private:
-  typedef DHMap<Term*, Term*> TermMap;
+  typedef Lib::DHMap<Term*, Term*> TermMap;
 
   static void ensureSkolemReplacement(Term* t, TermMap& map);
   static void collectSkolemReplacements(Clause* c, TermMap& map);
 
   static Term* applyReplacement(Term* t, TermMap& map);
-  static void collectColoredConstants(Clause* c, Stack<Term*>& acc);
+  static void collectColoredConstants(Clause* c, Lib::Stack<Term*>& acc);
 };
 
 }

--- a/Kernel/EqHelper.cpp
+++ b/Kernel/EqHelper.cpp
@@ -27,6 +27,7 @@
 
 namespace Kernel {
 
+using namespace Lib;
 using namespace Shell;
 
 /*

--- a/Kernel/EqHelper.hpp
+++ b/Kernel/EqHelper.hpp
@@ -28,7 +28,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace Shell;
 
 class EqHelper
@@ -36,15 +35,15 @@ class EqHelper
 public:
   static TermList getOtherEqualitySide(Literal* eq, TermList lhs);
   static bool hasGreaterEqualitySide(Literal* eq, const Ordering& ord, TermList& lhs, TermList& rhs);
-  static VirtualIterator<Term*> getSubtermIterator(Literal* lit, const Ordering& ord);
-  static VirtualIterator<Term*> getFoSubtermIterator(Literal* lit, const Ordering& ord);
+  static Lib::VirtualIterator<Term*> getSubtermIterator(Literal* lit, const Ordering& ord);
+  static Lib::VirtualIterator<Term*> getFoSubtermIterator(Literal* lit, const Ordering& ord);
   static TermIterator getBooleanSubtermIterator(Literal* lit, const Ordering& ord);  
   static TermIterator getNarrowableSubtermIterator(Literal* lit, const Ordering& ord);  
-  static VirtualIterator<TypedTermList> getRewritableVarsIterator(DHSet<unsigned>* unstableVars, Literal* lit, const Ordering& ord);
-  static VirtualIterator<TypedTermList> getLHSIterator(Literal* lit, const Ordering& ord);
-  static VirtualIterator<TypedTermList> getSuperpositionLHSIterator(Literal* lit, const Ordering& ord, const Options& opt);
-  static VirtualIterator<TypedTermList> getSubVarSupLHSIterator(Literal* lit, const Ordering& ord);
-  static std::pair<VirtualIterator<TypedTermList>,bool> getDemodulationLHSIterator(Literal* lit, bool onlyPreordered, const Ordering& ord);
+  static Lib::VirtualIterator<TypedTermList> getRewritableVarsIterator(Lib::DHSet<unsigned>* unstableVars, Literal* lit, const Ordering& ord);
+  static Lib::VirtualIterator<TypedTermList> getLHSIterator(Literal* lit, const Ordering& ord);
+  static Lib::VirtualIterator<TypedTermList> getSuperpositionLHSIterator(Literal* lit, const Ordering& ord, const Options& opt);
+  static Lib::VirtualIterator<TypedTermList> getSubVarSupLHSIterator(Literal* lit, const Ordering& ord);
+  static std::pair<Lib::VirtualIterator<TypedTermList>,bool> getDemodulationLHSIterator(Literal* lit, bool onlyPreordered, const Ordering& ord);
   static TermIterator getEqualityArgumentIterator(Literal* lit);
 
   //WARNING, this function cannot be used when @param t is a sort.
@@ -55,7 +54,7 @@ public:
   {
     LHSIteratorFn(const Ordering& ord) : _ord(ord) {}
 
-    VirtualIterator<std::pair<Literal*, TypedTermList> > operator()(Literal* lit)
+    Lib::VirtualIterator<std::pair<Literal*, TypedTermList> > operator()(Literal* lit)
     {
       return pvi( pushPairIntoRightIterator(lit, getLHSIterator(lit, _ord)) );
     }
@@ -67,7 +66,7 @@ public:
   {
     SuperpositionLHSIteratorFn(const Ordering& ord, const Options& opt) : _ord(ord), _opt(opt) {}
 
-    VirtualIterator<std::pair<Literal*, TypedTermList> > operator()(Literal* lit)
+    Lib::VirtualIterator<std::pair<Literal*, TypedTermList> > operator()(Literal* lit)
     {
       return pvi( pushPairIntoRightIterator(lit, getSuperpositionLHSIterator(lit, _ord, _opt)) );
     }
@@ -80,7 +79,7 @@ public:
   {
     SubVarSupLHSIteratorFn(const Ordering& ord) : _ord(ord) {}
 
-    VirtualIterator<std::pair<Literal*, TypedTermList> > operator()(Literal* lit)
+    Lib::VirtualIterator<std::pair<Literal*, TypedTermList> > operator()(Literal* lit)
     {
       return pvi( pushPairIntoRightIterator(lit, getSubVarSupLHSIterator(lit, _ord)) );
     }
@@ -91,7 +90,7 @@ public:
 
   struct EqualityArgumentIteratorFn
   {
-    VirtualIterator<std::pair<Literal*, TermList> > operator()(Literal* lit)
+    Lib::VirtualIterator<std::pair<Literal*, TermList> > operator()(Literal* lit)
     {
       return pvi( pushPairIntoRightIterator(lit, getEqualityArgumentIterator(lit)) );
     }
@@ -104,7 +103,7 @@ public:
 private:
 
   template<class SubtermIterator>
-  static VirtualIterator<ELEMENT_TYPE(SubtermIterator)> getRewritableSubtermIterator(Literal* lit, const Ordering& ord);
+  static Lib::VirtualIterator<ELEMENT_TYPE(SubtermIterator)> getRewritableSubtermIterator(Literal* lit, const Ordering& ord);
 
   struct IsNonVariable;
 

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -21,6 +21,7 @@
 namespace Kernel {
 
 using namespace std;
+using namespace Lib;
 
 std::string Formula::DEFAULT_LABEL = "none";
 

--- a/Kernel/Formula.hpp
+++ b/Kernel/Formula.hpp
@@ -32,7 +32,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 class Formula
 {
@@ -355,10 +354,10 @@ class BoolTermFormula
       }
     } else {
       unsigned functor = term->functor();
-      if (env.signature->isFoolConstantSymbol(true, functor)) {
+      if (Lib::env.signature->isFoolConstantSymbol(true, functor)) {
         return new Formula(true);
       } else {
-        ASS(env.signature->isFoolConstantSymbol(false, functor));
+        ASS(Lib::env.signature->isFoolConstantSymbol(false, functor));
         return new Formula(false);
       }
     }

--- a/Kernel/FormulaTransformer.cpp
+++ b/Kernel/FormulaTransformer.cpp
@@ -28,6 +28,8 @@
 namespace Kernel
 {
 
+using namespace Lib;
+
 Formula* FormulaTransformer::transform(Formula* f) {
   Formula* res = apply(f);
   return res;

--- a/Kernel/FormulaTransformer.hpp
+++ b/Kernel/FormulaTransformer.hpp
@@ -119,7 +119,7 @@ protected:
   TermList getVarSort(unsigned var) const;
 
 private:
-  Recycled<DHMap<unsigned,TermList>> _varSorts;
+  Lib::Recycled<Lib::DHMap<unsigned,TermList>> _varSorts;
   int _polarity;
 };
 

--- a/Kernel/FormulaUnit.hpp
+++ b/Kernel/FormulaUnit.hpp
@@ -21,7 +21,6 @@
 
 #include "Unit.hpp"
 
-using namespace Lib;
 
 namespace Kernel {
 

--- a/Kernel/FormulaVarIterator.hpp
+++ b/Kernel/FormulaVarIterator.hpp
@@ -27,7 +27,6 @@
 #include "Kernel/Term.hpp"
 #include "Kernel/Formula.hpp"
 
-using namespace Lib;
 
 namespace Kernel {
 
@@ -74,19 +73,19 @@ private:
   unsigned _nextVar;
 
   /** Counter used to store bound variables, together with the number of times they are bound */
-  MultiCounter _bound;
+  Lib::MultiCounter _bound;
   /** To store previously found free variables */
-  MultiCounter _free;
+  Lib::MultiCounter _free;
   /** Stack of formulas to be processed */
-  Stack<const Formula*> _formulas;
+  Lib::Stack<const Formula*> _formulas;
   /** Stack of terms to process */
-  Stack<const Term*> _terms;
+  Lib::Stack<const Term*> _terms;
   /** Stack of term lists to process */
-  Stack<TermList> _termLists;
+  Lib::Stack<TermList> _termLists;
   /** Stack of instructions telling what to do next */
-  Stack<Instruction> _instructions;
+  Lib::Stack<Instruction> _instructions;
   /** Stack of lists of variables to process */
-  Stack<const VList*> _vars;
+  Lib::Stack<const VList*> _vars;
 }; // class FormulaVarIterator
 
 template<typename T> // a template to work with Term*, TermList*, and Formula*

--- a/Kernel/Grounder.cpp
+++ b/Kernel/Grounder.cpp
@@ -34,6 +34,7 @@
 #include "Grounder.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 
 /**

--- a/Kernel/Grounder.hpp
+++ b/Kernel/Grounder.hpp
@@ -25,7 +25,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace SAT;
 
 class Grounder {
@@ -53,7 +52,7 @@ private:
   SATLiteral groundNormalized(Literal*);
 
   /** Map from positive literals to SAT variable numbers */
-  DHMap<Literal*, unsigned> _asgn;
+  Lib::DHMap<Literal*, unsigned> _asgn;
   
   /** Pointer to a SATSolver instance for which the grounded clauses
    * are being prepared. Used to request new variables from the Solver.

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -24,6 +24,7 @@
 #include "Inference.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 
 

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -25,7 +25,6 @@
 #include <type_traits>
 #include <limits>
 
-using namespace Lib;
 
 namespace Kernel {
 

--- a/Kernel/InferenceStore.hpp
+++ b/Kernel/InferenceStore.hpp
@@ -32,14 +32,13 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 class InferenceStore
 {
 public:
   static InferenceStore* instance();
 
-  typedef List<int> IntList;
+  typedef Lib::List<int> IntList;
 
   struct FullInference
   {
@@ -84,16 +83,16 @@ private:
 
   ProofPrinter* createProofPrinter(std::ostream& out);
 
-  DHMultiset<Clause*> _nextClIds;
+  Lib::DHMultiset<Clause*> _nextClIds;
 
-  DHMap<Unit*, Literal*> _splittingNameLiterals;
+  Lib::DHMap<Unit*, Literal*> _splittingNameLiterals;
 
 
   /** first records the type of the symbol (PRED,FUNC or TYPE_CON), second is symbol number */
   typedef std::pair<SymbolType,unsigned> SymbolId;
-  typedef Stack<SymbolId> SymbolStack;
-  DHMap<unsigned,SymbolStack> _introducedSymbols;
-  DHMap<unsigned,std::string> _introducedSplitNames;
+  typedef Lib::Stack<SymbolId> SymbolStack;
+  Lib::DHMap<unsigned,SymbolStack> _introducedSymbols;
+  Lib::DHMap<unsigned,std::string> _introducedSplitNames;
 
 };
 

--- a/Kernel/InterpretedLiteralEvaluator.hpp
+++ b/Kernel/InterpretedLiteralEvaluator.hpp
@@ -48,13 +48,13 @@ protected:
   class RatEvaluator;
   class RealEvaluator;
 
-  typedef Stack<Evaluator*> EvalStack;
+  typedef Lib::Stack<Evaluator*> EvalStack;
   virtual TermList transformSubterm(TermList trm);
   Evaluator* getFuncEvaluator(unsigned func);
   Evaluator* getPredEvaluator(unsigned pred);
   EvalStack _evals;
-  DArray<Evaluator*> _funEvaluators;
-  DArray<Evaluator*> _predEvaluators;
+  Lib::DArray<Evaluator*> _funEvaluators;
+  Lib::DArray<Evaluator*> _predEvaluators;
 
   bool balancable(Literal* lit);
   bool balance(Literal* lit,Literal*& res);
@@ -80,7 +80,7 @@ protected:
   
 private:
   template<class Fn>
-  Evaluator* getEvaluator(unsigned func, DArray<Evaluator*>& evaluators, Fn canEval);
+  Evaluator* getEvaluator(unsigned func, Lib::DArray<Evaluator*>& evaluators, Fn canEval);
   const bool _normalize;
 };
 

--- a/Kernel/KBO.hpp
+++ b/Kernel/KBO.hpp
@@ -34,7 +34,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 #if __KBO__CUSTOM_PREDICATE_WEIGHTS__
 struct PredSigTraits;
@@ -100,7 +99,7 @@ struct KboSpecialWeights<FuncSigTraits>
 template<class SigTraits>
 struct KboWeightMap {
   friend class KBO;
-  DArray<KboWeight> _weights;
+  Lib::DArray<KboWeight> _weights;
 
   /** KboWeight of function symbols not occurring in the signature, i.e. that are introduced during proof search */
   KboWeight _introducedSymbolWeight;
@@ -137,10 +136,10 @@ public:
 #endif
 
       // precedence ordering params
-      DArray<int> funcPrec, 
-      DArray<int> typeConPrec,       
-      DArray<int> predPrec, 
-      DArray<int> predLevels,
+      Lib::DArray<int> funcPrec, 
+      Lib::DArray<int> typeConPrec,       
+      Lib::DArray<int> predPrec, 
+      Lib::DArray<int> predLevels,
 
       // other
       bool reverseLCM);
@@ -180,7 +179,7 @@ private:
 #endif
 
   template<class SigTraits> const KboWeightMap<SigTraits>& getWeightMap() const;
-  template<class SigTraits> KboWeightMap<SigTraits> weightsFromOpts(const Options& opts, const DArray<int>& rawPrecedence) const;
+  template<class SigTraits> KboWeightMap<SigTraits> weightsFromOpts(const Options& opts, const Lib::DArray<int>& rawPrecedence) const;
   template<class SigTraits> KboWeightMap<SigTraits> weightsFromFile(const Options& opts) const;
 
   template<class SigTraits> 

--- a/Kernel/KBOComparator.hpp
+++ b/Kernel/KBOComparator.hpp
@@ -23,7 +23,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * Runtime specialized KBO ordering check, based on the linear KBO check
@@ -42,7 +41,7 @@ public:
 
 private:
   // TODO this could be done with KBO::State
-  static void countSymbols(const KBO& kbo, DHMap<unsigned,int>& vars, int& w, TermList t, int coeff);
+  static void countSymbols(const KBO& kbo, Lib::DHMap<unsigned,int>& vars, int& w, TermList t, int coeff);
 
   enum InstructionTag {
     DATA = 0u,
@@ -114,7 +113,7 @@ private:
     uint64_t _content;
   };
   const KBO& _kbo;
-  Stack<Instruction> _instructions;
+  Lib::Stack<Instruction> _instructions;
 };
 
 }

--- a/Kernel/LPO.hpp
+++ b/Kernel/LPO.hpp
@@ -26,7 +26,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * Class for instances of the lexicographic path orderings
@@ -38,8 +37,8 @@ public:
   LPO(Problem& prb, const Options& opt) :
     PrecedenceOrdering(prb, opt)
   {}
-  LPO(const DArray<int>& funcPrec, const DArray<int>& typeConPrec, 
-      const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM) :
+  LPO(const Lib::DArray<int>& funcPrec, const Lib::DArray<int>& typeConPrec, 
+      const Lib::DArray<int>& predPrec, const Lib::DArray<int>& predLevels, bool reverseLCM) :
     PrecedenceOrdering(funcPrec, typeConPrec, predPrec, predLevels, reverseLCM)
   {}
   ~LPO() override = default;

--- a/Kernel/LPOComparator.hpp
+++ b/Kernel/LPOComparator.hpp
@@ -17,7 +17,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace std;
 
 /**
@@ -102,14 +101,14 @@ public:
   };
 
 private:
-  static pair<Stack<Instruction>,Instruction::BranchTag> majoChain(const LPO& lpo, TermList tl1, Term* t, unsigned i);
-  static pair<Stack<Instruction>,Instruction::BranchTag> alphaChain(const LPO& lpo, Term* s, unsigned i, TermList tl2);
-  static pair<Stack<Instruction>,Instruction::BranchTag>* createHelper(TermList tl1, TermList tl2, const LPO& lpo);
+  static pair<Lib::Stack<Instruction>,Instruction::BranchTag> majoChain(const LPO& lpo, TermList tl1, Term* t, unsigned i);
+  static pair<Lib::Stack<Instruction>,Instruction::BranchTag> alphaChain(const LPO& lpo, Term* s, unsigned i, TermList tl2);
+  static pair<Lib::Stack<Instruction>,Instruction::BranchTag>* createHelper(TermList tl1, TermList tl2, const LPO& lpo);
 
   const LPO& _lpo;
 
   /** This is non-empty if @b _res is @b BranchTag::T_JUMP */
-  Stack<Instruction> _instructions;
+  Lib::Stack<Instruction> _instructions;
 
   /** It contains the result of the comparison if the terms
    * are comparable, otherwise it contains @b BranchTag::T_JUMP

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -27,7 +27,6 @@
 namespace Kernel {
 namespace LiteralComparators {
 
-using namespace Lib;
 
 
 //typedef CompositeComaprator Composite;
@@ -50,9 +49,10 @@ template<class Comp1, class Comp2>
 class Composite : public LiteralComparator
 {
 public:
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
-    Comparison res1=_c1.compare(l1,l2);
+    using namespace Lib;
+    Lib::Comparison res1=_c1.compare(l1,l2);
     return (res1==EQUAL)?_c2.compare(l1,l2):res1;
   }
 
@@ -71,7 +71,7 @@ template<class Comp>
 class Inverse : public LiteralComparator
 {
 public:
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
     return _c.compare(l2,l1);
   }
@@ -87,8 +87,9 @@ private:
 
 struct ColoredFirst : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
+    using namespace Lib;
     if(l1->color()!=COLOR_TRANSPARENT && l2->color()==COLOR_TRANSPARENT) {
       return GREATER;
     } else if(l1->color()==COLOR_TRANSPARENT && l2->color()!=COLOR_TRANSPARENT) {
@@ -101,8 +102,9 @@ struct ColoredFirst : public LiteralComparator
 
 struct NoPositiveEquality : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
+    using namespace Lib;
     bool l1PE=l1->isEquality()&&l1->isPositive();
     bool l2PE=l2->isEquality()&&l2->isPositive();
     if( l1PE && !l2PE ) {
@@ -117,8 +119,9 @@ struct NoPositiveEquality : public LiteralComparator
 
 struct Negative : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
+    using namespace Lib;
     ASS(_selector);
 
     bool l1N=_selector->isNegativeForSelection(l1);
@@ -135,8 +138,9 @@ struct Negative : public LiteralComparator
 
 struct NegativeEquality : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
+    using namespace Lib;
     bool l1NE=l1->isEquality()&&l1->isNegative();
     bool l2NE=l2->isEquality()&&l2->isNegative();
     if( l1NE && !l2NE ) {
@@ -151,33 +155,33 @@ struct NegativeEquality : public LiteralComparator
 
 struct MaximalSize : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
-    return Int::compare(l1->weight(), l2->weight());
+    return Lib::Int::compare(l1->weight(), l2->weight());
   }
 };
 
 struct LeastVariables : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
-    return Int::compare(l2->numVarOccs(), l1->numVarOccs());
+    return Lib::Int::compare(l2->numVarOccs(), l1->numVarOccs());
   }
 };
 
 struct LeastDistinctVariables : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
-    return Int::compare(l2->getDistinctVars(), l1->getDistinctVars());
+    return Lib::Int::compare(l2->getDistinctVars(), l1->getDistinctVars());
   }
 };
 
 struct LeastTopLevelVariables : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
-    return Int::compare(getTLVarCnt(l2), getTLVarCnt(l1));
+    return Lib::Int::compare(getTLVarCnt(l2), getTLVarCnt(l1));
   }
 private:
   unsigned getTLVarCnt(Literal* l)
@@ -194,13 +198,14 @@ private:
 
 struct LexComparator : public LiteralComparator
 {
-  Comparison compare(Literal* l1, Literal* l2)
+  Lib::Comparison compare(Literal* l1, Literal* l2)
   {
+    using namespace Lib;
     ASS(l1->shared());
     ASS(l2->shared());
 
     if(l1->header()!=l2->header()) {
-      return Int::compare(l1->header(),l2->header());
+      return Lib::Int::compare(l1->header(),l2->header());
     }
 
     SubtermIterator sit1(l1);
@@ -214,7 +219,7 @@ struct LexComparator : public LiteralComparator
 	  unsigned f1=st1.term()->functor();
 	  unsigned f2=st2.term()->functor();
 	  if(f1!=f2) {
-	    return Int::compare(f1,f2);
+	    return Lib::Int::compare(f1,f2);
 	  }
 	} else {
 	  return GREATER;
@@ -224,7 +229,7 @@ struct LexComparator : public LiteralComparator
 	  return LESS;
 	} else {
 	  if(st1.var()!=st2.var()) {
-	    return Int::compare(st1.var(),st2.var());
+	    return Lib::Int::compare(st1.var(),st2.var());
 	  }
 	}
       }
@@ -243,19 +248,20 @@ struct LexComparator : public LiteralComparator
 template<bool ignorePolarity=false>
 struct NormalizedLinearComparatorByWeight : public LiteralComparator
 {
-  Comparison compare(Term* t1, Term* t2)
+  Lib::Comparison compare(Term* t1, Term* t2)
   {
+    using namespace Lib;
     ASS_EQ(t1->isLiteral(), t2->isLiteral());
 
     if(t1->weight()!=t2->weight()) {
-      return Int::compare(t1->weight(),t2->weight());
+      return Lib::Int::compare(t1->weight(),t2->weight());
     }
     if(t1->functor()!=t2->functor()) {
-      return Int::compare(t1->functor(),t2->functor());
+      return Lib::Int::compare(t1->functor(),t2->functor());
     }
     if(t1->isLiteral() && !ignorePolarity &&
 	    static_cast<Literal*>(t1)->polarity()!=static_cast<Literal*>(t2)->polarity()) {
-      return Int::compare(static_cast<Literal*>(t1)->polarity(),
+      return Lib::Int::compare(static_cast<Literal*>(t1)->polarity(),
 	      static_cast<Literal*>(t2)->polarity());
     }
 
@@ -272,8 +278,8 @@ struct NormalizedLinearComparatorByWeight : public LiteralComparator
       }
     }
 
-    static DHMap<unsigned, unsigned> firstNums;
-    static DHMap<unsigned, unsigned> secondNums;
+    static Lib::DHMap<unsigned, unsigned> firstNums;
+    static Lib::DHMap<unsigned, unsigned> secondNums;
     firstNums.reset();
     secondNums.reset();
 
@@ -283,7 +289,7 @@ struct NormalizedLinearComparatorByWeight : public LiteralComparator
       if(dis.first.isTerm()) {
 	if(dis.second.isTerm()) {
 	  ASS_NEQ(dis.first.term()->functor(), dis.second.term()->functor());
-	  return Int::compare(dis.first.term()->functor(), dis.second.term()->functor());
+	  return Lib::Int::compare(dis.first.term()->functor(), dis.second.term()->functor());
 	}
 	return GREATER;
       }
@@ -293,15 +299,16 @@ struct NormalizedLinearComparatorByWeight : public LiteralComparator
       int firstNorm=firstNums.findOrInsert(dis.first.var(), firstNums.size());
       int secondNorm=secondNums.findOrInsert(dis.second.var(), secondNums.size());
       if(firstNorm!=secondNorm) {
-	return Int::compare(secondNorm, firstNorm);
+	return Lib::Int::compare(secondNorm, firstNorm);
       }
     }
     //they're variants of each other
     return EQUAL;
   }
 
-  Comparison compare(TermList t1, TermList t2)
+  Lib::Comparison compare(TermList t1, TermList t2)
   {
+    using namespace Lib;
     if(t1.isVar()) {
       if(t2.isVar()) {
 	return EQUAL;

--- a/Kernel/LiteralSelector.cpp
+++ b/Kernel/LiteralSelector.cpp
@@ -39,6 +39,7 @@ namespace Kernel
 {
 
 using namespace std;
+using namespace Lib;
 
 /**
  * Return true if literal @b l is positive for the purpose of

--- a/Kernel/LiteralSelector.hpp
+++ b/Kernel/LiteralSelector.hpp
@@ -26,7 +26,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace Shell;
 
 /**

--- a/Kernel/LookaheadLiteralSelector.hpp
+++ b/Kernel/LookaheadLiteralSelector.hpp
@@ -46,7 +46,7 @@ protected:
 private:
   Literal* pickTheBest(Literal** lits, unsigned cnt);
   void removeVariants(LiteralStack& lits);
-  VirtualIterator<std::tuple<>> getGeneraingInferenceIterator(Literal* lit);
+  Lib::VirtualIterator<std::tuple<>> getGeneraingInferenceIterator(Literal* lit);
 
   struct GenIteratorIterator;
 

--- a/Kernel/MLMatcher.hpp
+++ b/Kernel/MLMatcher.hpp
@@ -21,7 +21,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 
 struct MLMatchStats

--- a/Kernel/MLMatcherSD.hpp
+++ b/Kernel/MLMatcherSD.hpp
@@ -16,7 +16,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 
 /**

--- a/Kernel/MLVariant.hpp
+++ b/Kernel/MLVariant.hpp
@@ -21,7 +21,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 class MLVariant {
 public:

--- a/Kernel/MainLoop.cpp
+++ b/Kernel/MainLoop.cpp
@@ -33,6 +33,7 @@
 #include "MainLoop.hpp"
 
 using namespace Kernel;
+using namespace Lib;
 using namespace Saturation;
 using namespace FMB;
 

--- a/Kernel/MainLoop.hpp
+++ b/Kernel/MainLoop.hpp
@@ -30,7 +30,6 @@ namespace Shell {
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace Inferences;
 using namespace Shell;
 
@@ -65,7 +64,7 @@ public:
    * A struct that is thrown as an exception when a refutation is found
    * during the main loop.
    */
-  struct RefutationFoundException : public ThrowableBase
+  struct RefutationFoundException : public Lib::ThrowableBase
   {
     RefutationFoundException(Clause* ref) : refutation(ref)
     {
@@ -79,7 +78,7 @@ public:
    * A struct that is thrown as an exception when a refutation is found
    * during the main loop.
    */
-  struct MainLoopFinishedException : public ThrowableBase
+  struct MainLoopFinishedException : public Lib::ThrowableBase
   {
     MainLoopFinishedException(const MainLoopResult& res) : result(res)
     {

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -23,6 +23,7 @@ namespace Kernel
 {
 
 using namespace std;
+using namespace Lib;
 
 namespace __MU_Aux {
 

--- a/Kernel/Matcher.hpp
+++ b/Kernel/Matcher.hpp
@@ -30,7 +30,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 class MatchingUtils
 {
@@ -144,7 +143,7 @@ public:
   };
 
 private:
-  typedef DHMap<unsigned,TermList,IdentityHash,DefaultHash> BindingMap;
+  typedef Lib::DHMap<unsigned,TermList,Lib::IdentityHash,Lib::DefaultHash> BindingMap;
   struct MapBinder
   {
     bool bind(unsigned var, TermList term)
@@ -205,8 +204,8 @@ private:
   { ASSERTION_VIOLATION; }
 
 
-  typedef DHMap<unsigned,TermList> BindingMap;
-  typedef Stack<unsigned> BoundStack;
+  typedef Lib::DHMap<unsigned,TermList> BindingMap;
+  typedef Lib::Stack<unsigned> BoundStack;
 
   BindingMap _bindings;
   BoundStack _bound;
@@ -219,7 +218,7 @@ private:
 };
 
 class Matcher
-: public Backtrackable
+: public Lib::Backtrackable
 {
 public:
   Matcher() : _binder(*this) {}
@@ -235,7 +234,7 @@ private:
 
   bool matchReversedArgs(Literal* base, Literal* instance);
 
-  typedef DHMap<unsigned,TermList> BindingMap;
+  typedef Lib::DHMap<unsigned,TermList> BindingMap;
   struct MapBinder
   {
     MapBinder(Matcher& parent) : _parent(parent) {}
@@ -258,7 +257,7 @@ private:
     Matcher& _parent;
 
     class BindingBacktrackObject
-    : public BacktrackObject
+    : public Lib::BacktrackObject
     {
     public:
       BindingBacktrackObject(MapBinder* bnd, unsigned var)
@@ -325,7 +324,7 @@ bool MatchingUtils::matchArgs(Term* base, Term* instance, Binder& binder)
   TermList* bt=base->args();
   TermList* it=instance->args();
 
-  static Stack<TermList*> subterms(32);
+  static Lib::Stack<TermList*> subterms(32);
   subterms.reset();
 
   for (;;) {

--- a/Kernel/NumTraits.hpp
+++ b/Kernel/NumTraits.hpp
@@ -90,7 +90,7 @@ struct NumTraits;
     static constexpr Theory::Interpretation name ## I = Theory::SORT_SHORT ## _INTERPRETATION;                \
                                                                                                               \
     static unsigned name ## F() {                                                                             \
-      static const unsigned functor = env.signature->getInterpretingSymbol(name ## I);                        \
+      static const unsigned functor = Lib::env.signature->getInterpretingSymbol(name ## I);                        \
       return functor;                                                                                         \
     }                                                                                                         \
 
@@ -169,15 +169,15 @@ struct NumTraits;
     static Term* constantT(int i) { return constantT(constant(i)); }                                          \
     static Term* constantT(ConstantType i) { return theory->representConstant(i); }                           \
     static TermList constantTl(int i) { return TermList(constantT(i)); }                                      \
-    static Option<ConstantType> tryNumeral(TermList t) {                                                      \
+    static Lib::Option<ConstantType> tryNumeral(TermList t) {                                                      \
       ConstantType out;                                                                                       \
       if (theory->tryInterpretConstant(t,out)) {                                                              \
-        return Option<ConstantType>(out);                                                                     \
+        return Lib::Option<ConstantType>(out);                                                                     \
       } else {                                                                                                \
-        return Option<ConstantType>();                                                                        \
+        return Lib::Option<ConstantType>();                                                                        \
       }                                                                                                       \
     }                                                                                                         \
-    static Option<ConstantType> tryNumeral(Term* t) { return tryNumeral(TermList(t)); }                       \
+    static Lib::Option<ConstantType> tryNumeral(Term* t) { return tryNumeral(TermList(t)); }                       \
                                                                                                               \
     static const char* name() {return #CamelCase;}                                                            \
   };                                                                                                          \

--- a/Kernel/OperatorType.hpp
+++ b/Kernel/OperatorType.hpp
@@ -41,7 +41,7 @@ namespace Kernel {
  *
  * https://link.springer.com/chapter/10.1007/978-3-030-51054-1_21
  *
- * The class stores data in a Vector<TermList>*, of length 
+ * The class stores data in a Lib::Vector<TermList>*, of length 
  * num_of_arg_sorts + 1. The number of bound variables is stored in
  * a field _typeArgsArity. It is assumed that the bound variables range from
  * 0 to _typeArgsArity - 1. In order for this assumption to be valid all sorts must
@@ -63,15 +63,15 @@ public:
     { 
       OperatorKey& key = *ot->key();
       unsigned typeArgsArity = ot->numTypeArguments();
-      return HashUtils::combine(
-        DefaultHash::hash(key),
-        DefaultHash::hash(typeArgsArity)
+      return Lib::HashUtils::combine(
+        Lib::DefaultHash::hash(key),
+        Lib::DefaultHash::hash(typeArgsArity)
       );
     }
   };
 
 private:
-  typedef Vector<TermList> OperatorKey; // Vector of argument sorts together with "0" appended for predicates and resultSort appended for functions
+  typedef Lib::Vector<TermList> OperatorKey; // Vector of argument sorts together with "0" appended for predicates and resultSort appended for functions
   OperatorKey* _key;
   unsigned _typeArgsArity; /** number of quantified variables of this type */
  
@@ -85,7 +85,7 @@ private:
   static OperatorKey* setupKey(std::initializer_list<TermList> sorts);
   static OperatorKey* setupKeyUniformRange(unsigned arity, TermList argsSort);
 
-  typedef Set<OperatorType*,TypeHash> OperatorTypes;
+  typedef Lib::Set<OperatorType*,TypeHash> OperatorTypes;
   static OperatorTypes& operatorTypes(); // just a wrapper around a static OperatorTypes object, to ensure a correct initialization order
 
   static OperatorType* getTypeFromKey(OperatorKey* key, unsigned taArity);

--- a/Kernel/Ordering.hpp
+++ b/Kernel/Ordering.hpp
@@ -96,8 +96,8 @@ public:
 
   void removeNonMaximal(LiteralList*& lits) const;
 
-  static Result fromComparison(Comparison c);
-  static Comparison intoComparison(Result c);
+  static Result fromComparison(Lib::Comparison c);
+  static Lib::Comparison intoComparison(Result c);
 
   static Result reverse(Result r)
   {
@@ -159,16 +159,16 @@ protected:
   // l1 and l2 are not equalities and have the same predicate
   virtual Result comparePredicates(Literal* l1,Literal* l2) const = 0;
 
-  PrecedenceOrdering(const DArray<int>& funcPrec, const DArray<int>& typeConPrec, 
-                     const DArray<int>& predPrec, const DArray<int>& predLevels, bool reverseLCM);
-  PrecedenceOrdering(Problem& prb, const Options& opt, const DArray<int>& predPrec);
+  PrecedenceOrdering(const Lib::DArray<int>& funcPrec, const Lib::DArray<int>& typeConPrec, 
+                     const Lib::DArray<int>& predPrec, const Lib::DArray<int>& predLevels, bool reverseLCM);
+  PrecedenceOrdering(Problem& prb, const Options& opt, const Lib::DArray<int>& predPrec);
   PrecedenceOrdering(Problem& prb, const Options& opt);
 
 
-  static DArray<int> typeConPrecFromOpts(Problem& prb, const Options& opt);
-  static DArray<int> funcPrecFromOpts(Problem& prb, const Options& opt);
-  static DArray<int> predPrecFromOpts(Problem& prb, const Options& opt);
-  static DArray<int> predLevelsFromOptsAndPrec(Problem& prb, const Options& opt, const DArray<int>& predicatePrecedences);
+  static Lib::DArray<int> typeConPrecFromOpts(Problem& prb, const Options& opt);
+  static Lib::DArray<int> funcPrecFromOpts(Problem& prb, const Options& opt);
+  static Lib::DArray<int> predPrecFromOpts(Problem& prb, const Options& opt);
+  static Lib::DArray<int> predLevelsFromOptsAndPrec(Problem& prb, const Options& opt, const Lib::DArray<int>& predicatePrecedences);
 
   Result compareFunctionPrecedences(unsigned fun1, unsigned fun2) const;
   Result compareTypeConPrecedences(unsigned tyc1, unsigned tyc2) const;
@@ -181,13 +181,13 @@ protected:
   /** number of functions in the signature at the time the order was created */
   unsigned _functions;
   /** Array of predicate levels */
-  DArray<int> _predicateLevels;
+  Lib::DArray<int> _predicateLevels;
   /** Array of predicate precedences */
-  DArray<int> _predicatePrecedences;
+  Lib::DArray<int> _predicatePrecedences;
   /** Array of function precedences */
-  DArray<int> _functionPrecedences;
+  Lib::DArray<int> _functionPrecedences;
   /** Array of type con precedences */
-  DArray<int> _typeConPrecedences;
+  Lib::DArray<int> _typeConPrecedences;
 
   bool _reverseLCM;
 };

--- a/Kernel/Polynomial.cpp
+++ b/Kernel/Polynomial.cpp
@@ -16,6 +16,8 @@
 
 namespace Kernel {
 
+using namespace Lib;
+
 PolyNf PolyNf::normalize(TypedTermList t)  
 { return normalizeTerm(t); }
 

--- a/Kernel/Polynomial.hpp
+++ b/Kernel/Polynomial.hpp
@@ -93,10 +93,10 @@ public:
   unsigned id() const;
   Theory::Interpretation interpretation() const;
   bool isInterpreted() const;
-  Option<Theory::Interpretation> tryInterpret() const;
+  Lib::Option<Theory::Interpretation> tryInterpret() const;
 
   template<class Number>
-  Option<typename Number::ConstantType> tryNumeral() const;
+  Lib::Option<typename Number::ConstantType> tryNumeral() const;
 };
 
 } // namespace Kernel
@@ -137,13 +137,13 @@ struct Monom
   using Numeral = typename Number::ConstantType;
 
   Numeral numeral;
-  Perfect<MonomFactors<Number>> factors;
+  Lib::Perfect<MonomFactors<Number>> factors;
 
-  Monom(Numeral numeral, Perfect<MonomFactors<Number>> factors);
+  Monom(Numeral numeral, Lib::Perfect<MonomFactors<Number>> factors);
 
   static Monom zero();
 
-  Option<Variable> tryVar() const;
+  Lib::Option<Variable> tryVar() const;
 
   /** performs an integrity check on the datastructure, only has an effect in debug mode */
   void integrity() const;
@@ -156,11 +156,11 @@ struct Monom
 class FuncTerm 
 {
   FuncId _fun;
-  Stack<PolyNf> _args;
+  Lib::Stack<PolyNf> _args;
 public:
   USE_ALLOCATOR(FuncTerm)
 
-  FuncTerm(FuncId f, Stack<PolyNf>&& args);
+  FuncTerm(FuncId f, Lib::Stack<PolyNf>&& args);
   FuncTerm(FuncId f, PolyNf* args);
 
   unsigned numTermArguments() const;
@@ -168,7 +168,7 @@ public:
   PolyNf const& arg(unsigned i) const;
 
   template<class Number> 
-  Option<typename Number::ConstantType> tryNumeral() const;
+  Lib::Option<typename Number::ConstantType> tryNumeral() const;
 
   friend std::ostream& operator<<(std::ostream& out, const FuncTerm& self);
   friend bool operator==(FuncTerm const& lhs, FuncTerm const& rhs);
@@ -176,27 +176,27 @@ public:
   friend struct std::hash<FuncTerm>;
 };
 
-using AnyPolySuper = Coproduct< 
-    Perfect<Polynom< IntTraits>>
-  , Perfect<Polynom< RatTraits>>
-  , Perfect<Polynom<RealTraits>>
+using AnyPolySuper = Lib::Coproduct< 
+    Lib::Perfect<Polynom< IntTraits>>
+  , Lib::Perfect<Polynom< RatTraits>>
+  , Lib::Perfect<Polynom<RealTraits>>
   >;
 
 class AnyPoly : public AnyPolySuper
 {
 public:
   /** creates a new dynamically typed polynom from a statically typed one */
-  template<class NumTraits> AnyPoly(Perfect<Polynom<NumTraits>> x);
+  template<class NumTraits> AnyPoly(Lib::Perfect<Polynom<NumTraits>> x);
 
   /** tries to turn this polynom into a polynom of the given NumTraits. */
-  template<class NumTraits> Option<Perfect<Polynom<NumTraits>> const&> downcast() const&;
+  template<class NumTraits> Lib::Option<Lib::Perfect<Polynom<NumTraits>> const&> downcast() const&;
 
   /** returns wether this is a Polynom of the given NumTraits. */
   template<class NumTraits> bool isType() const;
 
   /** if this polynom has the right sort, and consist of a single summand that is a numeral, then this numeral
    * is returned. otherwise an empty Option is returned. */
-  template<class NumTraits> Option<typename NumTraits::ConstantType> tryNumeral() const&;
+  template<class NumTraits> Lib::Option<typename NumTraits::ConstantType> tryNumeral() const&;
 
   /** \see template<class N> Polynom<N>::replaceTerms */
   AnyPoly replaceTerms(PolyNf* newTs) const;
@@ -217,7 +217,7 @@ public:
   friend struct std::hash<AnyPoly>;
 };
 
-using PolyNfSuper = Lib::Coproduct<Perfect<FuncTerm>, Variable, AnyPoly>;
+using PolyNfSuper = Lib::Coproduct<Lib::Perfect<FuncTerm>, Variable, AnyPoly>;
 
 /**
  * Represents the polynomial normal form of a term, that is used for performing several simplifications and evaluations.
@@ -228,7 +228,7 @@ class PolyNf : public PolyNfSuper
 {
 public:
 
-  PolyNf(Perfect<FuncTerm> t);
+  PolyNf(Lib::Perfect<FuncTerm> t);
   PolyNf(Variable               t);
   PolyNf(AnyPoly                t);
 
@@ -239,7 +239,7 @@ public:
    * otherwise an empty Option is returned
    */
   template<class NumTraits>
-  Option<Perfect<Polynom<NumTraits>>> downcast() const;
+  Lib::Option<Lib::Perfect<Polynom<NumTraits>>> downcast() const;
 
   /** turns the normal form term PolyNf into an ordenary vampire term TermList. */
   TermList denormalize() const;
@@ -252,21 +252,21 @@ public:
    * wrapped in a polynom.
    */
   template<class Number> 
-  Perfect<Polynom<Number>> wrapPoly() const;
+  Lib::Perfect<Polynom<Number>> wrapPoly() const;
   
 
   /** if this PolyNf is a numeral, the numeral is returned */
   template<class Number>
-  Option<typename Number::ConstantType> tryNumeral() const;
+  Lib::Option<typename Number::ConstantType> tryNumeral() const;
 
   /** if this PolyNf is a Variable, the variable is returned */
-  Option<Variable> tryVar() const;
+  Lib::Option<Variable> tryVar() const;
 
   /** an iterator over all PolyNf s that are subterms of this one */
   class SubtermIter;
 
   /** returns an iterator over all PolyNf s that are subterms of this one */
-  IterTraits<SubtermIter> iterSubterms() const;
+  Lib::IterTraits<SubtermIter> iterSubterms() const;
 
   friend struct std::hash<PolyNf>;
   friend bool operator==(PolyNf const& lhs, PolyNf const& rhs);
@@ -293,7 +293,7 @@ struct MonomFactor
   MonomFactor(PolyNf term, int power);
    
   /** if this monomfactor is a Variable and has power one it is turned into a variable */
-  Option<Variable> tryVar() const;
+  Lib::Option<Variable> tryVar() const;
 };
 
 
@@ -308,7 +308,7 @@ class MonomFactors
   using Monom       = Kernel::Monom<Number>;
   using Polynom     = Kernel::Polynom<Number>;
   using Numeral = typename Number::ConstantType;
-  Stack<MonomFactor> _factors;
+  Lib::Stack<MonomFactor> _factors;
   friend struct std::hash<MonomFactors>;
 
 public:
@@ -318,7 +318,7 @@ public:
    * constructs a new MonomFactors. 
    * \pre factors must be sorted
    */
-  MonomFactors(Stack<MonomFactor>&& factors);
+  MonomFactors(Lib::Stack<MonomFactor>&& factors);
 
   /** constructs an empty product, which corresponds to the numeral one.  */
   MonomFactors();
@@ -347,7 +347,7 @@ public:
   /** turns this monom into a polynom. 
    * \pre isPolynom  must be true
    */
-  Perfect<Polynom> asPolynom() const;
+  Lib::Perfect<Polynom> asPolynom() const;
 
   /** returns the (empty) product one */
   static MonomFactors one();
@@ -357,7 +357,7 @@ public:
 
 
   /** if this MonomFactors consist of a single variable if will be returnd  */
-  Option<Variable> tryVar() const;
+  Lib::Option<Variable> tryVar() const;
 
   /** performs an integrity check on the datastructure, only has an effect in debug mode */
   void integrity() const;
@@ -368,7 +368,7 @@ public:
 
   /** returns an iterator over all factors */
   auto iter() const&
-  { return arrayIter(_factors); }
+  { return Lib::arrayIter(_factors); }
 
   explicit MonomFactors(const MonomFactors&) = default;
   explicit MonomFactors(MonomFactors&) = default;
@@ -382,7 +382,7 @@ public:
   /** helper function for PolyNf::denormalize() */
   TermList denormalize(TermList* results)  const;
 
-  Stack<MonomFactor>& raw();
+  Lib::Stack<MonomFactor>& raw();
 };
 
 template<class Number>
@@ -394,7 +394,7 @@ class Polynom
   using MonomFactors = Kernel::MonomFactors<Number>;
   using Monom        = Kernel::Monom<Number>;
 
-  Stack<Monom> _summands;
+  Lib::Stack<Monom> _summands;
 
 public:
   USE_ALLOCATOR(Polynom)
@@ -403,7 +403,7 @@ public:
    * constructs a new Polynom with a list of summands 
    * \pre summands must be sorted
    */
-  explicit Polynom(Stack<Monom>&& summands);
+  explicit Polynom(Lib::Stack<Monom>&& summands);
 
   /** creates a Polynom that consists of only one summand */
   explicit Polynom(Monom m);
@@ -421,7 +421,7 @@ public:
   static Polynom zero();
 
   /** if this Polynom consists only of one summand that is a numeral the numeral is returned */
-  Option<Numeral> toNumber() const&;
+  Lib::Option<Numeral> toNumber() const&;
 
   /** turns this Polynom into a numeral if it consists only of one summand that is a numeral, or throws an assertion violation 
    * \pre isNumeral is true*
@@ -463,9 +463,9 @@ public:
 
   /** returns iterator over all summands of this Polyom */
   auto iterSummands() const&
-  { return arrayIter(_summands); }
+  { return Lib::arrayIter(_summands); }
 
-  Stack<Monom>& raw();
+  Lib::Stack<Monom>& raw();
 
   template<class N> friend bool operator==(const Polynom<N>& lhs, const Polynom<N>& rhs);
   template<class N> friend std::ostream& operator<<(std::ostream& out, const Polynom<N>& self);
@@ -487,7 +487,7 @@ public:
 };
 
 /** convienent constructor for IterArgsPnf */
-IterTraits<IterArgsPnf> iterArgsPnf(Literal* lit);
+Lib::IterTraits<IterArgsPnf> iterArgsPnf(Literal* lit);
 
 } // namespace Kernel
 
@@ -497,7 +497,7 @@ IterTraits<IterArgsPnf> iterArgsPnf(Literal* lit);
 namespace Kernel {
 
 class PolyNf::SubtermIter {
-  Stack<BottomUpChildIter<PolyNf>> _stack;
+  Lib::Stack<Lib::BottomUpChildIter<PolyNf>> _stack;
 public:
   DECL_ELEMENT_TYPE(PolyNf);
 
@@ -525,21 +525,21 @@ public:
 namespace Kernel {
 
 template<class Number>
-Monom<Number>::Monom(Monom<Number>::Numeral numeral, Perfect<MonomFactors<Number>> factors) 
+Monom<Number>::Monom(Monom<Number>::Numeral numeral, Lib::Perfect<MonomFactors<Number>> factors) 
   : numeral(numeral), factors(factors)
 {}
 
 template<class Number>
 Monom<Number> Monom<Number>::zero() 
 { 
-  static Monom p = Monom(Numeral(0), perfect(MonomFactors<Number>()));
+  static Monom p = Monom(Numeral(0), Lib::perfect(MonomFactors<Number>()));
   return p; 
 }
 
 template<class Number>
-Option<Variable> Monom<Number>::tryVar() const 
+Lib::Option<Variable> Monom<Number>::tryVar() const 
 {
-  using Opt = Option<Variable>;
+  using Opt = Lib::Option<Variable>;
   if (numeral == Numeral(1)) {
     return  factors->tryVar();
   } else {
@@ -590,14 +590,14 @@ std::ostream& operator<<(std::ostream& out, const Monom<Number>& self)
 namespace Kernel {
 
 template<class Number>
-Option<typename Number::ConstantType> FuncId::tryNumeral() const
+Lib::Option<typename Number::ConstantType> FuncId::tryNumeral() const
 { 
   using Numeral = typename Number::ConstantType;
   Numeral out;
   if (theory->tryInterpretConstant(_num, out)) {
-    return Option<Numeral>(out);
+    return Lib::Option<Numeral>(out);
   } else {
-    return Option<Numeral>();
+    return Lib::Option<Numeral>();
   }
 }
 
@@ -612,7 +612,7 @@ Option<typename Number::ConstantType> FuncId::tryNumeral() const
 namespace Kernel {
 
 template<class Number>
-Option<typename Number::ConstantType> FuncTerm::tryNumeral() const
+Lib::Option<typename Number::ConstantType> FuncTerm::tryNumeral() const
 { return _fun.template tryNumeral<Number>(); }
 
 } // namespace Kernel
@@ -621,7 +621,7 @@ Option<typename Number::ConstantType> FuncTerm::tryNumeral() const
 template<> struct std::hash<Kernel::FuncTerm> 
 {
   size_t operator()(Kernel::FuncTerm const& f) const 
-  { return Lib::HashUtils::combine(std::hash<Kernel::FuncId>{}(f._fun), std::hash<Stack<Kernel::PolyNf>>{}(f._args));  }
+  { return Lib::HashUtils::combine(std::hash<Kernel::FuncId>{}(f._fun), std::hash<Lib::Stack<Kernel::PolyNf>>{}(f._args));  }
 };
 
 /////////////////////////////////////////////////////////
@@ -631,29 +631,29 @@ template<> struct std::hash<Kernel::FuncTerm>
 namespace Kernel {
 
 template<class NumTraits>
-AnyPoly::AnyPoly(Perfect<Polynom<NumTraits>> x) : Coproduct(std::move(x)) {  }
+AnyPoly::AnyPoly(Lib::Perfect<Polynom<NumTraits>> x) : Coproduct(std::move(x)) {  }
 
 template<class NumTraits> 
-Option<Perfect<Polynom<NumTraits>> const&>  AnyPoly::downcast() const& 
-{ return as<Perfect<Polynom<NumTraits>>>(); }
+Lib::Option<Lib::Perfect<Polynom<NumTraits>> const&>  AnyPoly::downcast() const& 
+{ return as<Lib::Perfect<Polynom<NumTraits>>>(); }
 
 template<class NumTraits> 
 bool AnyPoly::isType() const 
-{ return is<Perfect<Polynom<NumTraits>>>(); }
+{ return is<Lib::Perfect<Polynom<NumTraits>>>(); }
 
 /* helper function for AnyPoly::tryNumeral */
 template<class NumIn, class NumOut>
 struct __ToNumeralHelper 
 {
-  Option<typename NumOut::ConstantType> operator()(Perfect<Polynom<NumIn>>) const
-  { return Option<typename NumOut::ConstantType>(); }
+  Lib::Option<typename NumOut::ConstantType> operator()(Lib::Perfect<Polynom<NumIn>>) const
+  { return Lib::Option<typename NumOut::ConstantType>(); }
 };
 
 /* helper function for AnyPoly::tryNumeral */
 template<class Num>
 struct __ToNumeralHelper<Num,Num>
 {
-  Option<typename Num::ConstantType> operator()(Perfect<Polynom<Num>> p) const
+  Lib::Option<typename Num::ConstantType> operator()(Lib::Perfect<Polynom<Num>> p) const
   { return p->toNumber(); }
 };
 
@@ -661,13 +661,13 @@ template<class NumOut>
 struct PolymorphicToNumeral 
 {
   template<class NumIn>
-  Option<typename NumOut::ConstantType> operator()(Perfect<Polynom<NumIn>> const& p) const
+  Lib::Option<typename NumOut::ConstantType> operator()(Lib::Perfect<Polynom<NumIn>> const& p) const
   { return __ToNumeralHelper<NumIn, NumOut>{}(p); }
 };
 
 
 template<class NumTraits>
-Option<typename NumTraits::ConstantType> AnyPoly::tryNumeral() const&
+Lib::Option<typename NumTraits::ConstantType> AnyPoly::tryNumeral() const&
 { return apply(PolymorphicToNumeral<NumTraits>{}); }
 
 } // namespace Kernel
@@ -688,9 +688,9 @@ namespace Kernel {
 
 
 template<class NumTraits>
-Option<Perfect<Polynom<NumTraits>>> PolyNf::downcast()  const
+Lib::Option<Lib::Perfect<Polynom<NumTraits>>> PolyNf::downcast()  const
 {
-  using Result = Perfect<Polynom<NumTraits>>;
+  using Result = Lib::Perfect<Polynom<NumTraits>>;
   return as<AnyPoly>()
     .andThen([](AnyPoly const& p) { return p.as<Result>(); })
     .map([](Result const& p) -> Result { return p; });
@@ -698,23 +698,23 @@ Option<Perfect<Polynom<NumTraits>>> PolyNf::downcast()  const
 
 
 template<class Number> 
-Perfect<Polynom<Number>> PolyNf::wrapPoly() const
+Lib::Perfect<Polynom<Number>> PolyNf::wrapPoly() const
 {
   if (this->is<AnyPoly>()) {
     return this->unwrap<AnyPoly>()
-            .unwrap<Perfect<Polynom<Number>>>();
+            .unwrap<Lib::Perfect<Polynom<Number>>>();
   } else {
-    return perfect(Polynom<Number>(*this));
+    return Lib::perfect(Polynom<Number>(*this));
   }
 }
 
 template<class Number>
-Option<typename Number::ConstantType> PolyNf::tryNumeral() const
+Lib::Option<typename Number::ConstantType> PolyNf::tryNumeral() const
 { 
   using Numeral = typename Number::ConstantType;
   return match(
-      [](Perfect<FuncTerm> t) { return (*t).tryNumeral<Number>(); },
-      [](Variable               t) { return Option<Numeral>();              },
+      [](Lib::Perfect<FuncTerm> t) { return (*t).tryNumeral<Number>(); },
+      [](Variable               t) { return Lib::Option<Numeral>();              },
       [](AnyPoly                t) { return t.template tryNumeral<Number>(); }
     );
 }
@@ -760,8 +760,8 @@ std::ostream& operator<<(std::ostream& out, const MonomFactor<Number>& self) {
 }
 
 template<class Number>
-Option<Variable> MonomFactor<Number>::tryVar() const 
-{ return power == 1 ? term.tryVar() : none<Variable>(); }
+Lib::Option<Variable> MonomFactor<Number>::tryVar() const 
+{ return power == 1 ? term.tryVar() : Lib::none<Variable>(); }
 
 } // namespace Kernel
 
@@ -770,7 +770,8 @@ struct std::hash<Kernel::MonomFactor<NumTraits>>
 {
   size_t operator()(Kernel::MonomFactor<NumTraits> const& x) const noexcept 
   {
-    return HashUtils::combine(
+    using namespace Lib;
+    return Lib::HashUtils::combine(
       StlHash::hash(x.term),
       StlHash::hash(x.power)
     );
@@ -785,7 +786,7 @@ struct std::hash<Kernel::MonomFactor<NumTraits>>
 namespace Kernel {
 
 template<class Number>
-MonomFactors<Number>::MonomFactors(Stack<MonomFactor>&& factors) 
+MonomFactors<Number>::MonomFactors(Lib::Stack<MonomFactor>&& factors) 
   : _factors(std::move(factors)) { }
 
 template<class Number>
@@ -820,7 +821,7 @@ PolyNf const& MonomFactors<Number>::termAt(unsigned i) const
 { return _factors[i].term; }
 
 template<class Number>
-Stack<MonomFactor<Number>> & MonomFactors<Number>::raw()
+Lib::Stack<MonomFactor<Number>> & MonomFactors<Number>::raw()
 { return _factors; }
 
 template<class Number>
@@ -830,12 +831,12 @@ bool MonomFactors<Number>::isPolynom() const
     && _factors[0].term.template is<AnyPoly>(); }
 
 template<class Number>
-Perfect<Polynom<Number>> MonomFactors<Number>::asPolynom() const
+Lib::Perfect<Polynom<Number>> MonomFactors<Number>::asPolynom() const
 { 
   ASS(isPolynom());
   return _factors[0].term
     .template unwrap<AnyPoly>()
-    .template unwrap<Perfect<Polynom>>(); 
+    .template unwrap<Lib::Perfect<Polynom>>(); 
 }
 
 template<class Number>
@@ -897,9 +898,9 @@ TermList MonomFactors<Number>::denormalize(TermList* results)  const
 }
 
 template<class Number>
-Option<Variable> MonomFactors<Number>::tryVar() const 
+Lib::Option<Variable> MonomFactors<Number>::tryVar() const 
 {
-  using Opt = Option<Variable>;
+  using Opt = Lib::Option<Variable>;
   if (nFactors() == 1 ) {
 
     return _factors[0].tryVar();
@@ -944,6 +945,7 @@ struct std::hash<Kernel::MonomFactors<NumTraits>>
 {
   size_t operator()(Kernel::MonomFactors<NumTraits> const& x) const noexcept 
   {
+    using namespace Lib;
     return StackHash<StlHash>::hash(x._factors);
   }
 };
@@ -957,22 +959,22 @@ namespace Kernel {
 
 
 template<class Number>
-Polynom<Number>::Polynom(Stack<Monom>&& summands) 
+Polynom<Number>::Polynom(Lib::Stack<Monom>&& summands) 
   : _summands(
       summands.isEmpty() 
-        ? Stack<Monom>{Monom::zero()} 
+        ? Lib::Stack<Monom>{Monom::zero()} 
         : std::move(summands)) 
 { }
 
 template<class Number>
 Polynom<Number>::Polynom(Monom m) 
   : Polynom(
-      Stack<Monom>{m})
+      Lib::Stack<Monom>{m})
 {  }
 
 template<class Number>
 Polynom<Number>::Polynom(Numeral numeral, PolyNf term) 
-  : Polynom(Monom(numeral, perfect(MonomFactors(term))))
+  : Polynom(Monom(numeral, Lib::perfect(MonomFactors(term))))
 {  }
 
 template<class Number>
@@ -982,7 +984,7 @@ Polynom<Number>::Polynom(PolyNf t)
 
 template<class Number>
 Polynom<Number>::Polynom(Numeral constant) 
-  : Polynom(Monom(constant, perfect(MonomFactors::one()))) 
+  : Polynom(Monom(constant, Lib::perfect(MonomFactors::one()))) 
 {  }
 
 
@@ -1012,22 +1014,22 @@ std::ostream& operator<<(std::ostream& out, const Polynom<Number>& self) {
 template<class Number>
 Polynom<Number> Polynom<Number>::zero() 
 { 
-  auto out = Polynom(Stack<Monom>{Monom::zero()}); 
+  auto out = Polynom(Lib::Stack<Monom>{Monom::zero()}); 
   out.integrity();
   return std::move(out);
 }
 
 template<class Number>
-Option<typename Number::ConstantType> Polynom<Number>::toNumber() const& 
+Lib::Option<typename Number::ConstantType> Polynom<Number>::toNumber() const& 
 { 
   if ( _summands.size() == 0) {
-    return Option<Numeral>(Numeral(0));
+    return Lib::Option<Numeral>(Numeral(0));
 
   } else if (_summands.size() == 1 && _summands[0].factors->nFactors() == 0) {
-    return Option<Numeral>(_summands[0].numeral);
+    return Lib::Option<Numeral>(_summands[0].numeral);
 
   } else {
-    return Option<Numeral>();
+    return Lib::Option<Numeral>();
   }
 }
 
@@ -1077,20 +1079,20 @@ TermList Polynom<Number>::denormalize(TermList* results) const
 }
 
 template<class Number>
-Stack<Monom<Number>>& Polynom<Number>::raw()
+Lib::Stack<Monom<Number>>& Polynom<Number>::raw()
 { return _summands; }
 
 template<class Number>
 Polynom<Number> Polynom<Number>::replaceTerms(PolyNf* simplifiedTerms) const 
 {
   int offs = 0;
-  Stack<Monom> out;
+  Lib::Stack<Monom> out;
   out.reserve(nSummands());
 
   for (auto& monom : _summands) {
     out.push(Monom(
           monom.numeral, 
-          perfect(monom.factors->replaceTerms(&simplifiedTerms[offs]))));
+          Lib::perfect(monom.factors->replaceTerms(&simplifiedTerms[offs]))));
     offs += monom.factors->nFactors();
   }
   return Polynom(std::move(out));
@@ -1121,7 +1123,7 @@ void Polynom<Number>::integrity() const {
     auto iter = this->_summands.begin();
     auto last = iter++;
     while (iter != _summands.end()) {
-      // ASS_REP(std::less<Perfect<MonomFactors>>{}(last->factors, iter->factors), *this);
+      // ASS_REP(std::less<Lib::Perfect<MonomFactors>>{}(last->factors, iter->factors), *this);
       ASS_REP(last->factors <= iter->factors, *this);
       iter->integrity();
       last = iter++;
@@ -1133,7 +1135,7 @@ void Polynom<Number>::integrity() const {
 
 template<class Number> 
 TermList Polynom<Number>::denormalize()  const
-{ return PolyNf(AnyPoly(perfect(Polynom(*this)))).denormalize(); }
+{ return PolyNf(AnyPoly(Lib::perfect(Polynom(*this)))).denormalize(); }
 
 } // namespace Kernel
 
@@ -1142,12 +1144,12 @@ struct std::hash<Kernel::Polynom<NumTraits>>
 {
   size_t operator()(Kernel::Polynom<NumTraits> const& x) const noexcept 
   {
-    using namespace Lib;
     using namespace Kernel;
+    using namespace Lib;
 
-    unsigned out = HashUtils::combine(0,0);
+    unsigned out = Lib::HashUtils::combine(0,0);
     for (auto c : x._summands) {
-      out = HashUtils::combine(
+      out = Lib::HashUtils::combine(
         StlHash::hash(c.factors),
         StlHash::hash(c.numeral),
         out

--- a/Kernel/PolynomialNormalizer.cpp
+++ b/Kernel/PolynomialNormalizer.cpp
@@ -16,6 +16,7 @@
 namespace Kernel {
 
 using namespace std;
+using namespace Lib;
 
 /** a struct that normalizes an object of type MonomFactors to a Monom */
 struct RenderMonom {

--- a/Kernel/PolynomialNormalizer.hpp
+++ b/Kernel/PolynomialNormalizer.hpp
@@ -37,7 +37,7 @@ namespace Kernel {
 
 using LitSimplResult = Inferences::SimplifyingGeneratingLiteralSimplification::Result;
 
-using NormalizationResult = Coproduct<PolyNf 
+using NormalizationResult = Lib::Coproduct<PolyNf 
         , Polynom< IntTraits>
         , Polynom< RatTraits>
         , Polynom<RealTraits>

--- a/Kernel/PolynomialNormalizer/PredicateEvaluator.hpp
+++ b/Kernel/PolynomialNormalizer/PredicateEvaluator.hpp
@@ -20,7 +20,7 @@ using LitSimplResult = Inferences::SimplifyingGeneratingLiteralSimplification::R
 #define IMPL_EVALUATE_PRED(interpretation, ...)                                                               \
   template<>                                                                                                  \
   struct PredicateEvaluator<interpretation> {                                                                 \
-    static Option<LitSimplResult> evaluate(Literal* orig, PolyNf* evaluatedArgs)                              \
+    static Lib::Option<LitSimplResult> evaluate(Literal* orig, PolyNf* evaluatedArgs)                              \
     {                                                                                                         \
       __VA_ARGS__                                                                                             \
     }                                                                                                         \
@@ -32,15 +32,15 @@ using LitSimplResult = Inferences::SimplifyingGeneratingLiteralSimplification::R
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 template<class ConstantType, class EvalGround>
-Option<LitSimplResult> tryEvalConstant2(Literal* orig, PolyNf* evaluatedArgs, EvalGround fun) 
+Lib::Option<LitSimplResult> tryEvalConstant2(Literal* orig, PolyNf* evaluatedArgs, EvalGround fun) 
 {
   using Number = NumTraits<ConstantType>;
   auto& lhs = *evaluatedArgs[0].downcast<Number>().unwrap();
   auto& rhs = *evaluatedArgs[1].downcast<Number>().unwrap();
   if (lhs.isNumber() && rhs.isNumber()) {
-    return Option<LitSimplResult>(LitSimplResult::constant(fun(lhs.unwrapNumber(), rhs.unwrapNumber())));
+    return Lib::Option<LitSimplResult>(LitSimplResult::constant(fun(lhs.unwrapNumber(), rhs.unwrapNumber())));
   } else {
-    return Option<LitSimplResult>();
+    return Lib::Option<LitSimplResult>();
   }
 }
 
@@ -48,13 +48,13 @@ Option<LitSimplResult> tryEvalConstant2(Literal* orig, PolyNf* evaluatedArgs, Ev
 /// Equality
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<class Number> inline Option<LitSimplResult> interpretEquality(bool polarity, Perfect<Polynom<Number>> lhs, Perfect<Polynom<Number>> rhs) {
+template<class Number> inline Lib::Option<LitSimplResult> interpretEquality(bool polarity, Lib::Perfect<Polynom<Number>> lhs, Lib::Perfect<Polynom<Number>> rhs) {
   if (lhs->isNumber() && rhs->isNumber()) {
-    return Option<LitSimplResult>(LitSimplResult::constant(polarity == (lhs->unwrapNumber() == rhs->unwrapNumber())));
+    return Lib::Option<LitSimplResult>(LitSimplResult::constant(polarity == (lhs->unwrapNumber() == rhs->unwrapNumber())));
   } else if (lhs == rhs) {
-    return Option<LitSimplResult>(LitSimplResult::constant(polarity));
+    return Lib::Option<LitSimplResult>(LitSimplResult::constant(polarity));
   } else {
-    return Option<LitSimplResult>();
+    return Lib::Option<LitSimplResult>();
   }
 }
 
@@ -70,7 +70,7 @@ IMPL_EVALUATE_PRED(Interpretation::EQUAL,
   auto sort = SortHelper::getEqualityArgumentSort(orig);
 
   if (lhs == rhs) {
-    return Option<LitSimplResult>(LitSimplResult::constant(polarity));
+    return Lib::Option<LitSimplResult>(LitSimplResult::constant(polarity));
   }
   if (sort == IntTraits::sort())
     return interpretEquality(polarity, lhs.template wrapPoly<IntTraits >(), rhs.template wrapPoly<IntTraits >());
@@ -79,14 +79,14 @@ IMPL_EVALUATE_PRED(Interpretation::EQUAL,
   if (sort == RealTraits::sort())
     return interpretEquality(polarity, lhs.template wrapPoly<RealTraits>(), rhs.template wrapPoly<RealTraits>());
   else
-    return Option<LitSimplResult>();
+    return Lib::Option<LitSimplResult>();
 )
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Inequalities
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<class ConstantType, class EvalIneq> Option<LitSimplResult> evaluateInequality(Literal* orig, PolyNf* evaluatedArgs, bool strict, EvalIneq evalIneq) {
+template<class ConstantType, class EvalIneq> Lib::Option<LitSimplResult> evaluateInequality(Literal* orig, PolyNf* evaluatedArgs, bool strict, EvalIneq evalIneq) {
   ASS(orig->numTermArguments() == 2);
 
 
@@ -95,11 +95,11 @@ template<class ConstantType, class EvalIneq> Option<LitSimplResult> evaluateIneq
 
   auto polarity = orig->polarity();
   if (lhs->isNumber() && rhs->isNumber()) {
-    return Option<LitSimplResult>(LitSimplResult::constant(polarity == evalIneq(lhs->unwrapNumber(), rhs->unwrapNumber())));
+    return Lib::Option<LitSimplResult>(LitSimplResult::constant(polarity == evalIneq(lhs->unwrapNumber(), rhs->unwrapNumber())));
   } else if (lhs == rhs) {
-    return Option<LitSimplResult>(LitSimplResult::constant(polarity != strict));
+    return Lib::Option<LitSimplResult>(LitSimplResult::constant(polarity != strict));
   } else {
-    return Option<LitSimplResult>();
+    return Lib::Option<LitSimplResult>();
   }
 }
 

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -31,6 +31,7 @@
 #undef LOGGING
 #define LOGGING 0
 
+using namespace Lib;
 using namespace Kernel;
 
 /**

--- a/Kernel/Problem.hpp
+++ b/Kernel/Problem.hpp
@@ -25,7 +25,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 using namespace Shell;
 
 /**
@@ -67,7 +66,7 @@ public:
   bool hadIncompleteTransformation() const { return _hadIncompleteTransformation; }
   void reportIncompleteTransformation() { _hadIncompleteTransformation = true; }
 
-  typedef DHMap<unsigned,bool> TrivialPredicateMap;
+  typedef Lib::DHMap<unsigned,bool> TrivialPredicateMap;
   void addTrivialPredicate(unsigned pred, bool assignment);
   /**
    * Return map of trivial predicates into their assignments.
@@ -81,9 +80,9 @@ public:
   void addEliminatedPredicate(unsigned pred, Unit* definition);
   void addPartiallyEliminatedPredicate(unsigned pred, Unit* definition);
  
-  DHMap<unsigned,Literal*> getEliminatedFunctions(){ return _deletedFunctions; }
-  DHMap<unsigned,Unit*> getEliminatedPredicates(){ return _deletedPredicates; }
-  DHMap<unsigned,Unit*> getPartiallyEliminatedPredicates(){ return _partiallyDeletedPredicates;}
+  Lib::DHMap<unsigned,Literal*> getEliminatedFunctions(){ return _deletedFunctions; }
+  Lib::DHMap<unsigned,Unit*> getEliminatedPredicates(){ return _deletedPredicates; }
+  Lib::DHMap<unsigned,Unit*> getPartiallyEliminatedPredicates(){ return _partiallyDeletedPredicates;}
   FunctionDefinitionHandler& getFunctionDefinitionHandler(){ return *_fnDefHandler; }
   
 
@@ -189,14 +188,14 @@ private:
   void readDetailsFromProperty() const;
 
   UnitList* _units;
-  DHMap<unsigned,Literal*> _deletedFunctions;
-  DHMap<unsigned,Unit*> _deletedPredicates;
-  DHMap<unsigned,Unit*> _partiallyDeletedPredicates; 
-  ScopedPtr<FunctionDefinitionHandler> _fnDefHandler;
+  Lib::DHMap<unsigned,Literal*> _deletedFunctions;
+  Lib::DHMap<unsigned,Unit*> _deletedPredicates;
+  Lib::DHMap<unsigned,Unit*> _partiallyDeletedPredicates; 
+  Lib::ScopedPtr<FunctionDefinitionHandler> _fnDefHandler;
 
   bool _hadIncompleteTransformation;
 
-  DHMap<unsigned,bool> _trivialPredicates;
+  Lib::DHMap<unsigned,bool> _trivialPredicates;
 
   mutable bool _mayHaveEquality;
   mutable bool _mayHaveFormulas;
@@ -204,20 +203,20 @@ private:
   mutable bool _mayHaveInequalityResolvableWithDeletion;
   mutable bool _mayHaveXEqualsY;
 
-  mutable MaybeBool _hasFormulas;
-  mutable MaybeBool _hasEquality;
-  mutable MaybeBool _hasInterpretedOperations;
-  mutable MaybeBool _hasNumerals;
-  mutable MaybeBool _hasFOOL;
-  mutable MaybeBool _hasCombs;
-  mutable MaybeBool _hasApp;
-  mutable MaybeBool _hasAppliedVar;
-  mutable MaybeBool _hasLogicalProxy;
-  mutable MaybeBool _hasPolymorphicSym;
-  mutable MaybeBool _quantifiesOverPolymorphicVar;
-  mutable MaybeBool _hasBoolVar;
-  mutable MaybeBool _higherOrder;
-  mutable MaybeBool _hasNonDefaultSorts;
+  mutable Lib::MaybeBool _hasFormulas;
+  mutable Lib::MaybeBool _hasEquality;
+  mutable Lib::MaybeBool _hasInterpretedOperations;
+  mutable Lib::MaybeBool _hasNumerals;
+  mutable Lib::MaybeBool _hasFOOL;
+  mutable Lib::MaybeBool _hasCombs;
+  mutable Lib::MaybeBool _hasApp;
+  mutable Lib::MaybeBool _hasAppliedVar;
+  mutable Lib::MaybeBool _hasLogicalProxy;
+  mutable Lib::MaybeBool _hasPolymorphicSym;
+  mutable Lib::MaybeBool _quantifiesOverPolymorphicVar;
+  mutable Lib::MaybeBool _hasBoolVar;
+  mutable Lib::MaybeBool _higherOrder;
+  mutable Lib::MaybeBool _hasNonDefaultSorts;
 
   SMTLIBLogic _smtlibLogic;
 

--- a/Kernel/RCClauseStack.hpp
+++ b/Kernel/RCClauseStack.hpp
@@ -23,7 +23,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * A clause stack that enforces reference counting on inserted clauses

--- a/Kernel/Rebalancing.hpp
+++ b/Kernel/Rebalancing.hpp
@@ -78,7 +78,7 @@ namespace Kernel {
     template<class C> class BalanceIter {
 
       /* "call-stack". top of the stack is the term that is currently being traversed. */
-      Stack<Node> _path;
+      Lib::Stack<Node> _path;
       /* index of the side of the equality that is to be investigated next. i.e.:
        */
       unsigned _litIndex;
@@ -129,7 +129,7 @@ template<class C>
 Balancer<C>::Balancer(const Literal& l) : _lit(l) { }
 
 template<class C> BalanceIter<C>::BalanceIter(const Balancer<C>& balancer, bool end) 
-  : _path(Stack<Node>())
+  : _path(Lib::Stack<Node>())
   , _litIndex(end ? 2 : 0)
   , _balancer(balancer)
 {

--- a/Kernel/Renaming.hpp
+++ b/Kernel/Renaming.hpp
@@ -25,7 +25,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 class Renaming {
 public:
@@ -100,13 +99,13 @@ private:
     Renaming* _parent;
   };
 
-  typedef DHMap<unsigned, unsigned, IdentityHash, DefaultHash> VariableMap;
+  typedef Lib::DHMap<unsigned, unsigned, Lib::IdentityHash, Lib::DefaultHash> VariableMap;
   VariableMap _data;
   unsigned _nextVar;
   bool _identity;
 public:
   typedef VariableMap::Item Item;
-  VirtualIterator<Item> items() const { return _data.items(); }
+  Lib::VirtualIterator<Item> items() const { return _data.items(); }
 
 };
 

--- a/Kernel/SKIKBO.hpp
+++ b/Kernel/SKIKBO.hpp
@@ -31,7 +31,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * Class for instances of the Knuth-Bendix orderings
@@ -47,19 +46,19 @@ public:
         KboWeightMap<FuncSigTraits> symbolWeights, 
 
         // precedence ordering params
-        DArray<int> funcPrec, 
-        DArray<int> typeConPrec,
+        Lib::DArray<int> funcPrec, 
+        Lib::DArray<int> typeConPrec,
         // pred prec and pred levels are useless
         // as in higher-order we treat all symbol as function symbols (or type cons)
-        DArray<int> predPrec, 
-        DArray<int> predLevels,
+        Lib::DArray<int> predPrec, 
+        Lib::DArray<int> predLevels,
 
         // other
         bool reverseLCM);
 
   virtual ~SKIKBO();
 
-  typedef SmartPtr<ApplicativeArgsIt> ArgsIt_ptr;
+  typedef Lib::SmartPtr<ApplicativeArgsIt> ArgsIt_ptr;
 
   using PrecedenceOrdering::compare;
   Result compare(TermList tl1, TermList tl2) const override;
@@ -71,7 +70,7 @@ public:
   static TermList reduce(TermStack& args, TermList& head);
 
 protected:
-  typedef DHMap<unsigned, DArray<DArray<unsigned>*>*> VarOccMap;
+  typedef Lib::DHMap<unsigned, Lib::DArray<Lib::DArray<unsigned>*>*> VarOccMap;
 
   //Result comparePredicates(Literal* l1, Literal* l2) const override;
 
@@ -95,7 +94,7 @@ protected:
   //VarCondRes compareVariables(VarOccMap&, VarOccMap&, VarCondRes) const;
   VarCondRes compareVariables(TermList tl1, TermList tl2) const;
   unsigned getMaxRedLength(TermList t) const;
-  bool varConditionHolds(DHMultiset<Term*>& tlTerms1, DHMultiset<Term*>& tlTerms2) const;
+  bool varConditionHolds(Lib::DHMultiset<Term*>& tlTerms1, Lib::DHMultiset<Term*>& tlTerms2) const;
   bool safe(Term* t1, Term* t2) const;
 
   /** Weight of variables */

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -21,6 +21,7 @@
 #include "Signature.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -41,8 +41,7 @@
 
 namespace Kernel {
 
-using namespace Lib;
-typedef Map<std::string, unsigned> SymbolMap;
+typedef Lib::Map<std::string, unsigned> SymbolMap;
 
 /**
  * Class implementing signatures
@@ -107,7 +106,7 @@ class Signature
     /** Either a FunctionType of a PredicateType object */
     mutable OperatorType* _type;
     /** List of distinct groups the constant is a member of, all members of a distinct group should be distinct from each other */
-    List<unsigned>* _distinctGroups;
+    Lib::List<unsigned>* _distinctGroups;
     /** number of times it is used in the problem */
     unsigned _usageCount;
     /** number of units it is used in in the problem */
@@ -315,7 +314,7 @@ class Signature
     inline RealConstantType realValue() const
     { ASS(realConstant()); return static_cast<const RealSymbol*>(this)->_realValue; }
 
-    const List<unsigned>* distinctGroups() const { return _distinctGroups; }
+    const Lib::List<unsigned>* distinctGroups() const { return _distinctGroups; }
     /** This takes the symbol number of this symbol as the symbol doesn't know it
         Note that this should only be called on a constant **/
     void addToDistinctGroup(unsigned group,unsigned this_number);
@@ -389,7 +388,7 @@ class Signature
 
   public:
     RealSymbol(const RealConstantType& val)
-    : Symbol((env.options->proof() == Shell::Options::Proof::PROOFCHECK) ? "$to_real("+val.toString()+")" : val.toNiceString(), 0, true), _realValue(val)
+    : Symbol((Lib::env.options->proof() == Shell::Options::Proof::PROOFCHECK) ? "$to_real("+val.toString()+")" : val.toNiceString(), 0, true), _realValue(val)
     {
       setType(OperatorType::getConstantsType(AtomicSort::realSort()));
     }
@@ -552,7 +551,7 @@ class Signature
     return _choiceSymbols.contains(fun);
   }
 
-  DHSet<unsigned>* getChoiceOperators(){
+  Lib::DHSet<unsigned>* getChoiceOperators(){
     return &_choiceSymbols;
   }
 
@@ -646,14 +645,14 @@ class Signature
   unsigned getFunctionNumber(const std::string& name, unsigned arity) const;
   unsigned getPredicateNumber(const std::string& name, unsigned arity) const;
 
-  typedef SmartPtr<Stack<unsigned>> DistinctGroupMembers;
+  typedef Lib::SmartPtr<Lib::Stack<unsigned>> DistinctGroupMembers;
   
   Unit* getDistinctGroupPremise(unsigned group);
   unsigned createDistinctGroup(Unit* premise = 0);
   void addToDistinctGroup(unsigned constantSymbol, unsigned groupId);
   bool hasDistinctGroups(){ return _distinctGroupsAddedTo; }
   void noDistinctGroupsLeft(){ _distinctGroupsAddedTo=false; }
-  Stack<DistinctGroupMembers> &distinctGroupMembers(){ return _distinctGroupMembers; }
+  Lib::Stack<DistinctGroupMembers> &distinctGroupMembers(){ return _distinctGroupMembers; }
 
   bool hasTermAlgebras() { return !_termAlgebras.isEmpty(); }
   bool hasDefPreds() const { return !_fnDefPreds.isEmpty() || !_boolDefPreds.isEmpty(); }
@@ -904,19 +903,19 @@ class Signature
     return _termAlgebras.get(sort.term()->functor());
   }
   void addTermAlgebra(Shell::TermAlgebra *ta) { _termAlgebras.insert(ta->sort().term()->functor(), ta); }
-  VirtualIterator<Shell::TermAlgebra*> termAlgebrasIterator() const { return _termAlgebras.range(); }
+  Lib::VirtualIterator<Shell::TermAlgebra*> termAlgebrasIterator() const { return _termAlgebras.range(); }
   Shell::TermAlgebraConstructor* getTermAlgebraConstructor(unsigned functor);
 
   void recordDividesNvalue(TermList n){
     _dividesNvalues.push(n);
   }
-  Stack<TermList>& getDividesNvalues(){ return _dividesNvalues; }
+  Lib::Stack<TermList>& getDividesNvalues(){ return _dividesNvalues; }
 
   static bool symbolNeedsQuoting(std::string name, bool interpreted, unsigned arity);
 
 private:
-  Stack<TermList> _dividesNvalues;
-  DHMap<Term*, int> _formulaCounts;
+  Lib::Stack<TermList> _dividesNvalues;
+  Lib::DHMap<Term*, int> _formulaCounts;
 
   bool _foolConstantsDefined;
   unsigned _foolTrue;
@@ -925,13 +924,13 @@ private:
   static bool isProtectedName(std::string name);
   static bool charNeedsQuoting(char c, bool first);
   /** Stack of function symbols */
-  Stack<Symbol*> _funs;
+  Lib::Stack<Symbol*> _funs;
   /** Stack of predicate symbols */
-  Stack<Symbol*> _preds;
+  Lib::Stack<Symbol*> _preds;
   /** Stack of type constructor symbols */  
-  Stack<Symbol*> _typeCons;
+  Lib::Stack<Symbol*> _typeCons;
 
-  DHSet<unsigned> _choiceSymbols;
+  Lib::DHSet<unsigned> _choiceSymbols;
   /**
    * Map from std::string "name_arity" to their numbers
    *
@@ -955,10 +954,10 @@ private:
   SymbolMap _varNames;
   
   // Store the premise of a distinct group for proof printing, if 0 then group is input
-  Stack<Unit*> _distinctGroupPremises;
+  Lib::Stack<Unit*> _distinctGroupPremises;
 
   // We only store members up until a hard-coded limit i.e. the limit at which we will expand the group
-  Stack<DistinctGroupMembers> _distinctGroupMembers;
+  Lib::Stack<DistinctGroupMembers> _distinctGroupMembers;
   // Flag to indicate if any distinct groups have members
   bool _distinctGroupsAddedTo;
 
@@ -969,7 +968,7 @@ private:
    * the MonomorphisedInterpretation value already determines whether we deal with a function
    * or a predicate.
    */
-  DHMap<Theory::MonomorphisedInterpretation, unsigned> _iSymbols;
+  Lib::DHMap<Theory::MonomorphisedInterpretation, unsigned> _iSymbols;
 
   /** the number of string constants */
   unsigned _strings;
@@ -983,8 +982,8 @@ private:
   unsigned _arrayCon;
   unsigned _arrowCon;
   unsigned _appFun;
-  DHSet<unsigned> _fnDefPreds;
-  DHMap<unsigned,unsigned> _boolDefPreds;
+  Lib::DHSet<unsigned> _fnDefPreds;
+  Lib::DHMap<unsigned,unsigned> _boolDefPreds;
 
   /**
    * Map from type constructor functor to the associated term algebra, if applicable for the sort.
@@ -992,7 +991,7 @@ private:
    * For a term algebra instance, this map gives the general term algebra based on the top-level
    * functor of its sort, the ctors and dtors still have to be instantiated to the right instances.
    */ 
-  DHMap<unsigned, Shell::TermAlgebra*> _termAlgebras;
+  Lib::DHMap<unsigned, Shell::TermAlgebra*> _termAlgebras;
 
   //TODO Why are these here? They are not used anywhere. AYB
   //void defineOptionTermAlgebra(unsigned optionSort);

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -28,6 +28,7 @@
 #include "SortHelper.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 
 

--- a/Kernel/SortHelper.hpp
+++ b/Kernel/SortHelper.hpp
@@ -48,11 +48,11 @@ private:
     TermList contextSort; // only used by TERMLIST and SPECIALTERM
   };
 
-  static void collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermList>& map, bool ignoreBound = false);
+  static void collectVariableSortsIter(CollectTask task, Lib::DHMap<unsigned,TermList>& map, bool ignoreBound = false);
 public:
   static TermList getResultSort(const Term* t);
   static TermList getResultSortMono(const Term* t);
-  static TermList getResultSort(TermList t, DHMap<unsigned,TermList>& varSorts);
+  static TermList getResultSort(TermList t, Lib::DHMap<unsigned,TermList>& varSorts);
   static TermList getArgSort(Term const* t, unsigned argIndex);
   static TermList getTermArgSort(Term const* t, unsigned argIndex);
 
@@ -69,9 +69,9 @@ public:
   [[deprecated("This function is usually only used if we loose the information about the sort of a variable somewhere while over subterms. Recovering the information using this method iterating the literal/term again, is very inefficient and should be avoided. Make sure to use TermIterators that return TypedTermList instead, or raise a discussion on slack/github if you have a use case where this function is *really* needed.")]]
   static TermList getTermSort(TermList trm, Literal* lit);
 
-  static void collectVariableSorts(Unit* u, DHMap<unsigned,TermList>& map);
-  static void collectVariableSorts(Term* t, DHMap<unsigned,TermList>& map);
-  static void collectVariableSorts(Formula* f, DHMap<unsigned,TermList>& map, bool ignoreBound = false);
+  static void collectVariableSorts(Unit* u, Lib::DHMap<unsigned,TermList>& map);
+  static void collectVariableSorts(Term* t, Lib::DHMap<unsigned,TermList>& map);
+  static void collectVariableSorts(Formula* f, Lib::DHMap<unsigned,TermList>& map, bool ignoreBound = false);
 
   static bool areImmediateSortsValidPoly(Term* t);
   static bool areImmediateSortsValidMono(Term* t);
@@ -91,7 +91,7 @@ public:
 
   static bool areSortsValid(Clause* cl);
   static bool areSortsValid(Term* t);
-  static bool areSortsValid(Term* t, DHMap<unsigned,TermList>& varSorts);
+  static bool areSortsValid(Term* t, Lib::DHMap<unsigned,TermList>& varSorts);
 private:
   static bool tryGetVariableSortTerm(TermList var, Term* t, TermList& result, bool recurseToSubformulas);
 };

--- a/Kernel/SubformulaIterator.hpp
+++ b/Kernel/SubformulaIterator.hpp
@@ -28,7 +28,7 @@ namespace Kernel {
  * Implements an iterator over subformulas of a formula or formula list.
  */
 class SubformulaIterator
-: public IteratorCore<Formula*>
+: public Lib::IteratorCore<Formula*>
 {
 public:
   SubformulaIterator (Formula*);

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -25,7 +25,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 struct SubstApplicator {
   virtual ~SubstApplicator() = default;
@@ -216,7 +215,7 @@ public:
   template<class Subst>
   static Literal* applyToLiteral(Literal* lit, Subst subst)
   {
-    static DArray<TermList> ts(32);
+    static Lib::DArray<TermList> ts(32);
 
     int arity = lit->arity();
     ts.ensure(arity);
@@ -387,7 +386,7 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
       // TODO in principle this should not be so difficult to handle
       ASSERTION_VIOLATION;
     case SpecialFunctor::MATCH: {
-      DArray<TermList> terms(trm->arity());
+      Lib::DArray<TermList> terms(trm->arity());
       for (unsigned i = 0; i < trm->arity(); i++) {
         terms[i] = applyImpl<ProcessSpecVars>(*trm->nthArgument(i), applicator, noSharing);
       }
@@ -397,10 +396,10 @@ Term* SubstHelper::applyImpl(Term* trm, Applicator& applicator, bool noSharing)
     ASSERTION_VIOLATION;
   }
 
-  Recycled<Stack<TermList*>> toDo;
-  Recycled<Stack<Term*>> terms;
-  Recycled<Stack<bool>> modified;
-  Recycled<Stack<TermList>> args;
+  Lib::Recycled<Lib::Stack<TermList*>> toDo;
+  Lib::Recycled<Lib::Stack<Term*>> terms;
+  Lib::Recycled<Lib::Stack<bool>> modified;
+  Lib::Recycled<Lib::Stack<TermList>> args;
 
   modified->push(false);
   toDo->push(trm->args());
@@ -630,7 +629,7 @@ FormulaList* SubstHelper::applyImpl(FormulaList* fs, Applicator& applicator, boo
     return fs;
   }
 
-  Stack<FormulaList*> args;
+  Lib::Stack<FormulaList*> args;
   while (FormulaList::isNonEmpty(fs)) {
     args.push(fs);
     fs = fs->tail();

--- a/Kernel/Substitution.hpp
+++ b/Kernel/Substitution.hpp
@@ -28,7 +28,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * The class Substitution implementing substitutions.
@@ -61,7 +60,7 @@ public:
 #endif
   friend std::ostream& operator<<(std::ostream& out, Substitution const&);
 private:
-  DHMap<unsigned,TermList> _map;
+  Lib::DHMap<unsigned,TermList> _map;
 }; // class Substitution
 
 

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -56,7 +56,6 @@ namespace Kernel {
   std::ostream& operator<<(std::ostream& out, Literal const& self);
   bool operator<(TermList const&,TermList const&);
 
-using namespace Lib;
 
 /** Tag denoting the kind of this term
  * @since 19/02/2008 Manchester, moved outside of the Term class
@@ -179,7 +178,7 @@ public:
   /** set the content manually - hazardous, such terms should then only be used as integers */
   void setContent(uint64_t content) { _content = content; }
   /** default hash is to hash the content */
-  unsigned defaultHash() const { return DefaultHash::hash(content()); }
+  unsigned defaultHash() const { return Lib::DefaultHash::hash(content()); }
   unsigned defaultHash2() const { return content(); }
 
   std::string toString(bool topLevel = true) const;
@@ -199,7 +198,7 @@ public:
 
   /** the top of a term is either a function symbol or a variable id. this class is model this */
   class Top {
-    using Inner = Coproduct<unsigned, SymbolId>;
+    using Inner = Lib::Coproduct<unsigned, SymbolId>;
     static constexpr unsigned VAR = 0;
     static constexpr unsigned FUN = 1;
     Inner _inner;
@@ -210,8 +209,8 @@ public:
     // static Top functor(unsigned f) { return Top(Inner::variant<FUN>(f)); }
     template<class T>
     static Top functor(T const* t) { return Top(Inner::variant<FUN>({ t->functor(), t->kind(), })); }
-    Option<unsigned> var()     const { return _inner.as<VAR>().toOwned(); }
-    Option<SymbolId> functor() const { return _inner.as<FUN>().toOwned(); }
+    Lib::Option<unsigned> var()     const { return _inner.as<VAR>().toOwned(); }
+    Lib::Option<SymbolId> functor() const { return _inner.as<FUN>().toOwned(); }
     Lib::Comparison compare(Top const& other) const 
     { return _inner.compare(other._inner); }
     IMPL_COMPARISONS_FROM_COMPARE(Top);
@@ -479,11 +478,11 @@ public:
   explicit Term(const Term& t) throw();
   static Term* create(unsigned function, unsigned arity, const TermList* args);
   static Term* create(unsigned fn, std::initializer_list<TermList> args);
-  static Term* create(unsigned fn, Stack<TermList> const& args) { return Term::create(fn, args.length(), args.begin()); }
+  static Term* create(unsigned fn, Lib::Stack<TermList> const& args) { return Term::create(fn, args.length(), args.begin()); }
   template<class Iter>
   static Term* createFromIter(unsigned fn, Iter args) 
   { 
-    Recycled<Stack<TermList>> stack;
+    Lib::Recycled<Lib::Stack<TermList>> stack;
     stack->loadFromIterator(args);
     return Term::create(fn, *stack); 
   }
@@ -614,15 +613,16 @@ public:
 
   template<class GetArg>
   static unsigned termHash(unsigned functor, GetArg getArg, unsigned arity) {
-    return DefaultHash::hashIter(
+    using namespace Lib;
+    return Lib::DefaultHash::hashIter(
         range(0, arity).map([&](auto i) {
           TermList t = getArg(i);
-          return DefaultHash::hashBytes(
+          return Lib::DefaultHash::hashBytes(
               reinterpret_cast<const unsigned char*>(&t),
               sizeof(TermList)
               );
           }),
-        DefaultHash::hash(functor));
+        Lib::DefaultHash::hash(functor));
   }
 
   /**
@@ -1106,12 +1106,12 @@ public:
   {
     return Literal::literalHash(functor(), polarity() ^ flip, 
         [&](auto i) -> TermList const& { return *nthArgument(i); }, arity(),
-        someIf(isTwoVarEquality(), [&](){ return twoVarEqSort(); }),
+        Lib::someIf(isTwoVarEquality(), [&](){ return twoVarEqSort(); }),
         commutative());
   }
 
   template<class GetArg>
-  static unsigned literalEquals(const Literal* lit, unsigned functor, bool polarity, GetArg getArg, unsigned arity, Option<TermList> twoVarEqSort, bool commutative) {
+  static unsigned literalEquals(const Literal* lit, unsigned functor, bool polarity, GetArg getArg, unsigned arity, Lib::Option<TermList> twoVarEqSort, bool commutative) {
     if (functor != lit->functor() || polarity != lit->polarity()) return false;
 
     if (commutative) {
@@ -1119,34 +1119,34 @@ public:
       ASS(rightArgOrder(getArg(0), getArg(1)))
       ASS(rightArgOrder(*lit->nthArgument(0), *lit->nthArgument(1)))
 
-      if (someIf(lit->isTwoVarEquality(), [&](){ return lit->twoVarEqSort(); }) != twoVarEqSort) {
+      if (Lib::someIf(lit->isTwoVarEquality(), [&](){ return lit->twoVarEqSort(); }) != twoVarEqSort) {
         return false;
       }
       return std::make_tuple(*lit->nthArgument(0), *lit->nthArgument(1)) == std::make_tuple(getArg(0), getArg(1));
 
     } else {
       ASS(twoVarEqSort.isNone())
-      return range(0, arity).all([&](auto i) { return *lit->nthArgument(i) == getArg(i); });
+      return Lib::range(0, arity).all([&](auto i) { return *lit->nthArgument(i) == getArg(i); });
     }
   }
 
   static bool rightArgOrder(TermList const& lhs, TermList const& rhs);
 
   template<class GetArg>
-  static unsigned literalHash(unsigned functor, bool polarity, GetArg getArg, unsigned arity, Option<TermList> twoVarEqSort, bool commutative) {
+  static unsigned literalHash(unsigned functor, bool polarity, GetArg getArg, unsigned arity, Lib::Option<TermList> twoVarEqSort, bool commutative) {
     if (commutative) {
       ASS_EQ(arity, 2)
       ASS(rightArgOrder(getArg(0), getArg(1)))
-      return HashUtils::combine(
-          DefaultHash::hash(polarity),
-          DefaultHash::hash(functor),
-          DefaultHash::hash(twoVarEqSort),
+      return Lib::HashUtils::combine(
+          Lib::DefaultHash::hash(polarity),
+          Lib::DefaultHash::hash(functor),
+          Lib::DefaultHash::hash(twoVarEqSort),
           getArg(0).defaultHash(),
           getArg(1).defaultHash());
     } else {
       ASS(twoVarEqSort.isNone())
-      return HashUtils::combine(
-          DefaultHash::hash(polarity),
+      return Lib::HashUtils::combine(
+          Lib::DefaultHash::hash(polarity),
           Term::termHash(functor, getArg, arity));
     }
   }
@@ -1232,7 +1232,7 @@ public:
 
 private:
   template<class GetArg>
-  static Literal* create(unsigned predicate, unsigned arity, bool polarity, bool commutative, GetArg args, Option<TermList> twoVarEqSort = Option<TermList>());
+  static Literal* create(unsigned predicate, unsigned arity, bool polarity, bool commutative, GetArg args, Lib::Option<TermList> twoVarEqSort = Lib::Option<TermList>());
 }; // class Literal
 
 // TODO used in some proofExtra output

--- a/Kernel/TermIterators.cpp
+++ b/Kernel/TermIterators.cpp
@@ -23,6 +23,8 @@
 namespace Kernel
 {
 
+using namespace Lib;
+
 typedef ApplicativeHelper AH;
 
 /**

--- a/Kernel/TermIterators.hpp
+++ b/Kernel/TermIterators.hpp
@@ -38,7 +38,7 @@ namespace Kernel {
  *   use VariableIterator2 below, having read its documentation.
  */
 class VariableIterator
-: public IteratorCore<TermList>
+: public Lib::IteratorCore<TermList>
 {
 public:
   DECL_ELEMENT_TYPE(TermList);
@@ -114,21 +114,21 @@ public:
     return *_stack.top();
   }
 private:
-  Stack<const TermList*> _stack;
+  Lib::Stack<const TermList*> _stack;
   bool _used;
   TermList _aux[2];
 };
 
 struct VariableIteratorFn
 {
-  VirtualIterator<TermList> operator()(Term* t)
+  Lib::VirtualIterator<TermList> operator()(Term* t)
   {
     return vi( new VariableIterator(t) );
   }
-  VirtualIterator<TermList> operator()(TermList t)
+  Lib::VirtualIterator<TermList> operator()(TermList t)
   {
     if(t.isVar()) {
-      return pvi( getSingletonIterator(t) );
+      return pvi( Lib::getSingletonIterator(t) );
     }
     else {
       return (*this)(t.term());
@@ -158,7 +158,7 @@ struct OrdVarNumberExtractorFn
  *   with SortHelper::collectVariableSorts as it is more efficient.
  */
 class VariableWithSortIterator
-: public IteratorCore<std::pair<TermList,TermList>>
+: public Lib::IteratorCore<std::pair<TermList,TermList>>
 {
 public:
 
@@ -182,9 +182,9 @@ public:
     return std::make_pair(*_stack.top(),  SortHelper::getArgSort(const_cast<Term*>(_terms.top()), _argNums.top()));
   }
 private:
-  Stack<const TermList*> _stack;
-  Stack<const Term*> _terms;
-  Stack<unsigned> _argNums;
+  Lib::Stack<const TermList*> _stack;
+  Lib::Stack<const Term*> _terms;
+  Lib::Stack<unsigned> _argNums;
   bool _used;
 };
 
@@ -193,7 +193,7 @@ private:
  * of @b term in DFS left to right order.
  */
 class SubtermIterator
-  : public IteratorCore<TermList>
+  : public Lib::IteratorCore<TermList>
 {
 public:
   SubtermIterator(const Term* term) : _used(false)
@@ -228,7 +228,7 @@ protected:
     }
   }
 
-  Recycled<Stack<const TermList*>> _stack;
+  Lib::Recycled<Lib::Stack<const TermList*>> _stack;
   bool _used;
 };
 
@@ -246,7 +246,7 @@ protected:
  * of @b applicative term
  */
 class ApplicativeArgsIt
-  : public IteratorCore<TermList>
+  : public Lib::IteratorCore<TermList>
 {
 public:
   ApplicativeArgsIt(const TermList term, bool returnTypeArgs = true)
@@ -305,7 +305,7 @@ protected:
 };
 
 class TopLevelVarLikeTermIterator
-  : public IteratorCore<Term*>
+  : public Lib::IteratorCore<Term*>
 {
 public:
   TopLevelVarLikeTermIterator(Term* term)
@@ -327,12 +327,12 @@ public:
   }
 
 private:
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
   Term* _next;
 };
 
 class TopLevelVarIterator
-  : public IteratorCore<TermList>
+  : public Lib::IteratorCore<TermList>
 {
 public:
   TopLevelVarIterator(TermList t);
@@ -357,7 +357,7 @@ class RewritableVarsIt
 {
 public: //includeSelf for compatibility
   DECL_ELEMENT_TYPE(TypedTermList);
-  RewritableVarsIt(DHSet<unsigned>* unstableVars, Term* t, bool includeSelf = false) :  _next(), _stack(8)
+  RewritableVarsIt(Lib::DHSet<unsigned>* unstableVars, Term* t, bool includeSelf = false) :  _next(), _stack(8)
   {
     _unstableVars = unstableVars;
     if(t->isLiteral()){
@@ -384,14 +384,14 @@ public: //includeSelf for compatibility
     return *_next.take();
   }
 private:
-  Option<TypedTermList> _next;
-  Stack<TermList> _stack;
-  Stack<TermList> _sorts;
-  DHSet<unsigned>* _unstableVars;
+  Lib::Option<TypedTermList> _next;
+  Lib::Stack<TermList> _stack;
+  Lib::Stack<TermList> _sorts;
+  Lib::DHSet<unsigned>* _unstableVars;
 };
 
 class UnstableVarIt
-  : public IteratorCore<TermList>
+  : public Lib::IteratorCore<TermList>
 {
 public: 
   UnstableVarIt(Term* t) : _stable(8), _stack(8)
@@ -419,12 +419,12 @@ public:
 
 private:
   TermList _next;
-  Stack<bool> _stable;
-  Stack<TermList> _stack;
+  Lib::Stack<bool> _stable;
+  Lib::Stack<TermList> _stack;
 };
 
 class FirstOrderSubtermIt
-: public IteratorCore<Term*>
+: public Lib::IteratorCore<Term*>
 {
 public:
   FirstOrderSubtermIt(Term* term, bool includeSelf=false) 
@@ -448,13 +448,13 @@ public:
   void right();
 
 private:
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
   int _added;
 };
 
 
 class NarrowableSubtermIt
-: public IteratorCore<TermList>
+: public Lib::IteratorCore<TermList>
 {
 public:
   NarrowableSubtermIt(Term* term, bool includeSelf=false) 
@@ -481,14 +481,14 @@ public:
 private:
   bool _used;
   TermList _next;
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
 };
 
 /*
  *  Returns Boolean subterms of a term.
  */
 class BooleanSubtermIt
-: public IteratorCore<TermList>
+: public Lib::IteratorCore<TermList>
 {
 public:
   BooleanSubtermIt(Term* term, bool includeSelf=false) 
@@ -514,7 +514,7 @@ public:
 private:
   bool _used;
   TermList _next;
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
 };
 
 //////////////////////////////////////////////////////////////////////////
@@ -555,7 +555,7 @@ private:
  * its arguments left to right, and then the function itself.
  */
 class PolishSubtermIterator
-: public IteratorCore<TermList>
+: public Lib::IteratorCore<TermList>
 {
 public:
   PolishSubtermIterator(const Term* term) : _stack(8), _used(false)
@@ -584,7 +584,7 @@ private:
       t=t->term()->args();
     }
   }
-  Stack<const TermList*> _stack;
+  Lib::Stack<const TermList*> _stack;
   bool _used;
 };
 
@@ -598,7 +598,7 @@ private:
  *   are required. 
  */
 class NonVariableIterator
-  : public IteratorCore<TermList>
+  : public Lib::IteratorCore<TermList>
 {
 public:
   NonVariableIterator(const NonVariableIterator&);
@@ -625,7 +625,7 @@ public:
   void right();
 private:
   /** available non-variable subterms */
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
   /** the number of non-variable subterms added at the last iteration, used by right() */
   int _added;
 }; // NonVariableIterator
@@ -643,7 +643,7 @@ private:
  *     another
  */
 class NonVariableNonTypeIterator
-  : public IteratorCore<Term*>
+  : public Lib::IteratorCore<Term*>
 {
 public:
   NonVariableNonTypeIterator(const NonVariableNonTypeIterator&);
@@ -667,7 +667,7 @@ public:
   void right();
 private:
   /** available non-variable subterms */
-  Stack<Term*> _stack;
+  Lib::Stack<Term*> _stack;
   /** the number of non-variable subterms added at the last iteration, used by right() */
   int _added;
 }; // NonVariableIterator
@@ -677,7 +677,7 @@ private:
  * or literals in DFS left to right order.
  */
 class DisagreementSetIterator
-: public IteratorCore<std::pair<TermList, TermList> >
+: public Lib::IteratorCore<std::pair<TermList, TermList> >
 {
 public:
   /**
@@ -764,7 +764,7 @@ public:
     return res;
   }
 private:
-  Stack<TermList*> _stack;
+  Lib::Stack<TermList*> _stack;
   bool _disjunctVariables;
   TermList _arg1;
   TermList _arg2;
@@ -779,7 +779,7 @@ private:
  * @since 26/05/2007 Manchester, made from class TermVarIterator
  */
 class TermFunIterator
-: public IteratorCore<unsigned>
+: public Lib::IteratorCore<unsigned>
 {
 public:
   TermFunIterator (const Term*);
@@ -792,7 +792,7 @@ private:
   /** next symbol, previously found */
   unsigned _next;
   /** Stack of term lists (not terms!) */
-  Stack<const TermList*> _stack;
+  Lib::Stack<const TermList*> _stack;
 }; // class TermFunIterator
 
 
@@ -802,7 +802,7 @@ private:
  * @since 26/05/2007 Manchester, reimplemented for different data structures
  */
 class TermVarIterator
-: public IteratorCore<unsigned>
+: public Lib::IteratorCore<unsigned>
 {
 public:
   TermVarIterator (const Term*);
@@ -816,7 +816,7 @@ private:
   /** next variable, previously found */
   unsigned _next;
   /** Stack of term lists (not terms!) */
-  Stack<const TermList*> _stack;
+  Lib::Stack<const TermList*> _stack;
 }; // class TermVarIterator
 
 
@@ -837,19 +837,19 @@ public:
 
 /** iterator over all term arguments of @code term */
 static const auto termArgIter = [](Term* term) 
-  { return iterTraits(getRangeIterator<unsigned>(0, term->numTermArguments()))
+  { return iterTraits(Lib::getRangeIterator<unsigned>(0, term->numTermArguments()))
       .map([=](auto i)
            { return term->termArg(i); }); };
 
 /** iterator over all type arguments of @code term */
 static const auto typeArgIter = [](Term* term) 
-  { return iterTraits(getRangeIterator<unsigned>(0, term->numTypeArguments()))
+  { return iterTraits(Lib::getRangeIterator<unsigned>(0, term->numTypeArguments()))
       .map([=](auto i)
            { return term->typeArg(i); }); };
 
 /** iterator over all type and term arguments of @code term */
 static const auto anyArgIter = [](Term* term) 
-  { return iterTraits(getRangeIterator<unsigned>(0, term->arity()))
+  { return iterTraits(Lib::getRangeIterator<unsigned>(0, term->arity()))
       .map([=](auto i)
            { return *term->nthArgument(i); }); };
 

--- a/Kernel/TermTransformer.cpp
+++ b/Kernel/TermTransformer.cpp
@@ -22,6 +22,7 @@ namespace Kernel
 {
 
 using namespace std;
+using namespace Lib;
 
 
 Literal* TermTransformerCommon::transformLiteral(Literal* lit)

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -37,7 +37,7 @@ class RealConstantType;
  * Exception to be thrown when the requested operation cannot be performed,
  * e.g. because of overflow of a native type.
  */
-class ArithmeticException : public Exception {
+class ArithmeticException : public Lib::Exception {
 protected:
   ArithmeticException(const char* msg) : Exception(msg) {}
 };
@@ -110,7 +110,7 @@ public:
   static IntegerConstantType ceiling(IntegerConstantType rat);
   IntegerConstantType abs() const;
 
-  static Comparison comparePrecedence(IntegerConstantType n1, IntegerConstantType n2);
+  static Lib::Comparison comparePrecedence(IntegerConstantType n1, IntegerConstantType n2);
   size_t hash() const;
 
   std::string toString() const;
@@ -185,7 +185,7 @@ struct RationalConstantType {
   const InnerType& denominator() const { return _den; }
   size_t hash() const;
 
-  static Comparison comparePrecedence(RationalConstantType n1, RationalConstantType n2);
+  static Lib::Comparison comparePrecedence(RationalConstantType n1, RationalConstantType n2);
 
 protected:
   void init(InnerType num, InnerType den);
@@ -238,7 +238,7 @@ public:
   std::string toNiceString() const;
 
   size_t hash() const;
-  static Comparison comparePrecedence(RealConstantType n1, RealConstantType n2);
+  static Lib::Comparison comparePrecedence(RealConstantType n1, RealConstantType n2);
 
   /** 
    * returns the internal represenation of this RealConstantType. 
@@ -410,7 +410,7 @@ public:
   typedef std::pair<Interpretation, OperatorType*> MonomorphisedInterpretation;
 
 private:
-  DHMap<ConcreteIndexedInterpretation,Interpretation> _indexedInterpretations;
+  Lib::DHMap<ConcreteIndexedInterpretation,Interpretation> _indexedInterpretations;
 
 public:
 
@@ -501,9 +501,9 @@ public:
 
 private:
   // For recording the templates for predicate and function symbols
-  DHMap<unsigned,std::string> _predLaTeXnamesPos;
-  DHMap<unsigned,std::string> _predLaTeXnamesNeg;
-  DHMap<unsigned,std::string> _funcLaTeXnames;
+  Lib::DHMap<unsigned,std::string> _predLaTeXnamesPos;
+  Lib::DHMap<unsigned,std::string> _predLaTeXnamesNeg;
+  Lib::DHMap<unsigned,std::string> _funcLaTeXnames;
 
 public:
 
@@ -560,7 +560,7 @@ private:
   Theory();
   static OperatorType* getConversionOperationType(Interpretation i);
 
-  DHMap<TermList,unsigned> _arraySkolemFunctions;
+  Lib::DHMap<TermList,unsigned> _arraySkolemFunctions;
 
 public:
   class Tuples {

--- a/Kernel/UnificationWithAbstraction.cpp
+++ b/Kernel/UnificationWithAbstraction.cpp
@@ -38,6 +38,8 @@
 namespace Kernel
 {
 
+using namespace Lib;
+
 Shell::Options::UnificationWithAbstraction AbstractionOracle::create()
 {
   if (env.options->unificationWithAbstraction()!=Options::UnificationWithAbstraction::OFF) {

--- a/Kernel/UnificationWithAbstraction.hpp
+++ b/Kernel/UnificationWithAbstraction.hpp
@@ -32,7 +32,7 @@ namespace Kernel
 
 class UnificationConstraintStack
 {
-  Stack<UnificationConstraint> _cont;
+  Lib::Stack<UnificationConstraint> _cont;
 public:
   USE_ALLOCATOR(UnificationConstraintStack)
   UnificationConstraintStack() : _cont() {}
@@ -42,7 +42,7 @@ public:
   auto iter() const
   { return iterTraits(_cont.iter()); }
 
-  Recycled<Stack<Literal*>> literals(RobSubstitution& s);
+  Lib::Recycled<Lib::Stack<Literal*>> literals(RobSubstitution& s);
 
   // returns the maximum number of constraints of this stack. this is not equal to the actual number of constraints it will hold, as constraints 
   // might become trivial (i.e. of the form t != t) after applying the substitution, so they will be filtered out when calling literals(RobSubstitution&)
@@ -61,8 +61,8 @@ public:
   bool isEmpty() const
   { return _cont.isEmpty(); }
 
-  void add(UnificationConstraint c, Option<BacktrackData&> bd);
-  UnificationConstraint pop(Option<BacktrackData&> bd);
+  void add(UnificationConstraint c, Lib::Option<Lib::BacktrackData&> bd);
+  UnificationConstraint pop(Lib::Option<Lib::BacktrackData&> bd);
 };
 
 class AbstractionOracle final
@@ -73,8 +73,8 @@ public:
   AbstractionOracle(Shell::Options::UnificationWithAbstraction mode) : _mode(mode) {}
 
   struct EqualIf { 
-    Recycled<Stack<UnificationConstraint>> _unify; 
-    Recycled<Stack<UnificationConstraint>> _constr; 
+    Lib::Recycled<Lib::Stack<UnificationConstraint>> _unify; 
+    Lib::Recycled<Lib::Stack<UnificationConstraint>> _constr; 
 
     EqualIf() : _unify(), _constr() {}
 
@@ -110,7 +110,7 @@ public:
     { return out << "NeverEqual"; } 
   };
 
-  using AbstractionResult = Coproduct<NeverEqual, EqualIf>;
+  using AbstractionResult = Lib::Coproduct<NeverEqual, EqualIf>;
 
   /** main function that either returns nothing, which means that unification with abstraction will 
    * shall not be applied for the given terms, or an AbstractionResult, which tells wether the given 
@@ -123,7 +123,7 @@ public:
    *
    * For details check out the paper "Refining Unification with Absraction" from LPAR 2023.
    */
-  Option<AbstractionResult> tryAbstract(
+  Lib::Option<AbstractionResult> tryAbstract(
       AbstractingUnifier* au,
       TermSpec const& t1,
       TermSpec const& t2) const;
@@ -142,9 +142,9 @@ private:
 
 class AbstractingUnifier 
 {
-  Recycled<RobSubstitution> _subs;
-  Recycled<UnificationConstraintStack> _constr;
-  Option<BacktrackData&> _bd;
+  Lib::Recycled<RobSubstitution> _subs;
+  Lib::Recycled<UnificationConstraintStack> _constr;
+  Lib::Option<Lib::BacktrackData&> _bd;
   AbstractionOracle _uwa;
 
   friend class RobSubstitution;
@@ -167,26 +167,26 @@ public:
   bool fixedPointIteration();
 
   // TODO document
-  Option<Recycled<Stack<unsigned>>> unifiableSymbols(SymbolId f);
+  Lib::Option<Lib::Recycled<Lib::Stack<unsigned>>> unifiableSymbols(SymbolId f);
 
 
-  static Option<AbstractingUnifier> unify(TermList t1, unsigned bank1, TermList t2, unsigned bank2, AbstractionOracle uwa, bool fixedPointIteration)
+  static Lib::Option<AbstractingUnifier> unify(TermList t1, unsigned bank1, TermList t2, unsigned bank2, AbstractionOracle uwa, bool fixedPointIteration)
   {
     auto au = AbstractingUnifier::empty(uwa);
     if (!au.unify(t1, bank1, t2, bank2)) return {};
-    if (!fixedPointIteration || au.fixedPointIteration()) return some(std::move(au));
+    if (!fixedPointIteration || au.fixedPointIteration()) return Lib::some(std::move(au));
     else return {};
   }
 
   UnificationConstraintStack& constr() { return *_constr; }
-  Recycled<Stack<Literal*>> computeConstraintLiterals() { return _constr->literals(*_subs); }
+  Lib::Recycled<Lib::Stack<Literal*>> computeConstraintLiterals() { return _constr->literals(*_subs); }
   unsigned maxNumberOfConstraints() { return _constr->maxNumberOfConstraints(); }
 
   RobSubstitution      & subs()       { return *_subs; }
   RobSubstitution const& subs() const { return *_subs; }
-  Option<BacktrackData&> bd() { return someIf(_subs->bdIsRecording(), [&]() -> decltype(auto) { return _subs->bdGet(); }); }
-  BacktrackData& bdGet() { return _subs->bdGet(); }
-  void bdRecord(BacktrackData& bd) { _subs->bdRecord(bd); }
+  Lib::Option<Lib::BacktrackData&> bd() { return Lib::someIf(_subs->bdIsRecording(), [&]() -> decltype(auto) { return _subs->bdGet(); }); }
+  Lib::BacktrackData& bdGet() { return _subs->bdGet(); }
+  void bdRecord(Lib::BacktrackData& bd) { _subs->bdRecord(bd); }
   void bdDone() { _subs->bdDone(); }
   bool usesUwa() const { return _uwa._mode != Options::UnificationWithAbstraction::OFF; }
 

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -35,6 +35,7 @@
 #include "Unit.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 
 unsigned Unit::_lastNumber = 0;

--- a/Kernel/Unit.hpp
+++ b/Kernel/Unit.hpp
@@ -25,7 +25,6 @@
 
 namespace Kernel {
 
-using namespace Lib;
 
 /**
  * Class to represent units of inference (such as clauses and formulas).

--- a/Lib/BitUtils.hpp
+++ b/Lib/BitUtils.hpp
@@ -116,12 +116,12 @@ public:
   }
 
   #define BITFIELD64_GET_AND_SET(type, name, Name, NAME) \
-    type _##name() const { return BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content); } \
-    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content, val); }
+    type _##name() const { return Lib::BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content); } \
+    void _set##Name(type val) { Lib::BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content, val); }
 
   #define BITFIELD64_GET_AND_SET_PTR(type, name, Name, NAME) \
-    type _##name() const { return reinterpret_cast<type>(BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content)); } \
-    void _set##Name(type val) { BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content, reinterpret_cast<uint64_t>(val)); }
+    type _##name() const { return reinterpret_cast<type>(Lib::BitUtils::getBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content)); } \
+    void _set##Name(type val) { Lib::BitUtils::setBits<NAME##_BITS_START, NAME##_BITS_END>(this->_content, reinterpret_cast<uint64_t>(val)); }
 };
 
 };

--- a/Lib/Coproduct.hpp
+++ b/Lib/Coproduct.hpp
@@ -279,7 +279,7 @@ namespace CoproductImpl {
 #else //!VDEBUG
                                 size;
 #endif // VDEBUG
-    static constexpr unsigned bitMask = ::bitMask(nTags);
+    static constexpr unsigned bitMask = Lib::bitMask(nTags);
 
     static_assert(nTags == 0 || nTags - 1 == ((nTags - 1) & bitMask), "bug in function neededBits");
 

--- a/Lib/Recycled.hpp
+++ b/Lib/Recycled.hpp
@@ -224,17 +224,17 @@ bool Recycled<T, Reset, Keep>::memAlive = true;
 };
 
 template<class T>
-using RStack = Recycled<Stack<T>>;
+using RStack = Lib::Recycled<Lib::Stack<T>>;
 
 template<class T>
-Recycled<Stack<T>> recycledStack() 
-{ return Recycled<Stack<T>>(); }
+Lib::Recycled<Lib::Stack<T>> recycledStack() 
+{ return Lib::Recycled<Lib::Stack<T>>(); }
 
 
 template<class T, class... Ts>
-Recycled<Stack<T>> recycledStack(T t, Ts... ts) 
+Lib::Recycled<Lib::Stack<T>> recycledStack(T t, Ts... ts) 
 {
-  Recycled<Stack<T>> out;
+  Lib::Recycled<Lib::Stack<T>> out;
   out->pushMany(std::move(t), std::move(ts)...);
   return out;
 }

--- a/Lib/Reflection.hpp
+++ b/Lib/Reflection.hpp
@@ -42,7 +42,7 @@
 
 #define __IMPL_COMPARISONS_FROM_COMPARE(Class, op, ...)                                   \
   friend bool operator op(Class const& l, Class const& r) {                               \
-    switch (DefaultComparator::compare(l,r)) {                                            \
+    switch (Lib::DefaultComparator::compare(l,r)) {                                            \
       __VA_ARGS__ return true;                                                            \
       default:    return false;                                                           \
     }                                                                                     \
@@ -50,16 +50,16 @@
 
 #define IMPL_EQ_FROM_COMPARE(Class)                                                       \
   friend bool operator==(Class const& l, Class const& r)                                  \
-  { return DefaultComparator::compare(l,r) == Comparison::EQUAL; }                        \
+  { return Lib::DefaultComparator::compare(l,r) == Lib::Comparison::EQUAL; }                        \
                                                                                           \
   friend bool operator!=(Class const& l, Class const& r)                                  \
   { return !(l == r); }                                                                   \
 
 #define IMPL_COMPARISONS_FROM_COMPARE(Class)                                              \
-    __IMPL_COMPARISONS_FROM_COMPARE(Class, > , case GREATER:             )                \
-    __IMPL_COMPARISONS_FROM_COMPARE(Class, < , case LESS   :             )                \
-    __IMPL_COMPARISONS_FROM_COMPARE(Class, >=, case GREATER: case EQUAL: )                \
-    __IMPL_COMPARISONS_FROM_COMPARE(Class, <=, case LESS   : case EQUAL: )                \
+    __IMPL_COMPARISONS_FROM_COMPARE(Class, > , case Lib::Comparison::GREATER:             )                \
+    __IMPL_COMPARISONS_FROM_COMPARE(Class, < , case Lib::Comparison::LESS   :             )                \
+    __IMPL_COMPARISONS_FROM_COMPARE(Class, >=, case Lib::Comparison::GREATER: case Lib::Comparison::EQUAL: )                \
+    __IMPL_COMPARISONS_FROM_COMPARE(Class, <=, case Lib::Comparison::LESS   : case Lib::Comparison::EQUAL: )                \
 
 
 #define IMPL_COMPARISONS_FROM_LESS_AND_EQUALS(Class)                                      \
@@ -69,8 +69,8 @@
   friend bool operator!=(Class const& l, Class const& r) { return !(l == r); }            \
 
 #define IMPL_HASH_FROM_TUPLE(Class)                                                       \
-  unsigned defaultHash() const { return DefaultHash::hash(asTuple()); }                   \
-  unsigned defaultHash2() const { return DefaultHash2::hash(asTuple()); }                 \
+  unsigned defaultHash() const { return Lib::DefaultHash::hash(asTuple()); }                   \
+  unsigned defaultHash2() const { return Lib::DefaultHash2::hash(asTuple()); }                 \
 
 //The obvious way to define this macro would be
 //#define DECL_ELEMENT_TYPE(T) typedef T _ElementType

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -36,6 +36,7 @@
 #define MEGA (1 << 20)
 
 using namespace std;
+using namespace Lib;
 
 // things that need to be signal-safe because they are used in timer_sigalrm_handler
 // in principle we also need is_lock_free() to avoid deadlock as well

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -58,6 +58,7 @@
 namespace Parse {
 
 using namespace std;
+using namespace Lib;
 
 static const char* PAR = "par";
 static const char* TYPECON_POSTFIX = "()";

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -28,7 +28,6 @@
 
 namespace Parse {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 
@@ -137,7 +136,7 @@ private:
   /**
    * Maps smtlib name of a defined sort to its SortDefinition struct.
    */
-  DHMap<std::string,SortDefinition> _sortDefinitions;
+  Lib::DHMap<std::string,SortDefinition> _sortDefinitions;
 
   /**
    * Handle "define-sort" entry.
@@ -230,7 +229,7 @@ private:
   /** <vampire signature id, symbol type> */
   typedef std::pair<unsigned,SymbolType> DeclaredSymbol;
   /** symbols are implicitly declared also when they are defined (see below) */
-  DHMap<std::string, DeclaredSymbol> _declaredSymbols;
+  Lib::DHMap<std::string, DeclaredSymbol> _declaredSymbols;
 
   /**
    * Given a symbol name, range sort (which can be Bool) and argSorts,
@@ -266,7 +265,7 @@ private:
   void readDeclareDatatypes(LExprList* sorts, LExprList* datatypes, bool codatatype = false);
 
   TermAlgebraConstructor* buildTermAlgebraConstructor(std::string constrName, TermList taSort,
-                                                      Stack<std::string> destructorNames, TermStack argSorts);
+                                                      Lib::Stack<std::string> destructorNames, TermStack argSorts);
 
   /**
    * Parse result of parsing an smtlib term (which can be of sort Bool and therefore represented in vampire by a formula)
@@ -339,8 +338,8 @@ private:
   /** < termlist, vampire sort id > */
   typedef std::pair<TermList,TermList> SortedTerm;
   /** mast an identifier to SortedTerm */
-  typedef DHMap<std::string,SortedTerm> TermLookup;
-  typedef Stack<TermLookup*> Scopes;
+  typedef Lib::DHMap<std::string,SortedTerm> TermLookup;
+  typedef Lib::Stack<TermLookup*> Scopes;
   /** Stack of parsing contexts:
    * for variables from quantifiers and
    * for symbols bound by let (which are variables from smtlib perspective,
@@ -351,7 +350,7 @@ private:
   /**
    * Stack of partial results used by parseTermOrFormula below.
    */
-  Stack<ParseResult> _results;
+  Lib::Stack<ParseResult> _results;
 
   /**
    * Possible operations during parsing a term.
@@ -379,7 +378,7 @@ private:
   /**
    * Main smtlib term parsing stack.
    */
-  Stack<std::pair<ParseOperation,LExpr*> > _todo;
+  Lib::Stack<std::pair<ParseOperation,LExpr*> > _todo;
 
   // global parsing data structures -- END
 
@@ -510,7 +509,7 @@ private:
    * To support a mechanism for dealing with large arithmetic constants.
    * Adapted from the tptp parser.
    */
-  Set<std::string> _overflow;
+  Lib::Set<std::string> _overflow;
 
   /**
    * Top-level expression that is parsed presently.

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -33,7 +33,6 @@
 
 //#define DEBUG_SHOW_STATE
 
-using namespace Lib;
 using namespace Kernel;
 
 namespace Kernel {
@@ -302,7 +301,7 @@ public:
    * Implements lexer and parser exceptions.
    */
   class ParseErrorException
-    : public ParsingRelatedException
+    : public Lib::ParsingRelatedException
   {
   public:
     ParseErrorException(std::string message,unsigned ln) : _message(message), _ln(ln) {}
@@ -352,7 +351,7 @@ public:
   static void assignAxiomName(const Unit* unit, std::string& name);
   unsigned lineNumber(){ return _lineNumber; }
 
-  static Map<int,std::string>* findQuestionVars(unsigned questionNumber) {
+  static Lib::Map<int,std::string>* findQuestionVars(unsigned questionNumber) {
     auto res = _questionVariableNames.findPtr(questionNumber);
     return res ? *res : nullptr;
   }
@@ -529,30 +528,30 @@ private:
    * This is to support the feature formula_selection of the include
    * directive of the TPTP format.
  */
-  Set<std::string>* _allowedNames;
+  Lib::Set<std::string>* _allowedNames;
   /** stacks of allowed names when include is used */
-  Stack<Set<std::string>*> _allowedNamesStack;
+  Lib::Stack<Lib::Set<std::string>*> _allowedNamesStack;
   /** set of files whose inclusion should be ignored */
-  Set<std::string> _forbiddenIncludes;
+  Lib::Set<std::string> _forbiddenIncludes;
   /** the input stream */
   std::istream* _in;
   /** in the case include() is used, previous streams will be saved here */
-  Stack<std::istream*> _inputs;
+  Lib::Stack<std::istream*> _inputs;
   /** the current include directory */
   std::string _includeDirectory;
   /** in the case include() is used, previous sequence of directories will be
    * saved here, this is required since TPTP requires the directory to be
    * relative to the "current directory, that is, the directory used by the last include()
    */
-  Stack<std::string> _includeDirectories;
+  Lib::Stack<std::string> _includeDirectories;
   /** input characters */
-  Array<char> _chars;
+  Lib::Array<char> _chars;
   /** position in the input stream of the 0th character in _chars[] */
   int _gpos;
   /** the position beyond the last read characters */
   int _cend;
   /** tokens currently at work */
-  Array<Token> _tokens;
+  Lib::Array<Token> _tokens;
   /** the position beyond the last processed token */
   int _tend;
   /** line number */
@@ -560,7 +559,7 @@ private:
   /** The list of units read (with additions directed to the end) */
   UnitList::FIFO _units;
   /** stack of unprocessed states */
-  Stack<State> _states;
+  Lib::Stack<State> _states;
   /** input type of the last read unit */ // it must be int since -1 can be used as a value
   UnitInputType _lastInputType;
   /** true if the last read unit is a question */
@@ -573,41 +572,41 @@ private:
   /** */
   bool _containsPolymorphism;
   /** various strings saved during parsing */
-  Stack<std::string> _strings;
+  Lib::Stack<std::string> _strings;
   /** various connectives saved during parsing */ // they must be int, since non-existing value -1 can be used
-  Stack<int> _connectives;
+  Lib::Stack<int> _connectives;
   /** various boolean values saved during parsing */
-  Stack<bool> _bools;
+  Lib::Stack<bool> _bools;
   /** various integer values saved during parsing */
-  Stack<int> _ints;
+  Lib::Stack<int> _ints;
   /** variable lists for building formulas */
-  Stack<VList*> _varLists;
+  Lib::Stack<VList*> _varLists;
   /** sort lists for building formulas */
-  Stack<SList*> _sortLists;
+  Lib::Stack<SList*> _sortLists;
   /** variable lists for binding variables */
-  Stack<VList*> _bindLists;
+  Lib::Stack<VList*> _bindLists;
   /** various tokens to consume */
-  Stack<Tag> _tags;
+  Lib::Stack<Tag> _tags;
   /** various formulas */
-  Stack<Formula*> _formulas;
+  Lib::Stack<Formula*> _formulas;
   /** various literals */
-  Stack<Literal*> _literals;
+  Lib::Stack<Literal*> _literals;
   /** term lists */
-  Stack<TermList> _termLists;
+  Lib::Stack<TermList> _termLists;
   /** name table for variable names */
-  IntNameTable _vars;
+  Lib::IntNameTable _vars;
   /** When parsing a question, make note of the inverse mapping to _vars, i.e. from the ints back to the vstrings, for better user reporting */
-  Map<int,std::string> _curQuestionVarNames;
+  Lib::Map<int,std::string> _curQuestionVarNames;
   /** parsed types */
-  Stack<Type*> _types;
+  Lib::Stack<Type*> _types;
   /** various type tags saved during parsing */
-  Stack<TypeTag> _typeTags;
+  Lib::Stack<TypeTag> _typeTags;
   /**  */
-  Stack<TheoryFunction> _theoryFunctions;
+  Lib::Stack<TheoryFunction> _theoryFunctions;
   /** bindings of variables to sorts */
-  Map<unsigned,SList*> _variableSorts;
+  Lib::Map<unsigned,SList*> _variableSorts;
   /** overflown arithmetical constants for which uninterpreted constants are introduced */
-  Set<std::string> _overflow;
+  Lib::Set<std::string> _overflow;
   /** current color, if the input contains colors */
   Color _currentColor;
   /** a robsubstitution object to be used temporarily that is kept around to safe memory allocation time  */
@@ -625,11 +624,11 @@ private:
   typedef std::pair<LetSymbolName, LetSymbolReference> LetSymbol;
 
   /** a scope of function definitions */
-  typedef Stack<LetSymbol> LetSymbols;
+  typedef Lib::Stack<LetSymbol> LetSymbols;
 
   /** a stack of scopes */
-  Stack<LetSymbols> _letSymbols;
-  Stack<LetSymbols> _letTypedSymbols;
+  Lib::Stack<LetSymbols> _letSymbols;
+  Lib::Stack<LetSymbols> _letTypedSymbols;
 
   /** Record wheter a formula or term has been pushed more recently */
   LastPushed _lastPushed;
@@ -638,8 +637,8 @@ private:
   bool findLetSymbol(LetSymbolName symbolName, LetSymbolReference& symbolReference);
   bool findLetSymbol(LetSymbolName symbolName, LetSymbols scope, LetSymbolReference& symbolReference);
 
-  typedef Stack<LetSymbolReference> LetDefinitions;
-  Stack<LetDefinitions> _letDefinitions;
+  typedef Lib::Stack<LetSymbolReference> LetDefinitions;
+  Lib::Stack<LetDefinitions> _letDefinitions;
 
   /** model definition formula */
   bool _modelDefinition;
@@ -818,10 +817,10 @@ private:
 
 public:
   // make the tptp routines for dealing with overflown constants available to other parsers
-  static unsigned addIntegerConstant(const std::string&, Set<std::string>& overflow, bool defaultSort);
-  static unsigned addRationalConstant(const std::string&, Set<std::string>& overflow, bool defaultSort);
-  static unsigned addRealConstant(const std::string&, Set<std::string>& overflow, bool defaultSort);
-  static unsigned addUninterpretedConstant(const std::string& name, Set<std::string>& overflow, bool& added);
+  static unsigned addIntegerConstant(const std::string&, Lib::Set<std::string>& overflow, bool defaultSort);
+  static unsigned addRationalConstant(const std::string&, Lib::Set<std::string>& overflow, bool defaultSort);
+  static unsigned addRealConstant(const std::string&, Lib::Set<std::string>& overflow, bool defaultSort);
+  static unsigned addUninterpretedConstant(const std::string& name, Lib::Set<std::string>& overflow, bool& added);
 
   // also here, simply made public static to share the code with another use site
   static Unit* processClaimFormula(Unit* unit, Formula* f, const std::string& nm);
@@ -842,12 +841,12 @@ public:
   };
   struct InferenceSourceRecord : SourceRecord{
     const std::string name;
-    Stack<std::string> premises;
+    Lib::Stack<std::string> premises;
     bool isFile(){ return false; }
     InferenceSourceRecord(std::string n) : name(n) {}
   };
 
-  void setUnitSourceMap(DHMap<Unit*,SourceRecord*>* m){
+  void setUnitSourceMap(Lib::DHMap<Unit*,SourceRecord*>* m){
     _unitSources = m;
   }
   SourceRecord* getSource();
@@ -855,11 +854,11 @@ public:
   void setFilterReserved(){ _filterReserved=true; }
 
 private:
-  DHMap<Unit*,SourceRecord*>* _unitSources;
+  Lib::DHMap<Unit*,SourceRecord*>* _unitSources;
 
   /** This field stores names of input units if the
    * output_axiom_names option is enabled */
-  static DHMap<unsigned, std::string> _axiomNames;
+  static Lib::DHMap<unsigned, std::string> _axiomNames;
 
   /**
    * During question parsing, we store the mapping from int variables
@@ -870,11 +869,11 @@ private:
    *
    * (Can there be more than one question? Yes, e.g., in the interactive mode.)
    */
-  static DHMap<unsigned, Map<int,std::string>*> _questionVariableNames;
+  static Lib::DHMap<unsigned, Lib::Map<int,std::string>*> _questionVariableNames;
 
   /** Stores the type arities of function symbols */
-  DHMap<std::string, unsigned> _typeArities;
-  DHMap<std::string, unsigned> _typeConstructorArities;
+  Lib::DHMap<std::string, unsigned> _typeArities;
+  Lib::DHMap<std::string, unsigned> _typeConstructorArities;
 
   bool _filterReserved;
   bool _seenConjecture;

--- a/SAT/BufferedSolver.hpp
+++ b/SAT/BufferedSolver.hpp
@@ -31,7 +31,6 @@
 
 namespace SAT {
 
-using namespace Lib;
 
 class BufferedSolver : public SATSolver {
 public:
@@ -79,12 +78,12 @@ private:
   // Add any clauses that have been buffered to _inner and solve.
   void flushUnadded();
 
-  ScopedPtr<SATSolver> _inner;
+  Lib::ScopedPtr<SATSolver> _inner;
 
  /**
   * A buffer for new literals that do not yet appear in the solver
   */
-  DHMap<unsigned, bool> _literalBuffer;
+  Lib::DHMap<unsigned, bool> _literalBuffer;
 
   /**
    * Clauses that have not been added to _inner as they are either implied by the assignment of _inner

--- a/SAT/FallbackSolverWrapper.cpp
+++ b/SAT/FallbackSolverWrapper.cpp
@@ -54,7 +54,7 @@ SATSolver::Status FallbackSolverWrapper::solve(unsigned conflictCountLimit)
     status = _fallback->solve(conflictCountLimit);
     _usingFallback = true;
     ASS(status != Status::UNKNOWN);
-    env.statistics->smtFallbacks++;
+    Lib::env.statistics->smtFallbacks++;
   } 
   else{
     _usingFallback = false;

--- a/SAT/FallbackSolverWrapper.hpp
+++ b/SAT/FallbackSolverWrapper.hpp
@@ -33,7 +33,6 @@
 
 namespace SAT {
 
-using namespace Lib;
 
 class FallbackSolverWrapper : public SATSolver {
 public:
@@ -105,8 +104,8 @@ public:
 
 private:
 
-  ScopedPtr<SATSolver> _inner;
-  ScopedPtr<SATSolver> _fallback;
+  Lib::ScopedPtr<SATSolver> _inner;
+  Lib::ScopedPtr<SATSolver> _fallback;
 
   bool _usingFallback;
 

--- a/SAT/MinimizingSolver.cpp
+++ b/SAT/MinimizingSolver.cpp
@@ -19,6 +19,8 @@
 namespace SAT
 {
 
+using namespace Lib;
+
 MinimizingSolver::MinimizingSolver(SATSolver* inner)
  : _varCnt(0), _inner(inner), _assignmentValid(false), _heap(CntComparator(_unsClCnt))
 {

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -32,7 +32,6 @@
 
 namespace SAT {
 
-using namespace Lib;
 
 class MinimizingSolver : public SATSolver {
 public:
@@ -88,7 +87,7 @@ private:
   void updateAssignment();
 
   unsigned _varCnt;
-  ScopedPtr<SATSolver> _inner;
+  Lib::ScopedPtr<SATSolver> _inner;
 
   /**
    * If true, _asgn assignment corresponds to the assignment in
@@ -111,7 +110,7 @@ private:
    * We define a literal "corresponding to variable var in _asgn"
    * as SATLiteral(var,_asgn[var]). Used below.
    */
-  DArray<bool> _asgn;
+  Lib::DArray<bool> _asgn;
 
   /**
    * Array of clauses made satisfied by giving up the don't-care value
@@ -119,9 +118,9 @@ private:
    *
    * The length of the array is _varCnt.
    */
-  DArray<SATClauseStack> _watcher;
+  Lib::DArray<SATClauseStack> _watcher;
 
-  typedef DArray<unsigned> CntArray;
+  typedef Lib::DArray<unsigned> CntArray;
   
   /**
    * Number of unsatisfied clauses for each literal
@@ -137,11 +136,11 @@ private:
   {
     CntComparator(CntArray& ctr) : _ctr(ctr) {}
 
-    Comparison compare(unsigned v1, unsigned v2)
+    Lib::Comparison compare(unsigned v1, unsigned v2)
     {
       // DynamicHeap is minimal and we want maximum, 
       // so we need to swap the arguments
-      return Int::compare(_ctr[v2], _ctr[v1]);
+      return Lib::Int::compare(_ctr[v2], _ctr[v1]);
     }
     CntArray& _ctr;
   };
@@ -151,7 +150,7 @@ private:
    * 
    * Heap is empty when _assignmentValid.
    */  
-  DynamicHeap<unsigned, CntComparator, ArrayMap<size_t> > _heap;
+  Lib::DynamicHeap<unsigned, CntComparator, Lib::ArrayMap<size_t> > _heap;
   
   /**
    * Not yet satisfied clauses indexed by each variable
@@ -162,14 +161,14 @@ private:
    *
    * The length of the array is _varCnt.
    */
-  DArray<SATClauseStack> _clIdx;
+  Lib::DArray<SATClauseStack> _clIdx;
 
   /**
    * A set of satisfied clauses. To correctly maintain
    * _unsClCnt, when there is more than one way to make clause
    * satisfied.
    */  
-  DHSet<SATClause*> _satisfiedClauses;
+  Lib::DHSet<SATClause*> _satisfiedClauses;
   
 };
 

--- a/SAT/SAT2FO.hpp
+++ b/SAT/SAT2FO.hpp
@@ -23,7 +23,6 @@
 
 namespace SAT {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -49,7 +48,7 @@ public:
   void reset(){ _posMap.reset(); }
   friend std::ostream& operator<<(std::ostream& out, SAT2FO const& self);
 private:
-  typedef Numbering<Literal *, 1 /* variables start from 1 */ > TwoWayMap;
+  typedef Lib::Numbering<Literal *, 1 /* variables start from 1 */ > TwoWayMap;
   TwoWayMap _posMap;
 };
 

--- a/SAT/SATClause.hpp
+++ b/SAT/SATClause.hpp
@@ -27,7 +27,6 @@
 
 namespace SAT {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -39,7 +38,7 @@ class SATClause
 public:
   DECL_ELEMENT_TYPE(SATLiteral);
 
-  auto iter() const { return arrayIter(*this); }
+  auto iter() const { return Lib::arrayIter(*this); }
 
   /** New clause */
   SATClause(unsigned length);
@@ -53,7 +52,7 @@ public:
   unsigned defaultHash() const {
     unsigned hash = 0;
     for(unsigned i = 0; i < length(); i++)
-      hash ^= DefaultHash::hash(_literals[i]);
+      hash ^= Lib::DefaultHash::hash(_literals[i]);
     return hash;
   }
 

--- a/SAT/SATInference.cpp
+++ b/SAT/SATInference.cpp
@@ -22,6 +22,7 @@
 namespace SAT
 {
 
+using namespace Lib;
 ///////////////////////
 // SATInference
 //

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -70,9 +70,9 @@ public:
   virtual InfType getType() const = 0;
   
   template <typename Filter>
-  static void collectFilteredFOPremises(SATClause* cl, Stack<Unit*>& acc, Filter f);
+  static void collectFilteredFOPremises(SATClause* cl, Lib::Stack<Unit*>& acc, Filter f);
   
-  static void collectFOPremises(SATClause* cl, Stack<Unit*>& acc);
+  static void collectFOPremises(SATClause* cl, Lib::Stack<Unit*>& acc);
 
   static void collectPropAxioms(SATClause* cl, SATClauseStack& res);
 
@@ -135,12 +135,12 @@ public:
  * Only consider those SATClauses and their parents which pass the given Filter f.
  */
 template <typename Filter>
-void SATInference::collectFilteredFOPremises(SATClause* cl, Stack<Unit*>& acc, Filter f)
+void SATInference::collectFilteredFOPremises(SATClause* cl, Lib::Stack<Unit*>& acc, Filter f)
 {
   ASS_ALLOC_TYPE(cl, "SATClause");
 
-  static Stack<SATClause*> toDo;
-  static DHSet<SATClause*> seen;
+  static Lib::Stack<SATClause*> toDo;
+  static Lib::DHSet<SATClause*> seen;
   toDo.reset();
   seen.reset();
 

--- a/SAT/SATLiteral.hpp
+++ b/SAT/SATLiteral.hpp
@@ -55,7 +55,7 @@ public:
   inline unsigned oppositePolarity() const { return 1-_polarity; }
   inline unsigned content() const { return _content; }
 
-  unsigned defaultHash() const { return DefaultHash::hash(content()); }
+  unsigned defaultHash() const { return Lib::DefaultHash::hash(content()); }
   unsigned defaultHash2() const { return content(); }
 
   inline SATLiteral opposite() const { return SATLiteral(content()^1); }

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -140,7 +140,7 @@ public:
    */
   virtual void randomizeForNextAssignment(unsigned maxVar) {
     for (unsigned var=1; var <= maxVar; var++) {
-      suggestPolarity(var,Random::getBit());
+      suggestPolarity(var,Lib::Random::getBit());
     }
   }
 
@@ -308,7 +308,7 @@ public:
       // randomly permute the content of _failedAssumptionBuffer
       // not to bias minimization from one side or another
       for(unsigned i=sz-1; i>0; i--) {
-        unsigned tgtPos=Random::getInteger(i+1);
+        unsigned tgtPos=Lib::Random::getInteger(i+1);
         std::swap(_failedAssumptionBuffer[i], _failedAssumptionBuffer[tgtPos]);
       }
     }

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -46,7 +46,7 @@
 
 namespace SAT{
 
-  struct UninterpretedForZ3Exception : public ThrowableBase
+  struct UninterpretedForZ3Exception : public Lib::ThrowableBase
   {
     UninterpretedForZ3Exception()
     {
@@ -178,8 +178,8 @@ public:
       out << (self.isPredicate ? "pred " : "func ");
       out << (
         self.isPredicate
-          ? env.signature->getPredicate(self.id)->name()
-          : env.signature->getFunction(self.id)->name()
+          ? Lib::env.signature->getPredicate(self.id)->name()
+          : Lib::env.signature->getFunction(self.id)->name()
       );
       if(self.forSorts)
         for(unsigned i = 0; i < self.forSorts->numTypeArguments(); i++)
@@ -190,16 +190,16 @@ public:
 
 private:
 
-  Map<SortId, z3::sort> _sorts;
+  Lib::Map<SortId, z3::sort> _sorts;
   struct Z3Hash {
     static unsigned hash(z3::func_decl const& c) { return c.hash(); }
     static unsigned hash(z3::expr const& c) { return c.hash(); }
     static bool equals(z3::func_decl const& l, z3::func_decl const& r) { return z3::eq(l,r); }
     static bool equals(z3::expr const& l, z3::expr const& r) { return z3::eq(l,r); }
   };
-  Map<z3::func_decl, FuncOrPredId , Z3Hash > _fromZ3;
-  Map<FuncOrPredId,  z3::func_decl, StlHash> _toZ3;
-  Set<SortId> _createdTermAlgebras;
+  Lib::Map<z3::func_decl, FuncOrPredId , Z3Hash > _fromZ3;
+  Lib::Map<FuncOrPredId,  z3::func_decl, Lib::StlHash> _toZ3;
+  Lib::Set<SortId> _createdTermAlgebras;
 
   z3::func_decl const& findConstructor(Term* t);
   void createTermAlgebra(TermList sort);
@@ -220,10 +220,10 @@ private:
 
   struct Representation
   {
-    Representation(z3::expr expr, Stack<z3::expr> defs) : expr(expr), defs(defs) {}
+    Representation(z3::expr expr, Lib::Stack<z3::expr> defs) : expr(expr), defs(defs) {}
     Representation(Representation&&) = default;
     z3::expr expr;
-    Stack<z3::expr> defs;
+    Lib::Stack<z3::expr> defs;
   };
 
   Representation getRepresentation(Term* trm);
@@ -241,14 +241,14 @@ private:
   z3::context _context;
   z3::solver _solver;
   z3::model _model;
-  Stack<z3::expr> _assumptions;
-  BiMap<SATLiteral, z3::expr, DefaultHash, Z3Hash> _assumptionLookup;
+  Lib::Stack<z3::expr> _assumptions;
+  Lib::BiMap<SATLiteral, z3::expr, Lib::DefaultHash, Z3Hash> _assumptionLookup;
   const bool _showZ3;
   const bool _unsatCore;
-  Option<std::ofstream> _out;
-  Map<unsigned, z3::expr> _varNames;
-  Map<TermList, z3::expr> _termIndexedConstants;
-  Map<Signature::Symbol*, z3::expr> _constantNames;
+  Lib::Option<std::ofstream> _out;
+  Lib::Map<unsigned, z3::expr> _varNames;
+  Lib::Map<TermList, z3::expr> _termIndexedConstants;
+  Lib::Map<Signature::Symbol*, z3::expr> _constantNames;
 
   bool     isNamedExpr(unsigned var) const;
   z3::expr getNameExpr(unsigned var);

--- a/SAT/Z3MainLoop.hpp
+++ b/SAT/Z3MainLoop.hpp
@@ -33,7 +33,6 @@ namespace SAT{
 
 using namespace Kernel;
 using namespace Shell;
-using namespace Lib;
 
 class Z3MainLoop : public MainLoop 
 {

--- a/SATSubsumption/SATSubsumptionAndResolution.cpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.cpp
@@ -85,6 +85,7 @@ using namespace Indexing;
 using namespace Kernel;
 using namespace SATSubsumption;
 using namespace std;
+using namespace Lib;
 
 const unsigned INVALID = std::numeric_limits<unsigned>::max();
 

--- a/SATSubsumption/SATSubsumptionAndResolution.hpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.hpp
@@ -160,10 +160,10 @@ private:
      * @param i the index of the row
      * @return a slice of the matches at row i
      */
-    Slice<Match> getIMatches(unsigned i)
+    Lib::Slice<Match> getIMatches(unsigned i)
     {
       ASS_L(i, _indexI.size())
-      return Slice<Match>(
+      return Lib::Slice<Match>(
           &_matchesByI[_indexI[i]],
           &_matchesByI[_indexI[i + 1]]);
     }
@@ -173,10 +173,10 @@ private:
      * @param j the index of the column
      * @return a slice of the matches at column j
      */
-    Slice<Match> getJMatches(unsigned j)
+    Lib::Slice<Match> getJMatches(unsigned j)
     {
       ASS_L(j, _indexJ.size())
-      return Slice<Match>(
+      return Lib::Slice<Match>(
           &_matchesByJ[_indexJ[j]],
           &_matchesByJ[_indexJ[j + 1]]);
     }

--- a/SATSubsumption/subsat/SubstitutionTheory.hpp
+++ b/SATSubsumption/subsat/SubstitutionTheory.hpp
@@ -365,7 +365,7 @@ private:
   // TODO: replace bindings_by_pos by a single contiguous vector, and instead of VampireVarPos; use an index/length into that vector.
   //       (probably only makes sense if we construct that data lazily? in the current version we'd need an extra loop to determine counts for each variable first.)
   //       OTOH the current version isn't that bad, since we do map the vampire variables into a contiguous range first. so the vectors in m_bindings_by_pos are being reused anyway.
-  Lib::DHMap<VampireVar, VampireVarPos, Kernel::IdentityHash> m_var_pos;
+  Lib::DHMap<VampireVar, VampireVarPos, Lib::IdentityHash> m_var_pos;
   vector_map<VampireVarPos, vector<std::pair<subsat::Var, VampireTerm>>> m_bindings_by_pos;
 };
 

--- a/Saturation/AWPassiveClauseContainer.hpp
+++ b/Saturation/AWPassiveClauseContainer.hpp
@@ -80,7 +80,7 @@ public:
 
   unsigned sizeEstimate() const override { return _size; }
 
-  static Comparison compareWeight(Clause* cl1, Clause* cl2, const Shell::Options& opt);
+  static Lib::Comparison compareWeight(Clause* cl1, Clause* cl2, const Shell::Options& opt);
 
 private:
   /** The age queue, empty if _ageRatio=0 */

--- a/Saturation/ClauseContainer.cpp
+++ b/Saturation/ClauseContainer.cpp
@@ -32,6 +32,7 @@ using namespace std;
 namespace Saturation
 {
 
+using namespace Lib;
 using namespace Kernel;
 using namespace Indexing;
 

--- a/Saturation/ClauseContainer.hpp
+++ b/Saturation/ClauseContainer.hpp
@@ -32,7 +32,6 @@
 namespace Saturation
 {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 
@@ -78,7 +77,7 @@ protected:
   virtual void onLimitsUpdated() {}
 private:
   SaturationAlgorithm* _salg;
-  SubscriptionData _limitChangeSData;
+  Lib::SubscriptionData _limitChangeSData;
 };
 
 class PlainClauseContainer : public ClauseContainer {
@@ -101,10 +100,10 @@ public:
   bool isEmpty() const
   { return _data.isEmpty(); }
 private:
-  Deque<Clause*> _data;
+  Lib::Deque<Clause*> _data;
 };
 
-typedef PlainEvent LimitsChangeEvent;
+typedef Lib::PlainEvent LimitsChangeEvent;
 
 class PassiveClauseContainer
 : public RandomAccessClauseContainer
@@ -179,7 +178,7 @@ public:
 protected:
   void onLimitsUpdated() override;
 private:
-  Set<Clause*> _clauses;
+  Lib::Set<Clause*> _clauses;
   // const Shell::Options& _opt;
 };
 

--- a/Saturation/ConsequenceFinder.hpp
+++ b/Saturation/ConsequenceFinder.hpp
@@ -57,24 +57,24 @@ private:
 
   SaturationAlgorithm* _sa;
 
-  Stack<unsigned> _redundantsToHandle;
+  Lib::Stack<unsigned> _redundantsToHandle;
 
-  typedef SkipList<Clause*,Int> ClauseSL;
+  typedef Lib::SkipList<Clause*,Lib::Int> ClauseSL;
 
   /** Index of clauses that contain specific consequence-finding
    * name predicate */
-  ZIArray<ClauseSL*> _index;
+  Lib::ZIArray<ClauseSL*> _index;
   /** Keeps information on which claims have already been found
    * redundant (implied by others) */
-  ZIArray<bool> _redundant;
+  Lib::ZIArray<bool> _redundant;
 
   TautologyDeletionISE _td;
   DuplicateLiteralRemovalISE _dlr;
 
   /** SubscriptionData for the @b onClauseInserted method */
-  SubscriptionData _sdInsertion;
+  Lib::SubscriptionData _sdInsertion;
   /** SubscriptionData for the @b onClauseRemoved method */
-  SubscriptionData _sdRemoval;
+  Lib::SubscriptionData _sdRemoval;
 };
 
 }

--- a/Saturation/ExtensionalityClauseContainer.cpp
+++ b/Saturation/ExtensionalityClauseContainer.cpp
@@ -20,6 +20,7 @@ namespace Saturation
 {
 
 using namespace std;
+using namespace Lib;
 using namespace Shell;
 
 /**

--- a/Saturation/ExtensionalityClauseContainer.hpp
+++ b/Saturation/ExtensionalityClauseContainer.hpp
@@ -39,9 +39,9 @@ struct ExtensionalityClause
   TermList sort;
 };
 
-typedef List<ExtensionalityClause> ExtensionalityClauseList;
-typedef VirtualIterator<ExtensionalityClause> ExtensionalityClauseIterator;
-typedef DHMap<TermList, ExtensionalityClauseList*> ClausesBySort;
+typedef Lib::List<ExtensionalityClause> ExtensionalityClauseList;
+typedef Lib::VirtualIterator<ExtensionalityClause> ExtensionalityClauseIterator;
+typedef Lib::DHMap<TermList, ExtensionalityClauseList*> ClausesBySort;
 /**
  * Container for tracking extensionality-like clauses, i.e. clauses with exactly
  * one positive equality between variables.

--- a/Saturation/LabelFinder.hpp
+++ b/Saturation/LabelFinder.hpp
@@ -36,11 +36,11 @@ public:
 
   void onNewPropositionalClause(Clause* cl);
 
-  Stack<unsigned> getFoundLabels(){ return _foundLabels;}
+  Lib::Stack<unsigned> getFoundLabels(){ return _foundLabels;}
 
 private:
 
-  Stack<unsigned> _foundLabels;
+  Lib::Stack<unsigned> _foundLabels;
 
 };
 

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -44,7 +44,6 @@ namespace Shell { class AnswerLiteralManager; }
 namespace Saturation
 {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Indexing;
 using namespace Inferences;
@@ -169,7 +168,7 @@ private:
   void handleEmptyClause(Clause* cl);
   Clause* doImmediateSimplification(Clause* cl);
   MainLoopResult saturateImpl();
-  SmartPtr<IndexManager> _imgr;
+  Lib::SmartPtr<IndexManager> _imgr;
 
   class TotalSimplificationPerformer;
   class PartialSimplificationPerformer;
@@ -192,24 +191,24 @@ protected:
   ActiveClauseContainer* _active;
   ExtensionalityClauseContainer* _extensionality;
 
-  ScopedPtr<SimplifyingGeneratingInference> _generator;
-  ScopedPtr<ImmediateSimplificationEngine> _immediateSimplifier;
+  Lib::ScopedPtr<SimplifyingGeneratingInference> _generator;
+  Lib::ScopedPtr<ImmediateSimplificationEngine> _immediateSimplifier;
 
-  typedef List<ForwardSimplificationEngine*> FwSimplList;
+  typedef Lib::List<ForwardSimplificationEngine*> FwSimplList;
   FwSimplList* _fwSimplifiers;
 
   //Simplification occurs at the same point in the loop
   //as forward and backward simplification, but does not involve
   //clauses in active. At the moment, the only simplification inference
   //is the higher-order cnfOnTheFly
-  typedef List<SimplificationEngine*> SimplList;
+  typedef Lib::List<SimplificationEngine*> SimplList;
   SimplList* _simplifiers;
 
-  typedef List<BackwardSimplificationEngine*> BwSimplList;
+  typedef Lib::List<BackwardSimplificationEngine*> BwSimplList;
   BwSimplList* _bwSimplifiers;
 
   OrderingSP _ordering;
-  ScopedPtr<LiteralSelector> _selector;
+  Lib::ScopedPtr<LiteralSelector> _selector;
 
   Splitter* _splitter;
 
@@ -221,8 +220,8 @@ protected:
   FunctionDefinitionHandler& _fnDefHandler;
   std::unique_ptr<ConditionalRedundancyHandler> _conditionalRedundancyHandler;
 
-  SubscriptionData _passiveContRemovalSData;
-  SubscriptionData _activeContRemovalSData;
+  Lib::SubscriptionData _passiveContRemovalSData;
+  Lib::SubscriptionData _activeContRemovalSData;
 
   /**
    * Literal selector for set-of-support.
@@ -230,7 +229,7 @@ protected:
    * This variable is initialized and used only by the
    * @c getSosLiteralSelector() function
    */
-  ScopedPtr<LiteralSelector> _sosLiteralSelector;
+  Lib::ScopedPtr<LiteralSelector> _sosLiteralSelector;
 
 
   // counters

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -41,14 +41,13 @@
 
 namespace Saturation {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 using namespace SAT;
 using namespace DP;
 using namespace Indexing;
 
-typedef Stack<SplitLevel> SplitLevelStack;
+typedef Lib::Stack<SplitLevel> SplitLevelStack;
 
 class Splitter;
 
@@ -97,10 +96,10 @@ private:
   Splitter& _parent;
 
   bool _solverIsSMT;
-  ScopedPtr<SATSolver> _solver;
-  ScopedPtr<DecisionProcedure> _dp;
+  Lib::ScopedPtr<SATSolver> _solver;
+  Lib::ScopedPtr<DecisionProcedure> _dp;
   // use a separate copy of the decision procedure for ccModel computations and fill it up only with equalities
-  ScopedPtr<SimpleCongruenceClosure> _dpModel;
+  Lib::ScopedPtr<SimpleCongruenceClosure> _dpModel;
   
   /**
    * Contains selected component names (splitlevels)
@@ -166,8 +165,8 @@ private:
 
     Clause* component;
     RCClauseStack children;
-    Stack<ReductionRecord> reduced;
-    Stack<ConditionalRedundancyEntry*> conditionalRedundancyEntries;
+    Lib::Stack<ReductionRecord> reduced;
+    Lib::Stack<ConditionalRedundancyEntry*> conditionalRedundancyEntries;
     bool active;
 
     USE_ALLOCATOR(SplitRecord);
@@ -209,7 +208,7 @@ public:
   SAT2FO& satNaming() { return _sat2fo; }
 
   UnitList* preprendCurrentlyAssumedComponentClauses(UnitList* clauses);
-  static bool getComponents(Clause* cl, Stack<LiteralStack>& acc, bool shuffle = false);
+  static bool getComponents(Clause* cl, Lib::Stack<LiteralStack>& acc, bool shuffle = false);
 
   /*
    * Clauses with answer literals cannot be split -- hence if we obtain a clause with
@@ -263,7 +262,7 @@ private:
 
   //utility objects
   SplittingBranchSelector _branchSelector;
-  ScopedPtr<ClauseVariantIndex> _componentIdx;
+  Lib::ScopedPtr<ClauseVariantIndex> _componentIdx;
   /**
    * Registers all the sat variables and keeps track
    * of associated ground literals for those variables
@@ -278,13 +277,13 @@ private:
    * Invariant: if there is a clause with a level in its splitting history,
    * the _db record of this level is non-null.
    */
-  Stack<SplitRecord*> _db;
+  Lib::Stack<SplitRecord*> _db;
 
   /**
    * Definitions of ground components C and ~C are shared and placed at the slot of C.
    * (So the key here is never odd!)
    **/
-  DHMap<SplitLevel,Unit*> _defs;
+  Lib::DHMap<SplitLevel,Unit*> _defs;
   
   //state variable used for flushing:  
   /** When this number of generated clauses is reached, it will cause flush */
@@ -313,7 +312,7 @@ private:
 
   // clauses we already added to the SAT solver
   // not just optimisation: also prevents the SAT solver oscillating between two models in some cases
-  Set<SATClause *, DerefPtrHash<DefaultHash>> _already_added;
+  Lib::Set<SATClause *, DerefPtrHash<DefaultHash>> _already_added;
 
 public:
   static std::string splPrefix;

--- a/Saturation/SymElOutput.hpp
+++ b/Saturation/SymElOutput.hpp
@@ -23,7 +23,6 @@
 
 namespace Saturation {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 
@@ -63,7 +62,7 @@ private:
    * It is used so that we output symbol eliminating clauses
    * after they are simplified and shown to be non-redundant.
    */
-  DHMap<Clause*,Clause*> _symElRewrites;
+  Lib::DHMap<Clause*,Clause*> _symElRewrites;
 
   /**
    * Contains record of colors that were aliminated in
@@ -71,7 +70,7 @@ private:
    *
    * Is reset in the call to the @b onAllProcessed method.
    */
-  DHMap<Clause*,Color> _symElColors;
+  Lib::DHMap<Clause*,Color> _symElColors;
 
 
   SaturationAlgorithm* _sa;

--- a/Shell/AnswerLiteralManager.cpp
+++ b/Shell/AnswerLiteralManager.cpp
@@ -45,6 +45,7 @@
 #include "AnswerLiteralManager.hpp"
 
 static bool isProperAnswerClause(Clause* cl) {
+  using namespace Lib;
   static bool ground_only = (env.options->questionAnswering() == Options::QuestionAnsweringMode::PLAIN) && (env.options->questionAnsweringGroundOnly());
 
   return !cl->isEmpty() && forAll(cl->iterLits(),[] (Literal* l) { return l->isAnswerLiteral() && (!ground_only || l->ground()); } );
@@ -52,6 +53,8 @@ static bool isProperAnswerClause(Clause* cl) {
 
 namespace Inferences
 {
+
+using namespace Lib;
 
 Clause* AnswerLiteralResolver::simplify(Clause* cl)
 {

--- a/Shell/AnswerLiteralManager.hpp
+++ b/Shell/AnswerLiteralManager.hpp
@@ -47,7 +47,6 @@ public:
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Indexing;
 
@@ -57,7 +56,7 @@ public:
   friend class Inferences::AnswerLiteralResolver;
   /**
    * There should be at most one AnswerLiteralManager instance in the whole wide world.
-   * Depending on env.options this will be
+   * Depending on Lib::env.options this will be
    * - either AnswerLiteralManager proper (for QuestionAnsweringMode::PLAIN)
    * - or a SynthesisALManager (for QuestionAnsweringMode::SYNTHESIS)
    */
@@ -67,7 +66,7 @@ public:
 
   virtual ~AnswerLiteralManager() {}
 
-  virtual bool tryGetAnswer(Clause* refutation, Stack<Clause*>& answer);
+  virtual bool tryGetAnswer(Clause* refutation, Lib::Stack<Clause*>& answer);
 
   void addAnswerLiterals(Problem& prb);
   bool addAnswerLiterals(UnitList*& units);
@@ -113,11 +112,11 @@ private:
    * (which, in particular, has the variables for arguments
    * as they were in the conecture).
    */
-  DHMap<unsigned, std::pair<Unit*,Literal*>> _originUnitsAndInjectedLiterals;
+  Lib::DHMap<unsigned, std::pair<Unit*,Literal*>> _originUnitsAndInjectedLiterals;
 
-  DHMap<unsigned, Clause*> _resolverClauses;
+  Lib::DHMap<unsigned, Clause*> _resolverClauses;
 
-  DHMap<unsigned,std::pair<unsigned,Unit*>> _skolemsOrigin;
+  Lib::DHMap<unsigned,std::pair<unsigned,Unit*>> _skolemsOrigin;
 };
 
 class PlainALManager : public AnswerLiteralManager
@@ -128,13 +127,13 @@ protected:
   void optionalAnswerPrefix(std::ostream& out) override;
   std::string postprocessAnswerString(std::string answer) override;
 private:
-  Stack<std::pair<Term*, std::string>> _skolemNames;
+  Lib::Stack<std::pair<Term*, std::string>> _skolemNames;
 };
 
 class SynthesisALManager : public AnswerLiteralManager
 {
 public:
-  bool tryGetAnswer(Clause* refutation, Stack<Clause*>& answer) override;
+  bool tryGetAnswer(Clause* refutation, Lib::Stack<Clause*>& answer) override;
   void onNewClause(Clause* cl) override;
 
   Clause* recordAnswerAndReduce(Clause* cl) override;
@@ -145,7 +144,7 @@ protected:
   void recordSkolemBinding(Term*,unsigned,std::string) override;
 
 private:
-  void getNeededUnits(Clause* refutation, ClauseStack& premiseClauses, Stack<Unit*>& conjectures, DHSet<Unit*>& allProofUnits);
+  void getNeededUnits(Clause* refutation, ClauseStack& premiseClauses, Lib::Stack<Unit*>& conjectures, Lib::DHSet<Unit*>& allProofUnits);
 
   class ConjectureSkolemReplacement : public TermTransformer {
    public:
@@ -158,7 +157,7 @@ private:
    private:
     std::map<Term*, unsigned> _skolemToVar;
     // Map from functions to predicates they represent in answer literal conditions
-    DHMap<unsigned, unsigned> _condFnToPred;
+    Lib::DHMap<unsigned, unsigned> _condFnToPred;
   };
 
   Formula* getConditionFromClause(Clause* cl);
@@ -170,9 +169,9 @@ private:
   static unsigned getITEFunctionSymbol(TermList sort) {
     std::string name = "$ite_" + sort.toString();
     bool added = false;
-    unsigned fn = env.signature->addFunction(name, 3, added);
+    unsigned fn = Lib::env.signature->addFunction(name, 3, added);
     if (added) {
-      Signature::Symbol* sym = env.signature->getFunction(fn);
+      Signature::Symbol* sym = Lib::env.signature->getFunction(fn);
       sym->setType(OperatorType::getFunctionType({AtomicSort::defaultSort(), sort, sort}, sort));
     }
     return fn;
@@ -180,7 +179,7 @@ private:
 
   ConjectureSkolemReplacement _skolemReplacement;
 
-  List<std::pair<unsigned,std::pair<Clause*, Literal*>>>* _answerPairs = nullptr;
+  Lib::List<std::pair<unsigned,std::pair<Clause*, Literal*>>>* _answerPairs = nullptr;
 
   Literal* _lastAnsLit = nullptr;
 };

--- a/Shell/BlockedClauseElimination.hpp
+++ b/Shell/BlockedClauseElimination.hpp
@@ -50,8 +50,8 @@ private:
   };
 
   struct CandidateComparator {
-    static Comparison compare(Candidate* c1, Candidate* c2) {
-      return Int::compare(c1->weight,c2->weight);
+    static Lib::Comparison compare(Candidate* c1, Candidate* c2) {
+      return Lib::Int::compare(c1->weight,c2->weight);
     }
   };
 
@@ -60,7 +60,7 @@ private:
 
     Clause* cl;            // the actual clause
     bool blocked;          // if already blocked, don't need to try again
-    Stack<Candidate*> toResurrect; // when getting block (effectively deleted, all these have a chance again)
+    Lib::Stack<Candidate*> toResurrect; // when getting block (effectively deleted, all these have a chance again)
 
     ClWrapper(Clause* cl) : cl(cl), blocked(false) {}
   };

--- a/Shell/CNF.cpp
+++ b/Shell/CNF.cpp
@@ -21,6 +21,7 @@
 #include "Kernel/FormulaUnit.hpp"
 #include "CNF.hpp"
 
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Shell/CNF.hpp
+++ b/Shell/CNF.hpp
@@ -27,7 +27,6 @@ namespace Kernel {
   class Literal;
 };
 
-using namespace Lib;
 using namespace Kernel;
 
 namespace Shell {
@@ -40,7 +39,7 @@ class CNF
 {
 public:
   CNF();
-  void clausify (Unit*,Stack<Clause*>& stack);
+  void clausify (Unit*,Lib::Stack<Clause*>& stack);
 private:
   void clausify(Formula*);
   // the original recurisive version (for documentation and reference)
@@ -48,11 +47,11 @@ private:
   /** The unit currently being processed */
   FormulaUnit* _unit;
   /** stack to collect the results */
-  Stack<Clause*>* _result;
+  Lib::Stack<Clause*>* _result;
   /** stack of literals collected so far */
-  Stack <Literal*> _literals;
+  Lib::Stack <Literal*> _literals;
   /** stack of formulas  */
-  Stack <Formula*> _formulas;
+  Lib::Stack <Formula*> _formulas;
 }; // class CNF
 
 }

--- a/Shell/DistinctGroupExpansion.cpp
+++ b/Shell/DistinctGroupExpansion.cpp
@@ -32,6 +32,7 @@
 #include "DistinctGroupExpansion.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Shell;
 
 /**

--- a/Shell/DistinctGroupExpansion.hpp
+++ b/Shell/DistinctGroupExpansion.hpp
@@ -30,7 +30,7 @@ public:
 
   void apply(Problem& prb);
   bool apply(UnitList*& units);
-  Formula* expand(Stack<unsigned>& constants);
+  Formula* expand(Lib::Stack<unsigned>& constants);
 private:
   unsigned _expandUpToSize;
 };

--- a/Shell/DistinctProcessor.cpp
+++ b/Shell/DistinctProcessor.cpp
@@ -26,6 +26,8 @@
 namespace Shell
 {
 
+using namespace Lib;
+
 //TODO: add expansion of non-top-level and negative distinct predicates
 
 /**

--- a/Shell/DistinctProcessor.hpp
+++ b/Shell/DistinctProcessor.hpp
@@ -23,7 +23,6 @@
 namespace Shell {
 
 using namespace Kernel;
-using namespace Lib;
 
 /**
  * Registers top-level distinct predicates in the Signature. Should be

--- a/Shell/EqResWithDeletion.hpp
+++ b/Shell/EqResWithDeletion.hpp
@@ -24,7 +24,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 class EqResWithDeletion
@@ -42,7 +41,7 @@ private:
 
   /** The substitution induced by resolved inequalities
    * (It is reset with each clause). */
-  DHMap<unsigned, TermList, IdentityHash, DefaultHash> _subst;
+  Lib::DHMap<unsigned, TermList, Lib::IdentityHash, Lib::DefaultHash> _subst;
   Literal* _ansLit = nullptr;
 };
 

--- a/Shell/EqualityProxy.hpp
+++ b/Shell/EqualityProxy.hpp
@@ -26,7 +26,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 // Polymorphic version of equality proxy transformation.
@@ -65,8 +64,8 @@ private:
   void addLocalAxioms(UnitList*& units);
   void addAxioms(UnitList*& units);
   void addCongruenceAxioms(UnitList*& units);
-  void getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits, Stack<TermList>& vars1,
-      Stack<TermList>& vars2, OperatorType* symbolType);
+  void getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits, Lib::Stack<TermList>& vars1,
+      Lib::Stack<TermList>& vars2, OperatorType* symbolType);
   Literal* apply(Literal* lit);
   Literal* makeProxyLiteral(bool polarity, TermList arg0, TermList arg1, TermList sort);
 
@@ -80,7 +79,7 @@ private:
   unsigned _proxyPredicate;
 
   /** array of proxy definitions E(x,y) <=> x = y  */
-  //static ZIArray<Unit*> s_proxyPremises;
+  //static Lib::ZIArray<Unit*> s_proxyPremises;
   Unit* _defUnit;
 
 };

--- a/Shell/EqualityProxyMono.hpp
+++ b/Shell/EqualityProxyMono.hpp
@@ -25,7 +25,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 // Monomorphic version of equality proxy transformation.
@@ -64,8 +63,8 @@ private:
   void addLocalAxioms(UnitList*& units, TermList sort);
   void addAxioms(UnitList*& units);
   void addCongruenceAxioms(UnitList*& units);
-  bool getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits, Stack<TermList>& vars1,
-      Stack<TermList>& vars2, OperatorType* symbolType, bool skipSortsWithoutEquality);
+  bool getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits, Lib::Stack<TermList>& vars1,
+      Lib::Stack<TermList>& vars2, OperatorType* symbolType, bool skipSortsWithoutEquality);
   Literal* apply(Literal* lit);
   Literal* makeProxyLiteral(bool polarity, TermList arg0, TermList arg1, TermList sort);
 
@@ -80,11 +79,11 @@ private:
    * Proxy predicate numbers for each sort (which can be a complex term, even in mono - think arrays)
    * but must be ground (and shared).
    */
-  static DHMap<TermList, unsigned> s_proxyPredicates;
+  static Lib::DHMap<TermList, unsigned> s_proxyPredicates;
   /** equality proxy predicate sorts */
-  static DHMap<unsigned,TermList> s_proxyPredicateSorts;
+  static Lib::DHMap<unsigned,TermList> s_proxyPredicateSorts;
   /** array of proxy definitions E(x,y) <=> x = y  */
-  static DHMap<TermList, Unit*> s_proxyPremises;
+  static Lib::DHMap<TermList, Unit*> s_proxyPremises;
 };
 
 };

--- a/Shell/FOOLElimination.hpp
+++ b/Shell/FOOLElimination.hpp
@@ -56,7 +56,7 @@ private:
   void addDefinition(FormulaUnit* unit);
 
   /** Lexical scope of the current unit */
-  DHMap<unsigned,TermList> _varSorts;
+  Lib::DHMap<unsigned,TermList> _varSorts;
 
   /** Process a given part of the unit */
   FormulaList* process(FormulaList* fs);

--- a/Shell/Flattening.cpp
+++ b/Shell/Flattening.cpp
@@ -30,6 +30,8 @@
 namespace Shell
 {
 
+using namespace Lib;
+
 /**
  * Assuming formula @c f is flattened, return its negation which is also flattened.
  */

--- a/Shell/FunctionDefinition.hpp
+++ b/Shell/FunctionDefinition.hpp
@@ -34,7 +34,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -80,7 +79,7 @@ private:
 
   bool isDefined(Term* t);
 
-  Term* applyDefinitions(Literal* t, Stack<Def*>* usedDefs);
+  Term* applyDefinitions(Literal* t, Lib::Stack<Def*>* usedDefs);
   Clause* applyDefinitions(Clause* cl);
 
   void checkDefinitions(Def* t);
@@ -97,15 +96,15 @@ private:
 //   void apply (TermList& ls,UnitList& parents);
 //   void apply (Term& l,UnitList& parents);
 
-  typedef DHMap<int, Def*, IdentityHash, DefaultHash> Fn2DefMap;
+  typedef Lib::DHMap<int, Def*, Lib::IdentityHash, Lib::DefaultHash> Fn2DefMap;
   Fn2DefMap _defs;
 
   /** stack where definitions are put when they're marked as blocked */
-  Stack<Def*> _blockedDefs;
+  Lib::Stack<Def*> _blockedDefs;
 
-  Stack<Def*> _safeDefs;
+  Lib::Stack<Def*> _safeDefs;
   /** Counters for occurrences of function symbols */
-  MultiCounter _counter;
+  Lib::MultiCounter _counter;
   /** The number of found definitions */
   int _found;
   /** The number of removed definitions */

--- a/Shell/FunctionDefinitionHandler.hpp
+++ b/Shell/FunctionDefinitionHandler.hpp
@@ -24,7 +24,6 @@ namespace Shell {
 
 using namespace Indexing;
 using namespace Kernel;
-using namespace Lib;
 
 /**
  * Corresponds to the branches of a function definition,
@@ -98,7 +97,7 @@ public:
   auto getGeneralizations(TypedTermList t)
   {
     if (_is.isEmpty()) {
-      return VirtualIterator<QueryRes<ResultSubstitutionSP, TermLiteralClause>>::getEmpty();
+      return Lib::VirtualIterator<QueryRes<ResultSubstitutionSP, TermLiteralClause>>::getEmpty();
     }
     return _is->getGeneralizations(t, true);
   }
@@ -110,8 +109,8 @@ public:
   }
 
 private:
-  ScopedPtr<CodeTreeTIS<TermLiteralClause>> _is;
-  DHMap<std::pair<unsigned, SymbolType>, InductionTemplate> _templates;
+  Lib::ScopedPtr<CodeTreeTIS<TermLiteralClause>> _is;
+  Lib::DHMap<std::pair<unsigned, SymbolType>, InductionTemplate> _templates;
 };
 
 /**

--- a/Shell/GoalGuessing.cpp
+++ b/Shell/GoalGuessing.cpp
@@ -30,6 +30,7 @@ namespace Shell
 {
 
 using namespace std;
+using namespace Lib;
 
 //////////////////////////
 // GoalGuessing

--- a/Shell/InequalitySplitting.hpp
+++ b/Shell/InequalitySplitting.hpp
@@ -22,7 +22,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 
@@ -43,7 +42,7 @@ private:
   bool isSplittable(Literal* lit);
   bool isSplittableEqualitySide(TermList t);
 
-  Stack<Clause*> _predDefs;
+  Lib::Stack<Clause*> _predDefs;
   unsigned _splittingTreshold;
   bool _appify; // do it the higher-order way
 };

--- a/Shell/InterpolantMinimizer.cpp
+++ b/Shell/InterpolantMinimizer.cpp
@@ -27,6 +27,7 @@
 namespace Shell
 {
     using namespace std;
+    using namespace Lib;
     using namespace Kernel;
 
     std::unordered_map<Kernel::Unit*, Kernel::Color> InterpolantMinimizer::computeSplittingFunction(Kernel::Unit* refutation,  UnitWeight weightFunction)

--- a/Shell/Interpolants.cpp
+++ b/Shell/Interpolants.cpp
@@ -64,6 +64,7 @@
 namespace Shell
 {
     using namespace std;
+    using namespace Lib;
     using namespace Kernel;
 
 

--- a/Shell/InterpretedNormalizer.cpp
+++ b/Shell/InterpretedNormalizer.cpp
@@ -32,6 +32,7 @@ namespace Shell
 {
 
 using namespace std;
+using namespace Lib;
 
 /**
  * Base term transforming class

--- a/Shell/LambdaElimination.hpp
+++ b/Shell/LambdaElimination.hpp
@@ -32,7 +32,7 @@ class LambdaElimination {
 public:
 
   LambdaElimination() {};
-//  LambdaElimination(DHMap<unsigned,TermList> varSorts) : _varSorts(varSorts){};
+//  LambdaElimination(Lib::DHMap<unsigned,TermList> varSorts) : _varSorts(varSorts){};
 
   /** Set of recursive functions that rconvert lambda terms to 
    *  combinatory terms and replace logical symbols by proxies.
@@ -40,7 +40,7 @@ public:
    */
   TermList elimLambda(Term* lambdaTerm);
   TermList elimLambda(TermList term);
-  TermList elimLambda(Stack<int>& vars, TermStack& sorts, TermList body, TermList sort);
+  TermList elimLambda(Lib::Stack<int>& vars, TermStack& sorts, TermList body, TermList sort);
   TermList elimLambda(int var, TermList varSort, TermList body, TermList sort);
   TermList elimLambda(Formula*);
   
@@ -66,21 +66,21 @@ private:
     
   TermList sortOf(TermList t);
 
-  void addToProcessed(TermList ts, TermList sort, Stack<unsigned> &_argNums);
+  void addToProcessed(TermList ts, TermList sort, Lib::Stack<unsigned> &_argNums);
   void dealWithApp(Term* app, const unsigned lambdaVar, 
-    TermStack &toBeProcessed, TermStack &sorts, Stack<unsigned> &argNums);
+    TermStack &toBeProcessed, TermStack &sorts, Lib::Stack<unsigned> &argNums);
 
   TermList createKTerm(TermList s1, TermList s2, TermList arg1);
   TermList createSCorBTerm(TermList arg1, TermList arg1sort, 
         TermList arg2, TermList arg2sort, Signature::Combinator comb);
   
-  void process(Stack<int> &vars, TermStack &varSorts, 
+  void process(Lib::Stack<int> &vars, TermStack &varSorts, 
                TermStack &toBeProcessed, TermStack &sorts);
   
   /** Lexical scope of the current unit */
   TermStack _processed;
   TermStack _processedSorts;
-  Stack<Signature::Combinator> _combinators;
+  Lib::Stack<Signature::Combinator> _combinators;
 };
 
 #endif // __LambdaElimination__

--- a/Shell/Lexer.hpp
+++ b/Shell/Lexer.hpp
@@ -24,7 +24,6 @@
 
 #include "Token.hpp"
 
-using namespace Lib;
 
 
 namespace Shell {
@@ -36,7 +35,7 @@ class Lexer;
  * @since 14/07/2004 Turku
  */
 class LexerException
-  : public ParsingRelatedException
+  : public Lib::ParsingRelatedException
 {
  public:
   LexerException(std::string message,const Lexer&);
@@ -69,7 +68,7 @@ protected:
   /** Last read character */
   int  _lastCharacter;
   /** Character buffer, used to store currently read token */
-  Array<char> _charBuffer;
+  Lib::Array<char> _charBuffer;
   /** cursor to the current character */
   int _charCursor;
   /** the input stream */

--- a/Shell/LispParser.hpp
+++ b/Shell/LispParser.hpp
@@ -27,7 +27,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 
 class LispLexer;
 
@@ -55,7 +54,7 @@ public:
     /** the value (for atoms and numbers) */
     std::string str;
     /** list of expressions */
-    List<Expression*>* list;
+    Lib::List<Expression*>* list;
     /** build a list expressions with the list initially empty */
     explicit Expression(Tag t)
       : tag(t),
@@ -108,7 +107,7 @@ private:
 }; // class LispParser
 
 typedef LispParser::Expression LExpr;
-typedef List<LExpr*> LExprList;
+typedef Lib::List<LExpr*> LExprList;
 
 
 class LispListReader {
@@ -201,7 +200,7 @@ public:
     ASS(!_destroyed);
 
     LExprList* res = 0;
-    LExprList::pushFromIterator(Stack<LExpr*>::TopFirstIterator(_elements), res);
+    LExprList::pushFromIterator(Lib::Stack<LExpr*>::TopFirstIterator(_elements), res);
     return res;
   }
 
@@ -216,7 +215,7 @@ private:
 #if VDEBUG
   bool _destroyed;
 #endif
-  Stack<LExpr*> _elements;
+  Lib::Stack<LExpr*> _elements;
 };
 
 }

--- a/Shell/NNF.cpp
+++ b/Shell/NNF.cpp
@@ -23,6 +23,7 @@
 
 #include "NNF.hpp"
 
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Shell/Normalisation.cpp
+++ b/Shell/Normalisation.cpp
@@ -27,6 +27,7 @@
 
 #include "Normalisation.hpp"
 
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Shell/Normalisation.hpp
+++ b/Shell/Normalisation.hpp
@@ -25,7 +25,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -42,19 +41,20 @@ public:
   bool lessThan(Unit*, Unit*);
 private:
   void normalise(Unit*);
-  Comparison compare(Term*, Term*);
-  Comparison compare(Formula*, Formula*);
-  Comparison compare(Literal*, Literal*);
+  Lib::Comparison compare(Term*, Term*);
+  Lib::Comparison compare(Formula*, Formula*);
+  Lib::Comparison compare(Literal*, Literal*);
   bool lessThan(Formula*, Formula*);
   bool lessThan(Clause*, Clause*);
-  Comparison compare(TermList ss, TermList ts);
+  Lib::Comparison compare(TermList ss, TermList ts);
 
   /**
    * Return the result of comparison of two integers i1 and i2
    */
   inline static
-  Comparison compare (int i1, int i2)
+  Lib::Comparison compare (int i1, int i2)
   {
+    using namespace Lib;
     return i1 > i2
            ? GREATER
            : i1 == i2
@@ -63,16 +63,20 @@ private:
   }
 
   inline static
-  Comparison compare (unsigned i1, unsigned i2)
-  { return i1 > i2 ? GREATER : i1 == i2 ? EQUAL : LESS; }
+  Lib::Comparison compare (unsigned i1, unsigned i2)
+  {
+    using namespace Lib;
+    return i1 > i2 ? GREATER : i1 == i2 ? EQUAL : LESS;
+  }
 
   /**
    * Return the result of comparison of two booleans b1 and b2.
    * @since 30/04/2005 Manchester
    */
   inline static
-  Comparison compare (bool b1, bool b2)
+  Lib::Comparison compare (bool b1, bool b2)
   {
+    using namespace Lib;
     return b1 ? (b2 ? EQUAL : LESS) : (b2 ? GREATER : EQUAL);
   }
 

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -58,7 +58,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 class Property;
@@ -81,7 +80,7 @@ static size_t distance(const std::string &s1, const std::string &s2)
   if( m==0 ) return n;
   if( n==0 ) return m;
 
-  DArray<size_t> costs = DArray<size_t>(n+1);
+  Lib::DArray<size_t> costs = Lib::DArray<size_t>(n+1);
 
   for( size_t k=0; k<=n; k++ ) costs[k] = k;
 
@@ -777,8 +776,8 @@ public:
     // The details are explained in comments below
 private:
     // helper function of sampleStrategy
-    void strategySamplingAssign(std::string optname, std::string value, DHMap<std::string,std::string>& fakes);
-    std::string strategySamplingLookup(std::string optname, DHMap<std::string,std::string>& fakes);
+    void strategySamplingAssign(std::string optname, std::string value, Lib::DHMap<std::string,std::string>& fakes);
+    std::string strategySamplingLookup(std::string optname, Lib::DHMap<std::string,std::string>& fakes);
 
     /**
      * These store the names of the choices for an option.
@@ -797,7 +796,7 @@ private:
       }
     public:
         OptionChoiceValues() : _names() { };
-        OptionChoiceValues(Stack<std::string> names) : _names(std::move(names))  
+        OptionChoiceValues(Lib::Stack<std::string> names) : _names(std::move(names))  
         {
           check_names_are_short();
         }
@@ -817,7 +816,7 @@ private:
         const std::string operator[](int i) const{ return _names[i];}
 
     private:
-        Stack<std::string> _names;
+        Lib::Stack<std::string> _names;
     };
 
     // Declare constraints here so they can be referred to, but define them below
@@ -930,7 +929,7 @@ private:
         bool _should_copy;
         bool shouldCopy() const { return _should_copy; }
        
-        typedef std::unique_ptr<DArray<std::string>> stringDArrayUP;
+        typedef std::unique_ptr<Lib::DArray<std::string>> stringDArrayUP;
 
         typedef std::pair<OptionProblemConstraintUP,stringDArrayUP> RandEntry;
  
@@ -940,7 +939,7 @@ private:
         Lib::Stack<Options::Mode> _modes;
 
         stringDArrayUP toArray(std::initializer_list<std::string>& list){
-          DArray<std::string>* array = new DArray<std::string>(list.size());
+          Lib::DArray<std::string>* array = new Lib::DArray<std::string>(list.size());
           unsigned index=0;
           for(typename std::initializer_list<std::string>::iterator it = list.begin();
            it!=list.end();++it){ (*array)[index++] =*it; }
@@ -952,8 +951,9 @@ private:
     };
 
     struct AbstractOptionValueCompatator{
-      Comparison compare(AbstractOptionValue* o1, AbstractOptionValue* o2)
+      Lib::Comparison compare(AbstractOptionValue* o1, AbstractOptionValue* o2)
       {
+        using namespace Lib;
         int value = strcmp(o1->longName.c_str(),o2->longName.c_str());
         return value < 0 ? LESS : (value==0 ? EQUAL : GREATER);
       }
@@ -1142,7 +1142,7 @@ private:
         IntOptionValue(){}
         IntOptionValue(std::string l,std::string s, int d) : OptionValue(l,s,d){}
         bool setValue(const std::string& value){
-            return Int::stringToInt(value.c_str(),actualValue);
+            return Lib::Int::stringToInt(value.c_str(),actualValue);
         }
         std::string getStringOfValue(int value) const{ return Lib::Int::toString(value); }
     };
@@ -1152,7 +1152,7 @@ private:
         UnsignedOptionValue(std::string l,std::string s, unsigned d) : OptionValue(l,s,d){}
 
         bool setValue(const std::string& value){
-            return Int::stringToUnsignedInt(value.c_str(),actualValue);
+            return Lib::Int::stringToUnsignedInt(value.c_str(),actualValue);
         }
         std::string getStringOfValue(unsigned value) const{ return Lib::Int::toString(value); }
     };
@@ -1174,7 +1174,7 @@ private:
         LongOptionValue(){}
         LongOptionValue(std::string l,std::string s, long d) : OptionValue(l,s,d){}
         bool setValue(const std::string& value){
-            return Int::stringToLong(value.c_str(),actualValue);
+            return Lib::Int::stringToLong(value.c_str(),actualValue);
         }
         std::string getStringOfValue(long value) const{ return Lib::Int::toString(value); }
     };
@@ -1183,7 +1183,7 @@ struct FloatOptionValue : public OptionValue<float>{
 FloatOptionValue(){}
 FloatOptionValue(std::string l,std::string s, float d) : OptionValue(l,s,d){}
 bool setValue(const std::string& value){
-    return Int::stringToFloat(value.c_str(),actualValue);
+    return Lib::Int::stringToFloat(value.c_str(),actualValue);
 }
 std::string getStringOfValue(float value) const{ return Lib::Int::toString(value); }
 };
@@ -1868,7 +1868,7 @@ bool _hard;
     static OptionProblemConstraintUP hasTheories() { return OptionProblemConstraintUP(new HasTheories); }
     static OptionProblemConstraintUP hasGoal() { return OptionProblemConstraintUP(new HasGoal); }
 
-    //Cheating - we refer to env.options to ask about option values
+    //Cheating - we refer to Lib::env.options to ask about option values
     // There is an assumption that the option values used have been
     // set to their final values
     // These are used in randomisation where we guarantee a certain
@@ -1887,7 +1887,7 @@ bool _hard;
 
       bool check(Property*p){
         bool res = is_and;
-        Stack<OptionProblemConstraintUP>::RefIterator it(cons);
+        Lib::Stack<OptionProblemConstraintUP>::RefIterator it(cons);
         while(it.hasNext()){
           bool n=it.next()->check(p);res = is_and ? (res && n) : (res || n);}
         return res;
@@ -1895,14 +1895,14 @@ bool _hard;
 
       std::string msg(){
         std::string res="";
-        Stack<OptionProblemConstraintUP>::RefIterator it(cons);
+        Lib::Stack<OptionProblemConstraintUP>::RefIterator it(cons);
         if(it.hasNext()){ res=it.next()->msg();}
         while(it.hasNext()){ res+=",and\n"+it.next()->msg();}
         return res;
       }
 
       void add(OptionProblemConstraintUP& c){ cons.push(std::move(c));}
-      Stack<OptionProblemConstraintUP> cons;
+      Lib::Stack<OptionProblemConstraintUP> cons;
       bool is_and;
     };
 
@@ -2333,21 +2333,21 @@ private:
             ASS(new_long && new_short);
         }
         AbstractOptionValue* findLong(std::string longName) const{
-            if(!_longMap.find(longName)){ throw ValueNotFoundException(); }
+            if(!_longMap.find(longName)){ throw Lib::ValueNotFoundException(); }
             return _longMap.get(longName);
         }
         AbstractOptionValue* findShort(std::string shortName) const{
-            if(!_shortMap.find(shortName)){ throw ValueNotFoundException(); }
+            if(!_shortMap.find(shortName)){ throw Lib::ValueNotFoundException(); }
             return _shortMap.get(shortName);
         }
 
-        VirtualIterator<AbstractOptionValue*> values() const {
+        Lib::VirtualIterator<AbstractOptionValue*> values() const {
             return _longMap.range();
         }
 
     private:
-        DHMap<std::string,AbstractOptionValue*> _longMap;
-        DHMap<std::string,AbstractOptionValue*> _shortMap;
+        Lib::DHMap<std::string,AbstractOptionValue*> _longMap;
+        Lib::DHMap<std::string,AbstractOptionValue*> _shortMap;
     };
 
     LookupWrapper _lookup;
@@ -2357,21 +2357,21 @@ private:
         try{
           return _lookup.findLong(name);
         }
-        catch(ValueNotFoundException&){
+        catch(Lib::ValueNotFoundException&){
           try{
             return _lookup.findShort(name);
           }
-          catch(ValueNotFoundException&){
+          catch(Lib::ValueNotFoundException&){
             return 0;
           }
         }
     }
   
-    Stack<std::string> getSimilarOptionNames(std::string name, bool is_short) const{
+    Lib::Stack<std::string> getSimilarOptionNames(std::string name, bool is_short) const{
 
-      Stack<std::string> similar_names;
+      Lib::Stack<std::string> similar_names;
 
-      VirtualIterator<AbstractOptionValue*> options = _lookup.values();
+      Lib::VirtualIterator<AbstractOptionValue*> options = _lookup.values();
       while(options.hasNext()){
         AbstractOptionValue* opt = options.next();
         std::string opt_name = is_short ? opt->shortName : opt->longName;

--- a/Shell/PredicateDefinition.hpp
+++ b/Shell/PredicateDefinition.hpp
@@ -27,7 +27,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -41,7 +40,7 @@ using namespace Kernel;
 class PredicateDefinition
 {
 public:
-  typedef DHMap<Unit*, Unit*> ReplMap;
+  typedef Lib::DHMap<Unit*, Unit*> ReplMap;
 
   PredicateDefinition();
   ~PredicateDefinition();
@@ -84,10 +83,10 @@ private:
   unsigned _predCnt;
   PredData* _preds;
 
-  DHMap<unsigned, Def*> _defs;
-  DHMap<unsigned, bool> _purePreds;
-  Stack<int> _eliminable;
-  Stack<int> _pureToReplace;
+  Lib::DHMap<unsigned, Def*> _defs;
+  Lib::DHMap<unsigned, bool> _purePreds;
+  Lib::Stack<int> _eliminable;
+  Lib::Stack<int> _pureToReplace;
 };
 
 };

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -61,6 +61,7 @@
 #include "Kernel/TermIterators.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Shell;
 
 /**

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -39,7 +39,6 @@ namespace Kernel {
 namespace Shell {
 
 using namespace Kernel;
-using namespace Lib;
 
 /**
  * Represents syntactic properties of problems.
@@ -301,7 +300,7 @@ public:
   /** Symbols in this formula, used during counting 
       Functions are positive, predicates stored in the negative part
   **/
-  DHSet<int> _symbolsInFormula;
+  Lib::DHSet<int> _symbolsInFormula;
 
   /** Bitwise OR of all properties of this problem */
   uint64_t _props;
@@ -314,13 +313,13 @@ public:
   /** Problem contains non-default sorts */
   bool _hasNonDefaultSorts;
   unsigned _sortsUsed;
-  Array<bool> _usesSort;
+  Lib::Array<bool> _usesSort;
 
   /** Makes sense for all interpretations, but for polymorphic ones we also keep
    *  the more precise information about which monomorphisations are present (see below).
    */
-  DArray<bool> _interpretationPresence;
-  DHSet<Theory::MonomorphisedInterpretation> _polymorphicInterpretations;
+  Lib::DArray<bool> _interpretationPresence;
+  Lib::DHSet<Theory::MonomorphisedInterpretation> _polymorphicInterpretations;
 
   bool _hasFOOL;
   bool _hasCombs;

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -31,6 +31,7 @@
 #include "Rectify.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Shell;
 
 bool Rectify::Renaming::tryGetBoundAndMarkUsed (int var,int& boundTo) const

--- a/Shell/Rectify.hpp
+++ b/Shell/Rectify.hpp
@@ -50,14 +50,14 @@ public:
   static void rectify(UnitList*& units);
 private:
   typedef std::pair<unsigned,bool> VarWithUsageInfo;
-  typedef List<VarWithUsageInfo> VarUsageTrackingList;
+  typedef Lib::List<VarWithUsageInfo> VarUsageTrackingList;
   /** Renaming stores bindings for free and bound variables */
   class Renaming
-    : public Array<VarUsageTrackingList*>
+    : public Lib::Array<VarUsageTrackingList*>
   {
   public:
     Renaming()
-      : Array<VarUsageTrackingList*>(15),
+      : Lib::Array<VarUsageTrackingList*>(15),
 	_nextVar(0)
     {
       fillInterval(0,15);

--- a/Shell/Shuffling.cpp
+++ b/Shell/Shuffling.cpp
@@ -29,6 +29,7 @@
 #include "Shuffling.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Shell/Shuffling.hpp
+++ b/Shell/Shuffling.hpp
@@ -26,7 +26,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 /**
@@ -36,7 +35,7 @@ using namespace Kernel;
 class Shuffling
 {
 private:
-  typedef Coproduct<Formula*, Literal*, TermList> Shufflable;
+  typedef Lib::Coproduct<Formula*, Literal*, TermList> Shufflable;
 
   static void shuffleIter(Shufflable sh);
 
@@ -59,7 +58,7 @@ public:
   // Implements Fisher–Yates shuffling (each permutation equally likely)
   static void shuffleArray(Arrayish& a, unsigned len) {
     for(unsigned i=0;i<len;i++){
-      unsigned j = Random::getInteger(len-i)+i;
+      unsigned j = Lib::Random::getInteger(len-i)+i;
       std::swap(a[i],a[j]);
     }
   }
@@ -70,17 +69,17 @@ public:
   // get a new list by shuffling the original
   // we leak the old one
   template<typename T>
-  static void shuffleList(List<T>*& list) {
-    unsigned len = List<T>::length(list);
+  static void shuffleList(Lib::List<T>*& list) {
+    unsigned len = Lib::List<T>::length(list);
 
     if (len <= 1) {
       return;
     }
 
-    DArray<List<T>*> aux(len);
+    Lib::DArray<Lib::List<T>*> aux(len);
     unsigned idx = 0;
 
-    List<T>* els = list;
+    Lib::List<T>* els = list;
     while (els != nullptr) {
       aux[idx++] = els;
       els = els->tail();
@@ -88,12 +87,12 @@ public:
     shuffleArray(aux,len);
 
     // create the new list
-    List<T>* res = nullptr;
+    Lib::List<T>* res = nullptr;
     for(idx = 0; idx < len; idx++) {
-      res = List<T>::cons(aux[idx]->head(),res);
+      res = Lib::List<T>::cons(aux[idx]->head(),res);
     }
 
-    // List<T>::destroy(list);
+    // Lib::List<T>::destroy(list);
     list = res;
   }
 
@@ -101,18 +100,18 @@ public:
   // get two new lists by shuffling the originals and leaking the old ones
   // they get shuffled "in sync"
   template<typename T, typename S>
-  static void shuffleTwoList(List<T>*& list1, List<S>*& list2) {
-    unsigned len = List<T>::length(list1);
+  static void shuffleTwoList(Lib::List<T>*& list1, Lib::List<S>*& list2) {
+    unsigned len = Lib::List<T>::length(list1);
 
     if (len <= 1) {
       return;
     }
 
-    DArray<std::pair<List<T>*,List<S>*>> aux(len);
+    Lib::DArray<std::pair<Lib::List<T>*,Lib::List<S>*>> aux(len);
     unsigned idx = 0;
 
-    List<T>* els1 = list1;
-    List<S>* els2 = list2;
+    Lib::List<T>* els1 = list1;
+    Lib::List<S>* els2 = list2;
     while (els1 != nullptr) {
       ASS_NEQ(els2,0);
       aux[idx++] = std::make_pair(els1,els2);
@@ -123,15 +122,15 @@ public:
     shuffleArray(aux,len);
 
     // create the new lists
-    List<T>* res1 = nullptr;
-    List<S>* res2 = nullptr;
+    Lib::List<T>* res1 = nullptr;
+    Lib::List<S>* res2 = nullptr;
     for(idx = 0; idx < len; idx++) {
-      res1 = List<T>::cons(aux[idx].first->head(),res1);
-      res2 = List<S>::cons(aux[idx].second->head(),res2);
+      res1 = Lib::List<T>::cons(aux[idx].first->head(),res1);
+      res2 = Lib::List<S>::cons(aux[idx].second->head(),res2);
     }
 
-    // List<T>::destroy(list1);
-    // List<S>::destroy(list2);
+    // Lib::List<T>::destroy(list1);
+    // Lib::List<S>::destroy(list2);
 
     list1 = res1;
     list2 = res2;

--- a/Shell/SineUtils.hpp
+++ b/Shell/SineUtils.hpp
@@ -22,14 +22,13 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 class SineSymbolExtractor
 {
 public:
   typedef unsigned SymId;
-  typedef VirtualIterator<SymId> SymIdIterator;
+  typedef Lib::VirtualIterator<SymId> SymIdIterator;
 
   SymId getSymIdBound();
 
@@ -38,9 +37,9 @@ public:
   static void decodeSymId(SymId s, bool& pred, unsigned& functor);
   bool validSymId(SymId s);
 private:
-  void addSymIds(Term* term,DHSet<SymId>& ids);
-  void addSymIds(Literal* lit,DHSet<SymId>& ids);
-  void extractFormulaSymbols(Formula* f,DHSet<SymId>& itms);
+  void addSymIds(Term* term,Lib::DHSet<SymId>& ids);
+  void addSymIds(Literal* lit,Lib::DHSet<SymId>& ids);
+  void extractFormulaSymbols(Formula* f,Lib::DHSet<SymId>& itms);
 };
 
 
@@ -53,7 +52,7 @@ protected:
   void initGeneralityFunction(UnitList* units);
 
   /** Stores symbol generality */
-  DArray<unsigned> _gen;
+  Lib::DArray<unsigned> _gen;
 
   SineSymbolExtractor _symExtr;
 };
@@ -73,7 +72,7 @@ public:
   void perform(Problem& prb);
 
   ~SineSelector() {
-    DArray<UnitList*>::Iterator it(_def);
+    Lib::DArray<UnitList*>::Iterator it(_def);
     while (it.hasNext()) {
       UnitList::destroy(it.next());
     }
@@ -92,14 +91,14 @@ private:
   bool _justForSineLevels;
 
   /** Stored the D-relation */
-  DArray<UnitList*> _def;
+  Lib::DArray<UnitList*> _def;
 
   /**
    * Stored formulas that don't contain any symbols
    *
    * These formulas are always selected.
    */
-  Stack<Unit*> _unitsWithoutSymbols;
+  Lib::Stack<Unit*> _unitsWithoutSymbols;
 };
 
 
@@ -141,17 +140,17 @@ private:
     unsigned short minTolerance;
     Unit* unit;
   };
-  typedef List<DEntry> DEntryList;
+  typedef Lib::List<DEntry> DEntryList;
 
   /** Stored the D-relation */
-  DArray<DEntryList*> _def;
+  Lib::DArray<DEntryList*> _def;
 
   /**
    * Stored formulas that don't contain any symbols
    *
    * These formulas are always selected.
    */
-  Stack<Unit*> _unitsWithoutSymbols;
+  Lib::Stack<Unit*> _unitsWithoutSymbols;
 
   const Options& _opt;
 };

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -35,6 +35,7 @@
 #include "Skolem.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Shell/Skolem.hpp
+++ b/Shell/Skolem.hpp
@@ -27,7 +27,6 @@ namespace Kernel {
   class Unit;
 }
 
-using namespace Lib;
 using namespace Kernel;
 
 namespace Shell {
@@ -62,7 +61,7 @@ private:
   /** the collected substitution */
   Substitution _subst;
 
-  typedef List<bool> BoolList;
+  typedef Lib::List<bool> BoolList;
 
   /** In the first pass (preskolemise) we collect information 
    * for each variable and in each quantified subformula
@@ -81,7 +80,7 @@ private:
     BoolList* occurs_below;
   };
   // from vars to their VarOccInfo
-  typedef DHMap<unsigned,VarOccInfo> VarOccInfos;
+  typedef Lib::DHMap<unsigned,VarOccInfo> VarOccInfos;
   /* starts empty at the top level, and fininshes also empty 
      after bubbling up from the recursion;
      Only used temporarily during preskolemise! */
@@ -94,17 +93,17 @@ private:
     VarSet* exist;
   };
   // stored by the blocks, i.e. those Formulas* with the EXISTS connective
-  typedef DHMap<Formula*,ExVarDepInfo> ExVarDepInfos; 
+  typedef Lib::DHMap<Formula*,ExVarDepInfo> ExVarDepInfos; 
   ExVarDepInfos _varDeps;
 
   // map from an existential variable to its quantified formula (= block of quantifiers)
-  DHMap<unsigned, Formula*> _blockLookup;
+  Lib::DHMap<unsigned, Formula*> _blockLookup;
 
   /** map var --> sort */
-  DHMap<unsigned,TermList> _varSorts;
+  Lib::DHMap<unsigned,TermList> _varSorts;
 
   // for some heuristic evaluations after we are done
-  Stack<std::pair<bool, unsigned>> _introducedSkolemSyms;
+  Lib::Stack<std::pair<bool, unsigned>> _introducedSkolemSyms;
   
   FormulaUnit* _beingSkolemised;
 

--- a/Shell/SubexpressionIterator.hpp
+++ b/Shell/SubexpressionIterator.hpp
@@ -23,7 +23,6 @@
 #include "Kernel/Term.hpp"
 
 namespace Shell {
-  using namespace Lib;
   using namespace Kernel;
 
   class SubexpressionIterator {
@@ -93,7 +92,7 @@ namespace Shell {
       SubexpressionIterator(TermList ts);
 
     private:
-      Stack<Expression> _subexpressions;
+      Lib::Stack<Expression> _subexpressions;
   };
 }
 

--- a/Shell/SymbolDefinitionInlining.hpp
+++ b/Shell/SymbolDefinitionInlining.hpp
@@ -17,7 +17,6 @@
 #include "Lib/Environment.hpp"
 #include "Lib/Set.hpp"
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 
@@ -32,7 +31,7 @@ class SymbolDefinitionInlining {
     FormulaList* process(FormulaList* formulas);
     TermList process(TermList ts);
 
-    List<std::pair<unsigned, unsigned>>* variableRenamings() { return _varRenames; };
+    Lib::List<std::pair<unsigned, unsigned>>* variableRenamings() { return _varRenames; };
 
   private:
     const bool _isPredicate;
@@ -47,13 +46,13 @@ class SymbolDefinitionInlining {
 
     unsigned _counter;
     unsigned _freshVarOffset;
-    List<std::pair<unsigned, unsigned>>* _varRenames;
+    Lib::List<std::pair<unsigned, unsigned>>* _varRenames;
 
     void collectBoundVariables(TermList);
     void collectBoundVariables(Term*);
     void collectBoundVariables(Formula*);
 
-    Set<Formula*> _superformulas;
+    Lib::Set<Formula*> _superformulas;
 };
 
 #endif // __SymbolDefinitionInlining__

--- a/Shell/SymbolOccurrenceReplacement.hpp
+++ b/Shell/SymbolOccurrenceReplacement.hpp
@@ -15,7 +15,6 @@
 #include "Kernel/Signature.hpp"
 #include "Lib/Environment.hpp"
 
-using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 
@@ -37,13 +36,13 @@ class SymbolOccurrenceReplacement {
             : _isPredicate(isPredicate), _freshApplication(freshApplication), _symbol(symbol), _argVars(argVars) {
         
         if(isPredicate){
-          ASS(VList::length(argVars) == env.signature->getPredicate(symbol)->arity());
+          ASS(VList::length(argVars) == Lib::env.signature->getPredicate(symbol)->arity());
         } else {
-          ASS(VList::length(argVars) == env.signature->getFunction(symbol)->arity());            
+          ASS(VList::length(argVars) == Lib::env.signature->getFunction(symbol)->arity());            
         }
         // The implementation of this class doesn't requite argVars to be
         // non-empty, however, its use case expects this constraint
-        //ASS(argVars || !env.signature->getFunction(symbol)->introduced());
+        //ASS(argVars || !Lib::env.signature->getFunction(symbol)->introduced());
     }
     Formula* process(Formula* formula);
     FormulaList* process(FormulaList* formulas);

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -41,6 +41,8 @@ namespace Shell
 {
 
 using namespace std;
+using namespace Lib;
+
 TPTPPrinter::TPTPPrinter(ostream* tgtStream)
 : _tgtStream(tgtStream), _headersPrinted(false)
 {

--- a/Shell/TheoryAxioms.hpp
+++ b/Shell/TheoryAxioms.hpp
@@ -24,7 +24,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 class TheoryAxioms {

--- a/Shell/TheoryFlattening.hpp
+++ b/Shell/TheoryFlattening.hpp
@@ -35,17 +35,17 @@ public:
   void apply(Problem& prb);
   bool apply(UnitList*& units);
   bool apply(ClauseList*& units);
-  Clause* apply(Clause*& cl,Stack<Literal*>& target);
+  Clause* apply(Clause*& cl,Lib::Stack<Literal*>& target);
   Clause* apply(Clause*& cl){
-    static Stack<Literal*> dummy;
+    static Lib::Stack<Literal*> dummy;
     return apply(cl,dummy);
   }
 private:
-  Literal* replaceTopTerms(Literal* lit, Stack<Literal*>& newLits,unsigned& maxVar,
-                           DHMap<Term*,unsigned>& abstracted);
-  Term* replaceTopTermsInTerm(Term* term, Stack<Literal*>& newLits,
+  Literal* replaceTopTerms(Literal* lit, Lib::Stack<Literal*>& newLits,unsigned& maxVar,
+                           Lib::DHMap<Term*,unsigned>& abstracted);
+  Term* replaceTopTermsInTerm(Term* term, Lib::Stack<Literal*>& newLits,
                               unsigned& maxVar,bool interpreted,
-                              DHMap<Term*,unsigned>& abstracted);
+                              Lib::DHMap<Term*,unsigned>& abstracted);
 
   bool _recursive;
   bool _sharing;

--- a/Shell/TweeGoalTransformation.cpp
+++ b/Shell/TweeGoalTransformation.cpp
@@ -38,6 +38,10 @@
 
 #include "TweeGoalTransformation.hpp"
 
+using Lib::DHMap;
+using Lib::DHSet;
+using Lib::env;
+using Lib::Stack;
 using Kernel::Clause;
 using Kernel::Literal;
 using Kernel::Problem;

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -24,7 +24,6 @@
 
 namespace Shell {
 
-using namespace Lib;
 using namespace Kernel;
 
 bool szsOutputMode();
@@ -43,7 +42,7 @@ private:
     SMTLIBLogic _smtLibLogic = SMT_UNDEFINED;
     bool _hasConjecture = false;
   };
-  static Stack<LoadedPiece> _loadedPieces;
+  static Lib::Stack<LoadedPiece> _loadedPieces;
 
   static void tryParseTPTP(std::istream& input);
   static void tryParseSMTLIB2(std::istream& input);

--- a/Test/ClausePattern.hpp
+++ b/Test/ClausePattern.hpp
@@ -34,13 +34,13 @@ struct AnyOf
  * A Clause matches a pattern Clause, if they are equal.
  * A Clause matches an AnyOf pattern if it matches both of the subpatterns.
  */
-class ClausePattern : Coproduct<Kernel::Clause const*, AnyOf>
+class ClausePattern : Lib::Coproduct<Kernel::Clause const*, AnyOf>
 {
 public:
   ClausePattern(Kernel::Clause const* clause) 
-    : Coproduct<Kernel::Clause const*, AnyOf>(clause) {}
+    : Lib::Coproduct<Kernel::Clause const*, AnyOf>(clause) {}
 
-  ClausePattern(ClausePattern l, ClausePattern r) : Coproduct<Kernel::Clause const*, AnyOf>(AnyOf {
+  ClausePattern(ClausePattern l, ClausePattern r) : Lib::Coproduct<Kernel::Clause const*, AnyOf>(AnyOf {
         std::make_unique<ClausePattern>(std::move(l)),
         std::make_unique<ClausePattern>(std::move(r))
       }) {}

--- a/Test/GenerationTester.hpp
+++ b/Test/GenerationTester.hpp
@@ -36,7 +36,7 @@ namespace Test {
   [] (std::string& s1, std::string& s2) {                          \
     bool res = (VAL1 == VAL2);                             \
     if (!res) {                                            \
-      s1 = Int::toString(VAL1);                            \
+      s1 = Lib::Int::toString(VAL1);                            \
       s1.append(" != ");                                   \
       s1.append(Int::toString(VAL2));                      \
       s2 = std::string(#VAL1);                                 \
@@ -47,14 +47,14 @@ namespace Test {
   }
 
 template<class... As>
-Stack<ClausePattern> exactly(As... as) 
+Lib::Stack<ClausePattern> exactly(As... as) 
 {
-  Stack<ClausePattern> out { as... };
+  Lib::Stack<ClausePattern> out { as... };
   return out;
 }
 
-inline Stack<ClausePattern> none() {
-  return Stack<ClausePattern>();
+inline Lib::Stack<ClausePattern> none() {
+  return Lib::Stack<ClausePattern>();
 }
 
 namespace Generation {
@@ -80,18 +80,18 @@ public:
 class TestCase
 {
   using Clause = Kernel::Clause;
-  using OptionMap = Stack<std::pair<std::string,std::string>>;
+  using OptionMap = Lib::Stack<std::pair<std::string,std::string>>;
   using Condition = std::function<bool(std::string&, std::string&)>;
-  Option<SimplifyingGeneratingInference*> _rule;
+  Lib::Option<SimplifyingGeneratingInference*> _rule;
   Clause* _input;
-  Stack<ClausePattern> _expected;
-  Stack<Clause*> _context;
+  Lib::Stack<ClausePattern> _expected;
+  Lib::Stack<Clause*> _context;
   bool _premiseRedundant;
-  Stack<Indexing::Index*> _indices;
+  Lib::Stack<Indexing::Index*> _indices;
   std::function<void(SaturationAlgorithm&)> _setup = [](SaturationAlgorithm&){};
   OptionMap _options;
-  Stack<Condition> _preConditions;
-  Stack<Condition> _postConditions;
+  Lib::Stack<Condition> _preConditions;
+  Lib::Stack<Condition> _postConditions;
 
   template<class Is, class Expected>
   void testFail(Is const& is, Expected const& expected) {
@@ -117,14 +117,14 @@ public:
 
   BUILDER_METHOD(Clause*, input)
   BUILDER_METHOD(ClauseStack, context)
-  BUILDER_METHOD(Stack<ClausePattern>, expected)
+  BUILDER_METHOD(Lib::Stack<ClausePattern>, expected)
   BUILDER_METHOD(bool, premiseRedundant)
   BUILDER_METHOD(SimplifyingGeneratingInference*, rule)
-  BUILDER_METHOD(Stack<Indexing::Index*>, indices)
+  BUILDER_METHOD(Lib::Stack<Indexing::Index*>, indices)
   BUILDER_METHOD(std::function<void(SaturationAlgorithm&)>, setup)
   BUILDER_METHOD(OptionMap, options)
-  BUILDER_METHOD(Stack<Condition>, preConditions)
-  BUILDER_METHOD(Stack<Condition>, postConditions)
+  BUILDER_METHOD(Lib::Stack<Condition>, preConditions)
+  BUILDER_METHOD(Lib::Stack<Condition>, postConditions)
 
   template<class Rule>
   void run(GenerationTester<Rule>& simpl) {
@@ -137,12 +137,12 @@ public:
     auto ul = UnitList::empty();
     UnitList::pushFromIterator(ClauseStack::Iterator(_context), ul);
     p.addUnits(ul);
-    env.setMainProblem(&p);
+    Lib::env.setMainProblem(&p);
 
     Options o;
     for (const auto& kv : _options) {
       o.set(kv.first, kv.second);
-      env.options->set(kv.first, kv.second);
+      Lib::env.options->set(kv.first, kv.second);
     }
     MockedSaturationAlgorithm alg(p, o);
     _setup(alg);
@@ -175,7 +175,7 @@ public:
 
     // run checks
     auto& sExp = this->_expected;
-    auto  sRes = Stack<Kernel::Clause*>::fromIterator(res.clauses);
+    auto  sRes = Lib::Stack<Kernel::Clause*>::fromIterator(res.clauses);
 
     if (!TestUtils::permEq(sExp, sRes, [&](auto exp, auto res) { return exp.matches(simpl, res); })) {
       testFail(sRes, sExp);

--- a/Test/SimplificationTester.hpp
+++ b/Test/SimplificationTester.hpp
@@ -38,7 +38,7 @@ public:
 class Success
 {
   Kernel::Clause* _input;
-  Option<ClausePattern> _expected;
+  Lib::Option<ClausePattern> _expected;
 
 public:
   Success() : _input(nullptr) {}
@@ -51,7 +51,7 @@ public:
 
   Success expected(ClausePattern x)
   {
-    _expected = Option<ClausePattern>(x); 
+    _expected = Lib::Option<ClausePattern>(x); 
     return *this;
   }
 

--- a/Test/TestUtils.cpp
+++ b/Test/TestUtils.cpp
@@ -28,6 +28,7 @@
 namespace Test {
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Shell;
 

--- a/Test/TestUtils.hpp
+++ b/Test/TestUtils.hpp
@@ -79,7 +79,7 @@ private:
   {
     class Inner {
       unsigned cnt = 0;
-      Map<unsigned, unsigned> _self;
+      Lib::Map<unsigned, unsigned> _self;
     public:
       unsigned get(unsigned var) 
       { return _self.getOrInit(std::move(var), [&](){ return cnt++; }); }
@@ -144,8 +144,8 @@ struct PrettyPrinter<A*> {
 };
 
 template<class A>
-struct PrettyPrinter<Stack<A>> {
-  void operator()(std::ostream& out, Stack<A> const& self)
+struct PrettyPrinter<Lib::Stack<A>> {
+  void operator()(std::ostream& out, Lib::Stack<A> const& self)
   {
     auto iter = self.iterFifo();
     out << "[ ";
@@ -160,8 +160,8 @@ struct PrettyPrinter<Stack<A>> {
 };
 
 template<class A>
-struct PrettyPrinter<Option<A>> {
-  void operator()(std::ostream& out, Option<A> const& self)
+struct PrettyPrinter<Lib::Option<A>> {
+  void operator()(std::ostream& out, Lib::Option<A> const& self)
   { self.isSome() ? out << pretty(self.unwrap()) : out << "none"; }
 };
 
@@ -227,7 +227,7 @@ struct PrettyPrinter<Kernel::Literal>
 #undef NUM_CASE
         }
       }
-      Signature::Symbol* sym = env.signature->getPredicate(func);
+      Signature::Symbol* sym = Lib::env.signature->getPredicate(func);
       out << sym->name();
       if (sym->arity() > 0) {
         out << "(" << pretty(*lit.nthArgument(0));
@@ -281,7 +281,7 @@ struct PrettyPrinter<Kernel::TermList>
         }
       }
 
-      Signature::Symbol* sym = env.signature->getFunction(func);
+      Signature::Symbol* sym = Lib::env.signature->getFunction(func);
       out << sym->name();
       if (sym->arity() > 0) {
         out << "(" << pretty(*term->nthArgument(0));
@@ -297,8 +297,8 @@ struct PrettyPrinter<Kernel::TermList>
 // Helper function for permEq -- checks whether lhs is a permutation of
 // rhs via initial permutation perm with elements [0,idx) fixed.
 template<class L1, class L2, class Eq>
-bool __permEq(L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
-  auto checkPerm = [] (L1& lhs, L2& rhs, Eq elemEq, DArray<unsigned>& perm, unsigned idx) {
+bool __permEq(L1& lhs, L2& rhs, Eq elemEq, Lib::DArray<unsigned>& perm, unsigned idx) {
+  auto checkPerm = [] (L1& lhs, L2& rhs, Eq elemEq, Lib::DArray<unsigned>& perm, unsigned idx) {
     ASS_EQ(lhs.size(), perm.size());
     ASS_EQ(rhs.size(), perm.size());
 
@@ -335,7 +335,7 @@ template<class L1, class L2, class Eq>
 bool TestUtils::permEq(L1& lhs, L2& rhs, Eq elemEq)
 {
   if (lhs.size() != rhs.size()) return false;
-  DArray<unsigned> perm(lhs.size());
+  Lib::DArray<unsigned> perm(lhs.size());
   for (unsigned i = 0; i < lhs.size(); i++) {
     perm[i] = i;
   }

--- a/Test/UnitTesting.hpp
+++ b/Test/UnitTesting.hpp
@@ -24,7 +24,6 @@
 
 namespace Test {
 
-using namespace Lib;
 
 typedef void (*TestProc)();
 
@@ -61,7 +60,7 @@ public:
 
   std::string const& id() const { return _name; }
 
-  Stack<Test> const& tests() { return _tests; }
+  Lib::Stack<Test> const& tests() { return _tests; }
 private:
   Test* findTest(std::string const& testCase);
   /** Runs a test as a single process and awaits its termination.
@@ -72,7 +71,7 @@ private:
   bool spawnTest(TestProc proc);
 
   // TODO replace by Map as soon as integer-arithmetic PR with Map additions has landed
-  Stack<Test> _tests;
+  Lib::Stack<Test> _tests;
   std::string _name;
 };
 
@@ -80,15 +79,15 @@ private:
 class UnitTesting 
 {
   static UnitTesting* _instance;
-  Stack<TestUnit> _units;
+  Lib::Stack<TestUnit> _units;
   UnitTesting() : _units() {}
 public:
   static UnitTesting& instance();
 
   bool add(std::string const& testUnit, TestUnit::Test test);
   TestUnit* findUnit(std::string const& id);
-  bool listTests(Stack<std::string>const& args);
-  bool run(Stack<std::string>const& args);
+  bool listTests(Lib::Stack<std::string>const& args);
+  bool run(Lib::Stack<std::string>const& args);
   bool runUnit(std::string const& args);
   bool runTest(std::string const& unit, std::string const& testCase);
 };

--- a/UnitTests/tArithmeticSubtermGeneralization.cpp
+++ b/UnitTests/tArithmeticSubtermGeneralization.cpp
@@ -25,6 +25,7 @@
 #include "Kernel/KBO.hpp"
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Inferences;
 using namespace Test;

--- a/UnitTests/tBottomUpEvaluation.cpp
+++ b/UnitTests/tBottomUpEvaluation.cpp
@@ -13,6 +13,7 @@
 #include "Kernel/BottomUpEvaluation.hpp"
 #include "Kernel/Term.hpp"
 
+using namespace Lib;
 using namespace Kernel;
 using namespace Inferences;
 using namespace Test;

--- a/UnitTests/tDHMap.cpp
+++ b/UnitTests/tDHMap.cpp
@@ -11,6 +11,8 @@
 #include "Lib/DHMap.hpp"
 #include "Test/UnitTesting.hpp"
 
+using namespace Lib;
+
 typedef DHMap<unsigned, unsigned> MyMap;
 
 TEST_FUN(dhmap1)

--- a/UnitTests/tKBO.cpp
+++ b/UnitTests/tKBO.cpp
@@ -21,6 +21,7 @@
 //////////////////////////////////////////////////////////////////////////////// 
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 
 KBO kbo(unsigned introducedSymbolWeight, 

--- a/UnitTests/tKBO.hpp
+++ b/UnitTests/tKBO.hpp
@@ -8,8 +8,8 @@
  * and in the source directory
  */
 
-inline DArray<int> predLevels() {
-  DArray<int> out(env.signature->predicates());
+inline Lib::DArray<int> predLevels() {
+  Lib::DArray<int> out(Lib::env.signature->predicates());
   out.init(out.size(), 1);
   return out;
 }
@@ -17,12 +17,12 @@ inline DArray<int> predLevels() {
 using namespace Kernel;
 
 template<class SigTraits>
-inline KboWeightMap<SigTraits> toWeightMap(unsigned introducedSymbolWeight, KboSpecialWeights<SigTraits> ws, const Map<unsigned, KboWeight>& xs, unsigned sz) 
+inline KboWeightMap<SigTraits> toWeightMap(unsigned introducedSymbolWeight, KboSpecialWeights<SigTraits> ws, const Lib::Map<unsigned, KboWeight>& xs, unsigned sz) 
 {
   auto df = KboWeightMap<SigTraits>::dflt();
   df._specialWeights = ws;
 
-  DArray<KboWeight> out(sz);
+  Lib::DArray<KboWeight> out(sz);
   for (unsigned i = 0; i < sz; i++) {
     auto w = xs.getPtr(i);
     out[i] = w == NULL ? df.symbolWeight(i) : *w;
@@ -34,18 +34,18 @@ inline KboWeightMap<SigTraits> toWeightMap(unsigned introducedSymbolWeight, KboS
   };
 }
 
-inline void __weights(Map<unsigned, KboWeight>& ws) {
+inline void __weights(Lib::Map<unsigned, KboWeight>& ws) {
 }
 
 template<class A, class... As>
-inline void __weights(Map<unsigned, KboWeight>& ws, std::pair<A, KboWeight> a, std::pair<As, KboWeight>... as) {
+inline void __weights(Lib::Map<unsigned, KboWeight>& ws, std::pair<A, KboWeight> a, std::pair<As, KboWeight>... as) {
   ws.insert(std::get<0>(a).functor(), std::get<1>(a));
   __weights(ws, as...);
 }
 
 template<class... As>
-inline Map<unsigned, KboWeight> weights(std::pair<As, KboWeight>... as) {
-  Map<unsigned, KboWeight> out;
+inline Lib::Map<unsigned, KboWeight> weights(std::pair<As, KboWeight>... as) {
+  Lib::Map<unsigned, KboWeight> out;
   __weights(out, as...);
   return out;
 }

--- a/UnitTests/tLPO.cpp
+++ b/UnitTests/tLPO.cpp
@@ -14,6 +14,8 @@
 #include "Kernel/Ordering.hpp"
 #include "Kernel/Problem.hpp"
 
+using namespace Lib;
+
 DArray<int> lpoPredLevels() {
   DArray<int> out(env.signature->predicates());
   out.init(out.size(), 1);

--- a/UnitTests/tRebalance.cpp
+++ b/UnitTests/tRebalance.cpp
@@ -18,6 +18,7 @@
 
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 using namespace Rebalancing;
 using namespace Inverters;

--- a/UnitTests/tSKIKBO.cpp
+++ b/UnitTests/tSKIKBO.cpp
@@ -20,6 +20,7 @@
 //////////////////////////////////////////////////////////////////////////////// 
 
 using namespace std;
+using namespace Lib;
 using namespace Kernel;
 
 SKIKBO skikbo(unsigned introducedSymbolWeight, 

--- a/UnitTests/tSet.cpp
+++ b/UnitTests/tSet.cpp
@@ -12,6 +12,8 @@
 #include "Test/UnitTesting.hpp"
 #include "UnitTests/dummyHash.hpp"
 
+using namespace Lib;
+
 TEST_FUN(find_remove_contains)
 {
   Set<int> *test_set = new Set<int>();

--- a/UnitTests/tTermAlgebra.cpp
+++ b/UnitTests/tTermAlgebra.cpp
@@ -13,6 +13,7 @@
 
 #include "Shell/TermAlgebra.hpp"
 
+using namespace Lib;
 using namespace Shell;
 
 #define DECL_VARS \

--- a/UnitTests/tTheoryInstAndSimp.cpp
+++ b/UnitTests/tTheoryInstAndSimp.cpp
@@ -93,7 +93,7 @@ TheoryInstAndSimp* theoryInstAndSimp(Options::TheoryInstSimp mode, bool withGene
       /* export smtlib */ "");
 }
 
-using Shell::Int;
+using Lib::Int;
 REGISTER_GEN_TESTER(TheoryInstAndSimp)
 
 TEST_GENERATION(test_01,

--- a/UnitTests/tZ3Interfacing.cpp
+++ b/UnitTests/tZ3Interfacing.cpp
@@ -24,6 +24,7 @@
 // #endif
 
 using namespace std;
+using namespace Lib;
 using namespace Shell;
 using namespace SAT;
 

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -62,6 +62,7 @@
 #include "FMB/ModelCheck.hpp"
 
 using namespace std;
+using namespace Lib;
 
 /**
  * Return value is non-zero unless we were successful.


### PR DESCRIPTION
This PR removes `using namespace Lib;` from hpp files. And either prepends `Lib::` or adds `using namespace Lib;` in cpp files.
Similar to #472 from last year.
@MichaelRawson 