### PR TITLE
Allocator.cpp: fix for macOS where aligned_alloc may not be supported

### DIFF
--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -24,6 +24,10 @@
 #include <cstdlib>
 #include <limits>
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 #ifndef INDIVIDUAL_ALLOCATIONS
 Lib::SmallObjectAllocator Lib::GLOBAL_SMALL_OBJECT_ALLOCATOR;
 #endif
@@ -47,8 +51,11 @@ void *operator new(size_t size, std::align_val_t align_val) {
     throw std::bad_alloc();
   ALLOCATED += size;
   {
+// aligned_alloc is not supported prior to macOS 10.13
+#if !defined(__APPLE__) || (defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED >= 101300)
     if(void *ptr = std::aligned_alloc(align, size))
       return ptr;
+#endif
 
     // we might be here because `aligned_alloc` is finicky (Apple, looking at you)
     // so try again with `malloc` and hope for good alignment


### PR DESCRIPTION
Fixes: https://github.com/vprover/vampire/issues/592

@MichaelRawson Could you please review this?