### PR TITLE
use rlimit to enforce memory limits rather than global allocators

### DIFF
--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -16,79 +16,23 @@
  * @since 24/07/2023, mostly replaced by a small-object allocator
  */
 
-#include <cstdlib>
-#include <limits>
-
 #include "Allocator.hpp"
-
-#include <cstdlib>
-#include <limits>
 
 #ifndef INDIVIDUAL_ALLOCATIONS
 Lib::SmallObjectAllocator Lib::GLOBAL_SMALL_OBJECT_ALLOCATOR;
 #endif
 
-static size_t ALLOCATED = 0;
-// set by main very soon after launch
-static size_t LIMIT = std::numeric_limits<size_t>::max();
+#if __has_include(<sys/resource.h>)
+#include <sys/resource.h>
+#define HAVE_RLIMIT
+#endif
 
-size_t Lib::getUsedMemory() { return ALLOCATED; }
-size_t Lib::getMemoryLimit() { return LIMIT; }
-void Lib::setMemoryLimit(size_t limit) { LIMIT = limit; }
-
-// override global allocators to keep track of allocated memory, doing very little else
-// TODO does not support get_new_handler/set_new_handler as we don't use it, but we could
-void *operator new(size_t size, std::align_val_t align_val) {
-  size_t align = static_cast<size_t>(align_val);
-  // standard says `size` must be an integer multiple of `align`
-  ASS_EQ(size % align, 0)
-
-  if(ALLOCATED + size > LIMIT)
-    throw std::bad_alloc();
-  ALLOCATED += size;
-  {
-    if(void *ptr = std::aligned_alloc(align, size))
-      return ptr;
-
-    // we might be here because `aligned_alloc` is finicky (Apple, looking at you)
-    // so try again with `malloc` and hope for good alignment
-    if(void *ptr = std::malloc(size))
-      return ptr;
-
-  }
-  // no, we're actually out of memory
-  throw std::bad_alloc();
-}
-
-// a version of the above operator-new without alignment information
-void *operator new(size_t size) {
-  if(ALLOCATED + size > LIMIT)
-    throw std::bad_alloc();
-  ALLOCATED += size;
-  {
-    if(void *ptr = std::malloc(size))
-      return ptr;
-  }
-  throw std::bad_alloc();
-}
-
-// normal delete, just decrements `ALLOCATED` and calls free()
-void operator delete(void *ptr, size_t size) noexcept {
-  ASS_GE(ALLOCATED, size)
-  ALLOCATED -= size;
-  std::free(ptr);
-}
-
-// aligned-and-sized delete
-// forwards to the sized delete as we don't use the alignment information
-void operator delete(void *ptr, size_t size, std::align_val_t align) noexcept {
-  operator delete(ptr, size);
-}
-
-// unsized (and unaligned) delete
-// called if we don't know the size of the deallocated object somehow,
-// occurs very rarely and usually from deep in the bowels of the standard library
-// TODO does cause us to slightly over-report allocated memory
-void operator delete(void *ptr) noexcept {
-  std::free(ptr);
+void Lib::setMemoryLimit(size_t limit) {
+#ifdef HAVE_RLIMIT
+  struct rlimit rlimit;
+  rlimit.rlim_cur = rlimit.rlim_max = limit;
+  ASS_EQ(setrlimit(RLIMIT_DATA, &rlimit), 0)
+#else
+  // TODO should we warn here?
+#endif
 }

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -16,8 +16,6 @@
  * @since 24/07/2023, mostly replaced by a small-object allocator
  */
 
-#include <cstdio>
-
 #include "Allocator.hpp"
 
 #ifndef INDIVIDUAL_ALLOCATIONS
@@ -39,8 +37,7 @@ void Lib::setMemoryLimit(size_t limit) {
 #ifdef HAVE_RLIMIT
   struct rlimit rlimit;
   rlimit.rlim_cur = rlimit.rlim_max = limit;
-  if(setrlimit(RLIMIT_DATA, &rlimit))
-    std::perror("memory limiting failed");
+  setrlimit(RLIMIT_DATA, &rlimit);
 #else
   // TODO should we warn here?
 #endif

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -16,6 +16,8 @@
  * @since 24/07/2023, mostly replaced by a small-object allocator
  */
 
+#include <cstdio>
+
 #include "Allocator.hpp"
 
 #ifndef INDIVIDUAL_ALLOCATIONS
@@ -28,10 +30,15 @@ Lib::SmallObjectAllocator Lib::GLOBAL_SMALL_OBJECT_ALLOCATOR;
 #endif
 
 void Lib::setMemoryLimit(size_t limit) {
+  // zero means no limit
+  if(!limit)
+    return;
+
 #ifdef HAVE_RLIMIT
   struct rlimit rlimit;
   rlimit.rlim_cur = rlimit.rlim_max = limit;
-  ASS_EQ(setrlimit(RLIMIT_DATA, &rlimit), 0)
+  if(setrlimit(RLIMIT_DATA, &rlimit))
+    std::perror("memory limiting failed");
 #else
   // TODO should we warn here?
 #endif

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -29,9 +29,11 @@ Lib::SmallObjectAllocator Lib::GLOBAL_SMALL_OBJECT_ALLOCATOR;
 #define HAVE_RLIMIT
 #endif
 
+const size_t MIN_MEMORY = 20971520;
+
 void Lib::setMemoryLimit(size_t limit) {
-  // zero means no limit
-  if(!limit)
+  // if limit is less than floor, ignore it
+  if(limit < MIN_MEMORY)
     return;
 
 #ifdef HAVE_RLIMIT

--- a/Lib/Allocator.cpp
+++ b/Lib/Allocator.cpp
@@ -39,12 +39,12 @@ void Lib::setMemoryLimit(size_t limit) {
 #ifdef HAVE_RLIMIT
   struct rlimit rlimit;
   rlimit.rlim_cur = rlimit.rlim_max = limit;
-  if(setrlimit(RLIMIT_DATA, &rlimit) != 0)
-// silence buggy failure on OSX
-#ifndef __OSX__
-    std::perror("memory limiting failed")
+  if (setrlimit(RLIMIT_DATA, &rlimit) != 0) {
+#if defined(__APPLE__) && defined(__MACH__)
+    if (errno != EINVAL) // silence buggy failure on OSX
 #endif
-    ;
+      std::perror("memory limiting failed");
+  }
 
 #else
   // TODO should we warn here?

--- a/Lib/Allocator.hpp
+++ b/Lib/Allocator.hpp
@@ -24,7 +24,6 @@
 #include <new>
 
 #include "Debug/Assertion.hpp"
-#include "Portability.hpp"
 
 /*
  * uncomment the following to use Valgrind more profitably
@@ -34,15 +33,8 @@
 // #define INDIVIDUAL_ALLOCATIONS
 
 namespace Lib {
-
-// get the amount of memory used by global operator new so far
-size_t getUsedMemory();
-
-// get the memory limit for global operator new
-size_t getMemoryLimit();
-// set the memory limit for global operator new
+// attempt to set a memory limit for this process by system call
 void setMemoryLimit(size_t bytes);
-
 }
 
 #ifdef INDIVIDUAL_ALLOCATIONS

--- a/Lib/Allocator.hpp
+++ b/Lib/Allocator.hpp
@@ -40,11 +40,11 @@ void setMemoryLimit(size_t bytes);
 #ifdef INDIVIDUAL_ALLOCATIONS
 namespace Lib {
 inline void *alloc(size_t size, size_t align = alignof(std::max_align_t)) {
-  return ::operator new(size, (std::max_align_t)align);
+  return ::operator new(size, (std::align_val_t)align);
 }
 
 inline void free(void *pointer, size_t size, size_t align = alignof(std::max_align_t)) {
-  ::operator delete(pointer);
+  ::operator delete(pointer, (std::align_val_t)align);
 }
 } // namespace Lib
 #define USE_GLOBAL_SMALL_OBJECT_ALLOCATOR(C)
@@ -207,7 +207,7 @@ public:
     if(size <= 8 * sizeof(void *))
       return FSA8.free(pointer);
 
-    ::operator delete(pointer, size, (std::align_val_t)align);
+    ::operator delete(pointer, (std::align_val_t)align);
   }
 
 private:

--- a/Saturation/ProvingHelper.cpp
+++ b/Saturation/ProvingHelper.cpp
@@ -57,9 +57,6 @@ using namespace Shell;
   catch(const std::bad_alloc &) {
     env.statistics->terminationReason=Statistics::MEMORY_LIMIT;
     env.statistics->refutation=0;
-    size_t limit=Lib::getMemoryLimit();
-    //add extra 1 MB to allow proper termination
-    Lib::setMemoryLimit(limit+1000000);
   }
   catch(TimeLimitExceededException&) {
     env.statistics->terminationReason=Statistics::TIME_LIMIT;
@@ -107,9 +104,6 @@ void ProvingHelper::runVampire(Problem& prb, const Options& opt)
   catch(const std::bad_alloc &) {
     env.statistics->terminationReason=Statistics::MEMORY_LIMIT;
     env.statistics->refutation=0;
-    size_t limit=Lib::getMemoryLimit();
-    //add extra 1 MB to allow proper termination
-    Lib::setMemoryLimit(limit+1000000);
   }
   catch(TimeLimitExceededException&) {
     env.statistics->terminationReason=Statistics::TIME_LIMIT;

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -93,7 +93,7 @@ void Options::init()
                                        131072   // 128 GB (current max on the StarExecs)
 #endif
                                        );
-    _memoryLimit.description="Attempt to limit memory use (in MB). Limits less than 20MB are ignored to allow Vampire to start.";
+    _memoryLimit.description="Attempt to limit memory use (in MB). Limits less than 20MB are ignored to allow Vampire to start. Known not to work on MacOS for mysterious reasons: https://forums.developer.apple.com/forums/thread/702803";
     _lookup.insert(&_memoryLimit);
 
 #if VAMPIRE_PERF_EXISTS

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -93,7 +93,7 @@ void Options::init()
                                        131072   // 128 GB (current max on the StarExecs)
 #endif
                                        );
-    _memoryLimit.description="Memory limit in MB";
+    _memoryLimit.description="Attempt to limit memory use (in MB). Limits less than 20MB are ignored to allow Vampire to start.";
     _lookup.insert(&_memoryLimit);
 
 #if VAMPIRE_PERF_EXISTS

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -18,7 +18,6 @@
 
 #include "Debug/RuntimeStatistics.hpp"
 
-#include "Lib/Allocator.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Timer.hpp"
 #include "SAT/Z3Interfacing.hpp"
@@ -469,13 +468,11 @@ void Statistics::print(ostream& out)
 
   }
 
-  COND_OUT("Memory used [KB]", Lib::getUsedMemory()/1024);
-
   addCommentSignForSZS(out);
   out << "Time elapsed: ";
   Timer::printMSString(out,Timer::elapsedMilliseconds());
   out << endl;
-  
+
   Timer::updateInstructionCount();
   unsigned instr = Timer::elapsedMegaInstructions();
   if (instr) {
@@ -483,7 +480,7 @@ void Statistics::print(ostream& out)
     out << "Instructions burned: " << instr << " (million)";
     out << endl;
   }
-  
+
   addCommentSignForSZS(out);
   out << "------------------------------\n";
 

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -106,7 +106,6 @@ void reportSpiderStatus(char status)
     << (problemName.length() == 0 ? "unknown" : problemName) << " "
     << Timer::elapsedDeciseconds() << " "
     << Timer::elapsedMegaInstructions() << " "
-    << Lib::getUsedMemory()/1048576 << " "
     << (Lib::env.options ? Lib::env.options->testId() : "unknown") << " "
     << commitNumber << ':' << z3Version << endl;
 #endif


### PR DESCRIPTION
As discussed with @quickbeam123 and related to #592. The current standard-compliant solution to memory limiting seems a bit fragile and under-reports memory use in some seemingly-random cases. Use POSIX `setrlimit` with `RLIMIT_DATA` to cause `ENOMEM` when we exceed the specified limit.