### PR TITLE
`enum class` and automatic stringification for SMTLIBLogic

### DIFF
--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -1568,18 +1568,18 @@ void Schedules::getCascSat2019Schedule(const Property& property, Schedule& quick
 void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick, Schedule& fallback)
 {
   switch (property.getSMTLIBLogic()) {
-  case SMT_AUFDTLIA:
-  case SMT_AUFDTLIRA: // Add new logic here even though probably not best schedule
-  case SMT_AUFDTNIRA: // Add new logic here even though probably not best schedule
+  case SMTLIBLogic::AUFDTLIA:
+  case SMTLIBLogic::AUFDTLIRA: // Add new logic here even though probably not best schedule
+  case SMTLIBLogic::AUFDTNIRA: // Add new logic here even though probably not best schedule
     quick.push("lrs+1010_5:4_afp=100000:afq=1.2:anc=none:cond=on:fsr=off:ile=on:irw=on:nm=64:nwc=1:stl=30:sac=on:sp=occurrence:urr=on_9");
     quick.push("dis+11_5_add=large:afr=on:afp=10000:afq=1.2:anc=none:gs=on:gsem=on:ile=on:irw=on:lma=on:lwlo=on:nm=64:nwc=1:sas=z3:sos=all:sac=on:sp=reverse_arity:urr=on:updr=off_273");
     quick.push("dis+1011_2:3_add=large:afr=on:afp=40000:afq=1.0:anc=none:br=off:cond=on:gs=on:gsem=on:ile=on:irw=on:lma=on:lwlo=on:nwc=1:sos=on:sac=on:sp=occurrence:tac=axiom:tar=off:urr=on:updr=off_264");
     break;
 
-  case SMT_UFDTLIA:
-  case SMT_UFDTLIRA: // Add new logic here even though probably not best schedule
-  case SMT_UFDTNIA:
-  case SMT_UFDTNIRA: // Add new logic here even though probably not best schedule
+  case SMTLIBLogic::UFDTLIA:
+  case SMTLIBLogic::UFDTLIRA: // Add new logic here even though probably not best schedule
+  case SMTLIBLogic::UFDTNIA:
+  case SMTLIBLogic::UFDTNIRA: // Add new logic here even though probably not best schedule
     quick.push("dis+1011_2:3_add=large:afr=on:afp=40000:afq=1.0:anc=none:br=off:cond=on:gs=on:gsem=on:ile=on:irw=on:lma=on:lwlo=on:nwc=1:sos=on:sac=on:sp=occurrence:tac=axiom:tar=off:urr=on:updr=off_2");
     quick.push("lrs+11_7_add=off:afr=on:afp=40000:afq=1.1:amm=off:anc=none:bsr=on:br=off:fde=unused:gs=on:gsem=on:inw=on:ile=on:irw=on:lma=on:nm=64:nwc=1:stl=30:sos=all:sac=on:urr=on:updr=off:uhcvi=on_5");
     quick.push("dis+1004_1_add=off:afr=on:afp=1000:afq=1.1:amm=off:anc=none:bd=off:fde=none:gs=on:gsaa=from_current:gsem=on:ile=on:irw=on:lwlo=on:nm=64:newcnf=on:nwc=1:sas=z3:sp=occurrence:tac=light:tar=off:tha=off:thi=all:urr=on:uhcvi=on_6");
@@ -1588,7 +1588,7 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("lrs+1011_3:1_ind=struct:newcnf=on:ile=on:irw=on:lma=on:lwlo=on:sac=on:updr=off_10");
     break;
 
-  case SMT_UFDT:
+  case SMTLIBLogic::UFDT:
     quick.push("lrs+11_8:1_av=off:cond=on:fde=none:ile=on:nm=16:nwc=1.3:stl=30:sp=reverse_arity:urr=on:updr=off_135");
     quick.push("ott+1003_14_av=off:fsr=off:fde=unused:ile=on:lcm=predicate:nm=0:newcnf=on:nwc=1:sp=occurrence:uhcvi=on_12");
     quick.push("lrs+10_3:1_av=off:cond=on:fde=none:ile=on:lma=on:lwlo=on:nm=64:nwc=1:stl=30:sp=reverse_arity:tar=off:uhcvi=on_148");
@@ -1622,7 +1622,7 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("lrs+10_5:1_av=off:fde=unused:ile=on:lwlo=on:nwc=1.1:stl=90:sp=occurrence:urr=on_343");
     break;
 
-  case SMT_LIA:
+  case SMTLIBLogic::LIA:
     quick.push("dis+1011_8_afp=10000:afq=1.2:amm=sco:anc=none:bce=on:gs=on:gsem=off:ile=on:lma=on:nm=16:newcnf=on:nwc=2.5:sas=z3:sos=all:sac=on:sp=occurrence:updr=off_2");
     quick.push("dis+11_3_afr=on:afp=4000:afq=2.0:amm=sco:anc=none:bce=on:cond=on:fsr=off:ile=on:lwlo=on:nm=64:newcnf=on:nwc=1:sas=z3:tha=off:thf=on_2");
     quick.push("dis-2_4_add=large:afp=1000:afq=1.0:amm=sco:anc=none:bce=on:gs=on:inw=on:ile=on:lwlo=on:nm=64:newcnf=on:nwc=1:sas=z3:sos=all:sp=reverse_arity:tha=off:thi=all_13");
@@ -1631,7 +1631,7 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("lrs-11_4:1_afp=4000:afq=2.0:anc=none:br=off:gs=on:lwlo=on:nm=64:nwc=3:stl=30:urr=on_1");
     break;
 
-  case SMT_UFNIA:
+  case SMTLIBLogic::UFNIA:
     quick.push("lrs+11_5:4_av=off:gs=on:gsem=on:irw=on:lma=on:lwlo=on:nm=32:newcnf=on:nwc=1.3:stl=30:sp=reverse_arity:updr=off_63");
     quick.push("ott+1010_7_av=off:fsr=off:fde=none:lma=on:nm=2:newcnf=on:nwc=1.3:sos=on:sp=reverse_arity:uhcvi=on_194");
     quick.push("dis+1011_8_av=off:bd=off:bsr=on:bce=on:cond=on:fsr=off:fde=unused:ile=on:nm=64:nwc=1.1:sd=10:ss=axioms:st=1.5:sos=all:sp=reverse_arity:tha=off_569");
@@ -1691,13 +1691,13 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("lrs+4_3:1_add=off:afp=1000:afq=2.0:anc=none:gs=on:gsem=on:ile=on:lma=on:nm=2:nwc=5:sas=z3:stl=30:sac=on:sp=occurrence:updr=off_8");
     break;
 
-  case SMT_ALIA:
+  case SMTLIBLogic::ALIA:
     quick.push("lrs+2_4_add=off:afr=on:afp=40000:afq=1.0:amm=off:anc=none:bd=off:bce=on:fde=none:gs=on:gsem=on:lma=on:nm=64:newcnf=on:nwc=1.3:sas=z3:stl=30:tha=off:thi=strong:uwa=one_side_interpreted:urr=on:updr=off:uhcvi=on_3");
     quick.push("ott-3_2:3_add=off:afr=on:afp=40000:afq=1.0:bsr=on:cond=fast:fsr=off:fde=none:gs=on:ile=on:lma=on:lwlo=on:nm=2:newcnf=on:nwc=1.2:nicw=on:sas=z3:sos=all:sp=reverse_arity:urr=ec_only:updr=off_44");
     quick.push("lrs-1_128_aac=none:add=off:afp=40000:afq=1.0:amm=off:anc=none:fsr=off:inw=on:ile=on:lcm=reverse:lma=on:nm=16:nwc=10:sas=z3:stl=30:sac=on:updr=off_195");
     break;
 
-  case SMT_UFLIA:
+  case SMTLIBLogic::UFLIA:
     quick.push("lrs-11_2:1_add=off:afr=on:afp=10000:afq=2.0:amm=sco:anc=none:inw=on:ile=on:irw=on:lcm=reverse:lma=on:nm=64:nwc=1.5:sas=z3:stl=30:sp=reverse_arity:urr=on_9");
     quick.push("lrs-10_3_av=off:bs=unit_only:bsr=on:cond=on:fsr=off:fde=unused:gs=on:inw=on:irw=on:lma=on:nm=64:newcnf=on:nwc=1.2:sas=z3:stl=30:tha=off:urr=ec_only_42");
     quick.push("lrs+1011_2:1_afr=on:afp=10000:afq=2.0:amm=off:gsp=on:gs=on:inw=on:ile=on:nm=2:nwc=1:sas=z3:stl=30:tha=off_296");
@@ -1806,12 +1806,12 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("lrs+1011_3:2_add=large:afp=10000:afq=1.4:amm=sco:anc=none:cond=fast:fde=unused:gsp=on:gs=on:ile=on:irw=on:lma=on:nwc=1:stl=30:sac=on:tha=off:updr=off:uhcvi=on_118");
     break;
 
-  case SMT_UFIDL:
+  case SMTLIBLogic::UFIDL:
     quick.push("dis+11_3_add=large:afp=100000:afq=1.4:amm=off:anc=none:fsr=off:gs=on:ile=on:irw=on:lma=on:nm=32:nwc=1:tha=off:updr=off_2");
     quick.push("dis+10_3_afr=on:afp=1000:afq=1.0:anc=none:cond=on:fsr=off:gs=on:ile=on:irw=on:lwlo=on:nm=32:nwc=1:sos=all:sp=occurrence:urr=on_3");
     break;
 
-  case SMT_LRA:
+  case SMTLIBLogic::LRA:
     quick.push("dis+1011_2:1_add=off:afp=40000:afq=1.1:amm=sco:anc=none:fsr=off:fde=unused:gsp=on:ile=on:irw=on:nm=64:newcnf=on:nwc=1.1:sas=z3:sos=all:sp=occurrence:updr=off:uhcvi=on_298");
     quick.push("dis+4_5_av=off:cond=on:fsr=off:gs=on:gsem=on:ile=on:irw=on:lwlo=on:nm=6:nwc=1:sos=on:sp=reverse_arity:updr=off_5");
     quick.push("ott+11_4_av=off:ile=on:lma=on:nm=64:nwc=1:sos=all:sp=occurrence:uwa=interpreted_only:updr=off:uhcvi=on_37");
@@ -1819,15 +1819,15 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("dis+11_2_add=large:afr=on:afp=1000:afq=1.1:anc=none:gs=on:gsaa=full_model:ile=on:irw=on:lma=on:nm=16:nwc=1:sas=z3:sos=on:sac=on:sp=occurrence:thi=strong:uhcvi=on_72");
     break;
 
-  case SMT_NIA:
+  case SMTLIBLogic::NIA:
     quick.push("dis+11_10_add=off:afr=on:afp=100000:afq=1.2:amm=off:anc=none:cond=on:gs=on:gsem=on:inw=on:ile=on:irw=on:lma=on:nm=64:newcnf=on:nwc=10:sas=z3:sac=on:sp=reverse_arity_2");
     break;
 
-  case SMT_UFLRA:
+  case SMTLIBLogic::UFLRA:
     quick.push("dis+11_4_afp=4000:afq=1.4:amm=sco:anc=none:gs=on:ile=on:lma=on:nm=64:nwc=1.7:sas=z3:sac=on:sp=occurrence_2");
     break;
 
-  case SMT_NRA:
+  case SMTLIBLogic::NRA:
     quick.push("dis+1011_4:1_anc=none:cond=fast:fsr=off:gs=on:gsaa=full_model:gsem=off:ile=on:lma=on:lwlo=on:nm=64:nwc=1:sas=z3:sac=on:sp=occurrence_9");
     quick.push("dis+11_2_add=large:afp=10000:afq=1.0:amm=sco:anc=none:gs=on:ile=on:lma=on:lwlo=on:nm=64:newcnf=on:nwc=1:sas=z3:sos=all:uwa=all:updr=off_2");
     quick.push("dis+11_3_afr=on:afp=40000:afq=2.0:anc=none:fsr=off:gs=on:lma=on:nm=64:newcnf=on:nwc=1:nicw=on:sas=z3:sos=all:sac=on:sp=occurrence:urr=on_2");
@@ -1835,10 +1835,10 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("lrs+1011_3_add=large:afp=1000:afq=1.1:anc=none:cond=on:fsr=off:ile=on:irw=on:lma=on:nm=64:newcnf=on:nwc=1:nicw=on:sas=z3:stl=30:sos=all:sac=on_182");
     break;
 
-  case SMT_ANIA: // a newcomer ANIA, let's put it next to ALL
-  case SMT_ALL: // Add ALL here as we don't currently have a  schedule for it and  this is better than just using fallback
-  case SMT_AUFLIA:
-  case SMT_AUFNIA:
+  case SMTLIBLogic::ANIA: // a newcomer ANIA, let's put it next to ALL
+  case SMTLIBLogic::ALL: // Add ALL here as we don't currently have a  schedule for it and  this is better than just using fallback
+  case SMTLIBLogic::AUFLIA:
+  case SMTLIBLogic::AUFNIA:
     quick.push("lrs+1011_1_add=off:afr=on:afp=1000:afq=1.1:amm=off:anc=none:br=off:bce=on:er=filter:gsp=on:gs=on:gsaa=full_model:inw=on:ile=on:nm=32:nwc=1.2:sas=z3:stl=30:uwa=one_side_constant:urr=on_7");
     quick.push("dis+11_3_add=off:afp=1000:afq=2.0:amm=off:anc=none:fsr=off:gs=on:gsaa=full_model:inw=on:ile=on:lcm=predicate:lma=on:nm=6:nwc=1:sas=z3:sos=all:sp=occurrence:tha=off:uhcvi=on_13");
     quick.push("fmb+10_1_av=off:fde=unused:ile=on:irw=on:lcm=predicate:lma=on:nm=16:nwc=1.7:sos=all:sp=reverse_arity_2");
@@ -1867,7 +1867,7 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     break;
 
     
-  case SMT_AUFNIRA:
+  case SMTLIBLogic::AUFNIRA:
     quick.push("dis+11_2_add=large:afp=1000:afq=1.1:anc=none:fsr=off:fde=none:ile=on:irw=on:lma=on:nm=64:nwc=1:sas=z3:sos=all:sac=on_5");
     quick.push("lrs+10_8_afr=on:afp=4000:afq=1.1:amm=sco:anc=none:bsr=on:cond=on:gs=on:gsem=off:irw=on:lma=on:nm=64:newcnf=on:nwc=1:nicw=on:sas=z3:stl=30:sac=on:tha=off:urr=on:updr=off_2");
     quick.push("dis+1002_5_add=large:afr=on:afp=4000:afq=1.4:amm=off:anc=none:fsr=off:gs=on:gsem=on:irw=on:lma=on:nm=64:newcnf=on:nwc=1:sos=all:sac=on:sp=occurrence:updr=off_6");
@@ -1890,7 +1890,7 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("ott+1004_8:1_afp=10000:afq=1.1:amm=sco:anc=none:bd=off:bsr=on:fde=unused:ile=on:nm=2:newcnf=on:nwc=1:nicw=on:sas=z3:sp=reverse_arity:tha=off:updr=off_146");
     break;
 
-  case SMT_UF:
+  case SMTLIBLogic::UF:
     quick.push("lrs+11_5_av=off:cond=on:lma=on:nm=64:newcnf=on:nwc=1:stl=30:updr=off_22");
     quick.push("fmb+10_1_av=off:fmbes=contour:fmbsr=1.5:ile=on:updr=off_28");
     quick.push("dis+11_50_add=large:afp=10000:afq=1.2:anc=none:fsr=off:gs=on:gsem=off:ile=on:irw=on:nm=64:newcnf=on:nwc=1:sac=on_4");
@@ -1956,7 +1956,7 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("ott+1011_8:1_add=off:afr=on:afp=40000:afq=1.2:amm=off:anc=none:bd=off:fsr=off:ile=on:nm=64:newcnf=on:nwc=1.1:sas=z3:sp=reverse_arity:updr=off_55");
     break;
 
-  case SMT_AUFLIRA:
+  case SMTLIBLogic::AUFLIRA:
     quick.push("lrs+1010_2_anc=none:fsr=off:gs=on:irw=on:newcnf=on:nwc=1:sas=z3:stl=30:sos=on:sp=occurrence:updr=off_4");
     quick.push("lrs+1010_4_av=off:bd=off:bs=unit_only:bsr=on:gs=on:inw=on:ile=on:lma=on:newcnf=on:nwc=2.5:stl=30:sp=occurrence:updr=off_6");
     quick.push("dis+2_3_add=off:afp=40000:afq=1.1:anc=none:cond=on:gs=on:inw=on:ile=on:lcm=reverse:nm=64:newcnf=on:nwc=1:sas=z3:sp=reverse_arity:tha=off:urr=on:updr=off_43");
@@ -1967,35 +1967,35 @@ void Schedules::getSmtcomp2018Schedule(const Property& property, Schedule& quick
     quick.push("dis+1011_32_aac=none:add=off:afr=on:afp=40000:afq=1.0:amm=sco:bs=on:bsr=on:br=off:fde=unused:gs=on:gsaa=full_model:ile=on:lcm=predicate:nm=6:newcnf=on:nwc=1.5:sas=z3:sos=all:sac=on:tha=off:thi=all:uwa=one_side_constant:urr=on_1");
     break;
 
-  case SMT_QF_ABV:
-  case SMT_QF_ALIA:
-  case SMT_QF_ANIA:
-  case SMT_QF_AUFBV:
-  case SMT_QF_AUFLIA:
-  case SMT_QF_AUFNIA:
-  case SMT_QF_AX:
-  case SMT_QF_BV:
-  case SMT_QF_IDL:
-  case SMT_QF_LIA:
-  case SMT_QF_LIRA:
-  case SMT_QF_LRA:
-  case SMT_QF_NIA:
-  case SMT_QF_NIRA:
-  case SMT_QF_NRA:
-  case SMT_QF_RDL:
-  case SMT_QF_UF:
-  case SMT_QF_UFBV:
-  case SMT_QF_UFIDL:
-  case SMT_QF_UFLIA:
-  case SMT_QF_UFLRA:
-  case SMT_QF_UFNIA:
-  case SMT_QF_UFNRA:
+  case SMTLIBLogic::QF_ABV:
+  case SMTLIBLogic::QF_ALIA:
+  case SMTLIBLogic::QF_ANIA:
+  case SMTLIBLogic::QF_AUFBV:
+  case SMTLIBLogic::QF_AUFLIA:
+  case SMTLIBLogic::QF_AUFNIA:
+  case SMTLIBLogic::QF_AX:
+  case SMTLIBLogic::QF_BV:
+  case SMTLIBLogic::QF_IDL:
+  case SMTLIBLogic::QF_LIA:
+  case SMTLIBLogic::QF_LIRA:
+  case SMTLIBLogic::QF_LRA:
+  case SMTLIBLogic::QF_NIA:
+  case SMTLIBLogic::QF_NIRA:
+  case SMTLIBLogic::QF_NRA:
+  case SMTLIBLogic::QF_RDL:
+  case SMTLIBLogic::QF_UF:
+  case SMTLIBLogic::QF_UFBV:
+  case SMTLIBLogic::QF_UFIDL:
+  case SMTLIBLogic::QF_UFLIA:
+  case SMTLIBLogic::QF_UFLRA:
+  case SMTLIBLogic::QF_UFNIA:
+  case SMTLIBLogic::QF_UFNRA:
     throw UserErrorException("Kein Kinderspiel, Bruder, use Z3 for quantifier-free problems!");
 
-  case SMT_BV:
-  case SMT_UFBV:
+  case SMTLIBLogic::BV:
+  case SMTLIBLogic::UFBV:
     throw UserErrorException("Sorry, we don't deal with bit-vectors!");
-  case SMT_UNDEFINED:
+  case SMTLIBLogic::UNDEFINED:
     throw UserErrorException("This version cannot be used with this logic!");
   }
 

--- a/Kernel/Problem.cpp
+++ b/Kernel/Problem.cpp
@@ -39,7 +39,7 @@ using namespace Kernel;
  * The new object takes ownership of the list @c units.
  */
 Problem::Problem(UnitList* units)
-: _units(0), _fnDefHandler(new FunctionDefinitionHandler()), _smtlibLogic(SMTLIBLogic::SMT_UNDEFINED), _property(0)
+: _units(0), _fnDefHandler(new FunctionDefinitionHandler()), _smtlibLogic(SMTLIBLogic::UNDEFINED), _property(0)
 {
   initValues();
 

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -64,7 +64,7 @@ static const char* TYPECON_POSTFIX = "()";
 
 SMTLIB2::SMTLIB2(UnitList::FIFO formulaBuffer)
 : _logicSet(false),
-  _logic(SMT_UNDEFINED),
+  _logic(SMTLIBLogic::UNDEFINED),
   _numeralsAreReal(false),
   _formulas(formulaBuffer),
   _topLevelExpr(nullptr)
@@ -430,66 +430,18 @@ void SMTLIB2::readBenchmark(LExprList* bench)
 
 //  ----------------------------------------------------------------------
 
+#define X(N) #N,
 const char * SMTLIB2::s_smtlibLogicNameStrings[] = {
-    "ALIA",
-    "ALL",
-    "ANIA",
-    "AUFDTLIA",
-    "AUFDTLIRA",
-    "AUFDTNIRA",
-    "AUFLIA",
-    "AUFLIRA",
-    "AUFNIA",
-    "AUFNIRA",
-    "BV",
-    "LIA",
-    "LRA",
-    "NIA",
-    "NRA",
-    "QF_ABV",
-    "QF_ALIA",
-    "QF_ANIA",
-    "QF_AUFBV",
-    "QF_AUFLIA",
-    "QF_AUFNIA",
-    "QF_AX",
-    "QF_BV",
-    "QF_IDL",
-    "QF_LIA",
-    "QF_LIRA",
-    "QF_LRA",
-    "QF_NIA",
-    "QF_NIRA",
-    "QF_NRA",
-    "QF_RDL",
-    "QF_UF",
-    "QF_UFBV",
-    "QF_UFIDL",
-    "QF_UFLIA",
-    "QF_UFLRA",
-    "QF_UFNIA",
-    "QF_UFNRA",
-    "UF",
-    "UFBV",
-    "UFDT",
-    "UFDTLIA",
-    "UFDTLIRA",
-    "UFDTNIA",
-    "UFDTNIRA",
-    "UFIDL",
-    "UFLIA",
-    "UFLRA",
-    "UFNIA"
+  SMTLIBLogic_X
 };
+#undef X
 
 SMTLIBLogic SMTLIB2::getLogicFromString(const std::string& str)
 {
   static NameArray smtlibLogicNames(s_smtlibLogicNameStrings, sizeof(s_smtlibLogicNameStrings)/sizeof(char*));
-  ASS_EQ(smtlibLogicNames.length, SMT_UNDEFINED);
-
   int res = smtlibLogicNames.tryToFind(str.c_str());
   if(res==-1) {
-    return SMT_UNDEFINED;
+    return SMTLIBLogic::UNDEFINED;
   }
   return static_cast<SMTLIBLogic>(res);
 }
@@ -500,64 +452,64 @@ void SMTLIB2::readLogic(const std::string& logicStr)
   _logicSet = true;
 
   switch (_logic) {
-  case SMT_ALL:
-  case SMT_ALIA:
-  case SMT_ANIA:
-  case SMT_AUFDTLIA:
-  case SMT_AUFDTLIRA:
-  case SMT_AUFDTNIRA:
-  case SMT_AUFLIA:
-  case SMT_AUFNIA:
-  case SMT_AUFLIRA:
-  case SMT_AUFNIRA:
-  case SMT_LIA:
-  case SMT_NIA:
-  case SMT_QF_ALIA:
-  case SMT_QF_ANIA:
-  case SMT_QF_AUFLIA:
-  case SMT_QF_AUFNIA:
-  case SMT_QF_AX:
-  case SMT_QF_IDL:
-  case SMT_QF_LIA:
-  case SMT_QF_LIRA:
-  case SMT_QF_NIA:
-  case SMT_QF_NIRA:
-  case SMT_QF_UF:
-  case SMT_QF_UFIDL:
-  case SMT_QF_UFLIA:
-  case SMT_QF_UFNIA:
-  case SMT_UF:
-  case SMT_UFDT:
-  case SMT_UFDTLIA:
-  case SMT_UFDTLIRA:
-  case SMT_UFDTNIA:
-  case SMT_UFDTNIRA:
-  case SMT_UFIDL:
-  case SMT_UFLIA:
-  case SMT_UFNIA:
+  case SMTLIBLogic::ALL:
+  case SMTLIBLogic::ALIA:
+  case SMTLIBLogic::ANIA:
+  case SMTLIBLogic::AUFDTLIA:
+  case SMTLIBLogic::AUFDTLIRA:
+  case SMTLIBLogic::AUFDTNIRA:
+  case SMTLIBLogic::AUFLIA:
+  case SMTLIBLogic::AUFNIA:
+  case SMTLIBLogic::AUFLIRA:
+  case SMTLIBLogic::AUFNIRA:
+  case SMTLIBLogic::LIA:
+  case SMTLIBLogic::NIA:
+  case SMTLIBLogic::QF_ALIA:
+  case SMTLIBLogic::QF_ANIA:
+  case SMTLIBLogic::QF_AUFLIA:
+  case SMTLIBLogic::QF_AUFNIA:
+  case SMTLIBLogic::QF_AX:
+  case SMTLIBLogic::QF_IDL:
+  case SMTLIBLogic::QF_LIA:
+  case SMTLIBLogic::QF_LIRA:
+  case SMTLIBLogic::QF_NIA:
+  case SMTLIBLogic::QF_NIRA:
+  case SMTLIBLogic::QF_UF:
+  case SMTLIBLogic::QF_UFIDL:
+  case SMTLIBLogic::QF_UFLIA:
+  case SMTLIBLogic::QF_UFNIA:
+  case SMTLIBLogic::UF:
+  case SMTLIBLogic::UFDT:
+  case SMTLIBLogic::UFDTLIA:
+  case SMTLIBLogic::UFDTLIRA:
+  case SMTLIBLogic::UFDTNIA:
+  case SMTLIBLogic::UFDTNIRA:
+  case SMTLIBLogic::UFIDL:
+  case SMTLIBLogic::UFLIA:
+  case SMTLIBLogic::UFNIA:
     break;
 
   // pure real arithmetic theories treat decimals as Real constants
-  case SMT_LRA:
-  case SMT_NRA:
-  case SMT_QF_LRA:
-  case SMT_QF_NRA:
-  case SMT_QF_RDL:
-  case SMT_QF_UFLRA:
-  case SMT_QF_UFNRA:
-  case SMT_UFLRA:
+  case SMTLIBLogic::LRA:
+  case SMTLIBLogic::NRA:
+  case SMTLIBLogic::QF_LRA:
+  case SMTLIBLogic::QF_NRA:
+  case SMTLIBLogic::QF_RDL:
+  case SMTLIBLogic::QF_UFLRA:
+  case SMTLIBLogic::QF_UFNRA:
+  case SMTLIBLogic::UFLRA:
     _numeralsAreReal = true;
     break;
 
   // we don't support bit vectors
-  case SMT_BV:
-  case SMT_QF_ABV:
-  case SMT_QF_AUFBV:
-  case SMT_QF_BV:
-  case SMT_QF_UFBV:
-  case SMT_UFBV:
+  case SMTLIBLogic::BV:
+  case SMTLIBLogic::QF_ABV:
+  case SMTLIBLogic::QF_AUFBV:
+  case SMTLIBLogic::QF_BV:
+  case SMTLIBLogic::QF_UFBV:
+  case SMTLIBLogic::UFBV:
     USER_ERROR_EXPR("unsupported logic "+logicStr);
-  default:
+  case SMTLIBLogic::UNDEFINED:
     if (env.options->ignoreUnrecognizedLogic()) {
       break;
     } else {

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -89,7 +89,7 @@ Property::Property()
     _allClausesGround(true),
     _allNonTheoryClausesGround(true),
     _allQuantifiersEssentiallyExistential(true),
-    _smtlibLogic(SMTLIBLogic::SMT_UNDEFINED)
+    _smtlibLogic(SMTLIBLogic::UNDEFINED)
 {
   _interpretationPresence.init(Theory::instance()->numberOfFixedInterpretations(), false);
 } // Property::Property

--- a/Shell/SMTLIBLogic.hpp
+++ b/Shell/SMTLIBLogic.hpp
@@ -22,61 +22,66 @@ namespace Shell {
   * UF - uninterpreted function = first order we know and love
   * DT - datatypes (term algebras)
   *
-  * VERY IMPORTANT if this is changed: must also update SMTLIB2::smtLogicNameStrings
-  * (which themselves must be in alphabetical order, so this is also alphabetic)
+  * https://en.wikipedia.org/wiki/X_macro
   */
-enum SMTLIBLogic {
-  SMT_ALIA,
-  SMT_ALL,
-  SMT_ANIA,
-  SMT_AUFDTLIA,
-  SMT_AUFDTLIRA,
-  SMT_AUFDTNIRA,
-  SMT_AUFLIA,
-  SMT_AUFLIRA,
-  SMT_AUFNIA,
-  SMT_AUFNIRA,
-  SMT_BV,
-  SMT_LIA,
-  SMT_LRA,
-  SMT_NIA,
-  SMT_NRA,
-  SMT_QF_ABV,
-  SMT_QF_ALIA,
-  SMT_QF_ANIA,
-  SMT_QF_AUFBV,
-  SMT_QF_AUFLIA,
-  SMT_QF_AUFNIA,
-  SMT_QF_AX,
-  SMT_QF_BV,
-  SMT_QF_IDL,
-  SMT_QF_LIA,
-  SMT_QF_LIRA,
-  SMT_QF_LRA,
-  SMT_QF_NIA,
-  SMT_QF_NIRA,
-  SMT_QF_NRA,
-  SMT_QF_RDL,
-  SMT_QF_UF,
-  SMT_QF_UFBV,
-  SMT_QF_UFIDL,
-  SMT_QF_UFLIA,
-  SMT_QF_UFLRA,
-  SMT_QF_UFNIA,
-  SMT_QF_UFNRA,
-  SMT_UF,
-  SMT_UFBV,
-  SMT_UFDT,
-  SMT_UFDTLIA,
-  SMT_UFDTLIRA,
-  SMT_UFDTNIA,
-  SMT_UFDTNIRA,
-  SMT_UFIDL,
-  SMT_UFLIA,
-  SMT_UFLRA,
-  SMT_UFNIA,
-  SMT_UNDEFINED
+
+#define SMTLIBLogic_X\
+  X(ALIA)\
+  X(ALL)\
+  X(ANIA)\
+  X(AUFDTLIA)\
+  X(AUFDTLIRA)\
+  X(AUFDTNIRA)\
+  X(AUFLIA)\
+  X(AUFLIRA)\
+  X(AUFNIA)\
+  X(AUFNIRA)\
+  X(BV)\
+  X(LIA)\
+  X(LRA)\
+  X(NIA)\
+  X(NRA)\
+  X(QF_ABV)\
+  X(QF_ALIA)\
+  X(QF_ANIA)\
+  X(QF_AUFBV)\
+  X(QF_AUFLIA)\
+  X(QF_AUFNIA)\
+  X(QF_AX)\
+  X(QF_BV)\
+  X(QF_IDL)\
+  X(QF_LIA)\
+  X(QF_LIRA)\
+  X(QF_LRA)\
+  X(QF_NIA)\
+  X(QF_NIRA)\
+  X(QF_NRA)\
+  X(QF_RDL)\
+  X(QF_UF)\
+  X(QF_UFBV)\
+  X(QF_UFIDL)\
+  X(QF_UFLIA)\
+  X(QF_UFLRA)\
+  X(QF_UFNIA)\
+  X(QF_UFNRA)\
+  X(UF)\
+  X(UFBV)\
+  X(UFDT)\
+  X(UFDTLIA)\
+  X(UFDTLIRA)\
+  X(UFDTNIA)\
+  X(UFDTNIRA)\
+  X(UFIDL)\
+  X(UFLIA)\
+  X(UFLRA)\
+  X(UFNIA)\
+  X(UNDEFINED)
+
+#define X(N) N,
+enum class SMTLIBLogic {
+  SMTLIBLogic_X
 };
+#undef X
 
 }
 

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -40,7 +40,7 @@ private:
   struct LoadedPiece {
     std::string _id;
     UnitList::FIFO _units;
-    SMTLIBLogic _smtLibLogic = SMT_UNDEFINED;
+    SMTLIBLogic _smtLibLogic = SMTLIBLogic::UNDEFINED;
     bool _hasConjecture = false;
   };
   static Stack<LoadedPiece> _loadedPieces;


### PR DESCRIPTION
We had some bug recently where the strings for SMTLIB logics were not kept in sync with the enumeration definition. Fix this by sneaky means and also convert to `enum class` while I'm at it.