### PR TITLE
Fix conditional redundancy handler literal constraints with encompassment demodulation incompleteness issue

### DIFF
--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -49,7 +49,7 @@ bool DemodulationHelper::redundancyCheckNeededForPremise(Clause* rwCl, Literal* 
 /**
  * Test whether the @param applicator is a renaming on the variables of @param t.
  */
-bool isRenamingOn(const SubstApplicator* applicator, TermList t)
+bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, TermList t)
 {
   DHSet<TermList> renamingDomain;
   DHSet<TermList> renamingRange;
@@ -76,18 +76,10 @@ bool isRenamingOn(const SubstApplicator* applicator, TermList t)
 bool DemodulationHelper::isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm,
   TermList tgtTerm, TermList eqLHS, const SubstApplicator* eqApplicator) const
 {
-  Ordering::Result temp;
-  return isPremiseRedundant(rwCl, rwLit, rwTerm, tgtTerm, eqLHS, eqApplicator, temp);
-}
-
-bool DemodulationHelper::isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm,
-  TermList tgtTerm, TermList eqLHS, const SubstApplicator* eqApplicator, Ordering::Result& tord) const
-{
   ASS(redundancyCheckNeededForPremise(rwCl, rwLit, rwTerm));
 
   TermList other=EqHelper::getOtherEqualitySide(rwLit, rwTerm);
-  tord = _ord->compare(tgtTerm, other);
-  if (tord == Ordering::LESS) {
+  if (_ord->compare(tgtTerm, other) == Ordering::LESS) {
     return true;
   }
 

--- a/Inferences/DemodulationHelper.hpp
+++ b/Inferences/DemodulationHelper.hpp
@@ -24,11 +24,11 @@ public:
   DemodulationHelper() = default;
   DemodulationHelper(const Options& opts, const Ordering* ord);
 
+  static bool isRenamingOn(const SubstApplicator* applicator, TermList t);
+
   bool redundancyCheckNeededForPremise(Clause* rwCl, Literal* rwLit, TermList rwTerm) const;
   bool isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm,
     TermList eqLHS, const SubstApplicator* applicator) const;
-  bool isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm,
-    TermList eqLHS, const SubstApplicator* applicator, Ordering::Result& tord) const;
 
 private:
   bool _redundancyCheck;

--- a/Shell/ConditionalRedundancyHandler.cpp
+++ b/Shell/ConditionalRedundancyHandler.cpp
@@ -18,6 +18,8 @@
 #include "Indexing/CodeTreeInterfaces.hpp"
 #include "Indexing/ResultSubstitution.hpp"
 
+#include "Inferences/DemodulationHelper.hpp"
+
 #include "Statistics.hpp"
 
 using namespace std;
@@ -437,22 +439,19 @@ void ConditionalRedundancyHandlerImpl<enabled, ordC, avatarC, litC>::insertSuper
   Applicator appl(subs, !eqIsResult);
   Ordering::Result otherComp;
 
-  auto redundancyCheck =
-    // TODO this demodulation redundancy check could be added as constraints
-    (!_demodulationHelper.redundancyCheckNeededForPremise(rwClause, rwLitS, rwTermS) ||
-      // TODO for rwClause->length()!=1 the function isPremiseRedundant does not work yet
-      (rwClause->length()==1 && _demodulationHelper.isPremiseRedundant(rwClause, rwLitS, rwTermS, tgtTermS, eqLHS, &appl, otherComp)));
+  auto premiseRedundant = isSuperpositionPremiseRedundant(
+    rwClause, rwLitS, rwTermS, tgtTermS, eqClause, eqLHS, &appl, otherComp);
 
   // create ordering constraints
   OrderingConstraints ordCons;
   if constexpr (ordC) {
     // TODO we cannot handle them together yet
     if (eqComp != Ordering::LESS) {
-      if (!redundancyCheck || !rwTermS.containsAllVariablesOf(tgtTermS)) {
+      if (!premiseRedundant || !rwTermS.containsAllVariablesOf(tgtTermS)) {
         return;
       }
       ordCons.push(OrderingConstraint(rwTermS, tgtTermS));
-    } else if (!redundancyCheck) {
+    } else if (!premiseRedundant) {
       TermList other = EqHelper::getOtherEqualitySide(rwLitS, rwTermS);
       if (otherComp != Ordering::INCOMPARABLE || !other.containsAllVariablesOf(tgtTermS)) {
         return;
@@ -460,7 +459,7 @@ void ConditionalRedundancyHandlerImpl<enabled, ordC, avatarC, litC>::insertSuper
       ordCons.push(OrderingConstraint(other, tgtTermS));
     }
   } else {
-    if (eqComp != Ordering::LESS || !redundancyCheck) {
+    if (eqComp != Ordering::LESS || !premiseRedundant) {
       return;
     }
   }
@@ -604,6 +603,45 @@ bool ConditionalRedundancyHandlerImpl<enabled, ordC, avatarC, litC>::handleReduc
     return false;
   }
   return true;
+}
+
+/**
+ * This function is similar to @b DemodulationHelper::isPremiseRedundant.
+ * However, here we do not assume that the rewriting equation is unit, which necessitates some additional checks.
+ */
+template<bool enabled, bool ordC, bool avatarC, bool litC>
+bool ConditionalRedundancyHandlerImpl<enabled, ordC, avatarC, litC>::isSuperpositionPremiseRedundant(
+  Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm, Clause* eqCl, TermList eqLHS,
+  const SubstApplicator* eqApplicator, Ordering::Result& tord) const
+{
+  // if check is turned off, we always report redundant
+  if (!_redundancyCheck) {
+    return true;
+  }
+
+  // if the top-level terms are not involved, premise is redundant
+  if (!rwLit->isEquality() || (rwTerm!=*rwLit->nthArgument(0) && rwTerm!=*rwLit->nthArgument(1))) {
+    return true;
+  }
+
+  // we can only check encompassment demodulation if eqCl is unit
+  if (_encompassing && eqCl->length()==1) {
+    // if we have a negative literal or non-unit, premise is redundant
+    if (rwLit->isNegative() || rwCl->length() != 1) {
+      return true;
+    }
+    // otherwise (we have a positive unit), if substitution is not
+    // renaming on side premise, main premise is redundant
+    if (!Inferences::DemodulationHelper::isRenamingOn(eqApplicator,eqLHS)) {
+      return true;
+    }
+  }
+
+  // else we do standard redundancy check
+  TermList other=EqHelper::getOtherEqualitySide(rwLit, rwTerm);
+  tord = _ord->compare(tgtTerm, other);
+  return tord == Ordering::LESS;
+  // TODO perform ordering check for rest of rwCl
 }
 
 }

--- a/Shell/ConditionalRedundancyHandler.hpp
+++ b/Shell/ConditionalRedundancyHandler.hpp
@@ -47,8 +47,6 @@
 #include "Lib/SharedSet.hpp"
 #include "Lib/Stack.hpp"
 
-#include "Inferences/DemodulationHelper.hpp"
-
 #include "Saturation/Splitter.hpp"
 
 #include "Options.hpp"
@@ -131,7 +129,9 @@ class ConditionalRedundancyHandlerImpl
 {
 public:
   ConditionalRedundancyHandlerImpl(const Options& opts, const Ordering* ord, Splitter* splitter)
-    : _ord(ord), _demodulationHelper(opts,ord), _splitter(splitter) {}
+    : _redundancyCheck(opts.demodulationRedundancyCheck() != Options::DemodulationRedundancyCheck::OFF),
+      _encompassing(opts.demodulationRedundancyCheck() == Options::DemodulationRedundancyCheck::ENCOMPASS),
+      _ord(ord), _splitter(splitter) {}
 
   /** Returns false if superposition should be skipped. */
   bool checkSuperposition(
@@ -148,9 +148,14 @@ public:
   /** Returns false if inference should be skipped. */
   bool handleReductiveUnaryInference(Clause* premise, RobSubstitution* subs) const override;
 
+  bool isSuperpositionPremiseRedundant(
+    Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm, Clause* eqCl, TermList eqLHS,
+    const SubstApplicator* eqApplicator, Ordering::Result& tord) const;
+
 private:
+  bool _redundancyCheck;
+  bool _encompassing;
   const Ordering* _ord;
-  Inferences::DemodulationHelper _demodulationHelper;
   Splitter* _splitter;
 };
 


### PR DESCRIPTION
We assume in `DemodulationHelper` that the rewriting clause is unit, which resulted in false redundancies inside `ConditionalRedundancyHandler` where this assumption is not true with `crlc=on`.

Instead of overcomplicating original code and potentially slowing down demodulation, I duplicated the relevant part in `ConditionalRedundancyHandler`.

Tests indicate no further incompleteness so far, efficiency is comparable to previous version.