### PR TITLE
Code tree subsumption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/BackwardSubsumptionDemodulation.cpp
     Inferences/BackwardSubsumptionAndResolution.cpp
     Inferences/BinaryResolution.cpp
+    Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
     Inferences/Condensation.cpp
     Inferences/DemodulationHelper.cpp
     Inferences/DistinctEqualitySimplifier.cpp
@@ -421,6 +422,7 @@ set(VAMPIRE_INFERENCE_SOURCES
     Inferences/BackwardDemodulation.hpp
     Inferences/BackwardSubsumptionAndResolution.hpp
     Inferences/BinaryResolution.hpp
+    Inferences/CodeTreeForwardSubsumptionAndResolution.hpp
     Inferences/Condensation.hpp
     Inferences/DemodulationHelper.hpp
     Inferences/DistinctEqualitySimplifier.hpp

--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -615,25 +615,6 @@ inline bool ClauseCodeTree::ClauseMatcher::canEnterLiteral(CodeOp* op)
     return false;
   }
 
-  if(ils->isVarEqLit) {
-    TermList idxVarSort = ils->varEqLitSort;
-    size_t matchIndex=ils->matchCnt;
-    while(matchIndex!=0) {
-      matchIndex--;
-      MatchInfo* mi=ils->getMatch(matchIndex);
-      unsigned liIntex = mi->liIndex;
-      Literal* lit = (*query)[lInfos[liIntex].litIndex];
-      ASS(lit->isEquality());
-      TermList argSort = SortHelper::getEqualityArgumentSort(lit); 
-      if(idxVarSort!=argSort) {//TODO check that this is what we want. Perhaps require unification
-        ils->deleteMatch(matchIndex); //decreases ils->matchCnt
-      }
-    }
-    if(!ils->matchCnt) {
-      return false;
-    }
-  }
-
   if(lms.size()>1) {
     //we have already matched and entered some index literals, so we
     //will check for compatibility of variable assignments

--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -92,7 +92,7 @@ struct ClauseCodeTree::InitialLiteralOrderingComparator
     if(l1->weight()!=l2->weight()) {
       return Int::compare(l2->weight(), l1->weight());
     }
-    return Int::compare(l1, l2);
+    return Int::compare(l1->getId(), l2->getId());
   }
 };
 

--- a/Indexing/ClauseCodeTree.cpp
+++ b/Indexing/ClauseCodeTree.cpp
@@ -67,19 +67,16 @@ void ClauseCodeTree::insert(Clause* cl)
 
   optimizeLiteralOrder(lits);
 
-  static CodeStack code;
-  code.reset();
-
-  static CompileContext cctx;
-  cctx.init();
+  CodeStack code;
+  LitCompiler compiler(code);
 
   for(unsigned i=0;i<clen;i++) {
-    cctx.nextLit();
-    compileTerm(lits[i], code, cctx, true);
+    compiler.nextLit();
+    compiler.handleTerm(lits[i]);
   }
   code.push(CodeOp::getSuccess(cl));
 
-  cctx.deinit(this);
+  compiler.updateCodeTree(this);
 
   incorporate(code);
   ASS(code.isEmpty());
@@ -149,15 +146,10 @@ void ClauseCodeTree::optimizeLiteralOrder(DArray<Literal*>& lits)
 
 void ClauseCodeTree::evalSharing(Literal* lit, CodeOp* startOp, size_t& sharedLen, size_t& unsharedLen, CodeOp*& nextOp)
 {
-  static CodeStack code;
-  static CompileContext cctx;
+  CodeStack code;
+  LitCompiler compiler(code);
 
-  code.reset();
-  cctx.init();
-
-  compileTerm(lit, code, cctx, true);
-
-  cctx.deinit(this, true);
+  compiler.handleTerm(lit);
 
   matchCode(code, startOp, sharedLen, nextOp);
 

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -303,6 +303,8 @@ CodeTree::CodeOp CodeTree::CodeOp::getLitEnd(ILStruct* ils)
   CodeOp res;
   res.setAlternative(0);
   res._setData(ils);
+  // order matters
+  res._setInstruction(LIT_END);
   ASS(res.isLitEnd());
   return res;
 }

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -683,6 +683,8 @@ void CodeTree::Compiler<forLits>::updateCodeTree(CodeTree* tree)
 template<bool forLits>
 void CodeTree::Compiler<forLits>::handleTerm(const Term* trm)
 {
+  ASS(!forLits || trm->isLiteral());
+
   static Stack<unsigned> globalCounterparts;
   globalCounterparts.reset();
 

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -292,7 +292,6 @@ CodeTree::CodeOp CodeTree::CodeOp::getLitEnd(ILStruct* ils)
   CodeOp res;
   res.setAlternative(0);
   res._setData(ils);
-  // order matters
   res._setInstruction(LIT_END);
   ASS(res.isLitEnd());
   return res;
@@ -334,11 +333,10 @@ bool CodeTree::CodeOp::equalsForOpMatching(const CodeOp& o) const
     return getILS()->equalsForOpMatching(*o.getILS());
   case SUCCESS_OR_FAIL:
   case CHECK_GROUND_TERM:
-    return _data<void>()==o._data<void>();
   case CHECK_FUN:
   case ASSIGN_VAR:
   case CHECK_VAR:
-    return _instruction()==o._instruction() && _arg()==o._arg();
+    return _content==o._content;
   default:
     //SEARCH_STRUCT operations in the tree should be handled separately
     //during insertion into the code tree

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -371,19 +371,27 @@ public:
 
   typedef DHMap<unsigned,unsigned> VarMap;
 
-  /** Context for code compilation */
-  struct CompileContext
+  template<bool forLits>
+  struct Compiler
   {
-    void init();
-    void deinit(CodeTree* tree, bool discarded=false);
+    Compiler(CodeStack& code);
+    void updateCodeTree(CodeTree* tree);
 
     void nextLit();
 
+    void handleTerm(const Term* trm);
+    void handleVar(unsigned var, Stack<unsigned>* globalCounterparts = nullptr);
+    void handleSubterms(const Term* trm, Stack<unsigned>& globalCounterparts);
+
+    CodeStack& code;
     unsigned nextVarNum;
     unsigned nextGlobalVarNum;
     VarMap varMap;
     VarMap globalVarMap;
   };
+
+  using LitCompiler = Compiler<true>;
+  using TermCompiler = Compiler<false>;
 
   static CodeBlock* buildBlock(CodeStack& code, size_t cnt, ILStruct* prev);
   void incorporate(CodeStack& code);
@@ -391,7 +399,6 @@ public:
   template<SearchStruct::Kind k>
   void compressCheckOps(CodeOp* chainStart);
 
-  static void compileTerm(const Term* trm, CodeStack& code, CompileContext& cctx, bool addLitEnd);
 
   //////////// removal //////////////
 

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -209,11 +209,11 @@ public:
     inline ILStruct* getILS()
     {
       ASS(isLitEnd());
-      return _data<ILStruct>();
+      return reinterpret_cast<ILStruct*>(reinterpret_cast<uint64_t>(_data<ILStruct>()) & ~LIT_END);
     }
     inline const ILStruct* getILS() const
     {
-      return _data<ILStruct>();
+      return reinterpret_cast<ILStruct*>(reinterpret_cast<uint64_t>(_data<ILStruct>()) & ~LIT_END);
     }
 
     const SearchStruct* getSearchStruct() const;

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -124,7 +124,7 @@ public:
     unsigned depth;
     ILStruct* previous;
 
-    unsigned varCnt:31;
+    unsigned varCnt;
 
     unsigned* globalVarNumbers;
 
@@ -172,6 +172,7 @@ public:
       CodeOp res;
       res.setAlternative(0);
       res._setData(ptr);
+      res._setInstruction(SUCCESS_OR_FAIL);
       ASS(res.isSuccess());
       return res;
     }
@@ -188,8 +189,8 @@ public:
      * on some architectures, pointers are only 4-byte aligned and
      * the instruction is stored in first three bits.
      */
-    inline bool isSuccess() const { return _instruction()==SUCCESS_OR_FAIL && _data<void>(); }
-    inline bool isFail() const { return !_data<void>(); }
+    inline bool isSuccess() const { static_assert(SUCCESS_OR_FAIL==0); return _instruction()==SUCCESS_OR_FAIL && _content; }
+    inline bool isFail() const { static_assert(SUCCESS_OR_FAIL==0); return !_content; }
     inline bool isLitEnd() const { return _instruction()==LIT_END; }
     inline bool isSearchStruct() const { return _instruction()==SEARCH_STRUCT; }
     inline bool isCheckFun() const { return _instruction()==CHECK_FUN; }
@@ -203,15 +204,8 @@ public:
 
     template<class T> inline T* getSuccessResult() { ASS(isSuccess()); return _data<T>(); }
 
-    inline ILStruct* getILS()
-    {
-      ASS(isLitEnd());
-      return reinterpret_cast<ILStruct*>(reinterpret_cast<uint64_t>(_data<ILStruct>()) & ~LIT_END);
-    }
-    inline const ILStruct* getILS() const
-    {
-      return reinterpret_cast<ILStruct*>(reinterpret_cast<uint64_t>(_data<ILStruct>()) & ~LIT_END);
-    }
+    inline ILStruct* getILS() { ASS(isLitEnd()); return _data<ILStruct>(); }
+    inline const ILStruct* getILS() const { return _data<ILStruct>(); }
 
     const SearchStruct* getSearchStruct() const;
     SearchStruct* getSearchStruct();
@@ -221,7 +215,7 @@ public:
 
     inline void setAlternative(CodeOp* op) { ASS_NEQ(op, this); _alternative=op; }
 
-    void makeFail() { _setData<void>(0); }
+    void makeFail() { static_assert(SUCCESS_OR_FAIL==0); _content = 0; }
 
     friend std::ostream& operator<<(std::ostream& out, const CodeOp& op);
 
@@ -230,20 +224,23 @@ public:
       INSTRUCTION_BITS_END = INSTRUCTION_BITS_START + 3,
       ARG_BITS_START = INSTRUCTION_BITS_END,
       ARG_BITS_END = CHAR_BIT * sizeof(uint64_t),
-      DATA_BITS_START = 0,
+      DATA_BITS_START = INSTRUCTION_BITS_END,
       DATA_BITS_END = CHAR_BIT * sizeof(void *);
 
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
     static_assert(SEARCH_STRUCT < 8, "must be able to squash instructions into 3 bits");
-    static_assert(alignof(Term) == 8);
 
     // getters and setters
     BITFIELD64_GET_AND_SET(unsigned, instruction, Instruction, INSTRUCTION)
     BITFIELD64_GET_AND_SET(unsigned, arg, Arg, ARG)
-    template<class T> T* _data() const
-    { return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(this->_content)); }
-    template<class T> void _setData(T* data)
-    { BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(this->_content, reinterpret_cast<uint64_t>(data)); }
+    template<class T> T* _data() const {
+      static_assert(alignof(T)>SEARCH_STRUCT);
+      return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(this->_content));
+    }
+    template<class T> void _setData(T* data) {
+      static_assert(alignof(T)>SEARCH_STRUCT);
+      BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(this->_content, reinterpret_cast<uint64_t>(data));
+    }
     // end bitfield
 
   private:

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -124,10 +124,7 @@ public:
     unsigned depth;
     ILStruct* previous;
 
-    unsigned isVarEqLit:1;
     unsigned varCnt:31;
-
-    TermList varEqLitSort; // at least in the non-polymorphic case a (64-bit) TermList could be replaced by a (32-bit) unsigned sort.term()->getId()
 
     unsigned* globalVarNumbers;
 

--- a/Indexing/CodeTreeInterfaces.hpp
+++ b/Indexing/CodeTreeInterfaces.hpp
@@ -70,6 +70,7 @@ class CodeTreeSubsumptionIndex
 : public Index
 {
 public:
+  ClauseCodeTree* getClauseCodeTree() { return &_ct; }
 protected:
   void handleClause(Clause* c, bool adding) override;
 private:

--- a/Indexing/TermCodeTree.cpp
+++ b/Indexing/TermCodeTree.cpp
@@ -59,11 +59,10 @@ void TermCodeTree<Data>::insert(Data* data)
   }
   else {
     ASS(t.isTerm());
-    
-    static CompileContext cctx;
-    cctx.init();
-    compileTerm(t.term(), code, cctx, false);
-    cctx.deinit(this);
+
+    TermCompiler compiler(code);
+    compiler.handleTerm(t.term());
+    compiler.updateCodeTree(this);
   }
 
   code.push(CodeOp::getSuccess(data));

--- a/Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
+++ b/Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file CodeTreeForwardSubsumptionAndResolution.cpp
+ * Implements class CodeTreeForwardSubsumptionAndResolution.
+ */
+
+#include "Saturation/SaturationAlgorithm.hpp"
+#include "Shell/Statistics.hpp"
+
+#include "Inferences/CodeTreeForwardSubsumptionAndResolution.hpp"
+
+namespace Inferences {
+
+void CodeTreeForwardSubsumptionAndResolution::attach(SaturationAlgorithm *salg)
+{
+  ForwardSimplificationEngine::attach(salg);
+  auto index = static_cast<CodeTreeSubsumptionIndex*>(
+    _salg->getIndexManager()->request(FW_SUBSUMPTION_CODE_TREE));
+  _ct = index->getClauseCodeTree();
+}
+
+void CodeTreeForwardSubsumptionAndResolution::detach()
+{
+  _ct = nullptr;
+  _salg->getIndexManager()->release(FW_SUBSUMPTION_CODE_TREE);
+  ForwardSimplificationEngine::detach();
+}
+
+bool CodeTreeForwardSubsumptionAndResolution::perform(Clause *cl, Clause *&replacement, ClauseIterator &premises)
+{
+  if (_ct->isEmpty()) {
+    return false;
+  }
+
+  static ClauseCodeTree::ClauseMatcher cm;
+
+  cm.init(_ct, cl, _subsumptionResolution);
+
+  Clause* resultCl;
+  int resolvedQueryLit;
+
+  while ((resultCl = cm.next(resolvedQueryLit))) {
+    if (resolvedQueryLit == -1) {
+      premises = pvi(getSingletonIterator(resultCl));
+      env.statistics->forwardSubsumed++;
+      cm.reset();
+      return true;
+    }
+
+    LiteralStack res;
+    for (unsigned i = 0; i < cl->length(); i++) {
+      if (i == resolvedQueryLit) {
+        continue;
+      }
+      res.push((*cl)[i]);
+    }
+    replacement = Clause::fromStack(res, SimplifyingInference2(InferenceRule::SUBSUMPTION_RESOLUTION, cl, resultCl));
+    premises = pvi(getSingletonIterator(resultCl));
+    env.statistics->forwardSubsumptionResolution++;
+    cm.reset();
+    return true;
+  }
+
+  cm.reset();
+  return false;
+}
+
+} // namespace Inferences

--- a/Inferences/CodeTreeForwardSubsumptionAndResolution.hpp
+++ b/Inferences/CodeTreeForwardSubsumptionAndResolution.hpp
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file CodeTreeForwardSubsumptionAndResolution.hpp
+ * Defines class CodeTreeForwardSubsumptionAndResolution.
+ */
+
+#ifndef __CodeTreeForwardSubsumptionAndResolution__
+#define __CodeTreeForwardSubsumptionAndResolution__
+
+#include "Inferences/InferenceEngine.hpp"
+#include "Indexing/CodeTreeInterfaces.hpp"
+
+namespace Inferences {
+
+class CodeTreeForwardSubsumptionAndResolution
+  : public ForwardSimplificationEngine
+{
+public:
+  CodeTreeForwardSubsumptionAndResolution(bool subsumptionResolution) : _subsumptionResolution(subsumptionResolution) {}
+
+  void attach(Saturation::SaturationAlgorithm *salg) override;
+  void detach() override;
+
+  bool perform(Kernel::Clause *cl,
+               Kernel::Clause *&replacement,
+               Kernel::ClauseIterator &premises) override;
+
+private:
+  bool _subsumptionResolution;
+  Indexing::ClauseCodeTree* _ct;
+};
+
+}; // namespace Inferences
+
+#endif /* __CodeTreeForwardSubsumptionAndResolution__ */

--- a/Kernel/FlatTerm.cpp
+++ b/Kernel/FlatTerm.cpp
@@ -64,8 +64,18 @@ size_t FlatTerm::getEntryCount(Term* t)
 {
   //FUNCTION_ENTRY_COUNT entries per function and one per variable
   if (t->isLiteral() && static_cast<Literal*>(t)->isEquality()) {
+    // we add the type to the flat term for equalities as an extra,
+    // which requires some additional calculation
     auto sort = SortHelper::getEqualityArgumentSort(static_cast<Literal*>(t));
-    return (t->weight()+1)*FUNCTION_ENTRY_COUNT-(FUNCTION_ENTRY_COUNT-1)*(t->isTwoVarEquality()?t->numVarOccs():(t->numVarOccs()+(sort.isVar()?1:sort.term()->numVarOccs())));
+    unsigned numVarOccs = t->numVarOccs();
+    if (!t->isTwoVarEquality()) {
+      // in case of non-two-var equalities, the variables in
+      // the type are not counted by Term::numVarOccs
+      numVarOccs += sort.isVar() ? 1 : sort.term()->numVarOccs();
+    }
+    // the weight is corrected to be conservative in the
+    // monomorphic case, we uncorrect it by adding 1
+    return (t->weight()+1)*FUNCTION_ENTRY_COUNT-(FUNCTION_ENTRY_COUNT-1)*numVarOccs;
   }
   return t->weight()*FUNCTION_ENTRY_COUNT-(FUNCTION_ENTRY_COUNT-1)*t->numVarOccs();
 }

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -105,6 +105,23 @@ public:
 private:
   static size_t getEntryCount(Term* t);
 
+  static inline void pushVar(FlatTerm* ft, size_t& position, unsigned var) {
+    (*ft)[position++] = Entry(VAR, var);
+  }
+  static inline void pushTerm(FlatTerm* ft, size_t& position, Term* t) {
+    (*ft)[position++] = Entry(FUN, t->functor());
+    (*ft)[position++] = Entry(t);
+    (*ft)[position++] = Entry(FUN_RIGHT_OFS, getEntryCount(t));
+  }
+  static inline void pushTermList(FlatTerm* ft, size_t& position, TermList t) {
+    if (t.isVar()) {
+      pushVar(ft, position, t.var());
+    } else {
+      ASS(t.isTerm());
+      pushTerm(ft, position, t.term());
+    }
+  }
+
   FlatTerm(size_t length);
   void* operator new(size_t,unsigned length);
 

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -17,6 +17,7 @@
 #define __FlatTerm__
 
 #include "Forwards.hpp"
+#include "Term.hpp"
 
 namespace Kernel {
 
@@ -99,7 +100,7 @@ public:
 
   void swapCommutativePredicateArguments();
   void changeLiteralPolarity()
-  { _data[0]._setNumber(_data[0]._number()^1); }
+  { _data[0]._setNumber(_data[0]._number()^1); _data[1]._setTerm(Literal::complementaryLiteral(static_cast<Literal*>(_data[1]._term()))); }
 
 private:
   static size_t getEntryCount(Term* t);

--- a/Makefile
+++ b/Makefile
@@ -238,6 +238,7 @@ VINF_OBJ=Inferences/BackwardDemodulation.o\
          Inferences/BackwardSubsumptionAndResolution.o\
          Inferences/BackwardSubsumptionDemodulation.o\
          Inferences/BinaryResolution.o\
+         Inferences/CodeTreeForwardSubsumptionAndResolution.o\
          Inferences/Condensation.o\
          Inferences/DemodulationHelper.o\
          Inferences/DistinctEqualitySimplifier.o\

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -52,6 +52,7 @@
 #include "Inferences/BackwardSubsumptionAndResolution.hpp"
 #include "Inferences/BackwardSubsumptionDemodulation.hpp"
 #include "Inferences/BinaryResolution.hpp"
+#include "Inferences/CodeTreeForwardSubsumptionAndResolution.hpp"
 #include "Inferences/EqualityFactoring.hpp"
 #include "Inferences/EqualityResolution.hpp"
 #include "Inferences/BoolEqToDiseq.hpp"
@@ -1603,13 +1604,21 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if (opt.forwardSubsumption()) {
-    if (opt.forwardSubsumptionResolution()) {
-      ForwardSubsumptionAndResolution* fwd = new ForwardSubsumptionAndResolution(true);
-      res->addForwardSimplifierToFront(fwd);
-    }
-    else {
-      ForwardSubsumptionAndResolution* fwd = new ForwardSubsumptionAndResolution(false);
-      res->addForwardSimplifierToFront(fwd);
+    if (opt.codeTreeSubsumption()) {
+      if (prb.getProperty()->hasPolymorphicSym()) {
+        USER_ERROR("Code tree subsumption does not work with polymorphism!");
+      }
+      if (opt.forwardSubsumptionResolution()) {
+        res->addForwardSimplifierToFront(new CodeTreeForwardSubsumptionAndResolution(true));
+      } else {
+        res->addForwardSimplifierToFront(new CodeTreeForwardSubsumptionAndResolution(false));
+      }
+    } else {
+      if (opt.forwardSubsumptionResolution()) {
+        res->addForwardSimplifierToFront(new ForwardSubsumptionAndResolution(true));
+      } else {
+        res->addForwardSimplifierToFront(new ForwardSubsumptionAndResolution(false));
+      }
     }
   }
   else if (opt.forwardSubsumptionResolution()) {

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1605,20 +1605,9 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
 
   if (opt.forwardSubsumption()) {
     if (opt.codeTreeSubsumption()) {
-      if (prb.getProperty()->hasPolymorphicSym()) {
-        USER_ERROR("Code tree subsumption does not work with polymorphism!");
-      }
-      if (opt.forwardSubsumptionResolution()) {
-        res->addForwardSimplifierToFront(new CodeTreeForwardSubsumptionAndResolution(true));
-      } else {
-        res->addForwardSimplifierToFront(new CodeTreeForwardSubsumptionAndResolution(false));
-      }
+      res->addForwardSimplifierToFront(new CodeTreeForwardSubsumptionAndResolution(opt.forwardSubsumptionResolution()));
     } else {
-      if (opt.forwardSubsumptionResolution()) {
-        res->addForwardSimplifierToFront(new ForwardSubsumptionAndResolution(true));
-      } else {
-        res->addForwardSimplifierToFront(new ForwardSubsumptionAndResolution(false));
-      }
+      res->addForwardSimplifierToFront(new ForwardSubsumptionAndResolution(opt.forwardSubsumptionResolution()));
     }
   }
   else if (opt.forwardSubsumptionResolution()) {

--- a/Shell/ConditionalRedundancyHandler.cpp
+++ b/Shell/ConditionalRedundancyHandler.cpp
@@ -104,7 +104,7 @@ private:
   Clause* _cl;
 #endif
 
-  void insert(const TermStack& ts, void* ptr)
+  void insert(const TermStack& ts, ConditionalRedundancyEntry* ptr)
   {
     CodeStack code;
     TermCompiler compiler(code);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -492,6 +492,13 @@ void Options::init()
     _tweeGoalTransformation.setExperimental();
     _lookup.insert(&_tweeGoalTransformation);
 
+    _codeTreeSubsumption = BoolOptionValue("code_tree_subsumption", "cts", false);
+    _codeTreeSubsumption.description =
+      "Use code tree implementation of forward subsumption and subsumption resolution.";
+    _codeTreeSubsumption.tag(OptionTag::INFERENCES);
+    _codeTreeSubsumption.setExperimental();
+    _lookup.insert(&_codeTreeSubsumption);
+
     _generalSplitting = BoolOptionValue("general_splitting","gsp",false);
     _generalSplitting.description=
     "Splits clauses in order to reduce number of different variables in each clause. "

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2182,6 +2182,7 @@ public:
   FunctionDefinitionElimination functionDefinitionElimination() const { return _functionDefinitionElimination.actualValue; }
   unsigned functionDefinitionIntroduction() const { return _functionDefinitionIntroduction.actualValue; }
   TweeGoalTransformation tweeGoalTransformation() const { return _tweeGoalTransformation.actualValue; }
+  bool codeTreeSubsumption() const { return _codeTreeSubsumption.actualValue; }
   bool outputAxiomNames() const { return _outputAxiomNames.actualValue; }
   void setOutputAxiomNames(bool newVal) { _outputAxiomNames.actualValue = newVal; }
   QuestionAnsweringMode questionAnswering() const { return _questionAnswering.actualValue; }
@@ -2491,6 +2492,7 @@ private:
   ChoiceOptionValue<FunctionDefinitionElimination> _functionDefinitionElimination;
   UnsignedOptionValue _functionDefinitionIntroduction;
   ChoiceOptionValue<TweeGoalTransformation> _tweeGoalTransformation;
+  BoolOptionValue _codeTreeSubsumption;
 
   BoolOptionValue _generalSplitting;
   BoolOptionValue _globalSubsumption;


### PR DESCRIPTION
Revival of code tree subsumption. The following fixes were necessary:
- Flat term size calculation was off for polymorphic equalities.
- `LIT_END` was not set properly in the code tree for `ILStruct` objects.
- Added equality type uniformly at the start of all equalities in `FlatTerm` and `CodeStack` to avoid unsoundness in the two-variable equality case. Some refactors were necessary to do this cleanly.

Debug tests were run, so far no assrtion violations. Correctness checks have been performed with the current SAT subsumption, showing that there is (i) no unsoundness, but (ii) code tree subsumption cannot detect set-based subsumption resolution, only multiset-based.

The final experimental data:

|  | master | regression | codetree |
|--------|--------|--------|--------|
| discount | 9981 (47) | 9981 (47) | 10150 (216) |
| otter | 9720 (42) | 9720 (43) | 9967 (289) | 

In parentheses the number of uniques are shown of master to codetree, regression to codetree and codetree to master, respectively.