### PR TITLE
Add `-DREV_COUNT=OFF` build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -913,6 +913,7 @@ endif() # COMPILE_TESTS
 # automated generation of Vampire revision information from git #
 #################################################################
 set(VAMPIRE_VERSION_NUMBER 4.9)
+option(REV_COUNT "Add Git revision count to binary name" ON)
 
 execute_process(
     COMMAND git rev-parse --is-inside-work-tree
@@ -936,16 +937,20 @@ if (GIT_IS_REPOSITORY STREQUAL true)
     OUTPUT_VARIABLE GIT_BRANCH
     OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-
-  execute_process(
-    COMMAND git rev-list HEAD --count
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_REV_COUNT
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
   set(VAMPIRE_BINARY_BRANCH "_${GIT_BRANCH}")
-  set(VAMPIRE_BINARY_REV_COUNT "_${GIT_REV_COUNT}")
+
+  if(REV_COUNT)
+    execute_process(
+      COMMAND git rev-list HEAD --count
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_REV_COUNT
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    set(VAMPIRE_BINARY_REV_COUNT "_${GIT_REV_COUNT}")
+  else()
+    set(VAMPIRE_BINARY_REV_COUNT "")
+  endif()
+
 endif()
 
 ################################################################


### PR DESCRIPTION
This PR adds a `-DREV_COUNT=OFF` build option to prevent the addition of the Git revision count to the Vampire binary name. That solves 2 problems with the current setup that attaches a revision count:

1. I cannot do a `vampire_latest` symbolic link because the Vampire binary name keeps changing with every commit.
2. The Vampire binaries start accumulating in the `bin/` directory. At 14M per binary, they are not exactly small.

This PR solves the above problems without the hassle of a post-build script. If I wanted to know what commit a binary is at, apparently I can just use `--version`.