### PR TITLE
raise USER_ERROR on undeclared type constructor

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -3257,10 +3257,12 @@ TermList TPTP::createTypeConApplication(std::string name, unsigned arity)
 { 
   ASS_GE(_termLists.size(), arity);
 
-  bool dummy;
+  bool added = false;
   //TODO not checking for overflown constant. Is that OK?
   //seems to be done this way for predicates as well.
-  unsigned typeCon = env.signature->addTypeCon(name,arity,dummy);
+  unsigned typeCon = env.signature->addTypeCon(name,arity,added);
+  if(added)
+    USER_ERROR("Undeclared type constructor ", name, "/", arity);
 
   auto args = nLastTermLists(arity);
   for (auto i : range(0, arity)) {


### PR DESCRIPTION
@quickbeam123 - refer e-mail chain with Geoff. Now raises an error if a TFF type constructor is used before it is declared.

Minimal example:

```prolog
% tff(set_type, type, set : $tType).
tff(member_type, type, member : set).
```