### PR TITLE
Polymorphism + Arithmetic

### DIFF
--- a/Kernel/Polynomial.cpp
+++ b/Kernel/Polynomial.cpp
@@ -11,6 +11,7 @@
 
 #include "Kernel/Polynomial.hpp"
 #include "Kernel/PolynomialNormalizer.hpp"
+#include "Debug/Output.hpp"
 
 #define DEBUG(...) // DBG(__VA_ARGS__)
 
@@ -47,7 +48,7 @@ std::ostream& operator<<(std::ostream& out, const Variable& self)
 // impl FuncId
 /////////////////////////////////////////////////////////
 
-FuncId::FuncId(unsigned num, const TermList* typeArgs) : _num(num) /*, _typeArgs(typeArgs)*/ {}
+FuncId::FuncId(unsigned num, const TermList* typeArgs) : _num(num), _typeArgs(typeArgs) {}
 
 FuncId FuncId::symbolOf(Term* term) 
 { return FuncId(term->functor(), term->typeArgs()); }
@@ -55,14 +56,14 @@ FuncId FuncId::symbolOf(Term* term)
 unsigned FuncId::numTermArguments() 
 { return symbol()->numTermArguments(); }
 
-bool operator==(FuncId const& lhs, FuncId const& rhs) 
-{ return lhs._num == rhs._num; }
-
-bool operator!=(FuncId const& lhs, FuncId const& rhs) 
-{ return !(lhs == rhs); }
-
 std::ostream& operator<<(std::ostream& out, const FuncId& self) 
-{ return out << self.symbol()->name(); }
+{ 
+  if (self.numTypeArgs() == 0) {
+    return out << self.symbol()->name(); 
+  } else {
+    return out << self.symbol()->name() << "<" << outputInterleaved(", ", self.iterTypeArgs())  << ">"; 
+  }
+}
 
 Signature::Symbol* FuncId::symbol() const 
 { return env.signature->getFunction(_num); }

--- a/Kernel/Polynomial.hpp
+++ b/Kernel/Polynomial.hpp
@@ -38,6 +38,7 @@
 #include "Kernel/NumTraits.hpp"
 #include "Kernel/Ordering.hpp"
 #include "Kernel/TypedTermList.hpp"
+#include "Lib/Reflection.hpp"
 #include <type_traits>
 
 #define DEBUG(...) // DBG(__VA_ARGS__)
@@ -76,17 +77,18 @@ namespace Kernel {
 class FuncId 
 {
   unsigned _num;
-  // const TermList* _typeArgs; // private field not used
+  const TermList* _typeArgs;
   
 public: 
   explicit FuncId(unsigned num, const TermList* typeArgs);
   static FuncId symbolOf(Term* term);
   unsigned numTermArguments();
+  TermList typeArg(unsigned i) const { return *(_typeArgs - i); }
+  unsigned numTypeArgs() const { return env.signature->getFunction(_num)->numTypeArguments(); }
 
-  friend struct std::hash<FuncId>;
-  friend bool operator==(FuncId const& lhs, FuncId const& rhs);
-  friend bool operator!=(FuncId const& lhs, FuncId const& rhs);
   friend std::ostream& operator<<(std::ostream& out, const FuncId& self);
+  auto iterTypeArgs() const 
+  { return range(0, numTypeArgs()).map([&](auto i) { return typeArg(i); }); }
 
   Signature::Symbol* symbol() const;
 
@@ -97,16 +99,13 @@ public:
 
   template<class Number>
   Option<typename Number::ConstantType> tryNumeral() const;
+  
+  auto asTuple() const { return std::tuple(_num, iterContOps(iterTypeArgs())); }
+  IMPL_COMPARISONS_FROM_TUPLE(FuncId)
+  IMPL_HASH_FROM_TUPLE(FuncId)
 };
 
 } // namespace Kernel
-
-
-template<> struct std::hash<Kernel::FuncId> 
-{
-  size_t operator()(Kernel::FuncId const& f) const 
-  { return std::hash<unsigned>{}(f._num); }
-};
 
 
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -621,7 +620,7 @@ Option<typename Number::ConstantType> FuncTerm::tryNumeral() const
 template<> struct std::hash<Kernel::FuncTerm> 
 {
   size_t operator()(Kernel::FuncTerm const& f) const 
-  { return Lib::HashUtils::combine(std::hash<Kernel::FuncId>{}(f._fun), std::hash<Stack<Kernel::PolyNf>>{}(f._args));  }
+  { return Lib::HashUtils::combine(f._fun.defaultHash(), std::hash<Stack<Kernel::PolyNf>>{}(f._args));  }
 };
 
 /////////////////////////////////////////////////////////

--- a/Kernel/PolynomialNormalizer.cpp
+++ b/Kernel/PolynomialNormalizer.cpp
@@ -11,7 +11,7 @@
 #include "PolynomialNormalizer.hpp"
 #include "Kernel/BottomUpEvaluation.hpp"
 
-#define DEBUG(...) //DBG(__VA_ARGS__)
+#define DEBUG(...) // DBG(__VA_ARGS__)
 
 namespace Kernel {
 
@@ -363,7 +363,12 @@ TermList PolyNf::denormalize() const
     .function(
         [&](PolyNf orig, TermList* results) -> TermList
         { return orig.match(
-            [&](Perfect<FuncTerm> t) { return TermList(Term::create(t->function().id(), t->numTermArguments(), results)); },
+            [&](Perfect<FuncTerm> t) { 
+            return TermList(Term::createFromIter(t->function().id(), 
+                concatIters(
+                  t->function().iterTypeArgs(),
+                  range(0, t->numTermArguments()).map([&](auto i){ return results[i]; })
+                ))); },
             [&](Variable          v) { return TermList::var(v.id()); },
             [&](AnyPoly           p) { return p.denormalize(results); }
             ); })


### PR DESCRIPTION
Fixes compatibility issue of polymorphism and arithmetic operations.

The problem was that in polynomial normalization the type argument information was not carried around.
Also updates BottomUpEvaluation to allow for optionally ignore or not ignore type arguments in the bottom-up traversal.