### PR TITLE
Remove clauses with multiple answer literals (for -qa synthesis)

### DIFF
--- a/Inferences/InvalidAnswerLiteralRemovals.cpp
+++ b/Inferences/InvalidAnswerLiteralRemovals.cpp
@@ -31,6 +31,23 @@ Clause* UncomputableAnswerLiteralRemoval::simplify(Clause* cl)
   return cl;
 }
 
+Clause* MultipleAnswerLiteralRemoval::simplify(Clause* cl)
+{
+  unsigned cLen = cl->length();
+  bool found = false;
+  for (unsigned li = 0; li < cLen; li++) {
+    Literal* lit = (*cl)[li];
+    if (lit->isAnswerLiteral()) {
+      if (found) {
+        return nullptr;
+      } else {
+        found = true;
+      }
+    }
+  }
+  return cl;
+}
+
 UndesiredAnswerLiteralRemoval::UndesiredAnswerLiteralRemoval(const std::string& avoidThese)
 {
   // TODO: catch parsing exceptions and complain properly

--- a/Inferences/InvalidAnswerLiteralRemovals.hpp
+++ b/Inferences/InvalidAnswerLiteralRemovals.hpp
@@ -32,6 +32,17 @@ public:
 };
 
 /*
+* Removes clauses containing multiple answer literals,
+* which is not allowed in program synthesis.
+*/
+class MultipleAnswerLiteralRemoval
+: public ImmediateSimplificationEngine
+{
+public:
+  Clause* simplify(Clause* cl) override;
+};
+
+/*
 * Removes clauses containing answer literals that
 * the user specified should be avoided.
 */

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1764,6 +1764,7 @@ ImmediateSimplificationEngine *SaturationAlgorithm::createISE(Problem& prb, cons
     }
   } else if (env.options->questionAnswering() == Options::QuestionAnsweringMode::SYNTHESIS) {
     res->addFront(new UncomputableAnswerLiteralRemoval());
+    res->addFront(new MultipleAnswerLiteralRemoval());
   }
   return res;
 }


### PR DESCRIPTION
In synthesis, we rely on all clauses containing at most 1 answer literal. This inference removes the clauses that contain multiple answer literals.