### PR TITLE
Configure version.cpp at build time if git repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -916,20 +916,24 @@ execute_process(
     )
 
 if (GIT_IS_REPOSITORY STREQUAL true)
-  # GIT_COMMIT_DESCRIPTION used by version.cpp.in
-  execute_process(
-    COMMAND git log -1 --format=%h\ on\ %ci
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_COMMIT_DESCRIPTION
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
+  # VAMPIRE_VERSION_NUMBER and CMAKE_BUILD_TYPE used by version.cpp.in through
+  # ConfigureGitVersionCpp.cmake
+  add_custom_target(update_git_version ALL
+    COMMAND cmake -DVAMPIRE_SOURCE_DIR=${CMAKE_SOURCE_DIR}
+                  -DVAMPIRE_VERSION_NUMBER=${VAMPIRE_VERSION_NUMBER}
+                  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+                  -P ${CMAKE_SOURCE_DIR}/ConfigureGitVersionCpp.cmake
+    BYPRODUCTS version.cpp
+    VERBATIM
+    )
+else()
+  configure_file(version.cpp.in version.cpp)
 endif()
 
 ################################################################
 # epilogue
 ################################################################
 add_executable(vampire vampire.cpp $<TARGET_OBJECTS:obj>)
-configure_file(version.cpp.in version.cpp)
 
 # enable IPO
 if(CMAKE_BUILD_TYPE STREQUAL Release AND IPO)

--- a/ConfigureGitVersionCpp.cmake
+++ b/ConfigureGitVersionCpp.cmake
@@ -1,0 +1,8 @@
+# GIT_COMMIT_DESCRIPTION used by version.cpp.in
+execute_process(
+  COMMAND git log -1 --format=%h\ on\ %ci
+  WORKING_DIRECTORY ${VAMPIRE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_COMMIT_DESCRIPTION
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+configure_file(${VAMPIRE_SOURCE_DIR}/version.cpp.in version.cpp)


### PR DESCRIPTION
As per https://github.com/vprover/vampire/pull/610#issuecomment-2371012934, this PR makes the `version.cpp.in` transformation happen at build time rather than configure time if the Vampire source folder is from git (i.e. there is a proper `.git` subdirectory), thus ensuring that the git version number in `vampire ‑‑version` is always updated even if one forgets to do `cmake ..` before `make`.

I think I have tested this comprehensively, but there might be a sequence of:

1. moving the git HEAD commit; and/or
2. `cmake ..`; and/or
3. `make`

that results in unexpected behavior. Please inform me if that's the case!

References:
1. https://cmake.org/pipermail/cmake/2012-May/050227.html for the `cmake -P` solution.
2. https://stackoverflow.com/a/43206544 for the `add_custom_target` solution.
