### PR TITLE
simplify GlobalSubsumptionGrounder interface

### DIFF
--- a/Indexing/GroundingIndex.cpp
+++ b/Indexing/GroundingIndex.cpp
@@ -34,7 +34,7 @@ using namespace std;
 GroundingIndex::GroundingIndex(const Options& opt)
 {
   _solver = new MinisatInterfacing(opt,true);
-  _grounder = new Kernel::GlobalSubsumptionGrounder(_solver.ptr());
+  _grounder = new Kernel::GlobalSubsumptionGrounder(*_solver);
 }
 
 void GroundingIndex::handleClause(Clause* c, bool adding)

--- a/Inferences/GlobalSubsumption.cpp
+++ b/Inferences/GlobalSubsumption.cpp
@@ -89,7 +89,7 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
     return cl;
   }
 
-  Grounder& grounder = _index->getGrounder();
+  GlobalSubsumptionGrounder &grounder = _index->getGrounder();
 
   // SAT literals of the prop. abstraction of cl
   static SATLiteralStack plits;

--- a/Kernel/Grounder.hpp
+++ b/Kernel/Grounder.hpp
@@ -18,73 +18,57 @@
 #include "Forwards.hpp"
 
 #include "Lib/DHMap.hpp"
-#include "Lib/ScopedPtr.hpp"
-#include "Lib/SmartPtr.hpp"
-
-#include "Kernel/Term.hpp"
 
 namespace Kernel {
 
 using namespace Lib;
 using namespace SAT;
 
-class Grounder {
+class GlobalSubsumptionGrounder {
+  struct OrderNormalizingComparator;
+
 public:
-  Grounder(SATSolver* satSolver) : _satSolver(satSolver) {}
-  virtual ~Grounder() {}
+  GlobalSubsumptionGrounder(SATSolver &satSolver) : _satSolver(satSolver) {}
 
-  // TODO: sort out the intended semantics and the names of these four beasts:
-  SATLiteral groundLiteral(Literal* lit);
-  SATClause* ground(Clause* cl);
-  SATClause* groundNonProp(Clause* cl, Literal** normLits=0);
-  void groundNonProp(Clause* cl, SATLiteralStack& acc, Literal** normLits=0);
+  /**
+   * Return SATClause that is a result of grounding of the
+   * non-propositional part of @c cl.
+   *
+   * The order of literals in @c cl is preserved.
+   *
+   * @param cl the clause
+   * @param acc previously accumulated literals
+   */
+  void groundNonProp(Clause* cl, SATLiteralStack& acc);
 
-  LiteralIterator groundedLits();
-
-protected:
+private:
   /**
    * Normalize literals before grounding.
    *
    * The order of literals in @c lits must be preserved.
    */
-  virtual void normalize(unsigned cnt, Literal** lits) = 0;
+  void normalize(unsigned cnt, Literal** lits);
 
-private:
+  /**
+   * Return SATLiteral corresponding to @c lit.
+   */
+  SATLiteral groundLiteral(Literal* lit);
+
+  /**
+   * Return SATLiteral corresponding to @c lit.
+   */
   SATLiteral groundNormalized(Literal*);
 
   /** Map from positive literals to SAT variable numbers */
   DHMap<Literal*, unsigned> _asgn;
-  
-  /** Pointer to a SATSolver instance for which the grounded clauses
+
+  /** Reference to a SATSolver instance for which the grounded clauses
    * are being prepared. Used to request new variables from the Solver.
    *
    * Also used to communicate source literals with IGGrounder. */
-  SATSolver* _satSolver;
+  SATSolver &_satSolver;
+
 };
-
-class GlobalSubsumptionGrounder : public Grounder {
-  struct OrderNormalizingComparator;
-
-  bool _doNormalization;
-public:
-  GlobalSubsumptionGrounder(SATSolver* satSolver, bool doNormalization=true) 
-          : Grounder(satSolver), _doNormalization(doNormalization) {}
-protected:
-  virtual void normalize(unsigned cnt, Literal** lits);
-};
-
-class IGGrounder : public Grounder {
-public:
-  IGGrounder(SATSolver* satSolver);
-private:
-  TermList _tgtTerm;
-protected:
-  virtual void normalize(unsigned cnt, Literal** lits);
-private:
-  class CollapsingApplicator;
-  Literal* collapseVars(Literal* lit);
-};
-
 
 }
 


### PR DESCRIPTION
I noticed in passing that some bits of `GlobalSubsumptionGrounder` are more complex than currently needed, and other bits are completely unused. Simplify.