### PR TITLE
Extended internal Time Profiling

### DIFF
--- a/Debug/TimeProfiling.cpp
+++ b/Debug/TimeProfiling.cpp
@@ -321,7 +321,7 @@ void TimeTrace::printPretty(std::ostream& out)
     node->measurements.remove(now - start);
   }
 
-  if (env.options->timeStatisticsFocus() != "") {
+  if (!env.options->timeStatisticsFocus().empty()) {
     out <<                                                  std::endl;
 
     auto focus = root.focus(env.options->timeStatisticsFocus().c_str());

--- a/Debug/TimeProfiling.cpp
+++ b/Debug/TimeProfiling.cpp
@@ -14,6 +14,7 @@
 #include <iomanip>
 #include <cstring>
 #include "Shell/Options.hpp"
+#include "Lib/Environment.hpp"
 
 namespace Shell {
 
@@ -182,9 +183,15 @@ void TimeTrace::Node::printPrettyRec(std::ostream& out, NodeFormatOpts& opts)
   }
   out << name << right;
 
-  out << " (total: "<< msetw(4) << total
-      << ", avg: "  << msetw(4) << total / cnt
-      << ", cnt: "  << msetw(6) << cnt
+
+  out << " (total: "<< msetw(4) << total;
+  out << ", avg: "  << msetw(4);
+  if (cnt == 0) {
+    out << "NaN";
+  } else {
+    out << total / cnt;
+  }
+  out << ", cnt: "  << msetw(6) << cnt
       << ")" << std::endl;
   std::sort(children.begin(), children.end(), [](auto& l, auto& r) { return l->totalDuration() > r->totalDuration(); });
   indent.push(indentBeforeLast);
@@ -211,6 +218,50 @@ TimeTrace::Node TimeTrace::Node::flatten()
   auto root = Node(name);
   root.children = std::move(s.nodes);
   root.measurements = measurements;
+  return root;
+}
+
+TimeTrace::Node TimeTrace::Node::clone() const 
+{
+  auto out = Node(name);
+  out.measurements = measurements;
+  out.children = iterTraits(children.iter())
+      .map([](auto& c) { return make_unique<TimeTrace::Node>(c->clone()); })
+      .template collect<Stack>();
+  return out;
+}
+
+void TimeTrace::Node::_focus(const char* name, Node& newRoot)
+{
+  if (strcmp(this->name,  name) == 0) {
+    newRoot.extendWith(*this);
+  } else {
+    for (auto& c : this->children) {
+      c->_focus(name, newRoot);
+    }
+  }
+}
+
+void TimeTrace::Node::extendWith(TimeTrace::Node const& other)
+{
+  ASS(strcmp(other.name, name) == 0)
+  measurements.extend(other.measurements);
+  for (auto& c : other.children) {
+    auto node_ = iterTraits(this->children.iter())
+      .find([&](auto& n) { return n->name == c->name; });
+    if (node_.isSome()) {
+      node_.unwrap()->extendWith(*c);
+    } else {
+      this->children.push(make_unique<TimeTrace::Node>(c->clone()));
+    }
+  }
+}
+
+TimeTrace::Node TimeTrace::Node::focus(const char* name)
+{
+  FlattenState s;
+  auto root = Node(name);
+  _focus(name, root);
   return root;
 }
 
@@ -268,6 +319,21 @@ void TimeTrace::printPretty(std::ostream& out)
     auto node = get<0>(x);
     auto start = get<1>(x);
     node->measurements.remove(now - start);
+  }
+
+  if (env.options->timeStatisticsFocus() != "") {
+    out <<                                                  std::endl;
+
+    auto focus = root.focus(env.options->timeStatisticsFocus().c_str());
+    out << "===== start of focussed time profile =====" << std::endl;
+    rootOpts.align = false;
+    focus.printPrettyRec(out, rootOpts);
+    out << "===== end of focussed time profile =====" << std::endl;
+
+    out << "===== start of flattened focussed time profile =====" << std::endl;
+    rootOpts.align = true;
+    focus.flatten().printPrettyRec(out, rootOpts);
+    out << "===== end of flattened focussed time profile =====" << std::endl;
   }
 }
 

--- a/Debug/TimeProfiling.hpp
+++ b/Debug/TimeProfiling.hpp
@@ -142,7 +142,12 @@ private:
     void serialize(std::ostream& out);
     Duration totalDuration() const;
 
+    Node clone() const;
+
     Node flatten();
+    void _focus(const char* name, Node& newRoot);
+    Node focus(const char* name);
+    void extendWith(Node const& n);
     struct FlattenState;
     void flatten_(FlattenState&);
   };

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -380,6 +380,12 @@ void Options::init()
     _timeStatistics.description="Show how much running time was spent in each part of Vampire";
     _lookup.insert(&_timeStatistics);
     _timeStatistics.tag(OptionTag::OUTPUT);
+
+    _timeStatisticsFocus = StringOptionValue("time_statistics_focus","tstat_focus","");
+    _timeStatisticsFocus.description="focus on some special subtree of the time statistics";
+    _lookup.insert(&_timeStatisticsFocus);
+    _timeStatisticsFocus.tag(OptionTag::OUTPUT);
+    _timeStatisticsFocus.onlyUsefulWith(_timeStatistics.is(equal(true)));
 #endif // VTIME_PROFILING
 
 //*********************** Input  ***********************

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2213,6 +2213,7 @@ public:
   bool generalSplitting() const { return _generalSplitting.actualValue; }
 #if VTIME_PROFILING
   bool timeStatistics() const { return _timeStatistics.actualValue; }
+  std::string const& timeStatisticsFocus() const { return _timeStatisticsFocus.actualValue; }
 #endif // VTIME_PROFILING
   bool splitting() const { return _splitting.actualValue; }
   void setSplitting(bool value){ _splitting.actualValue=value; }
@@ -2707,7 +2708,10 @@ private:
 
   /** Time limit in deciseconds */
   TimeLimitOptionValue _timeLimitInDeciseconds;
+#if VTIME_PROFILING
   BoolOptionValue _timeStatistics;
+  StringOptionValue _timeStatisticsFocus;
+#endif // VTIME_PROFILING
 
   ChoiceOptionValue<URResolution> _unitResultingResolution;
   BoolOptionValue _unusedPredicateDefinitionRemoval;


### PR DESCRIPTION
Added the option `-tstat_focus` which displays the time trace for some subnode in the time trace tree specified as agrument. This is helpful if you want to see only the time trace of some function you are currently optimizing, and want to skip the time trace all the other functions. Also all calls in the time trace tree to this function will be merged instead of potentially having multiple disjoint subtrees with calls with this node, which also helps for getting a good understanding of the time profile of your function.