### PR TITLE
Z3 Problem Export as c++

### DIFF
--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -69,7 +69,8 @@ TheoryInstAndSimp::TheoryInstAndSimp(Options& opts) : TheoryInstAndSimp(
     opts.thiTautologyDeletion(), 
     opts.showZ3(),  
     opts.thiGeneralise(),
-    opts.exportThiProblem()
+    opts.exportThiProblem(),
+    opts.problemExportSyntax()
     ) {}
 
 
@@ -87,12 +88,12 @@ Options::TheoryInstSimp manageDeprecations(Options::TheoryInstSimp mode)
   }
 }
 
-TheoryInstAndSimp::TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, std::string const& exportSmtlib) 
+TheoryInstAndSimp::TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, std::string const& exportSmtlib, Shell::Options::ProblemExportSyntax problemExportSyntax) 
   : _splitter(0)
   , _mode(manageDeprecations(mode))
   , _thiTautologyDeletion(thiTautologyDeletion)
   , _naming()
-  , _solver(new Z3Interfacing(_naming, showZ3, /* unsatCoresForAssumptions = */ generalisation, exportSmtlib))
+  , _solver(new Z3Interfacing(_naming, showZ3, /* unsatCoresForAssumptions = */ generalisation, exportSmtlib, problemExportSyntax))
   , _generalisation(generalisation)
   , _instantiationConstants ("$inst")
   , _generalizationConstants("$inst$gen")

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -52,7 +52,7 @@ public:
   TheoryInstAndSimp(TheoryInstAndSimp&&) = default;
 
   TheoryInstAndSimp(Options& opts);
-  TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, std::string const& exportSmtlib);
+  TheoryInstAndSimp(Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, std::string const& exportSmtlib, Shell::Options::ProblemExportSyntax problemExportSyntax);
 
   void attach(SaturationAlgorithm* salg);
 

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -54,6 +54,22 @@ public:
   DivByZeroException() : ArithmeticException("divided by zero"){} 
 };
 
+enum class Sign : uint8_t {
+  Zero = 0,
+  Pos = 1,
+  Neg = 2,
+};
+
+inline std::ostream& operator<<(std::ostream& out, Sign const& self)
+{
+  switch(self) {
+    case Sign::Zero: return out << "0";
+    case Sign::Pos: return out << "+";
+    case Sign::Neg: return out << "-";
+  }
+  ASSERTION_VIOLATION
+}
+
 class IntegerConstantType
 {
 public:
@@ -99,6 +115,11 @@ public:
   bool operator<=(const IntegerConstantType& o) const { return !((*this)>o); }
 
   InnerType toInner() const { return _val; }
+
+  Sign sign() const 
+  { return _val > 0 ? Sign::Pos
+     : _val < 0 ? Sign::Neg
+     :            Sign::Zero; }
 
   bool isZero(){ return _val==0; }
   bool isNegative(){ return _val<0; }

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -12,10 +12,14 @@
  * Implements class Z3Interfacing
  */
 
+#include "Lib/Allocator.hpp"
 #if VZ3
 #define UNIMPLEMENTED ASSERTION_VIOLATION
+#define MODEL_COMPLETION true
 
 #include "Forwards.hpp"
+#include "Lib/StringUtils.hpp"
+#include "z3.h"
 
 #include "SATSolver.hpp"
 #include "SATLiteral.hpp"
@@ -37,8 +41,12 @@
 #include "Indexing/TermSharing.hpp"
 #include "Z3Interfacing.hpp"
 
-#define DEBUG(...) //DBG(__VA_ARGS__)
+#define DEBUG(...) // DBG(__VA_ARGS__)
+
 #define TRACE_Z3 0
+#define INSTANTIATE_EXPRESSIONS 0
+#define ENABLE_Z3_PROOF_GENERATION 0
+
 namespace Lib {
 using SortId = TermList;
 
@@ -66,17 +74,35 @@ struct BottomUpChildIter<z3::expr>
 
 } // namespace Lib
 
+
+auto quotient0_name(char c, z3::sort s) 
+{ return outputToString("quot-0-", c, "-", s); }
+
+auto remainder0_name(char c, z3::sort s) 
+{ return outputToString("rem-0-", c, "-", s); }
+
+template<class UInt64ToExpr>
+z3::expr int_to_z3_expr(IntegerConstantType const& val, UInt64ToExpr toExpr) {
+    auto sign = val.sign();
+    auto abs = val.abs().toInner();
+
+    static_assert(sizeof(decltype(abs)) <= sizeof(uint64_t), "unexpected inner type for integers");
+    auto res = toExpr(abs);
+    return sign == Sign::Neg ? -res : res;
+};
+
 namespace SAT
 {
 
 using namespace std;
 using namespace Shell;
 using namespace Lib;
+using ProblemExportSyntax = Shell::Options::ProblemExportSyntax;
 
 //using namespace z3;
 
-Z3Interfacing::Z3Interfacing(const Shell::Options& opts, SAT2FO& s2f, bool unsatCoresForAssumptions, std::string const& exportSmtlib):
-  Z3Interfacing(s2f, opts.showZ3(), /* unsatCoresForAssumptions = */ unsatCoresForAssumptions, exportSmtlib)
+Z3Interfacing::Z3Interfacing(const Shell::Options& opts, SAT2FO& s2f, bool unsatCore, std::string const& exportFile,Shell::Options::ProblemExportSyntax exportSyntax):
+  Z3Interfacing(s2f, opts.showZ3(), /* unsatCore */ unsatCore, exportFile, exportSyntax)
 { }
 
 const char* errToString(Z3_error_code code)
@@ -95,9 +121,117 @@ const char* errToString(Z3_error_code code)
     case Z3_INVALID_USAGE: return "Z3_INVALID_USAGE";
     case Z3_DEC_REF_ERROR: return "Z3_DEC_REF_ERROR";
     case Z3_EXCEPTION: return "Z3_EXCEPTION";
-    default: ASSERTION_VIOLATION; return "UNKNOWN ERROR";
   }
+  ASSERTION_VIOLATION; return "UNKNOWN ERROR";
 }
+
+struct Z3MkConstructorCall {
+  Z3_context c;
+  Z3_symbol name;
+  Z3_symbol tester;
+  Stack<Z3_symbol> field_names;
+  Stack<Z3_sort> sorts;
+  Stack<unsigned> sort_refs;
+
+  unsigned arity() { return field_names.size(); }
+  Z3_constructor operator()() {
+    return Z3_mk_constructor(
+        c,
+        name,
+        tester,
+        arity(),
+        field_names.begin(),
+        sorts.begin(),
+        sort_refs.begin()
+    );
+  }
+};
+
+struct Z3Constructor
+{
+  z3::func_decl func;
+  z3::func_decl tester;
+  Stack<z3::func_decl> args;
+};
+
+struct Z3Datatype
+{
+  z3::sort sort;
+  Stack<Z3Constructor> ctors;
+};
+
+struct Z3MkDatatypesCall
+{
+  std::unique_ptr<z3::context>& _context;
+  Stack<Z3_symbol> sortNames;               // <- needed for Z3_mk_datatypes(...)
+  Stack<Stack<Z3MkConstructorCall>> mkConstrs;
+
+
+  Z3MkDatatypesCall(decltype(_context) context, Stack<TermAlgebra*> const& tas)
+    : _context(context)
+    , sortNames(tas.size())
+    , mkConstrs(tas.size())
+  { }
+
+  unsigned nDtys() { return sortNames.size(); }
+
+  Stack<Z3Datatype> operator()(){
+    Array<Z3_sort> sorts;                     // <- needed for Z3_mk_datatypes(...)
+
+    /* re-arranging datat for Z3_mk_datatypes call */
+    Stack<Z3_constructor_list> z3_ctor_lists(nDtys()); // <- needed for Z3_mk_datatypes(...)
+    Stack<Stack<Z3_constructor>> ctorss;      // <- needed for Z3_query_constructor(..)
+    for (auto& mks : mkConstrs) {
+      Stack<Z3_constructor> ctors(mks.size());
+      for (auto& mkConstr : mks) {
+        ctors.push(mkConstr());
+      }
+      z3_ctor_lists.push(Z3_mk_constructor_list(*_context, ctors.size(),  ctors.begin()));
+      ctorss.push(std::move(ctors));
+    }
+
+    Z3_mk_datatypes(*_context, nDtys(), sortNames.begin(), sorts.begin(), z3_ctor_lists.begin());
+
+    /* querying result of Z3_mk_datatypes call */
+    Stack<Z3Datatype> out(nDtys());
+
+    for (unsigned i = 0; i < ctorss.size(); i++) {
+      auto sort = z3::sort(*_context, sorts[i]);
+      Stack<Z3Constructor> ctors_res(ctorss[i].size());
+      for (unsigned j = 0; j < ctorss[i].size(); j++) {
+        Z3_func_decl func;
+        Z3_func_decl tester;
+        DArray<Z3_func_decl> args(mkConstrs[i][j].arity());
+
+        Z3_query_constructor(*_context, ctorss[i][j], mkConstrs[i][j].arity(), &func, &tester, args.begin());
+
+        ctors_res.push(Z3Constructor {
+            .func   = z3::func_decl(*_context, func),
+            .tester = z3::func_decl(*_context, tester),
+            .args   = arrayIter(args)
+                         .map([&](auto arg) { return z3::func_decl(*_context, arg); })
+                         .template collect<Stack>(),
+          });
+      }
+      out.push(Z3Datatype { .sort = sort, .ctors = std::move(ctors_res), });
+    }
+
+    /* clean up */
+
+    for (auto& lst : z3_ctor_lists) {
+      Z3_del_constructor_list(*_context, lst);
+    }
+
+    for (auto& ctors : ctorss) {
+      for (auto& ctor : ctors) {
+        Z3_del_constructor(*_context, ctor);
+      }
+    }
+
+    return out;
+  }
+};
+
 
 void handleZ3Error(Z3_context ctxt, Z3_error_code code)
 {
@@ -105,19 +239,40 @@ void handleZ3Error(Z3_context ctxt, Z3_error_code code)
   throw z3::exception(errToString(code));
 }
 
-Z3Interfacing::Z3Interfacing(SAT2FO& s2f, bool showZ3, bool unsatCoresForAssumptions, std::string const& exportSmtlib):
+Z3Interfacing::Z3Interfacing(SAT2FO& s2f, bool showZ3, bool unsatCore, std::string const& exportSmtlib, Options::ProblemExportSyntax exportSyntax):
   _hasSeenArrays(false),
   _varCnt(0),
   _sat2fo(s2f),
+  _outSyntax(exportSyntax),
   _status(Status::SATISFIABLE),
-  _config(),
-  _context(_config),
-  _solver(_context),
+  _context(new z3::context()),
+  _solver(*_context),
   _model((_solver.check(), _solver.get_model())),
-  _assumptions(),
+  _assumptions([]() {
+      if (ENABLE_Z3_PROOF_GENERATION) {
+        // needs to be called before _context is initialized, therefore we call it in
+        // a closure that must be evaluated before _context is initialized
+        z3::set_param("proof", true);
+      }
+      return decltype(_assumptions)();
+      }()),
   _showZ3(showZ3),
-  _unsatCore(unsatCoresForAssumptions),
-  _out()
+  _unsatCore(unsatCore),
+  _exporter([&](){
+      using namespace ProblemExport;
+      if (exportSmtlib == "") {
+        return decltype(_exporter)(NoExport{});
+      } else {
+        std::ofstream file(exportSmtlib.c_str());
+        if (file.fail())
+          throw UserErrorException("Failed to open file: ", exportSmtlib);
+        switch (exportSyntax) {
+        case Shell::Options::ProblemExportSyntax::SMTLIB:    return decltype(_exporter)(Smtlib  (std::move(file), *_context));
+        case Shell::Options::ProblemExportSyntax::API_CALLS: return decltype(_exporter)(ApiCalls(std::move(file), *_context));
+        }
+        ASSERTION_VIOLATION
+      }
+    }())
 {
   _out = exportSmtlib == "" ? Option<std::ofstream>()
                             : Option<std::ofstream>(std::ofstream(exportSmtlib.c_str())) ;
@@ -125,31 +280,575 @@ Z3Interfacing::Z3Interfacing(SAT2FO& s2f, bool showZ3, bool unsatCoresForAssumpt
     throw UserErrorException("Failed to open file: ", exportSmtlib);
   }
 
-  _solver.reset();
-  outputln("(check-sat)");
-  outputln("(get-model)");
-  outputln("(reset)");
+  _exporter.apply([&](auto& e) { e.initialize(); });
 
-  z3::params p(_context);
-  auto setOption = [&](auto k, auto v){
-    p.set(k,v);
-    outputln(";- z3 parameter: ", k, "=", v);
-  };
-  setOption("rewriter.expand_store_eq", true);
-  setOption("model.compact", true);
+  z3_set_param("rewriter.expand_store_eq", true);
+  z3_set_param("model.completion", MODEL_COMPLETION);
+  z3_set_param("model.compact", true); // keeps z3 from compressing its model. ~50% of the runtime of get_model is spent doing that otherwise
+
   if (_unsatCore) {
-    setOption(":unsat-core", true);
+    z3_set_param(":unsat-core", true);
   }
-  // Z3_set_error_handler(_context, handleZ3Error); // MS: a handled error only reveals Z3_error_code, a propragated z3::exception is typically more informative
+  // Z3_set_error_handler(*_context, handleZ3Error); // MS: a handled error only reveals Z3_error_code, a propragated z3::exception is typically more informative
 
 #if TRACE_Z3
-  setOption("trace", "true");
-  Z3_enable_trace("memory");
-  Z3_enable_trace("datatype");
+  z3_enable_trace("arith");
 #endif // TRACE_Z3
 
-  _solver.set(p);
-  // TODO some way to serizalize the params for z3 to an smtlib file
+  for (auto c : { 'f', 't' }) {
+    for (auto s : { _context->real_sort(), _context->int_sort() }) {
+      // we need these auxilary variables to make $quotient_t and friends
+      // uninterpreted functions for a zero divisor. i.e. we need to make
+      // sure that they are completely freely interpreted, and that there
+      // is for example no relationship between $quotient_t(2, 0),
+      // $remainder_t(2, 0). in previous definitions they functionally
+      // deptendet on the result of 2/0, which is not sound.
+      // We make sure that they are freely interpreted by introducing
+      // an uninterpreted function $quotient_t0, and defining
+      // $quotient_t(x, y) = if(y == 0) $quotient_t0(y)
+      //                     else <actual definition >
+      //
+      // This is done later in ToZ3Expr
+      z3::sort_vector dom(*_context);
+      dom.push_back(s);
+      z3_declare_fun(quotient0_name(c, s), dom, s);
+      z3_declare_fun(remainder0_name(c,s), dom, s);
+    }
+  }
+}
+
+void ProblemExport::Smtlib::initialize()                               {                                                        }
+void ProblemExport::Smtlib::terminate()                                { out <<                                      std::endl; }
+void ProblemExport::Smtlib::declareSort(z3::sort sort)                 { out << "(declare-sort " << sort << " 0)" << std::endl; }
+void ProblemExport::Smtlib::eval(z3::expr const& x)                    { out << "(get-value (" << x << "))"       << std::endl; }
+void ProblemExport::Smtlib::unsatCore()                                { out << "(get-unsat-core)"                << std::endl; }
+void ProblemExport::Smtlib::addAssert(z3::expr const& x)               { out << "(assert " << x << ")"            << std::endl; }
+void ProblemExport::Smtlib::get_model()                                { out << "(get-model)"                     << std::endl; }
+void ProblemExport::Smtlib::reset()                                    { out << "(reset)"                         << std::endl; }
+
+void ProblemExport::Smtlib::declare_const(std::string const& name, z3::sort codomain)
+{ return declare_fun(name, z3::sort_vector(codomain.ctx()), codomain); }
+
+void ProblemExport::Smtlib::declare_fun(std::string const& name, z3::sort_vector domain, z3::sort codomain) {
+  out << "(declare-fun " << name << " (";
+  for (auto s : domain)
+    out << " "  << s;
+  out << " ) " << codomain << ")" << std::endl;
+}
+
+void ProblemExport::Smtlib::check(Stack<z3::expr> const& assumptions)  {
+  out << "(check-sat-assuming (";
+  for (auto const& a : assumptions)
+    out << " " << a;
+  out << " ))" << std::endl;
+}
+
+void ProblemExport::Smtlib::instantiate_expression(z3::expr const&) { }
+
+void ProblemExport::Smtlib::declare_array_sort(z3::sort array, z3::sort index, z3::sort result) { }
+
+template<class Value>
+void ProblemExport::Smtlib::set_param(const char* k, Value const& v)
+{ out << ";- setting z3 parameter: " << k << "=" << v << std::endl; }
+
+void ProblemExport::Smtlib::Z3_mk_datatypes(Z3MkDatatypesCall const& call) {
+  auto quote = [&](auto x){
+    std::stringstream s;
+    s << x;
+    auto str = s.str();
+    if (str[0] == '\'') {
+      return "|" + str + "|";
+    } else {
+      return str;
+    }
+  };
+
+  out << "(declare-datatypes (" << std::endl;
+  for (auto& s : call.sortNames) {
+    out << " (" << quote(z3::symbol(_ctxt, s)) << " 0)";
+  }
+  out << " ) (" << std::endl;
+
+  for (unsigned i = 0; i < call.sortNames.size(); i++) {
+    out << "    ( ;-- datatype " << z3::symbol(_ctxt, call.sortNames[i]) << std::endl;
+    for (auto& ctor : call.mkConstrs[i]) {
+      out << "        ( " << quote(z3::symbol(_ctxt, ctor.name));
+      for (unsigned j = 0; j < ctor.field_names.size(); j++) {
+        out << " ( " << quote(z3::symbol(_ctxt, ctor.field_names[j])) << " ";
+        if (ctor.sorts[j] == nullptr) out << quote(z3::symbol(_ctxt, call.sortNames[ctor.sort_refs[j]]));
+        else                          out << z3::sort(_ctxt, ctor.sorts[j]);
+        out << " )";
+      }
+      out << " )" << std::endl;
+    }
+    out << "    )";
+  }
+  out << "))" << std::endl;
+}
+
+std::string ProblemExport::ApiCalls::escapeVarName(z3::sort const& sym)
+{
+  if (sym.is_array()) {
+    // Array sorts have argments. Hence we need to escape the arguments as well, not only the sort name
+    return _escapeVarName(sym);
+  } else {
+    return Z3_ast(sym) == nullptr 
+      ? std::string("nullptr")
+      : _escapeVarName(sym.name());
+  }
+}
+
+std::string ProblemExport::ApiCalls::escapeVarName(z3::symbol const& sym)
+{ return _escapeVarName(sym); }
+
+
+template<class Outputable>
+std::string ProblemExport::ApiCalls::_escapeVarName(Outputable const& sym) {
+  std::stringstream cvar;
+  auto generatePrefix = [&](std::string const& toEscape) -> std::string {
+    unsigned iter = 0;
+    while (iter < toEscape.length()) {
+      if (std::isalnum(toEscape[iter]) || toEscape[iter] == '_') break;
+      else iter++;
+    }
+    if (iter == toEscape.length()) {
+      /* none alphanumeric or _ */
+      cvar << "_";
+    } else {
+      if ('0' <= toEscape[iter] && toEscape[iter] <= '9')
+        cvar << "_";
+
+      while (iter != toEscape.length()) {
+        // we replace every letter that is not alphanumeric by '_'
+        if (std::isalnum(toEscape[iter]) || toEscape[iter] == '_') {
+          cvar << toEscape[iter];
+        } else {
+          cvar << '_';
+        }
+        iter++;
+      }
+    }
+    return std::string(cvar.str());
+  };
+
+
+  auto origName = outputToString(sym);
+  return _escapedNames.getOrInit(origName, [&](){
+    auto& ids = _escapePrefixes.getOrInit(generatePrefix(origName));
+    auto nextId = ids.size();
+    auto id = ids.getOrInit(origName, [&](){ return nextId; });
+    if (id != 0)
+      cvar << "_" << id;
+
+    // DBG(sym, " -> ", cvar, " -> ", cvar.str())
+    return cvar.str();
+  });
+}
+
+void ProblemExport::ApiCalls::enableTrace(const char* name)
+{
+  out << "Z3_enable_trace(\"" << name << "\");" << std::endl;
+}
+
+void ProblemExport::ApiCalls::instantiate_expression(z3::expr const& expr)
+{
+#if INSTANTIATE_EXPRESSIONS
+  out << "  (void) " << serialize(expr) << ";" << std::endl;
+#endif
+}
+
+void ProblemExport::ApiCalls::initialize() {
+  out << R"(
+#include <z3++.h>
+#include <z3_api.h>
+#include <iostream>
+#include <vector>
+
+int main() {)" << std::endl;
+#if ENABLE_Z3_PROOF_GENERATION
+    out << "  z3::set_param(\"proof\", true);" << std::endl;
+#endif
+  out << R"(
+  z3::context ctx;
+  z3::solver solver(ctx);
+  z3::model  model(ctx);
+  auto sort_vec = [&](std::initializer_list<z3::sort> xs) {
+    z3::sort_vector vec(ctx);
+    for (auto s : xs) vec.push_back(s);
+    return vec;
+  };
+  auto expr_vec = [&](std::initializer_list<z3::expr> xs) {
+    z3::expr_vector vec(ctx);
+    for (auto s : xs) vec.push_back(std::move(s));
+    return vec;
+  };
+
+  auto query_constructor = [&](Z3_constructor& ctor,
+                               z3::func_decl* name,
+                               z3::func_decl* tester,
+                               std::vector<z3::func_decl*> accessors) {
+
+    Z3_func_decl _name;
+    Z3_func_decl _tester;
+    std::vector<Z3_func_decl> _accessors;
+    for (auto a : accessors)
+      _accessors.push_back(Z3_func_decl(a));
+    Z3_query_constructor(ctx, ctor, accessors.size(), &_name, &_tester, accessors.size() == 0 ? nullptr : &_accessors[0]);
+    *name   = z3::func_decl(ctx, _name);
+    *tester = z3::func_decl(ctx, _tester);
+    for (auto i = 0; i < accessors.size(); i++) {
+      *accessors[i] = z3::func_decl(ctx, _accessors[i]);
+    }
+  };
+
+  auto mk_constructor = [&](Z3_symbol name,
+                            Z3_symbol tester,
+                            std::vector<Z3_symbol> argNames,
+                            std::vector<Z3_sort>   sorts,
+                            std::vector<unsigned>  sortRefs) {
+    return Z3_mk_constructor(ctx, name, tester, argNames.size(),
+                             argNames.size() == 0 ? nullptr : &argNames[0],
+                                sorts.size() == 0 ? nullptr :    &sorts[0],
+                             sortRefs.size() == 0 ? nullptr : &sortRefs[0]);
+  };
+
+
+  auto mk_constructor_list = [&](std::vector<Z3_constructor> ctors) {
+    return Z3_mk_constructor_list(ctx, ctors.size(), ctors.size() == 0 ? nullptr : &ctors[0]);
+  };
+
+)" << std::endl;
+  #define ADD_BUILTIN_SORT(name, Name) \
+    out << "  z3::sort " << escapeVarName(_ctxt.str_symbol(Name))  \
+        << " = ctx." << name << "_sort();" << std::endl;
+    ADD_BUILTIN_SORT("bool", "Bool")
+    ADD_BUILTIN_SORT("int", "Int")
+    ADD_BUILTIN_SORT("real", "Real")
+  #undef ADD_BUILTIN_SORT
+  out << endl;
+}
+
+void ProblemExport::ApiCalls::declare_array_sort(z3::sort array, z3::sort index, z3::sort result)
+{
+  out << "  z3::sort " << escapeVarName(array)
+      << " = ctx.array_sort("
+      << escapeVarName(index) << ", "
+      << escapeVarName(result) << ");" << std::endl;
+}
+
+void ProblemExport::ApiCalls::terminate()
+{
+  out << "} // int main();" << std::endl;
+}
+
+struct ProblemExport::ApiCalls::EscapeString {
+  std::string s;
+  EscapeString(std::string s) : s(s) {}
+  EscapeString(z3::expr const& x) : EscapeString(outputToString(x)) {}
+  friend std::ostream& operator<<(std::ostream& out, EscapeString const& self)
+  { return out << "R\"(" << self.s << ")\""; }// TODO mask occurences of )"
+};
+
+std::ostream& ProblemExport::operator<<(std::ostream& out, ProblemExport::ApiCalls::Serialize<std::string> const& self)
+{ return out << ProblemExport::ApiCalls::EscapeString{self.inner}; }
+
+std::ostream& ProblemExport::operator<<(std::ostream& out, ProblemExport::ApiCalls::Serialize<bool> const& self)
+{ return out << ( self.inner ? "true" : "false" ); }
+
+std::ostream& ProblemExport::operator<<(std::ostream& out, ProblemExport::ApiCalls::Serialize<z3::expr> const& self)
+{
+  auto& x = self.inner;
+  auto& state = self.state;
+  #define ARG(idx) state.serialize(x.arg(idx))
+  auto vec_func = [&](auto f) -> std::ostream& {
+    out << f << "(expr_vec({";
+    if (x.num_args() > 0) {
+      out << ARG(0);
+      for (unsigned i = 1; i < x.num_args(); i++)
+        out << ", " << ARG(i);
+    }
+    return out << "}))";
+  };
+  auto func = [&](auto f) -> std::ostream& {
+    if (x.num_args() > 4)
+      return vec_func(f);
+    else {
+      if (x.num_args() == 0 && state._predeclaredConstants.contains(f)) {
+        return out << f;
+      } else {
+        out << f << "(";
+        if (x.num_args() > 0) {
+          out << ARG(0);
+          for (unsigned i = 1; i < x.num_args(); i++)
+            out << ", " << ARG(i);
+        }
+        return out << ")";
+      }
+    }
+  };
+
+  auto bin = [&](auto op) -> std::ostream& {
+    ASS_EQ(x.num_args(), 2)
+    return out << "(" << ARG(0) << " " << op << " " << ARG(1) << ")";
+  };
+
+       if (x.is_eq())       return bin("==");
+  else if (x.is_and())      return bin("&&");
+  else if (x.is_or())       return bin("||");
+  else if (x.is_not())      return func("!");
+  else if (x.is_ite())      return func("z3::ite");
+  else if (x.is_distinct()) return vec_func("z3::distinct");
+  else if (x.is_implies())  return func("z3::implies");
+  else if (x.is_true())     return out << "ctx.bool_val(true)";
+  else if (x.is_false())    return out << "ctx.bool_val(false)";
+  else if (x.is_numeral())  return out << "ctx.int_val(\""  << x << "\")";
+  else if (x.is_app()) {
+    auto f = x.decl();
+    if (f.name().kind() == Z3_STRING_SYMBOL) {
+      if (f.name().str() == "/" ) return bin("/");
+      if (f.name().str() == "*" ) return bin("*");
+      if (f.name().str() == "+" ) return bin("+");
+      if (f.name().str() == "-" ) return x.num_args() == 1 ? func("-") : bin("-");
+      if (f.name().str() == "<=") return bin("<=");
+      if (f.name().str() == "<" ) return bin("<" );
+      if (f.name().str() == ">=") return bin(">=");
+      if (f.name().str() == ">" ) return bin(">" );
+    }
+    return func(self.state.escapeVarName(f.name()));
+  } else  {
+    ASSERTION_VIOLATION
+  }
+  #undef ARG
+  // return out << "ctx.parse_string(" << EscapeString(self.inner) << ")[0]";
+}
+
+template<class A>
+std::ostream& ProblemExport::operator<<(std::ostream& out, ProblemExport::ApiCalls::Serialize<A> const& self)
+{ return out << self.inner; }
+
+std::ostream& ProblemExport::operator<<(std::ostream& out, ProblemExport::ApiCalls::Serialize<z3::symbol> const& self)
+{
+  if (self.inner.kind() == Z3_INT_SYMBOL) {
+    return out << "ctx.int_symbol(" << self.inner.to_int() << ")";
+  } else  {
+    auto str = toString(self.inner);
+    return out << "ctx.str_symbol(" << ProblemExport::ApiCalls::EscapeString(str) << ")";
+  }
+}
+
+void ProblemExport::ApiCalls::declareSort(z3::sort sort) {
+  out << "  z3::sort " << escapeVarName(sort)
+      << " = ctx.uninterpreted_sort(" <<  serialize(sort.name()) << ");" << std::endl;
+}
+
+void ProblemExport::ApiCalls::eval(z3::expr const& x)
+{ out << "  std::cout << \"model.eval(" << serialize(x) << ") = \" << model.eval(" << serialize(x) << " , " << MODEL_COMPLETION << ") << std::endl;" << std::endl; }
+
+void ProblemExport::ApiCalls::unsatCore()
+{
+  out << "  std::cout << \"===== start solver.unsat_core() ====\" << std::endl;" << std::endl
+      << "  std::cout << solver.unsat_core()                      << std::endl;" << std::endl
+      << "  std::cout << \"=====   end solver.unsat_core() ====\" << std::endl;" << std::endl;
+}
+
+
+void ProblemExport::ApiCalls::addAssert(z3::expr const& x)
+{
+  // out << "  /* " << x <<  " */" << std::endl;
+  out << "  solver.add(" << serialize(x) << ");" << std::endl;
+}
+
+void ProblemExport::ApiCalls::check(Stack<z3::expr> const& xs)
+{
+  out << std::endl;
+  out << std::endl << "  std::cout << \"solver.check(..) = \" << solver.check(expr_vec({";
+  for (auto& x : xs) {
+    out << serialize(x) << ", ";
+  }
+  out << "})) << std::endl;" << std::endl;
+  out << std::endl;
+}
+
+void ProblemExport::ApiCalls::get_model() {
+  out << std::endl;
+  out << "  model = solver.get_model();" << std::endl;
+  out << "  std::cout                               << std::endl;" << std::endl;
+  out << "  std::cout << \"===== start model ====\" << std::endl;" << std::endl;
+  out << "  std::cout << model                      << std::endl;" << std::endl;
+  out << "  std::cout << \"=====   end model ====\" << std::endl;" << std::endl;
+  out << "  std::cout                               << std::endl;" << std::endl;
+  out << std::endl;
+}
+void ProblemExport::ApiCalls::reset()     { out << "  std::cout << solver.reset() << std::endl;"     << std::endl; }
+
+template<class Value>
+void ProblemExport::ApiCalls::set_param(const char* k, Value const& v)
+{ out << "  solver.set(" << EscapeString{k} << "," << serialize(v) << ");" << std::endl; }
+
+template<class A, class F> struct InitList { A const& inner; F output; };
+template<class A, class F> InitList<A, F> initList(A const& a, F f) { return InitList<A,F> { a, std::move(f), }; }
+template<class A, class F> std::ostream& operator<<(std::ostream& out, InitList<A, F> const& self)
+{
+  out << "{ ";
+  for (auto& x : self.inner) {
+    self.output(out, x);
+    out << ", ";
+  }
+  return out << "}";
+}
+
+void ProblemExport::ApiCalls::Z3_mk_datatypes(Z3MkDatatypesCall const& call) {
+
+  out << std::endl << "  // datatypes:";
+  for (auto s : call.sortNames) {
+    out << " " << z3::symbol(_ctxt, s);
+  }
+  out << std::endl;
+
+  for (auto& cs : call.mkConstrs) {
+    for (auto& c : cs)  {
+      out << "  z3::func_decl " << escapeVarName(z3::symbol(_ctxt, c.name))   << "(ctx);" << std::endl;
+      out << "  z3::func_decl " << escapeVarName(z3::symbol(_ctxt, c.tester)) << "(ctx);" << std::endl;
+      for (auto f : c.field_names)
+        out << "  z3::func_decl " << escapeVarName(z3::symbol(_ctxt, f)) << "(ctx);" << std::endl;
+    }
+  }
+
+  for (auto s : call.sortNames)
+    out << "  z3::sort " << escapeVarName(z3::symbol(_ctxt,s)) << "(ctx);" << std::endl;
+  // for (auto s : call.sortNames)
+  //   out << "  z3::sort " << escapeVarName(z3::symbol(_ctxt,s)) << "(ctx);" << std::endl;
+
+  out << "  {" << std::endl
+      << "    Z3_symbol sort_names[] = " << initList(call.sortNames, [&](auto& out, auto& s) { z3::symbol sym(_ctxt, s); out << serialize(sym); }) << ";" << std::endl
+      << "    Z3_sort sorts[] = "        << initList(call.sortNames, [&](auto& out, auto&  ) { out << "nullptr"; }) << ";" << std::endl;
+
+  auto ctor_name = [&](auto& c) { return "ctor_" + escapeVarName(z3::symbol(_ctxt, c.name)); };
+  for (auto& cs : call.mkConstrs) {
+    for (auto& c : cs) {
+      z3::symbol name(_ctxt, c.name);
+      z3::symbol tester(_ctxt, c.tester);
+      out << "    auto " << ctor_name(c) << " = mk_constructor("
+          << serialize(name) << ", "
+          << serialize(tester) << ", "
+          << initList(c.field_names, [&](auto& out, auto& f){ out << serialize(z3::symbol(_ctxt,f)); }) << ", "
+          << initList(c.sorts,       [&](auto& out, auto& s){ out << escapeVarName(z3::sort(_ctxt,s)); }) << ", "
+          << initList(c.sort_refs,   [&](auto& out, auto& s){ out << serialize(s); }) << ");" << std::endl;
+    }
+  }
+
+  out << "    Z3_constructor_list constructor_lists[] = {" << std::endl;
+  for (auto& cs : call.mkConstrs) {
+    out << "      mk_constructor_list({";
+    for (auto c : cs)
+      out << ctor_name(c) << ", ";
+    out << "      })," << std::endl;
+  }
+  out << "    };" << std::endl;
+
+  out << "    Z3_mk_datatypes(ctx, " << call.sortNames.size() << ", sort_names, sorts, constructor_lists);" << std::endl;
+  int i = 0;
+  for (auto s : call.sortNames)
+    out << "    " << escapeVarName(z3::symbol(_ctxt,s)) << " = z3::sort(ctx, sorts[" << i++ <<"]);" << std::endl;
+
+
+  for (auto& cs : call.mkConstrs) {
+    for (auto c : cs){
+      out << "      query_constructor("
+          << ctor_name(c) << ", "
+          << "&" << escapeVarName(z3::symbol(_ctxt, c.name)) << ", "
+          << "&" << escapeVarName(z3::symbol(_ctxt, c.tester)) << ", "
+          << "{";
+      for (auto f : c.field_names) {
+        out << "&" << escapeVarName(z3::symbol(_ctxt, f)) << ", ";
+      }
+      out << "});" << std::endl;
+    }
+  }
+
+  // TODO z3::func_decl for ctors
+  out << "  }" << std::endl << std::endl;
+}
+
+void ProblemExport::ApiCalls::declare_fun(std::string const& name, z3::sort_vector domain, z3::sort codomain) {
+  out << "  z3::func_decl " << escapeVarName(_ctxt.str_symbol(name.c_str())) << " = ctx.function(" << EscapeString{name} << ", sort_vec({";
+  for (auto s : domain)
+    out << escapeVarName(s) << ", ";
+  out << "}), " << escapeVarName(codomain) << " );" << std::endl;
+}
+
+void ProblemExport::ApiCalls::declare_const(std::string const& name, z3::sort codomain) {
+  auto varName = escapeVarName(_ctxt.str_symbol(name.c_str()));
+  out << "  z3::expr " << varName
+      << " = ctx.constant(" << EscapeString{name} << ", " << escapeVarName(codomain) << " );" << std::endl;
+  _predeclaredConstants.insert(std::move(varName));
+}
+
+z3::sort Z3Interfacing::z3_array_sort(z3::sort const& index_sort, z3::sort const& value_sort)
+{
+  auto z3_sort = _context->array_sort(index_sort,value_sort);
+  _exporter.apply([&](auto& e) { e.declare_array_sort(z3_sort, index_sort, value_sort); });
+  return z3_sort;
+}
+
+void Z3Interfacing::z3_enable_trace(const char* name) {
+  Z3_enable_trace(name);
+  _exporter.apply([&](auto& e) { e.enableTrace(name); });
+}
+
+
+z3::sort Z3Interfacing::z3_declare_sort(std::string const& name) {
+  auto sort = _context->uninterpreted_sort(_context->str_symbol(name.c_str()));
+  _exporter.apply([&](auto& e) { e.declareSort(sort); });
+  return sort;
+}
+
+z3::expr Z3Interfacing::z3_eval(z3::expr const& x) {
+  _exporter.apply([&](auto& e) { e.eval(x); });
+  return _model.eval(x, MODEL_COMPLETION);
+}
+
+z3::expr_vector Z3Interfacing::z3_unsat_core() {
+  _exporter.apply([&](auto& e) { e.unsatCore(); });
+  return _solver.unsat_core();
+}
+
+void Z3Interfacing::z3_add(z3::expr const& x) {
+  _exporter.apply([&](auto& e) { e.addAssert(x); });
+  _solver.add(x);
+}
+
+z3::check_result Z3Interfacing::z3_check() {
+  _exporter.apply([&](auto& e) { e.check(_assumptions); });
+  return _solver.check(_assumptions.size(), _assumptions.begin());
+}
+
+z3::model Z3Interfacing::z3_get_model() {
+  _exporter.apply([&](auto& e) { e.get_model(); });
+  return _solver.get_model();
+}
+
+// void Z3Interfacing::z3_reset() {
+//   _exporter.apply([&](auto& e) { e.reset(); });
+//   _solver.reset();
+// }
+
+z3::expr Z3Interfacing::z3_declare_const(std::string const& name, z3::sort sort) {
+  _exporter.apply([&](auto& e) { e.declare_const(name, sort); });
+  return _context->function(name.c_str(), z3::sort_vector(*_context), sort)();
+}
+
+
+z3::func_decl Z3Interfacing::z3_declare_fun(std::string const& name, z3::sort_vector domain, z3::sort codomain) {
+  _exporter.apply([&](auto& e) { e.declare_fun(name, domain, codomain); });
+  return _context->function(name.c_str(), domain, codomain);
+}
+
+template<class Value>
+void Z3Interfacing::z3_set_param(const char* k, Value const& v)
+{
+  _exporter.apply([&](auto& e) { e.set_param(k, v); });
+  _solver.set(k, v);
 }
 
 char const* Z3Interfacing::z3_full_version()
@@ -162,7 +861,8 @@ unsigned Z3Interfacing::newVar()
   ++_varCnt;
 
   // to make sure all the literals we will ask about later have allocated counterparts internally
-  getRepresentation(SATLiteral(_varCnt,1));
+  auto rep = getRepresentation(SATLiteral(_varCnt,1));
+  _exporter.apply([&](auto& exp){ exp.instantiate_expression(rep.expr); });
 
   return _varCnt;
 }
@@ -180,17 +880,12 @@ void Z3Interfacing::addClause(SATClause* cl)
     std::cout << "[Z3] add (clause): " << z3clause.expr << std::endl;
   }
 
-  auto add = [&](auto x) {
-    outputln("(assert ", x, ")");
-    _solver.add(x);
-  };
-
   for (auto def : z3clause.defs)  {
     DEBUG("adding def: ", def)
-    add(def);
+    z3_add(def);
   }
 
-  add(z3clause.expr);
+  z3_add(z3clause.expr);
   DEBUG("adding expr: ", z3clause.expr)
 }
 
@@ -222,7 +917,7 @@ void Z3Interfacing::addAssumption(SATLiteral lit)
 Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATClause* cl)
 {
 
-  z3::expr z3clause = _context.bool_val(false);
+  z3::expr z3clause = _context->bool_val(false);
 
   Stack<z3::expr> defs;
 
@@ -230,6 +925,7 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATClause* cl)
   for(unsigned i=0;i<clen;i++){
     SATLiteral l = (*cl)[i];
     auto repr = getRepresentation(l);
+    _exporter.apply([&](auto& exp){ exp.instantiate_expression(repr.expr); });
 
     defs.loadFromIterator(repr.defs.iterFifo());
 
@@ -242,12 +938,6 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATClause* cl)
 SATSolver::Status Z3Interfacing::solve()
 {
   DEBUG("assumptions: ", _assumptions);
-
-  output("(check-sat-assuming (");
-  for (auto const& a : _assumptions) {
-    outputln(" ", a);
-  }
-  outputln(" ))");
 
   /* The purpose of this class is to conditionally disable variable elimination inside Z3's _solver.check,
    * which results in some literals not being evaluated to either true and false, that we need for AVATAR.
@@ -263,15 +953,15 @@ SATSolver::Status Z3Interfacing::solve()
     ~ScopedPushAndPop() { if (_dpp) {_s.pop();} }
   } _maybePushAndPop(_solver,_hasSeenArrays);
 
-  z3::check_result result = _solver.check(_assumptions.size(), _assumptions.begin());
+
+  auto result = z3_check();
 
   if(_showZ3){
     std::cout << "[Z3] solve result: " << result << std::endl;
   }
 
   if (_unsatCore) {
-    auto core = _solver.unsat_core();
-    outputln("(get-unsat-core)");
+    auto core = z3_unsat_core();
     for (auto phi : core) {
       _assumptionLookup
              .tryGet(phi)
@@ -286,15 +976,14 @@ SATSolver::Status Z3Interfacing::solve()
       break;
     case z3::check_result::sat:
       _status = Status::SATISFIABLE;
-      _model = _solver.get_model();
-      outputln("(get-model)");
+      _model = z3_get_model();
       break;
     case z3::check_result::unknown:
       _status = Status::UNKNOWN;
       break;
     default: ASSERTION_VIOLATION;
   }
-  
+
   return _status;
 }
 
@@ -317,10 +1006,10 @@ SATSolver::Status Z3Interfacing::solveUnderAssumptions(const SATLiteralStack& as
 SATSolver::VarAssignment Z3Interfacing::getAssignment(unsigned var)
 {
   ASS_EQ(_status,Status::SATISFIABLE);
-  bool named = isNamedExpr(var);
-  z3::expr rep = named ? getNameExpr(var) : getRepresentation(SATLiteral(var,1)).expr;
-  outputln("(get-value (", rep, "))");
-  z3::expr assignment = _model.eval(rep, true /*model_completion*/);
+  z3::expr rep = isNamedExpr(var) ? getNameExpr(var) : getRepresentation(SATLiteral(var,1)).expr;
+  _exporter.apply([&](auto& exp){ exp.instantiate_expression(rep); });
+  ASS(isNamedExpr(var) || getRepresentation(SATLiteral(var,1)).defs.isEmpty())
+  auto assignment = z3_eval(rep);
 
   if(assignment.bool_value()==Z3_L_TRUE){
     return VarAssignment::TRUE;
@@ -328,6 +1017,11 @@ SATSolver::VarAssignment Z3Interfacing::getAssignment(unsigned var)
     return VarAssignment::FALSE;
   } else {
 #if VDEBUG
+    std::cout << std::endl;
+    std::cout << "===== start _model ====" << std::endl;
+    std::cout << _model << std::endl;
+    std::cout << "=====   end _model ====" << std::endl;
+    std::cout << std::endl;
     std::cout << rep << std::endl;
     ASSERTION_VIOLATION_REP(assignment);
 #endif
@@ -357,9 +1051,8 @@ Term* Z3Interfacing::evaluateInModel(Term* trm)
   DEBUG("model: \n", _model)
   ASS(!trm->isLiteral());
 
-  z3::expr rep = getRepresentation(trm).expr;
-  output("(get-value (", rep, "))");
-  z3::expr ev = _model.eval(rep,true); // true means "model_completion"
+  auto ev = z3_eval(getRepresentation(trm).expr);
+  ASS(getRepresentation(trm).defs.isEmpty())
   SortId sort = SortHelper::getResultSort(trm);
 
   DEBUG("z3 expr: ", ev)
@@ -493,26 +1186,23 @@ z3::sort Z3Interfacing::getz3sort(SortId s)
     // TODO what about built-in tuples?
 
     // Deal with known sorts differently
-         if(s == AtomicSort::boolSort()) insert(_context.bool_sort());
-    else if(s ==  IntTraits::sort()) insert( _context.int_sort());
-    else if(s == RealTraits::sort()) insert(_context.real_sort());
-    else if(s ==  RatTraits::sort()) insert(_context.real_sort()); // Drops notion of rationality
+         if(s == AtomicSort::boolSort()) insert(_context->bool_sort());
+    else if(s ==  IntTraits::sort()) insert( _context->int_sort());
+    else if(s == RealTraits::sort()) insert(_context->real_sort());
+    else if(s ==  RatTraits::sort()) insert(_context->real_sort()); // Drops notion of rationality
     // TODO: are we really allowed to do this ???                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     else if(s.isArraySort()) {
       _hasSeenArrays = true;
-
-      z3::sort index_sort = getz3sort(SortHelper::getIndexSort(s));
-      z3::sort value_sort = getz3sort(SortHelper::getInnerSort(s));
-
-      insert(_context.array_sort(index_sort,value_sort));
+      insert(z3_array_sort(
+            getz3sort(SortHelper::getIndexSort(s)),
+            getz3sort(SortHelper::getInnerSort(s))
+            ));
 
     } else if (env.signature->isTermAlgebraSort(s)) {
       createTermAlgebra(s);
 
     } else {
-      auto sort = _context.uninterpreted_sort(_context.str_symbol(s.toString().c_str()));
-      outputln("(declare-sort ", sort, " 0)");
-      insert(sort);
+      insert(z3_declare_sort(s.toString()));
     }
   }
   return _sorts.get(s);
@@ -545,7 +1235,7 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
   }
 
   auto new_string_symbol = [this](unsigned f, const std::string& typePostfix, bool pred = false)
-  { return Z3_mk_string_symbol(_context,
+  { return Z3_mk_string_symbol(*_context,
     ((pred ? env.signature->getPredicate(f) : env.signature->getFunction(f))->name()+'_'+typePostfix).c_str()); };
 
   // create the data needed for Z3_mk_datatypes(...)
@@ -575,6 +1265,7 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
     Stack<SerCtor> serCtors;
 
     for (auto cons : ta->iterCons()) {
+
       // data needed for the  Z3_mk_constructor call
       Stack<SerDtor> serDtors;
       auto consTermArity = cons->arity()-cons->numTypeArguments();
@@ -587,7 +1278,7 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
         auto dtorName = new_string_symbol(cons->destructorFunctor(i-cons->numTypeArguments()),typePostfix);
         if (_out.isSome())
           serDtors.push(SerDtor {
-              .name = z3::symbol(_context, dtorName),
+              .name = z3::symbol(*_context, dtorName),
               .sort = argSort,
           });
         argNames.push(dtorName);
@@ -606,17 +1297,17 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
 
       DEBUG("\t", taSort.toString(), "::", env.signature->getFunction(cons->functor())->name(), ": ");//, SubstHelper::apply(cons->sort(), typeSubst));
 
-      Z3_symbol ctorName = Z3_mk_string_symbol(_context, env.signature->getFunction(cons->functor())->name().c_str());
+      Z3_symbol ctorName = Z3_mk_string_symbol(*_context, env.signature->getFunction(cons->functor())->name().c_str());
 
       ASS_EQ(argSortRefs.size(), consTermArity);
       ASS_EQ(   argSorts.size(), consTermArity);
       ASS_EQ(   argNames.size(), consTermArity);
       if (_out.isSome())
         serCtors.push(SerCtor{
-            .name = z3::symbol(_context, ctorName),
+            .name = z3::symbol(*_context, ctorName),
             .dtors = std::move(serDtors),
         });
-      ctors.push(Z3_mk_constructor(_context,
+      ctors.push(Z3_mk_constructor(*_context,
           ctorName,
           new_string_symbol(cons->discriminator(), typePostfix, true/*predicate*/),
           consTermArity,
@@ -630,14 +1321,15 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
 
     ctorss.push(std::move(ctors));
     ASS_EQ(ctorss.top().size(), ta->nConstructors());
-    ctorss_z3.push(Z3_mk_constructor_list(_context, ctorss.top().size(),  ctorss.top().begin()));
-    sortNames.push(Z3_mk_string_symbol(_context, taSort.toString().c_str()));
+    ctorss_z3.push(Z3_mk_constructor_list(*_context, ctorss.top().size(),  ctorss.top().begin()));
+    sortNames.push(Z3_mk_string_symbol(*_context, taSort.toString().c_str()));
     if (_out.isSome())
       toSerialize.push(SerDtype {
         .name = taSort,
         .ctors = std::move(serCtors),
       });
-  }
+    }
+  //   mkDatatypes.sortNames.push(new_string_symbol(ta->sort().toString()));
 
   ASS_EQ(sortNames.size(), taSorts.size())
   ASS_EQ(ctorss.size()   , taSorts.size())
@@ -646,96 +1338,49 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
   Array<Z3_sort> sorts(taSorts.size());
 
   // actually created the datatypes
-  Z3_mk_datatypes(_context, taSorts.size(), sortNames.begin(), sorts.begin(), ctorss_z3.begin());
+  Z3_mk_datatypes(*_context, taSorts.size(), sortNames.begin(), sorts.begin(), ctorss_z3.begin());
 
   // register the `z3::func_decl`s created by `Z3_mk_datatypes` in indices to be queried when needed
   for (unsigned iSort = 0; iSort < sorts.size(); iSort++) {
-    _sorts.insert(taSorts[iSort], z3::sort(_context, sorts[iSort]));
+    _sorts.insert(taSorts[iSort], z3::sort(*_context, sorts[iSort]));
     auto ta = env.signature->getTermAlgebraOfSort(taSorts[iSort]);
     auto& ctors = ctorss[iSort];
     for (unsigned iCons = 0; iCons < ta->nConstructors(); iCons++) {
-      auto ctor = ta->constructor(iCons);
-      auto ctorTermArity = ctor->arity()-ctor->numTypeArguments();
+      auto ctor_v = ta->constructor(iCons);
+      auto ctorTermArity = ctor_v->arity() - ctor_v->numTypeArguments();
 
-      Z3_func_decl constr_;
-      Z3_func_decl discr_;
+      Z3_func_decl ctor_z3;
+      Z3_func_decl discr_z3;
       Array<Z3_func_decl> destr(ctorTermArity);
 
-      Z3_query_constructor(_context,
+      Z3_query_constructor(*_context,
                            ctors[iCons],
                            ctorTermArity,
-                           &constr_,
-                           &discr_,
+                           &ctor_z3,
+                           &discr_z3,
                            destr.begin());
 
-      auto discr = z3::func_decl(_context, discr_);
-      auto constr = z3::func_decl(_context, constr_);
-
-      auto ctorId = FuncOrPredId::monomorphicFunction(ctor->functor());
-      _toZ3.insert(ctorId, constr);
-      _fromZ3.insert(constr, ctorId);
-
-      if (ctor->hasDiscriminator()) {
-        auto discrId = FuncOrPredId::monomorphicPredicate(ctor->discriminator());
-        _toZ3.insert(discrId, discr);
-        // _fromZ3.insert(discr, discrId);
+      auto registerDecl = [&](auto vampireId, auto z3Id) {
+        _toZ3.insert(vampireId, z3Id);
+        _fromZ3.insert(z3Id, vampireId);
+      };
+      registerDecl(FuncOrPredId::monomorphicFunction(ctor_v->functor()), z3::func_decl(*_context, ctor_z3));
+      if (ctor_v->hasDiscriminator()) {
+        registerDecl(FuncOrPredId::monomorphicPredicate(ctor_v->discriminator()), z3::func_decl(*_context, discr_z3));
       }
       for (unsigned iDestr = 0; iDestr < ctorTermArity; iDestr++)  {
-        auto dtor = z3::func_decl(_context, destr[iDestr]);
+        auto dtor = z3::func_decl(*_context, destr[iDestr]);
 
         // careful: datatypes can have boolean fields!
         // NB: polymorphic destructors instantiated with booleans are still functions (?)
-        bool is_predicate = ctor->argSort(iDestr).isBoolSort();
-        auto id = FuncOrPredId(ctor->destructorFunctor(iDestr), is_predicate);
+        bool is_predicate = ctor_v->argSort(iDestr).isBoolSort();
+        auto id = FuncOrPredId(ctor_v->destructorFunctor(iDestr), is_predicate);
 
-        _toZ3.insert(id, dtor);
-        _fromZ3.insert(dtor, id);
+        registerDecl(id, dtor);
       }
     }
+
   }
-
-  // clean up
-  for (auto clist : ctorss_z3) {
-    Z3_del_constructor_list(_context, clist);
-  }
-
-  for (auto ctors : ctorss) {
-    for (auto ctor : ctors) {
-      Z3_del_constructor(_context, ctor);
-    }
-  }
-
-  // serizalize to z3
-  output("(declare-datatypes (");
-  for (auto& s : toSerialize) {
-    output(" (", getz3sort(s.name), " 0)");
-  }
-  outputln(" ) (");
-
-  auto quote = [&](auto x){
-    std::stringstream s;
-    s << x;
-    auto str = s.str();
-    if (str[0] == '\'') {
-      return "|" + str + "|";
-    } else {
-      return str;
-    }
-  };
-
-  for (auto& dty : toSerialize) {
-    outputln("    ( ;-- datatype ", getz3sort(dty.name));
-    for (auto& ctor : dty.ctors) {
-      output("        ( ", quote(ctor.name));
-      for (auto& dtor : ctor.dtors) {
-        output(" ( ", quote(dtor.name), " ", getz3sort(dtor.sort), " )");
-      }
-      outputln(" )");
-    }
-    outputln("    )");
-  }
-  outputln("))");
-
 }
 
 z3::func_decl const& Z3Interfacing::findConstructor(Term* t)
@@ -746,6 +1391,7 @@ z3::func_decl const& Z3Interfacing::findConstructor(Term* t)
     return f.unwrap();
   } else {
     createTermAlgebra(SortHelper::getResultSort(t));
+    ASS(_toZ3.find(id))
     return _toZ3.get(id);
   }
 }
@@ -765,14 +1411,35 @@ namespace tptp {
   z3::expr truncate(z3::expr x)
   { return ite(x >= 0, tptp::floor(x), tptp::ceiling(x)); }
 
-  z3::expr quotient_e(z3::expr n, z3::expr d)
-  { return ite(d >= 0, floor(n / d), ceiling(n / d)); }
+  z3::expr quotient0(char kind, z3::expr x)
+  {
+    std::string fname = quotient0_name(kind, x.get_sort());
+      // uninterpreted remainder for zero division
+      auto quotient0 = x.ctx().function(fname.c_str(), x.get_sort(), x.get_sort());
+      return quotient0(x);
+  }
+
+  z3::expr remainder0(char kind, z3::expr x)
+  {
+    std::string fname = remainder0_name(kind, x.get_sort());
+      // uninterpreted remainder for zero division
+      auto remainder0 = x.ctx().function(fname.c_str(), x.get_sort(), x.get_sort());
+      return remainder0(x);
+  }
+
+  z3::expr quotient_e(z3::expr l, z3::expr r)
+  { return l / r; }
+
+  z3::expr remainder_e(z3::expr l, z3::expr r)
+  { return z3::mod(l, r); }
 
   z3::expr quotient_t(z3::expr l, z3::expr r)
-  { return tptp::truncate(l / r); }
+  { return ite(r == 0, tptp::quotient0('t', r)
+                     , tptp::truncate(l / r)); }
 
   z3::expr quotient_f(z3::expr l, z3::expr r)
-  { return tptp::floor(l / r); }
+  { return ite(r == 0, tptp::quotient0('f', l / r)
+                     , tptp::floor(l / r)); }
 
   template<class F>
   struct LiftInt
@@ -787,11 +1454,14 @@ namespace tptp {
   template<class F>
   struct RemainderOp
   {
+    char kind;
     F quotient;
 
-    z3::expr operator()(z3::expr l, z3::expr r) { return l - r*quotient(l,r); }
+    z3::expr operator()(z3::expr l, z3::expr r)
+    { return ite(r == 0, remainder0(kind, l)
+                       , l - r * quotient(l,r)); }
   };
-  template<class F> RemainderOp<F> remainder(F f) { return RemainderOp<F>{ f }; }
+  template<class F> RemainderOp<F> remainder(char kind, F f) { return RemainderOp<F>{ kind, f }; }
 }
 
 
@@ -818,19 +1488,14 @@ z3::func_decl Z3Interfacing::z3Function(FuncOrPredId functor)
         namebuf += functor.forSorts->typeArg(i).toString();
     }
 
-    z3::sort_vector domain_sorts = z3::sort_vector(self._context);
+    z3::sort_vector domain_sorts = z3::sort_vector(*self._context);
     for (unsigned i=type->numTypeArguments(); i<type->arity(); i++) {
       TermList arg = SubstHelper::apply(type->arg(i), typeSubst);
       domain_sorts.push_back(self.getz3sort(arg));
     }
-
-    z3::symbol name = self._context.str_symbol(namebuf.c_str());
-    auto range_sort = functor.isPredicate
-      ? self._context.bool_sort()
-      : self.getz3sort(SubstHelper::apply(type->result(), typeSubst));
-    auto decl = self._context.function(name,domain_sorts,range_sort);
-    outputln(decl);
-    self._toZ3.insert(functor, decl); // (declare-fun ...)
+    auto codomain = functor.isPredicate ? self._context->bool_sort() : self.getz3sort(type->result());
+    auto decl = self.z3_declare_fun(namebuf, domain_sorts, codomain);
+    self._toZ3.insert(functor, decl);
     return decl;
   }
 }
@@ -882,21 +1547,25 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(Term* trm)
         if(trm->arity() == 0) {
           if(symb->integerConstant()){
             IntegerConstantType value = symb->integerValue();
-            return _context.int_val(value.toInner());
+            return int_to_z3_expr(symb->integerValue(), [&](uint64_t i) { return _context->int_val(i); });
           }
           if(symb->realConstant()) {
             RealConstantType value = symb->realValue();
-            return _context.real_val(value.numerator().toInner(),value.denominator().toInner());
+            auto num = int_to_z3_expr(value.numerator()  , [&](uint64_t i) { return _context->real_val(i); });
+            auto den = int_to_z3_expr(value.denominator(), [&](uint64_t i) { return _context->real_val(i); });
+            return num / den;
           }
           if(symb->rationalConstant()) {
             RationalConstantType value = symb->rationalValue();
-            return _context.real_val(value.numerator().toInner(),value.denominator().toInner());
+            auto num = int_to_z3_expr(value.numerator()  , [&](uint64_t i) { return _context->real_val(i); });
+            auto den = int_to_z3_expr(value.denominator(), [&](uint64_t i) { return _context->real_val(i); });
+            return num / den;
           }
           if(!isLit && env.signature->isFoolConstantSymbol(true,trm->functor())) {
-            return _context.bool_val(true);
+            return _context->bool_val(true);
           }
           if(!isLit && env.signature->isFoolConstantSymbol(false,trm->functor())) {
-            return _context.bool_val(false);
+            return _context->bool_val(false);
           }
           if(symb->termAlgebraCons()) {
             auto ctor = findConstructor(trm);
@@ -907,11 +1576,11 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(Term* trm)
             // too large for native representation, but z3 should cope
             auto s = symb->fnType()->result();
             if (s == IntTraits::sort()) {
-              return _context.int_val(symb->name().c_str());
+              return _context->int_val(symb->name().c_str());
             } else if (s == RatTraits::sort()) {
-              return _context.real_val(symb->name().c_str());
+              return _context->real_val(symb->name().c_str());
             } else if (s == RealTraits::sort()) {
-              return _context.real_val(symb->name().c_str());
+              return _context->real_val(symb->name().c_str());
             } else {
               ; // intentional fallthrough; the input is fof (and not tff), so let's just treat this as a constant
             }
@@ -944,14 +1613,14 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(Term* trm)
             }
 
           } else {
-            auto int_zero = _context.int_val(0);
-            auto real_zero = _context.real_val(0);
+            auto int_zero = _context->int_val(0);
+            auto real_zero = _context->real_val(0);
 
             switch(interp){
             // Numerical operations
             case Theory::INT_DIVIDES:
               {
-              auto k = getNamingConstantFor(toEval, _context.int_sort());
+              auto k = getNamingConstantFor(toEval, _context->int_sort());
               // a divides b <-> k * a ==  b
               return k * args[0] == args[1];
               }
@@ -987,23 +1656,23 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(Term* trm)
             case Theory::RAT_QUOTIENT_E:
             case Theory::REAL_QUOTIENT_E:  return                 tptp::quotient_e (args[0], args[1]);
             case Theory::RAT_REMAINDER_E:
-            case Theory::REAL_REMAINDER_E: return tptp::remainder(tptp::quotient_e)(args[0], args[1]);
+            case Theory::REAL_REMAINDER_E: return tptp::remainder('e', tptp::quotient_e)(args[0], args[1]);
 
              /** {quotient,remainder}_t */
             case Theory::INT_QUOTIENT_T:  return tptp::liftInt(                tptp::quotient_t )(args[0],args[1]);
-            case Theory::INT_REMAINDER_T: return tptp::liftInt(tptp::remainder(tptp::quotient_t))(args[0],args[1]);
+            case Theory::INT_REMAINDER_T: return tptp::liftInt(tptp::remainder('t', tptp::quotient_t))(args[0],args[1]);
             case Theory::RAT_QUOTIENT_T:
             case Theory::REAL_QUOTIENT_T: return                 tptp::quotient_t (args[0], args[1]);
             case Theory::REAL_REMAINDER_T:
-            case Theory::RAT_REMAINDER_T: return tptp::remainder(tptp::quotient_t)(args[0], args[1]);
+            case Theory::RAT_REMAINDER_T: return tptp::remainder('t', tptp::quotient_t)(args[0], args[1]);
 
             /** {quotient,remainder}_f */
             case Theory::INT_QUOTIENT_F:  return tptp::liftInt(                tptp::quotient_f )(args[0], args[1]);
-            case Theory::INT_REMAINDER_F: return tptp::liftInt(tptp::remainder(tptp::quotient_f))(args[0],args[1]);
+            case Theory::INT_REMAINDER_F: return tptp::liftInt(tptp::remainder('f', tptp::quotient_f))(args[0],args[1]);
             case Theory::RAT_QUOTIENT_F:
             case Theory::REAL_QUOTIENT_F: return                 tptp::quotient_f (args[0], args[1]);
             case Theory::REAL_REMAINDER_F:
-            case Theory::RAT_REMAINDER_F: return tptp::remainder(tptp::quotient_f)(args[0], args[1]);
+            case Theory::RAT_REMAINDER_F: return tptp::remainder('f', tptp::quotient_f)(args[0], args[1]);
 
 
             case Theory::RAT_TO_INT:
@@ -1035,7 +1704,7 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(Term* trm)
             case Theory::REAL_ROUND: {
                 z3::expr t = args[0];
                 z3::expr i = to_int(t);
-                z3::expr i2 = i + _context.real_val(1,2);
+                z3::expr i2 = i + _context->real_val(1,2);
                 return ite(t > i2, i+1, ite(t==i2, ite(z3::mod(i, 2),i ,i+1 ),i));
               }
 
@@ -1092,12 +1761,15 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATLiteral slit)
     // Now translate it into an SMT object
     try{
       auto repr = getRepresentation(lit);
+      _exporter.apply([&expr = repr.expr](auto& exp){ exp.instantiate_expression(expr); });
 
       /* we name all literals in order to make z3 cache their truth values.
        * this gives a massive performance boost in many cases.              */
 
       z3::expr bname = getNameExpr(slit.var());
+      _exporter.apply([&](auto& exp){ exp.instantiate_expression(bname); });
       z3::expr naming = (bname == repr.expr);
+      _exporter.apply([&](auto& exp){ exp.instantiate_expression(naming); });
       repr.defs.push(naming);
       repr.expr = bname;
 
@@ -1107,7 +1779,9 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATLiteral slit)
 
       if(slit.isNegative()) {
         repr.expr = !repr.expr;
+        _exporter.apply([&expr = repr.expr](auto& exp){ exp.instantiate_expression(expr); });
       }
+
 
       return repr;
     }catch(z3::exception& exception){
@@ -1118,8 +1792,9 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(SATLiteral slit)
   } else {
     //if non ground then just create a propositional variable
     z3::expr e = getNameExpr(slit.var());
-    return Representation(slit.isPositive() ? e : !e,
-                          Stack<z3::expr>());
+    e = slit.isPositive() ? e : !e;
+    _exporter.apply([&](auto& exp){ exp.instantiate_expression(e); });
+    return Representation(e, Stack<z3::expr>());
   }
 }
 
@@ -1137,7 +1812,7 @@ Z3Interfacing::~Z3Interfacing()
   _sorts.clear();
   _toZ3.clear();
   _fromZ3.clear();
-  outputln(); // flush the output file
+  _exporter.apply([&](auto& e) { e.terminate(); });
 }
 
 
@@ -1147,32 +1822,23 @@ bool Z3Interfacing::isNamedExpr(unsigned var) const
 
 z3::expr Z3Interfacing::getNameExpr(unsigned var)
 {
-  return _varNames.getOrInit(var, [&](){
       // this method is called very often in runs with a lot of avatar reasoning. Cache the constants to avoid that z3 has to search for the string name in its function index
-      std::string name = "v"+Lib::Int::toString(var);
-      outputln("(declare-fun ", name, " () Bool)");
-      return _context.bool_const(name.c_str());
-  });
+  return _varNames.getOrInit(var, [&]()
+      { return z3_declare_const("v"+Lib::Int::toString(var), _context->bool_sort()); });
 }
 
 
 z3::expr Z3Interfacing::getNamingConstantFor(TermList toName, z3::sort sort)
 {
-  return _termIndexedConstants.getOrInit(toName, [&](){
-      auto name = "n" + toName.toString();
-      outputln("(declare-fun ", name, " () ", sort, ")");
-      return _context.constant(name.c_str(), sort);
-  });
+  return _termIndexedConstants.getOrInit(toName, [&]()
+    { return z3_declare_const("n" + toName.toString(), sort); });
 }
 
 z3::expr Z3Interfacing::getConst(Signature::Symbol* symb, z3::sort sort)
 {
-  return _constantNames.getOrInit(symb, [&]() {
+  return _constantNames.getOrInit(symb, [&]()
     // careful: keep native constants' names distinct from the above ones (hence the "c"-prefix below)
-    std::string name("c" + symb->name());
-    outputln("(declare-fun ", name, " () ", sort, ")");
-    return _context.constant(name.c_str(), sort);
-  });
+    { return z3_declare_const("c" + symb->name(), sort); });
 }
 
 } // namespace SAT

--- a/SAT/Z3MainLoop.cpp
+++ b/SAT/Z3MainLoop.cpp
@@ -42,7 +42,7 @@ MainLoopResult Z3MainLoop::runImpl()
   }
 
   SAT2FO s2f;
-  Z3Interfacing solver(_opt,s2f, /* unsat core */ false, /* export smtlib problem */ "");
+  Z3Interfacing solver(_opt,s2f, /* unsat core */ false, /* export smtlib problem */ "", Shell::Options::ProblemExportSyntax::SMTLIB);
 
  ClauseIterator cit(_prb.clauseIterator());
  while(cit.hasNext()){

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -74,7 +74,7 @@ void SplittingBranchSelector::init()
     case Options::SatSolver::Z3:
       {
         _solverIsSMT = true;
-        _solver = new Z3Interfacing(_parent.getOptions(),_parent.satNaming(), /* unsat core */ false, _parent.getOptions().exportAvatarProblem());
+        _solver = new Z3Interfacing(_parent.getOptions(),_parent.satNaming(), /* unsat core */ false, _parent.getOptions().exportAvatarProblem(), _parent.getOptions().problemExportSyntax());
         if(_parent.getOptions().satFallbackForSMT()){
           // TODO make fallback minimizing?
           SATSolver* fallback = new MinisatInterfacing(_parent.getOptions(),true);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -709,6 +709,12 @@ void Options::init()
     _lookup.insert(&_showZ3);
     _showZ3.tag(OptionTag::DEVELOPMENT);
 
+    _problemExportSyntax = ChoiceOptionValue<ProblemExportSyntax>("export_syntax","",ProblemExportSyntax::SMTLIB, {"smtlib", "api_calls",});
+    _problemExportSyntax.description="Set the syntax for exporting z3 problems.";
+    _lookup.insert(&_problemExportSyntax);
+    _problemExportSyntax.tag(OptionTag::DEVELOPMENT);
+    _problemExportSyntax.reliesOn(Or(_exportAvatarProblem.is(notEqual(std::string(""))), _exportThiProblem.is(notEqual(std::string("")))));
+
     _exportAvatarProblem = StringOptionValue("export_avatar","","");
     _exportAvatarProblem.description="Export the avatar problems to solve in smtlib syntax.";
     _lookup.insert(&_exportAvatarProblem);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -721,6 +721,11 @@ public:
     OFF = 3
   };
 
+  enum class ProblemExportSyntax : unsigned int {
+    SMTLIB = 0,
+    API_CALLS = 1,
+  };
+
     //==========================================================
     // The Internals
     //==========================================================
@@ -1985,6 +1990,7 @@ public:
 
 #if VZ3
   bool showZ3() const { return showAll() || _showZ3.actualValue; }
+  ProblemExportSyntax problemExportSyntax() const { return _problemExportSyntax.actualValue; }
   std::string const& exportAvatarProblem() const { return _exportAvatarProblem.actualValue; }
   std::string const& exportThiProblem() const { return _exportThiProblem.actualValue; }
 #endif
@@ -2586,6 +2592,7 @@ private:
 #endif // VAMPIRE_CLAUSE_TRACING
 #if VZ3
   BoolOptionValue _showZ3;
+  ChoiceOptionValue<ProblemExportSyntax> _problemExportSyntax;
   StringOptionValue _exportAvatarProblem;
   StringOptionValue _exportThiProblem;
   BoolOptionValue _satFallbackForSMT;

--- a/Test/TestUtils.cpp
+++ b/Test/TestUtils.cpp
@@ -250,7 +250,7 @@ bool TestUtils::eqModAC(TermList lhs, TermList rhs)
 struct AcRectComp {
   Stack<TermList> const& vl;
   Stack<TermList> const& vr;
-  DArray<unsigned>& perm;
+  DArray<unsigned> const& perm;
 
   bool var(unsigned lhs, unsigned rhs) const 
   { 
@@ -278,7 +278,7 @@ bool TestUtils::eqModACRect(Kernel::TermList lhs, Kernel::TermList rhs)
 
   if (vl.size() != vr.size()) return false;
 
-  return anyPerm(vl.size(), [&](DArray<unsigned> perm) {
+  return anyPerm(vl.size(), [&](DArray<unsigned> const& perm) {
     AcRectComp c {vl, vr, perm};
     return eqModAC_(lhs, rhs, c);
   });

--- a/UnitTests/tTheoryInstAndSimp.cpp
+++ b/UnitTests/tTheoryInstAndSimp.cpp
@@ -91,7 +91,8 @@ TheoryInstAndSimp* theoryInstAndSimp(Options::TheoryInstSimp mode, bool withGene
       /* thiTautologyDeletion */ true,
       /* showZ3 */ false,
       withGeneralization,
-      /* export smtlib */ ""
+      /* export smtlib */ "", 
+      Shell::Options::ProblemExportSyntax::SMTLIB
       );
 }
 

--- a/UnitTests/tZ3Interfacing.cpp
+++ b/UnitTests/tZ3Interfacing.cpp
@@ -63,7 +63,7 @@ void checkStatus(SAT::Z3Interfacing& z3, SAT2FO& s2f, SATSolver::Status expected
 void checkStatus(SATSolver::Status expected, Stack<Literal*> assumptions)
 {
   SAT2FO s2f;
-  SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "");
+  SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "", Shell::Options::ProblemExportSyntax::SMTLIB);
   checkStatus(z3, s2f, expected, assumptions);
 }
 
@@ -239,7 +239,7 @@ void checkInstantiation(SAT::Z3Interfacing& z3, SAT2FO& s2f, Stack<Literal*> ass
 void checkInstantiation(Stack<Literal*> assumptions, TermList toInstantiate, TermList expected)
 {
   SAT2FO s2f;
-  SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "");
+  SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "", Shell::Options::ProblemExportSyntax::SMTLIB);
   return checkInstantiation(z3, s2f, assumptions, toInstantiate, expected);
 }
 
@@ -347,7 +347,7 @@ TEST_FUN(segfault02) {
 
 
   SAT2FO s2f;
-  SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "");
+  SAT::Z3Interfacing z3(s2f, /* show z3 */ DBG_ON == 1, /* unsat core */ false, /* export smtlib */ "", Shell::Options::ProblemExportSyntax::SMTLIB);
 
   checkStatus(z3, s2f, SATSolver::Status::SATISFIABLE, { inst159 == inst160 });
   z3.solve();


### PR DESCRIPTION
This PR adds the feature that problems passed to z3 cannot only be exported as smtlib files, but also as c++ file where the z3 api is called in the same way that vampire would call it during the proof search run. This was helpful for debugging some very nasty bug that only occured when we used the z3 api calls, but not when z3 ran reading from an smt file. I think this feature is not needed very often but handy to have in case we run into similar issues again. 
It can be enabled with `--export_syntax api_calls`. 

This required some refactoring of the Z3Interfacing code, which was mainly moving things around, but no real change in functionality. 

The main change is that all the problem exporting is now wrapped in one of three classes (`ProblemExport::{ApiCalls, Smtlib,NoExport}`, which log the functions that are called to the smt interface.