### PR TITLE
Signature optimization

### DIFF
--- a/Inferences/Instantiation.cpp
+++ b/Inferences/Instantiation.cpp
@@ -182,27 +182,21 @@ Term* Instantiation::tryGetDifferentValue(Term* t)
 {
   TermList sort = SortHelper::getResultSort(t);
 
-  try {
-        if(sort == AtomicSort::intSort()){
-              IntegerConstantType constant;
-              if(theory->tryInterpretConstant(t,constant)){
-                return theory->representConstant(constant+1);
-              }
-        } else if(sort == AtomicSort::rationalSort()){
-              RationalConstantType constant;
-              RationalConstantType one(1,1);
-              if(theory->tryInterpretConstant(t,constant)){
-                return theory->representConstant(constant+one);
-              }
-        } else if(sort == AtomicSort::realSort()){
-              RealConstantType constant;
-              RealConstantType one(RationalConstantType(1,1));
-              if(theory->tryInterpretConstant(t,constant)){
-                return theory->representConstant(constant+one);
-              }
-        }
-  } catch (ArithmeticException&) {
-    // return 0 as well
+  if(sort == AtomicSort::intSort()){
+    IntegerConstantType constant;
+    if(theory->tryInterpretConstant(t,constant)){
+      return theory->representConstant(constant+1);
+    }
+  } else if(sort == AtomicSort::rationalSort()){
+    RationalConstantType constant;
+    if(theory->tryInterpretConstant(t,constant)){
+      return theory->representConstant(constant + 1);
+    }
+  } else if(sort == AtomicSort::realSort()){
+    RealConstantType constant;
+    if(theory->tryInterpretConstant(t,constant)){
+      return theory->representConstant(constant + 1);
+    }
   }
 
   return 0;

--- a/Inferences/PolynomialEvaluation.cpp
+++ b/Inferences/PolynomialEvaluation.cpp
@@ -283,7 +283,8 @@ Polynom<Number> simplifyPoly(Polynom<Number> const& in, PolyNf* simplifiedArgs)
     auto poly = Polynom(std::move(out));
     poly.integrity();
     return poly;
-  } catch (ArithmeticException&) { 
+  } catch (DivByZeroException&) { 
+    // TODO can we remove this?
     return in.replaceTerms(simplifiedArgs);
   }
 }

--- a/Kernel/InterpretedLiteralEvaluator.cpp
+++ b/Kernel/InterpretedLiteralEvaluator.cpp
@@ -401,7 +401,7 @@ public:
 	ASSERTION_VIOLATION;
       }
     }
-    catch(ArithmeticException&)
+    catch(DivByZeroException&)
     {
       return false;
     }
@@ -534,9 +534,8 @@ public:
       res = TermList(theory->representConstant(resNum));
       return true;
     }
-    catch(ArithmeticException&)
+    catch(DivByZeroException&)
     {
-       DEBUG( "ArithmeticException" );
       return false;
     }
   }
@@ -571,7 +570,7 @@ public:
       }
       return PredEvalResult::trivial(res);
     }
-    catch(ArithmeticException&)
+    catch(DivByZeroException&)
     {
       return PredEvalResult::nop();
     }

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -30,7 +30,7 @@ const unsigned Signature::STRING_DISTINCT_GROUP = 0;
  * Standard constructor.
  * @author Andrei Voronkov
  */
-Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interpreted, bool preventQuoting, bool overflownConstant, bool super)
+Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interpreted, bool preventQuoting, bool super)
   : _name(nm),
     _arity(arity),
     _typeArgsArity(0),
@@ -47,7 +47,6 @@ Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interprete
     _wasFlipped(0),
     _color(COLOR_TRANSPARENT),
     _answerPredicate(0),
-    _overflownConstant(overflownConstant ? 1 : 0),
     _termAlgebraCons(0),
     _termAlgebraDest(0),
     _inGoal(0),
@@ -455,13 +454,11 @@ unsigned Signature::getPredicateNumber(const std::string& name, unsigned arity) 
  * @param name name of the symbol
  * @param arity arity of the symbol
  * @param added will be set to true if the function did not exist
- * @param overflowConstant
  * @since 07/05/2007 Manchester
  */
 unsigned Signature::addFunction (const std::string& name,
 				 unsigned arity,
-				 bool& added,
-				 bool overflowConstant)
+				 bool& added)
 {
   auto symbolKey = key(name,arity);
   unsigned result;
@@ -487,8 +484,7 @@ unsigned Signature::addFunction (const std::string& name,
   bool super = (name == "$tType");
   _funs.push(new Symbol(name, arity, 
         /*       interpreted */ false, 
-        /*    preventQuoting */ overflowConstant || super, 
-                                overflowConstant, 
+        /*    preventQuoting */ super, 
                                 super));
   _funNames.insert(symbolKey, result);
   added = true;
@@ -516,7 +512,6 @@ unsigned Signature::addStringConstant(const std::string& name)
         /*             arity */ 0, 
         /*       interpreted */ false, 
         /*    preventQuoting */ true, 
-        /* overflownConstant */ false, 
         /*             super */ false);
   sym->addToDistinctGroup(STRING_DISTINCT_GROUP,result);
   _funs.push(sym);
@@ -662,7 +657,7 @@ unsigned Signature::addTypeCon (const std::string& name,
   //TODO no arity check. Is this safe?
 
   result = _typeCons.length();
-  _typeCons.push(new Symbol(name,arity, /* interpreted */ false, /* preventQuoting */ false, /* overflownConstant */ false, /* super */ false));
+  _typeCons.push(new Symbol(name,arity, /* interpreted */ false, /* preventQuoting */ false, /* super */ false));
   _typeConNames.insert(symbolKey,result);
   added = true;
   return result;
@@ -709,7 +704,6 @@ unsigned Signature::addPredicate (const std::string& name,
   _preds.push(new Symbol(name, arity, 
         /*       interpreted */ false, 
         /*    preventQuoting */ false, 
-        /* overflownConstant */ false, 
         /*             super */ false));
   _predNames.insert(symbolKey,result);
   added = true;

--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -12,10 +12,10 @@
  * Implements class Signature for handling signatures
  */
 
+#include "Debug/Assertion.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Int.hpp"
 #include "Shell/Options.hpp"
-#include "Shell/DistinctGroupExpansion.hpp"
 #include "Kernel/SortHelper.hpp"
 
 #include "Signature.hpp"
@@ -28,11 +28,9 @@ const unsigned Signature::STRING_DISTINCT_GROUP = 0;
 
 /**
  * Standard constructor.
- * @since 03/05/2013 train London-Manchester, argument numericConstant added
  * @author Andrei Voronkov
  */
-Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interpreted, bool stringConstant,bool numericConstant,
-                          bool overflownConstant)
+Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interpreted, bool preventQuoting, bool overflownConstant, bool super)
   : _name(nm),
     _arity(arity),
     _typeArgsArity(0),
@@ -48,8 +46,6 @@ Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interprete
     _equalityProxy(0),
     _wasFlipped(0),
     _color(COLOR_TRANSPARENT),
-    _stringConstant(stringConstant ? 1: 0),
-    _numericConstant(numericConstant ? 1: 0),
     _answerPredicate(0),
     _overflownConstant(overflownConstant ? 1 : 0),
     _termAlgebraCons(0),
@@ -65,10 +61,7 @@ Signature::Symbol::Symbol(const std::string& nm, unsigned arity, bool interprete
     _prox(NOT_PROXY),
     _comb(NOT_COMB)
 {
-  ASS(!stringConstant || arity==0);
-
-  if (!stringConstant && !numericConstant && !overflownConstant &&
-       symbolNeedsQuoting(_name, interpreted,arity)) {
+  if (!preventQuoting && symbolNeedsQuoting(_name, interpreted,arity)) {
     _name="'"+_name+"'";
   }
   if (_interpreted || isProtectedName(nm)) {
@@ -266,152 +259,6 @@ Signature::~Signature ()
 } // Signature::~Signature
 
 /**
- * Add an integer constant to the signature. If defaultSort is true, treat it as
- * a term of the default sort, otherwise as an interepreted integer value.
- * @since 03/05/2013 train Manchester-London
- * @author Andrei Voronkov
- */
-unsigned Signature::addIntegerConstant(const std::string& number,bool defaultSort)
-{
-  IntegerConstantType value(number);
-  if (!defaultSort) {
-    return addIntegerConstant(value);
-  }
-
-  // default sort should be used
-  std::string name = Output::toString(value);
-  std::string symbolKey = name + "_n";
-  unsigned result;
-  if (_funNames.find(symbolKey,result)) {
-    return result;
-  }
-
-  result = _funs.length();
-  Symbol* sym = new Symbol(name,0,false,false,true);
-  /*
-  sym->addToDistinctGroup(INTEGER_DISTINCT_GROUP,result);
-  if(defaultSort){ 
-     sym->addToDistinctGroup(STRING_DISTINCT_GROUP,result); // numbers are disctinct from strings
-  }
-  */
-  _funs.push(sym);
-  _funNames.insert(symbolKey,result);
-  return result;
-} // Signature::addIntegerConstant
-
-/**
- * Add an integer constant to the signature.
- * @todo something smarter, so that we don't need to convert all values to string
- */
-unsigned Signature::addIntegerConstant(const IntegerConstantType& value)
-{
-  std::string key = Output::toString(value, "_n");
-  unsigned result;
-  if (_funNames.find(key, result)) {
-    return result;
-  }
-  _integers++;
-  result = _funs.length();
-  Symbol* sym = new IntegerSymbol(value);
-  _funs.push(sym);
-  _funNames.insert(key,result);
-  /*
-  sym->addToDistinctGroup(INTEGER_DISTINCT_GROUP,result);
-  */
-  return result;
-} // addIntegerConstant
-
-/**
- * Add a rational constant to the signature. If defaultSort is true, treat it as
- * a term of the default sort, otherwise as an interepreted rational value.
- * @since 03/05/2013 London
- * @author Andrei Voronkov
- */
-unsigned Signature::addRationalConstant(const std::string& numerator, const std::string& denominator,bool defaultSort)
-{
-  auto value = RationalConstantType(IntegerConstantType(numerator), IntegerConstantType(denominator));
-  if (!defaultSort) {
-    return addRationalConstant(value);
-  }
-
-  std::string name = Output::toString(value);
-  std::string key = name + "_q";
-  unsigned result;
-  if (_funNames.find(key,result)) {
-    return result;
-  }
-  result = _funs.length();
-  Symbol* sym = new Symbol(name,0,false,false,true);
-  /*
-  if(defaultSort){ 
-    sym->addToDistinctGroup(STRING_DISTINCT_GROUP,result); // numbers are distinct from strings
-  }
-  sym->addToDistinctGroup(RATIONAL_DISTINCT_GROUP,result);
-  */
-  _funs.push(sym);
-  _funNames.insert(key,result);
-  return result;
-} // addRatonalConstant
-
-unsigned Signature::addRationalConstant(const RationalConstantType& value)
-{
-  std::string key = Output::toString(value, "_q");
-  unsigned result;
-  if (_funNames.find(key, result)) {
-    return result;
-  }
-  _rationals++;
-  result = _funs.length();
-  _funs.push(new RationalSymbol(value));
-  _funNames.insert(key, result);
-  return result;
-} // Signature::addRationalConstant
-
-/**
- * Add a real constant to the signature. If defaultSort is true, treat it as
- * a term of the default sort, otherwise as an interepreted real value.
- * @since 03/05/2013 London
- * @author Andrei Voronkov
- */
-unsigned Signature::addRealConstant(const std::string& number,bool defaultSort)
-{
-  RealConstantType value(number);
-  if (!defaultSort) {
-    return addRealConstant(value);
-  }
-  std::string key = Output::toString(value, "_r");
-  unsigned result;
-  if (_funNames.find(key,result)) {
-    return result;
-  }
-  result = _funs.length();
-  Symbol* sym = new Symbol(Output::toString(value),0,false,false,true);
-  /*
-  if(defaultSort){ 
-    sym->addToDistinctGroup(STRING_DISTINCT_GROUP,result); // numbers are distinct from strings
-  }
-  sym->addToDistinctGroup(REAL_DISTINCT_GROUP,result);
-  */
-  _funs.push(sym);
-  _funNames.insert(key,result);
-  return result;
-} // addRealConstant
-
-unsigned Signature::addRealConstant(const RealConstantType& value)
-{
-  std::string key = Output::toString(value, "_r");
-  unsigned result;
-  if (_funNames.find(key, result)) {
-    return result;
-  }
-  _reals++;
-  result = _funs.length();
-  _funs.push(new RealSymbol(value));
-  _funNames.insert(key, result);
-  return result;
-}
-
-/**
  * Add interpreted function
  */
 unsigned Signature::addInterpretedFunction(Interpretation interpretation, OperatorType* type, const std::string& name)
@@ -429,7 +276,7 @@ unsigned Signature::addInterpretedFunction(Interpretation interpretation, Operat
     return res;
   }
 
-  std::string symbolKey = name+"_i"+Int::toString(interpretation)+(Theory::isPolymorphic(interpretation) ? type->toString() : "");
+  auto symbolKey = SymbolKey(std::make_pair(interpretation, type));
   ASS_REP(!_funNames.find(symbolKey), name);
 
   unsigned fnNum = _funs.length();
@@ -463,7 +310,7 @@ unsigned Signature::addInterpretedPredicate(Interpretation interpretation, Opera
     return res;
   }
 
-  std::string symbolKey = name+"_i"+Int::toString(interpretation)+(Theory::isPolymorphic(interpretation) ? type->toString() : "");
+  auto symbolKey = SymbolKey(std::make_pair(interpretation, type));
 
   // cout << "symbolKey " << symbolKey << endl;
 
@@ -616,7 +463,7 @@ unsigned Signature::addFunction (const std::string& name,
 				 bool& added,
 				 bool overflowConstant)
 {
-  std::string symbolKey = key(name,arity);
+  auto symbolKey = key(name,arity);
   unsigned result;
   if (_funNames.find(symbolKey,result)) {
     added = false;
@@ -637,7 +484,12 @@ unsigned Signature::addFunction (const std::string& name,
   }
 
   result = _funs.length();
-  _funs.push(new Symbol(name, arity, false, false, false, overflowConstant));
+  bool super = (name == "$tType");
+  _funs.push(new Symbol(name, arity, 
+        /*       interpreted */ false, 
+        /*    preventQuoting */ overflowConstant || super, 
+                                overflowConstant, 
+                                super));
   _funNames.insert(symbolKey, result);
   added = true;
   return result;
@@ -650,16 +502,22 @@ unsigned Signature::addFunction (const std::string& name,
  */
 unsigned Signature::addStringConstant(const std::string& name)
 {
-  std::string symbolKey = name + "_c";
+  auto symbolKey = SymbolKey(name);
   unsigned result;
   if (_funNames.find(symbolKey,result)) {
     return result;
   }
 
   _strings++;
+  // TODO shouldn't we also quote inside of name?
   std::string quotedName = "\"" + name + "\"";
   result = _funs.length();
-  Symbol* sym = new Symbol(quotedName,0,false,true);
+  Symbol* sym = new Symbol(quotedName,
+        /*             arity */ 0, 
+        /*       interpreted */ false, 
+        /*    preventQuoting */ true, 
+        /* overflownConstant */ false, 
+        /*             super */ false);
   sym->addToDistinctGroup(STRING_DISTINCT_GROUP,result);
   _funs.push(sym);
   _funNames.insert(symbolKey,result);
@@ -795,7 +653,7 @@ unsigned Signature::addTypeCon (const std::string& name,
          unsigned arity,
          bool& added)
 {
-  std::string symbolKey = key(name,arity);
+  auto symbolKey = key(name,arity);
   unsigned result;
   if (_typeConNames.find(symbolKey,result)) {
     added = false;
@@ -804,7 +662,7 @@ unsigned Signature::addTypeCon (const std::string& name,
   //TODO no arity check. Is this safe?
 
   result = _typeCons.length();
-  _typeCons.push(new Symbol(name,arity));
+  _typeCons.push(new Symbol(name,arity, /* interpreted */ false, /* preventQuoting */ false, /* overflownConstant */ false, /* super */ false));
   _typeConNames.insert(symbolKey,result);
   added = true;
   return result;
@@ -827,7 +685,7 @@ unsigned Signature::addPredicate (const std::string& name,
 				  unsigned arity,
 				  bool& added)
 {
-  std::string symbolKey = key(name,arity);
+  auto symbolKey = key(name,arity);
   unsigned result;
   if (_predNames.find(symbolKey,result)) {
     added = false;
@@ -848,7 +706,11 @@ unsigned Signature::addPredicate (const std::string& name,
   }
 
   result = _preds.length();
-  _preds.push(new Symbol(name,arity));
+  _preds.push(new Symbol(name, arity, 
+        /*       interpreted */ false, 
+        /*    preventQuoting */ false, 
+        /* overflownConstant */ false, 
+        /*             super */ false));
   _predNames.insert(symbolKey,result);
   added = true;
   return result;
@@ -1017,9 +879,9 @@ unsigned Signature::addSkolemPredicate(unsigned arity, const char* suffix)
  * @since 27/02/2006 Redmond
  * @author Andrei Voronkov
  */
-std::string Signature::key(const std::string& name,int arity)
+Signature::SymbolKey Signature::key(const std::string& name,int arity)
 {
-  return name + '_' + Int::toString(arity);
+  return SymbolKey(std::make_pair(name,unsigned(arity)));
 } // Signature::key
 
 

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -22,7 +22,6 @@
 
 #include "Debug/Assertion.hpp"
 
-#include "Lib/Allocator.hpp"
 #include "Lib/Stack.hpp"
 #include "Lib/DHSet.hpp"
 #include "Lib/Map.hpp"
@@ -30,7 +29,6 @@
 #include "Lib/DHMap.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/SmartPtr.hpp"
-#include "Lib/StringUtils.hpp"
 
 #include "Shell/TermAlgebra.hpp"
 #include "Shell/Options.hpp"
@@ -145,8 +143,6 @@ class Signature
     unsigned _color : 2;
     /** predicate introduced for query answering */
     unsigned _answerPredicate : 1;
-    /** marks numbers too large to represent natively */
-    unsigned _overflownConstant : 1;
     /** marks term algebra constructors */
     unsigned _termAlgebraCons : 1;
     /** marks term algebra destructors */
@@ -176,7 +172,7 @@ class Signature
 
   public:
     /** standard constructor */
-    Symbol(const std::string& name, unsigned arity, bool interpreted, bool preventQuoting, bool overflownConstant, bool super);
+    Symbol(const std::string& name, unsigned arity, bool interpreted, bool preventQuoting, bool super);
     void destroyFnSymbol();
     void destroyPredSymbol();
     void destroyTypeConSymbol();
@@ -199,8 +195,6 @@ class Signature
     void markEqualityProxy() { _equalityProxy=1; }
     /** mark predicate as (polarity) flipped */
     void markFlipped() { _wasFlipped=1; }
-    /** mark constant as overflown */
-    void markOverflownConstant() { _overflownConstant=1; }
     /** mark symbol as a term algebra constructor */
     void markTermAlgebraCons() { _termAlgebraCons=1; }
     /** mark symbol as a term algebra destructor */
@@ -249,8 +243,6 @@ class Signature
     inline bool equalityProxy() const { return _equalityProxy; }
     /** Return true iff symbol was polarity flipped */
     inline bool wasFlipped() const { return _wasFlipped; }
-    /** Return true iff symbol is an overflown constant */
-    inline bool overflownConstant() const { return _overflownConstant; }
     /** Return true iff symbol is a term algebra constructor */
     inline bool termAlgebraCons() const { return _termAlgebraCons; }
     /** Return true iff symbol is a term algebra destructor */
@@ -357,7 +349,6 @@ class Signature
         /* arity */ Theory::getArity(interp), 
         /*       interpreted */ true, 
         /*    preventQuoting */ false, 
-        /* overflownConstant */ false, 
         /*             super */ false),
       _interp(interp)
     {
@@ -381,7 +372,6 @@ class Signature
         /*             arity */ 0, 
         /*       interpreted */ true, 
         /*    preventQuoting */ false, 
-        /* overflownConstant */ false, 
         /*             super */ false),
       _intValue(std::move(val))
     {
@@ -403,7 +393,6 @@ class Signature
         /*             arity */ 0, 
         /*       interpreted */ true, 
         /*    preventQuoting */ false, 
-        /* overflownConstant */ false, 
         /*             super */ false),
        _ratValue(std::move(val))
     {
@@ -426,7 +415,6 @@ class Signature
         /*             arity */ 0, 
         /*       interpreted */ true, 
         /*    preventQuoting */ false, 
-        /* overflownConstant */ false, 
         /*             super */ false),
        _realValue(std::move(val))
     {
@@ -440,7 +428,7 @@ class Signature
 
   unsigned addPredicate(const std::string& name,unsigned arity,bool& added);
   unsigned addTypeCon(const std::string& name,unsigned arity,bool& added);
-  unsigned addFunction(const std::string& name,unsigned arity,bool& added,bool overflowConstant = false);
+  unsigned addFunction(const std::string& name,unsigned arity,bool& added);
 
   /**
    * If a predicate with this name and arity exists, return its number.
@@ -528,7 +516,6 @@ class Signature
             /*             arity */ 0, 
             /*       interpreted */ false, 
             /*    preventQuoting */ true, 
-            /* overflownConstant */ false, 
             /*             super */ false)
                   : newNumeralConstantSymbol(std::move(number));
     _funs.push(sym);
@@ -536,7 +523,7 @@ class Signature
     return result;
   }
 
-  unsigned addIntegerConstant(const std::string& number,bool defaultSort) 
+  unsigned addIntegerConstant(const std::string& number, bool defaultSort)
   { return addNumeralConstant(IntegerConstantType(number), defaultSort); }
 
   unsigned addRationalConstant(const std::string& numerator, const std::string& denominator,bool defaultSort)

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -52,7 +52,7 @@ class Signature
     , std::string // <- string-constant
     // (number, arity). 
     // if arity = 0 we mean a numeral constant
-    // if arity = 1 we mean a linear multiplication (this is not yet merged into master bug come with alasca)
+    // if arity = 1 we mean a linear multiplication (this is not yet merged into master but will come with alasca)
     , std::pair<IntegerConstantType, unsigned> 
     , std::pair<RationalConstantType, unsigned> 
     , std::pair<RealConstantType, unsigned> 

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -523,15 +523,6 @@ class Signature
     return result;
   }
 
-  unsigned addIntegerConstant(const std::string& number, bool defaultSort)
-  { return addNumeralConstant(IntegerConstantType(number), defaultSort); }
-
-  unsigned addRationalConstant(const std::string& numerator, const std::string& denominator,bool defaultSort)
-  { return addNumeralConstant(RationalConstantType(IntegerConstantType(numerator), IntegerConstantType(denominator)), defaultSort); }
-
-  unsigned addRealConstant(const std::string& number,bool defaultSort)
-  { return addNumeralConstant(RealConstantType(number), defaultSort); }
-
  private:
   void noteOccurrence(IntegerConstantType const&)  { _integers++; }
   void noteOccurrence(RationalConstantType const&)  { _rationals++; }

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -33,9 +33,9 @@
 #if VMINI_GMP
 #include "mini-gmp.c"
 #include "mini-mpq.c"
+#else
+#include <gmpxx.h>
 #endif
-
-#include "Theory.hpp"
 
 std::string to_string(mpz_t const& self) {
   auto s = mpz_sizeinbase(self, /* base */ 10);
@@ -46,19 +46,13 @@ std::string to_string(mpz_t const& self) {
   return out;
 }
 
-#if VMINI_GMP
-std::ostream& operator<<(std::ostream& out, mpz_t const& self)
+std::ostream& output(std::ostream& out, mpz_t const& self)
+// TODO: make this faster usign gmpxx output operator somehow if compiled with !VMINI_GMP
 { return out << to_string(self); }
-#endif
-
-namespace Kernel
-{
 
 using namespace Lib;
 
-///////////////////////
-// IntegerConstantType
-//
+namespace Kernel {
 
 IntegerConstantType::IntegerConstantType(std::string const& str)
   : Kernel::IntegerConstantType()
@@ -1413,9 +1407,7 @@ bool Theory::isInterpretedPredicate(Literal* lit)
 
 
 bool Theory::isInterpretedPredicate(unsigned pred, Interpretation itp)
-{
-  return isInterpretedPredicate(pred) && interpretPredicate(pred) == itp;
-}
+{ return isInterpretedPredicate(pred) && interpretPredicate(pred) == itp; }
 
 /**
  * Return true iff @b lit has an interpreted predicate interpreted
@@ -1608,19 +1600,19 @@ bool Theory::tryInterpretConstant(unsigned func, RealConstantType& res)
 
 Term* Theory::representConstant(const IntegerConstantType& num)
 {
-  unsigned func = env.signature->addIntegerConstant(num);
+  unsigned func = env.signature->addNumeralConstant(num);
   return Term::create(func, 0, 0);
 }
 
 Term* Theory::representConstant(const RationalConstantType& num)
 {
-  unsigned func = env.signature->addRationalConstant(num);
+  unsigned func = env.signature->addNumeralConstant(num);
   return Term::create(func, 0, 0);
 }
 
 Term* Theory::representConstant(const RealConstantType& num)
 {
-  unsigned func = env.signature->addRealConstant(num);
+  unsigned func = env.signature->addNumeralConstant(num);
   return Term::create(func, 0, 0);
 }
 
@@ -1763,7 +1755,7 @@ std::ostream& operator<<(std::ostream& out, Kernel::Theory::Interpretation const
 }
 
 std::ostream& operator<<(std::ostream& out, IntegerConstantType const& self)
-{ return out << self._val; }
+{ return output(out, self._val); }
 
 std::ostream& operator<<(std::ostream& out, RationalConstantType const& self)
 #if NICE_THEORY_OUTPUT

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -58,7 +58,7 @@ IntegerConstantType::IntegerConstantType(std::string const& str)
   : Kernel::IntegerConstantType()
 {
   if (-1 == mpz_set_str(_val, str.c_str(), /* base */ 10)) {
-    throw UserErrorException("not a valit string literal: ", str);
+    throw UserErrorException("not a valid integer literal: ", str);
   }
 }
 

--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -1900,22 +1900,4 @@ bool Theory::isInterpretedFunction(TermList t, Interpretation itp)
   return t.isTerm() && isInterpretedFunction(t.term(), itp);
 }
 
-IntegerConstantType naiveInverseModulo(IntegerConstantType const& l, IntegerConstantType const& m)
-{
-  ASS(!m.isZero())
-  if (m == IntegerConstantType(1)) {
-    return IntegerConstantType(0);
-  }
-  // TODO use extended euclidean algorithm instead
-  ASS(l.isPositive()) // <- can be done but not implemented
-  ASS(m.isPositive()) // <- can be done but not implemented
-  auto one = IntegerConstantType(1);
-  for (auto i : range(0, m)) {
-    if ((l * i).remainderE(m) == 1) {
-      return IntegerConstantType(i);
-    }
-  }
-  ASSERTION_VIOLATION_REP("inverse does not exists")
-}
-
 } // namespace Kernel

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -66,19 +66,10 @@ struct QR { T quot; T rem; };
   bool isPositive() const { return sign() == Sign::Pos;  }                                \
 
 
-/**
- * Exception to be thrown when the requested operation cannot be performed,
- * e.g. because of overflow of a native type.
- */
-class ArithmeticException : public Exception {
-protected:
-  ArithmeticException(std::string msg) : Exception(msg) {}
-};
-
-class DivByZeroException         : public ArithmeticException 
+class DivByZeroException : public Exception 
 { 
 public:
-  DivByZeroException() : ArithmeticException("divided by zero"){} 
+  DivByZeroException() : Exception("divided by zero"){} 
 };
 
 enum class Sign : uint8_t {

--- a/Lib/Coproduct.hpp
+++ b/Lib/Coproduct.hpp
@@ -27,6 +27,8 @@
 #include "Lib/Option.hpp"
 #include <memory>
 #include <functional>
+#include <type_traits>
+#include <vector>
 #include <tuple>
 
 namespace Lib {
@@ -652,10 +654,10 @@ public:
   IMPL_COMPARISONS_FROM_COMPARE(Coproduct)
 
   unsigned defaultHash() const
-  { return Lib::HashUtils::combine( std::hash<unsigned>{}(tag()), apply([](auto const& x){ return x.defaultHash(); })); }
+  { return Lib::HashUtils::combine( std::hash<unsigned>{}(tag()), this->apply([](auto const& x){ return DefaultHash::hash(x); })); }
 
   unsigned defaultHash2() const
-  { return Lib::HashUtils::combine( std::hash<unsigned>{}(tag()), apply([](auto const& x){ return x.defaultHash2(); })); }
+  { return Lib::HashUtils::combine( std::hash<unsigned>{}(tag()), this->apply([](auto const& x){ return DefaultHash2::hash(x); })); }
 
   inline Coproduct clone() const { return apply([](auto& x){ return Coproduct(x.clone()); }); }
 }; // class Coproduct<As...>

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -125,7 +125,7 @@ static std::chrono::time_point<std::chrono::steady_clock> START_TIME;
       Timer::updateInstructionCount();
       if (env.options->instructionLimit() && LAST_INSTRUCTION_COUNT_READ >= MEGA*(long long)env.options->instructionLimit()) {
         // in principle could have a race on terminationReason, seems unlikely/harmless in practice
-        env.statistics->terminationReason = Shell::Statistics::INSTUCTION_LIMIT;
+        env.statistics->terminationReason = Shell::Statistics::INSTRUCTION_LIMIT;
         limitReached(INSTRUCTION_LIMIT);
       }
     }

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -696,7 +696,7 @@ SMTLIB2::DeclaredSymbol SMTLIB2::declareFunctionOrPredicate(const std::string& n
     if (argSorts.size() > 0 || taArity > 0) {
       symNum = env.signature->addFunction(name, argSorts.size()+taArity, added);
     } else {
-      symNum = TPTP::addUninterpretedConstant(name,_overflow,added);
+      symNum = TPTP::addUninterpretedConstant(name,added);
     }
 
     sym = env.signature->getFunction(symNum);
@@ -1976,7 +1976,7 @@ bool SMTLIB2::parseAsSpecConstant(const std::string& id)
       goto real_constant; // just below
     }
 
-    unsigned symb = TPTP::addIntegerConstant(id,_overflow,false);
+    unsigned symb = TPTP::addIntegerConstant(id,false);
     TermList res = TermList(Term::createConstant(symb));
     _results.push(ParseResult(AtomicSort::intSort(),res));
 
@@ -1986,7 +1986,7 @@ bool SMTLIB2::parseAsSpecConstant(const std::string& id)
   if (StringUtils::isPositiveDecimal(id)) {
     real_constant:
 
-    unsigned symb = TPTP::addRealConstant(id,_overflow,false);
+    unsigned symb = TPTP::addRealConstant(id,false);
     TermList res = TermList(Term::createConstant(symb));
     _results.push(ParseResult(AtomicSort::realSort(),res));
 
@@ -2624,7 +2624,7 @@ void SMTLIB2::parseRankedFunctionApplication(LExpr* exp)
       USER_ERROR_EXPR("Expected numeral as an argument of a ranked function in "+head->toString());
     }
 
-    unsigned divisorSymb = TPTP::addIntegerConstant(numeral,_overflow,false);
+    unsigned divisorSymb = TPTP::addIntegerConstant(numeral,false);
     TermList divisorTerm = TermList(Term::createConstant(divisorSymb));
 
     TermList arg;

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1976,7 +1976,7 @@ bool SMTLIB2::parseAsSpecConstant(const std::string& id)
       goto real_constant; // just below
     }
 
-    unsigned symb = TPTP::addIntegerConstant(id,false);
+    unsigned symb = TPTP::addNumeralConstant<IntegerConstantType>(id,false);
     TermList res = TermList(Term::createConstant(symb));
     _results.push(ParseResult(AtomicSort::intSort(),res));
 
@@ -1986,7 +1986,7 @@ bool SMTLIB2::parseAsSpecConstant(const std::string& id)
   if (StringUtils::isPositiveDecimal(id)) {
     real_constant:
 
-    unsigned symb = TPTP::addRealConstant(id,false);
+    unsigned symb = TPTP::addNumeralConstant<RealConstantType>(id,false);
     TermList res = TermList(Term::createConstant(symb));
     _results.push(ParseResult(AtomicSort::realSort(),res));
 
@@ -2624,7 +2624,7 @@ void SMTLIB2::parseRankedFunctionApplication(LExpr* exp)
       USER_ERROR_EXPR("Expected numeral as an argument of a ranked function in "+head->toString());
     }
 
-    unsigned divisorSymb = TPTP::addIntegerConstant(numeral,false);
+    unsigned divisorSymb = TPTP::addNumeralConstant<IntegerConstantType>(numeral,false);
     TermList divisorTerm = TermList(Term::createConstant(divisorSymb));
 
     TermList arg;

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -507,12 +507,6 @@ private:
   UnitList::FIFO _formulas;
 
   /**
-   * To support a mechanism for dealing with large arithmetic constants.
-   * Adapted from the tptp parser.
-   */
-  Set<std::string> _overflow;
-
-  /**
    * Top-level expression that is parsed presently.
    * Saved for better error output.
    */

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -1411,7 +1411,7 @@ void TPTP::tff()
         unsigned arity = getConstructorArity();
         bool added = false;
         unsigned fun = arity == 0
-            ? addUninterpretedConstant(nm, _overflow, added)
+            ? addUninterpretedConstant(nm, added)
             : env.signature->addFunction(nm, arity, added);
         Signature::Symbol* symbol = env.signature->getFunction(fun);
         OperatorType* ot = OperatorType::getTypeConType(arity);
@@ -2893,13 +2893,13 @@ void TPTP::term()
           );
           break;
         case T_INT:
-          number = addIntegerConstant(tok.content,_overflow,_isFof);
+          number = addIntegerConstant(tok.content,_isFof);
           break;
         case T_REAL:
-          number = addRealConstant(tok.content,_overflow,_isFof);
+          number = addRealConstant(tok.content,_isFof);
           break;
         case T_RAT:
-          number = addRationalConstant(tok.content,_overflow,_isFof);
+          number = addRationalConstant(tok.content,_isFof);
           break;
         default:
           ASSERTION_VIOLATION;
@@ -3218,7 +3218,7 @@ TermList TPTP::createFunctionApplication(std::string name, unsigned arity)
     if (arity > 0) {
       fun = addFunction(name, arity, dummy, _termLists.top());
     } else {
-      fun = addUninterpretedConstant(name, _overflow, dummy);
+      fun = addUninterpretedConstant(name, dummy);
     }
   }
 
@@ -3258,8 +3258,6 @@ TermList TPTP::createTypeConApplication(std::string name, unsigned arity)
   ASS_GE(_termLists.size(), arity);
 
   bool added = false;
-  //TODO not checking for overflown constant. Is that OK?
-  //seems to be done this way for predicates as well.
   unsigned typeCon = env.signature->addTypeCon(name,arity,added);
   if(added)
     USER_ERROR("Undeclared type constructor ", name, "/", arity);
@@ -3779,7 +3777,7 @@ void TPTP::endTff()
     }
   } else {
     unsigned fun = arity == 0
-                   ? addUninterpretedConstant(name, _overflow, added)
+                   ? addUninterpretedConstant(name, added)
                    : env.signature->addFunction(name, arity, added);
     symbol = env.signature->getFunction(fun);
     if (!added) {
@@ -4578,7 +4576,7 @@ unsigned TPTP::addFunction(std::string name,int arity,bool& added,TermList& arg)
   if (arity > 0) {
     return env.signature->addFunction(name,arity,added);
   }
-  return addUninterpretedConstant(name,_overflow,added);
+  return addUninterpretedConstant(name,added);
 } // addFunction
 
 /** Add a predicate to the signature
@@ -4741,110 +4739,39 @@ TermList TPTP::sortOf(TermList t)
 
 /**
  * Add an integer constant by reading it from the std::string name.
- * If it overflows, create an uninterpreted constant of the
- * integer type and the name 'name'. Check that the name of the constant
- * does not collide with user-introduced names of uninterpreted constants.
- * @since 22/07/2011 Manchester
- * @since 03/05/2013 train Manchester-London, bug fix: integers are treated
- *   as terms of the default sort when fof() or cnf() is used
- * @author Andrei Voronkov
  */
-unsigned TPTP::addIntegerConstant(const std::string& name, Set<std::string>& overflow, bool defaultSort)
+unsigned TPTP::addIntegerConstant(const std::string& name, bool defaultSort)
 {
-  try {
-    return env.signature->addIntegerConstant(name,defaultSort);
-  }
-  catch (Kernel::ArithmeticException&) {
-    bool added;
-    unsigned fun = env.signature->addFunction(name,0,added,true /* overflown constant*/);
-    if (added) {
-      overflow.insert(name);
-      Signature::Symbol* symbol = env.signature->getFunction(fun);
-      symbol->setType(OperatorType::getConstantsType(defaultSort ? AtomicSort::defaultSort() : AtomicSort::intSort()));
-    }
-    else if (!overflow.contains(name)) {
-      USER_ERROR((std::string)"Cannot use name '" + name + "' as an atom name since it collides with an integer number");
-    }
-    return fun;
-  }
+  return env.signature->addNumeralConstant(IntegerConstantType(name),defaultSort);
 } // TPTP::addIntegerConstant
 
 /**
  * Add an rational constant by reading it from the std::string name.
- * If it overflows, create an uninterpreted constant of the
- * rational type and the name 'name'. Check that the name of the constant
- * does not collide with user-introduced names of uninterpreted constants.
- * @since 22/07/2011 Manchester
- * @since 03/05/2013 train Manchester-London, fix to handle difference
- *    between treating rationals using fof() and tff()
- * @author Andrei Voronkov
  */
-unsigned TPTP::addRationalConstant(const std::string& name, Set<std::string>& overflow, bool defaultSort)
+unsigned TPTP::addRationalConstant(const std::string& name, bool defaultSort)
 {
   size_t i = name.find_first_of("/");
   ASS(i != std::string::npos);
-  try {
-    return env.signature->addRationalConstant(name.substr(0,i),
-					      name.substr(i+1),
-					      defaultSort);
-  }
-  catch(Kernel::ArithmeticException&) {
-    bool added;
-    unsigned fun = env.signature->addFunction(name,0,added,true /* overflown constant*/);
-    if (added) {
-      overflow.insert(name);
-      Signature::Symbol* symbol = env.signature->getFunction(fun);
-      symbol->setType(OperatorType::getConstantsType(defaultSort ? AtomicSort::defaultSort() : AtomicSort::rationalSort()));
-    }
-    else if (!overflow.contains(name)) {
-      USER_ERROR((std::string)"Cannot use name '" + name + "' as an atom name since it collides with an rational number");
-    }
-    return fun;
-  }
+  return env.signature->addNumeralConstant(RationalConstantType(
+        IntegerConstantType(name.substr(0,i)),
+        IntegerConstantType(name.substr(i+1))), defaultSort);
 } // TPTP::addRationalConstant
 
 /**
  * Add an real constant by reading it from the std::string name.
- * If it overflows, create an uninterpreted constant of the
- * real type and the name 'name'. Check that the name of the constant
- * does not collide with user-introduced names of uninterpreted constants.
- * @since 22/07/2011 Manchester
- * @since 03/05/2013 train Manchester-London, fix to handle difference
- *    between treating rationals using fof() and tff()
- * @author Andrei Voronkov
  */
-unsigned TPTP::addRealConstant(const std::string& name, Set<std::string>& overflow, bool defaultSort)
+unsigned TPTP::addRealConstant(const std::string& name, bool defaultSort)
 {
-  try {
-    return env.signature->addRealConstant(name,defaultSort);
-  }
-  catch(Kernel::ArithmeticException&) {
-    bool added;
-    unsigned fun = env.signature->addFunction(name,0,added,true /* overflown constant*/);
-    if (added) {
-      overflow.insert(name);
-      Signature::Symbol* symbol = env.signature->getFunction(fun);
-      symbol->setType(OperatorType::getConstantsType(defaultSort ? AtomicSort::defaultSort() : AtomicSort::realSort()));
-    }
-    else if (!overflow.contains(name)) {
-      USER_ERROR((std::string)"Cannot use name '" + name + "' as an atom name since it collides with an real number");
-    }
-    return fun;
-  }
+  return env.signature->addNumeralConstant(RealConstantType(IntegerConstantType(name)),defaultSort);
 }  // TPTP::addRealConstant
 
 
 /**
  * Add an uninterpreted constant by reading it from the std::string name.
- * Check that the name of the constant does not collide with uninterpreted constants
- * created by the parser from overflown input numbers.
  * @since 22/07/2011 Manchester
  */
-unsigned TPTP::addUninterpretedConstant(const std::string& name, Set<std::string>& overflow, bool& added)
+unsigned TPTP::addUninterpretedConstant(const std::string& name, bool& added)
 {
-  if (overflow.contains(name)) {
-    USER_ERROR((std::string)"Cannot use name '" + name + "' as an atom name since it collides with an integer number");
-  }
   //TODO make sure Vampire internal names are unique to Vampire
   //and cannot occur in the input AYB
   if(name == "vAND" || name == "vOR" || name == "vIMP" ||

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -2893,13 +2893,13 @@ void TPTP::term()
           );
           break;
         case T_INT:
-          number = addIntegerConstant(tok.content,_isFof);
+          number = addNumeralConstant<IntegerConstantType>(tok.content,_isFof);
           break;
         case T_REAL:
-          number = addRealConstant(tok.content,_isFof);
+          number = addNumeralConstant<RealConstantType>(tok.content,_isFof);
           break;
         case T_RAT:
-          number = addRationalConstant(tok.content,_isFof);
+          number = addNumeralConstant<RationalConstantType>(tok.content,_isFof);
           break;
         default:
           ASSERTION_VIOLATION;
@@ -4736,34 +4736,6 @@ TermList TPTP::sortOf(TermList t)
     }
   }
 } // sortOf
-
-/**
- * Add an integer constant by reading it from the std::string name.
- */
-unsigned TPTP::addIntegerConstant(const std::string& name, bool defaultSort)
-{
-  return env.signature->addNumeralConstant(IntegerConstantType(name),defaultSort);
-} // TPTP::addIntegerConstant
-
-/**
- * Add an rational constant by reading it from the std::string name.
- */
-unsigned TPTP::addRationalConstant(const std::string& name, bool defaultSort)
-{
-  size_t i = name.find_first_of("/");
-  ASS(i != std::string::npos);
-  return env.signature->addNumeralConstant(RationalConstantType(
-        IntegerConstantType(name.substr(0,i)),
-        IntegerConstantType(name.substr(i+1))), defaultSort);
-} // TPTP::addRationalConstant
-
-/**
- * Add an real constant by reading it from the std::string name.
- */
-unsigned TPTP::addRealConstant(const std::string& name, bool defaultSort)
-{
-  return env.signature->addNumeralConstant(RealConstantType(name),defaultSort);
-}  // TPTP::addRealConstant
 
 
 /**

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -4762,7 +4762,7 @@ unsigned TPTP::addRationalConstant(const std::string& name, bool defaultSort)
  */
 unsigned TPTP::addRealConstant(const std::string& name, bool defaultSort)
 {
-  return env.signature->addNumeralConstant(RealConstantType(IntegerConstantType(name)),defaultSort);
+  return env.signature->addNumeralConstant(RealConstantType(name),defaultSort);
 }  // TPTP::addRealConstant
 
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -606,8 +606,6 @@ private:
   Stack<TheoryFunction> _theoryFunctions;
   /** bindings of variables to sorts */
   Map<unsigned,SList*> _variableSorts;
-  /** overflown arithmetical constants for which uninterpreted constants are introduced */
-  Set<std::string> _overflow;
   /** current color, if the input contains colors */
   Color _currentColor;
   /** a robsubstitution object to be used temporarily that is kept around to safe memory allocation time  */
@@ -817,11 +815,10 @@ private:
   OperatorType* constructOperatorType(Type* t, VList* vars = 0);
 
 public:
-  // make the tptp routines for dealing with overflown constants available to other parsers
-  static unsigned addIntegerConstant(const std::string&, Set<std::string>& overflow, bool defaultSort);
-  static unsigned addRationalConstant(const std::string&, Set<std::string>& overflow, bool defaultSort);
-  static unsigned addRealConstant(const std::string&, Set<std::string>& overflow, bool defaultSort);
-  static unsigned addUninterpretedConstant(const std::string& name, Set<std::string>& overflow, bool& added);
+  static unsigned addIntegerConstant(const std::string&, bool defaultSort);
+  static unsigned addRationalConstant(const std::string&, bool defaultSort);
+  static unsigned addRealConstant(const std::string&, bool defaultSort);
+  static unsigned addUninterpretedConstant(const std::string& name, bool& added);
 
   // also here, simply made public static to share the code with another use site
   static Unit* processClaimFormula(Unit* unit, Formula* f, const std::string& nm);

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -815,9 +815,21 @@ private:
   OperatorType* constructOperatorType(Type* t, VList* vars = 0);
 
 public:
-  static unsigned addIntegerConstant(const std::string&, bool defaultSort);
-  static unsigned addRationalConstant(const std::string&, bool defaultSort);
-  static unsigned addRealConstant(const std::string&, bool defaultSort);
+
+  /**
+   * Add a numeral constant by reading it from the std::string name.
+   */
+  template<class Numeral>
+  static unsigned addNumeralConstant(const std::string& name, bool defaultSort)
+  {
+    if (auto n = Numeral::parse(name)) {
+      return env.signature->addNumeralConstant(*n,defaultSort);
+    } else {
+      throw UserErrorException("not a valid ", Numeral::getSort(), " literal: ", name);
+    }
+  } 
+
+
   static unsigned addUninterpretedConstant(const std::string& name, bool& added);
 
   // also here, simply made public static to share the code with another use site

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -1586,20 +1586,6 @@ Z3Interfacing::Representation Z3Interfacing::getRepresentation(Term* trm)
             auto ctor = findConstructor(trm);
             return ctor();
           }
-          // TODO do we really have overflownConstants ?? not in evaluation(s) at least
-          if (symb->overflownConstant()) {
-            // too large for native representation, but z3 should cope
-            auto s = symb->fnType()->result();
-            if (s == IntTraits::sort()) {
-              return _context->int_val(symb->name().c_str());
-            } else if (s == RatTraits::sort()) {
-              return _context->real_val(symb->name().c_str());
-            } else if (s == RealTraits::sort()) {
-              return _context->real_val(symb->name().c_str());
-            } else {
-              ; // intentional fallthrough; the input is fof (and not tff), so let's just treat this as a constant
-            }
-          }
 
           // If not value then create constant symbol
           return getConst(symb, getz3sort(range_sort));

--- a/Shell/Statistics.cpp
+++ b/Shell/Statistics.cpp
@@ -233,6 +233,9 @@ void Statistics::print(std::ostream& out)
   case Statistics::TIME_LIMIT:
     out << "Time limit";
     break;
+  case Statistics::INSTRUCTION_LIMIT:
+    out << "Instruction limit";
+    break;
   case Statistics::MEMORY_LIMIT:
     out << "Memory limit";
     break;

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -204,8 +204,6 @@ void TPTPPrinter::outputSymbolTypeDefinitions(unsigned symNumber, SymbolType sym
   bool func = symType == SymbolType::FUNC ;
   if(func && theory->isInterpretedConstant(symNumber)) { return; }
 
-  if (func && sym->overflownConstant()) { return; }
-
   if(sym->interpreted()) {
     Interpretation interp = static_cast<Signature::InterpretedSymbol*>(sym)->getInterpretation();
     switch(interp) {

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -671,11 +671,6 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool funct
     return;
   }
 
-  if (sym->overflownConstant()) {
-    // don't output definitions of numbers; not even big ones
-    return;
-  }
-
   unsigned dummy;
   if (!typeCon && Theory::tuples()->findProjection(symNumber, !function, dummy)) {
     return;

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -528,6 +528,14 @@ void UIHelper::outputResult(std::ostream& out)
     addCommentSignForSZS(out);
     out << "Time limit reached!\n";
     break;
+  case Statistics::INSTRUCTION_LIMIT:
+    if(env.options->outputMode() == Options::Output::SMTCOMP){
+      out << "unknown" << endl;
+      return;
+    }
+    addCommentSignForSZS(out);
+    out << "Instruction limit reached!\n";
+    break;
   case Statistics::MEMORY_LIMIT:
     if(env.options->outputMode() == Options::Output::SMTCOMP){
       out << "unknown" << endl;

--- a/UnitTests/tIntegerConstantType.cpp
+++ b/UnitTests/tIntegerConstantType.cpp
@@ -39,6 +39,6 @@ TEST_FUN(to_string)
       "-1111111111111111111111111111111111111111111",
       "1111111189123097123890102111111111111111111",
       }) {
-    ASS_EQ(Output::toString(IntegerConstantType(str)), str);
+    ASS_EQ(Output::toString(IntegerConstantType::parse(str).unwrap()), str);
   }
 }


### PR DESCRIPTION
Optimized the signature such that no intermediate strings are created when looking up a symbol. This is espcially important for numerals.
Before this PR, whenever we wanted to find a numeral's function-id we did the following: 
- turn the numeral into a string
- hash that string
- look up the symbol id from `_funNames`
Now we will directly hash the number, which is way faster. Similar optimizations have been performed for looking up interpreted functions. Further I managed to shrink the codebase a bit as a sideeffect.

Also while i was on it I removed the unused flag `overflownConstant` as that is not necessary anymore since we're using GMP.