### PR TITLE
exponent noation real parsing

### DIFF
--- a/Kernel/Theory.cpp
+++ b/Kernel/Theory.cpp
@@ -374,10 +374,11 @@ Option<RationalConstantType> parseExponentInteger(std::string const& number, con
   auto i = number.find_first_of(exponentChars);
   if (i != std::string::npos) {
     auto base = parseRat(number.substr(0, i));
-    // auto exp = IntegerConstantType(number.substr(i + 1));
-    unsigned exp = 0;
-    if (Int::stringToUnsignedInt(number.substr(i + 1).c_str(), exp) && base.isSome()) {
-      return some((*base) * (IntegerConstantType(10) ^ (unsigned long)exp));
+    int exp = 0;
+    if (Int::stringToInt(number.substr(i + 1).c_str(), exp) && base.isSome()) {
+      return some(
+          exp >= 0 ? (*base) * (IntegerConstantType(10) ^ (unsigned long)exp)
+                   : (*base) / RationalConstantType((IntegerConstantType(10) ^ (unsigned long)abs(exp))));
     }
   }
   return {};

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -159,6 +159,7 @@ public:
 
   IntegerConstantType operator+(const IntegerConstantType& num) const;
   IntegerConstantType operator-(const IntegerConstantType& num) const;
+  IntegerConstantType operator^(unsigned long num) const;
 
   IntegerConstantType operator-() const;
   IntegerConstantType operator*(const IntegerConstantType& num) const;
@@ -317,6 +318,7 @@ public:
   explicit RealConstantType(int number) : RealConstantType(RationalConstantType(number)) {}
   RealConstantType(typename RationalConstantType::InnerType  num, typename RationalConstantType::InnerType den) : RealConstantType(RationalConstantType(num, den)) {}
 
+
 #define BIN_OP_FROM_RAT(op) \
   RealConstantType operator op(const RealConstantType& num) const \
   { return RealConstantType(RationalConstantType::operator op(num)); } \
@@ -350,8 +352,6 @@ public:
   MK_CAST_OPS(RealConstantType, IntegerConstantType)
   MK_CAST_OP(RealConstantType, /, int)
 
-private:
-  static bool parseDouble(const std::string& num, RationalConstantType& res);
 };
 
 inline bool operator<(const RealConstantType& lhs ,const RealConstantType& rhs) { 

--- a/UnitTests/tIntegerConstantType.cpp
+++ b/UnitTests/tIntegerConstantType.cpp
@@ -42,3 +42,15 @@ TEST_FUN(to_string)
     ASS_EQ(Output::toString(IntegerConstantType::parse(str).unwrap()), str);
   }
 }
+
+TEST_FUN(parse_real)
+{
+  ASS_EQ(RealConstantType::parse("0.123E20"), 
+         RealConstantType::parse("12300000000000000000"));
+  ASS_EQ(RealConstantType::parse("0.123e20"), 
+         RealConstantType::parse("12300000000000000000"));
+  ASS_EQ(RealConstantType::parse("0.123E-8"), 
+         RealConstantType::parse("0.00000000123"));
+  ASS_EQ(RealConstantType::parse("0.123e-8"), 
+         RealConstantType::parse("0.00000000123"));
+}


### PR DESCRIPTION
Fixed the parsing of exponent notation integers that was broken by introducing gmp as @quickbeam123  pointed out. 
Now we can parse problems like

```
tff(p_real_type,type,
    p_real: $real > $o ).

tff(reals,axiom,
    ( p_real(123.456e78)
    | p_real(123.456E78)
    | p_real(-123.456E78)
    | p_real(123.456E-78)
    | p_real(-123.456E-78) ) ).

```

again.