### PR TITLE
remove `TPTP::_isFof`, now redundant

### DIFF
--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -499,7 +499,7 @@ class Signature
   // Interpreted symbol declarations
 
   template<class Numeral>
-  unsigned addNumeralConstant(Numeral number_, bool defaultSort = false) {
+  unsigned addNumeralConstant(Numeral number_) {
     auto key = SymbolKey(std::make_pair(std::move(number_), unsigned(0)));
     unsigned result;
     if (_funNames.find(key,result)) {
@@ -508,16 +508,8 @@ class Signature
     result = _funs.length();
     // copy number out of key again
     auto number = key.as<std::pair<Numeral, unsigned>>()->first;
-    if (!defaultSort)
-      noteOccurrence(number);
-    Symbol* sym = 
-      defaultSort ? 
-        new Symbol(Output::toString(number),
-            /*             arity */ 0, 
-            /*       interpreted */ false, 
-            /*    preventQuoting */ true, 
-            /*             super */ false)
-                  : newNumeralConstantSymbol(std::move(number));
+    noteOccurrence(number);
+    Symbol* sym = newNumeralConstantSymbol(std::move(number));
     _funs.push(sym);
     _funNames.insert(key,result);
     return result;

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1976,7 +1976,7 @@ bool SMTLIB2::parseAsSpecConstant(const std::string& id)
       goto real_constant; // just below
     }
 
-    unsigned symb = TPTP::addNumeralConstant<IntegerConstantType>(id,false);
+    unsigned symb = TPTP::addNumeralConstant<IntegerConstantType>(id);
     TermList res = TermList(Term::createConstant(symb));
     _results.push(ParseResult(AtomicSort::intSort(),res));
 
@@ -1986,7 +1986,7 @@ bool SMTLIB2::parseAsSpecConstant(const std::string& id)
   if (StringUtils::isPositiveDecimal(id)) {
     real_constant:
 
-    unsigned symb = TPTP::addNumeralConstant<RealConstantType>(id,false);
+    unsigned symb = TPTP::addNumeralConstant<RealConstantType>(id);
     TermList res = TermList(Term::createConstant(symb));
     _results.push(ParseResult(AtomicSort::realSort(),res));
 
@@ -2624,7 +2624,7 @@ void SMTLIB2::parseRankedFunctionApplication(LExpr* exp)
       USER_ERROR_EXPR("Expected numeral as an argument of a ranked function in "+head->toString());
     }
 
-    unsigned divisorSymb = TPTP::addNumeralConstant<IntegerConstantType>(numeral,false);
+    unsigned divisorSymb = TPTP::addNumeralConstant<IntegerConstantType>(numeral);
     TermList divisorTerm = TermList(Term::createConstant(divisorSymb));
 
     TermList arg;

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -78,7 +78,6 @@ Clause* TPTP::parseClauseFromString(const std::string& str)
 {
   std::stringstream input(str+")."); // to fake endFOF, which creates the clause
   Parse::TPTP parser(input);
-  parser._isFof = true;
   parser._lastInputType = UnitInputType::AXIOM;
   parser._bools.push(false);     // this is what cnf normally pushes (but we start "from the middle")
   parser._strings.push("dummy_name");
@@ -150,17 +149,14 @@ void TPTP::parseImpl(State initialState)
       unitList();
       break;
     case FOF:
-      _isFof = true;
       fof(true);
       break;
     case THF:
       _isThf = true;
     case TFF:
-      _isFof = false;
       tff();
       break;
     case CNF:
-      _isFof = true;
       fof(false);
       break;
     case FORMULA:
@@ -2893,13 +2889,13 @@ void TPTP::term()
           );
           break;
         case T_INT:
-          number = addNumeralConstant<IntegerConstantType>(tok.content,_isFof);
+          number = addNumeralConstant<IntegerConstantType>(tok.content);
           break;
         case T_REAL:
-          number = addNumeralConstant<RealConstantType>(tok.content,_isFof);
+          number = addNumeralConstant<RealConstantType>(tok.content);
           break;
         case T_RAT:
-          number = addNumeralConstant<RationalConstantType>(tok.content,_isFof);
+          number = addNumeralConstant<RationalConstantType>(tok.content);
           break;
         default:
           ASSERTION_VIOLATION;
@@ -4659,7 +4655,6 @@ unsigned TPTP::addOverloadedFunction(std::string name,int arity,int symbolArity,
     if(sortOf(*n)!=srt){
       std::string msg = "The interpreted function symbol " + name + " is not used with a single sort.";
       msg += "\nArgument 0 is "+srt.toString()+" and argument "+Lib::Int::toString(i)+" is "+sortOf(*n).toString();
-      if(_isFof){ msg += "\nCheck that you are using tff if you want numbers to be interpreted"; }
       USER_ERROR(msg);
     }
     n = n->next();
@@ -4689,7 +4684,6 @@ unsigned TPTP::addOverloadedPredicate(std::string name,int arity,int symbolArity
     if(sortOf(*n)!=srt){
       std::string msg = "The interpreted predicate symbol " + name + " is not used with a single sort.";
       msg += "\nArgument 0 is "+srt.toString()+" and argument "+Lib::Int::toString(i)+" is "+sortOf(*n).toString();
-      if(_isFof){ msg += "Check that you are using tff if you want numbers to be interpreted"; }
       USER_ERROR(msg);
     }
     n = n->next(); 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -19,7 +19,6 @@
 
 #include <iostream>
 
-#include "Kernel/RobSubstitution.hpp"
 #include "Lib/Array.hpp"
 #include "Lib/Set.hpp"
 #include "Lib/Stack.hpp"
@@ -30,19 +29,15 @@
 #include "Kernel/Unit.hpp"
 #include "Kernel/Theory.hpp"
 #include "Kernel/Inference.hpp"
+#include "Kernel/RobSubstitution.hpp"
 
 //#define DEBUG_SHOW_STATE
-
-using namespace Lib;
-using namespace Kernel;
 
 namespace Kernel {
   class Clause;
 };
 
 namespace Parse {
-
-class TPTP;
 
 /**
  * Implements a TPTP parser
@@ -565,9 +560,6 @@ private:
   UnitInputType _lastInputType;
   /** true if the last read unit is a question */
   bool _isQuestion;
-  /** true if the last read unit is fof() or cnf() due to a subtle difference
-   * between fof() and tff() in treating numeric constants */
-  bool _isFof;
   /** */
   bool _isThf;
   /** */
@@ -820,10 +812,10 @@ public:
    * Add a numeral constant by reading it from the std::string name.
    */
   template<class Numeral>
-  static unsigned addNumeralConstant(const std::string& name, bool defaultSort)
+  static unsigned addNumeralConstant(const std::string& name)
   {
     if (auto n = Numeral::parse(name)) {
-      return env.signature->addNumeralConstant(*n,defaultSort);
+      return env.signature->addNumeralConstant(*n);
     } else {
       throw UserErrorException("not a valid ", Numeral::getSort(), " literal: ", name);
     }


### PR DESCRIPTION
As numeral constants like `37` are no longer permitted in FOF, we could either:
1. Refuse to parse them altogether.
2. Do anything we like.

Let's say that (2) is better for us and our users. Interpret them as _typed, interpreted_ numeric constants, as we would for TFF, and simplify the parsing code.