### PR TITLE
Fix OrderingComparator for non-specialized orderings

### DIFF
--- a/Kernel/OrderingComparator.cpp
+++ b/Kernel/OrderingComparator.cpp
@@ -291,6 +291,7 @@ void OrderingComparator::processTermNode()
 {
   ASS(_curr->node() && !_curr->node()->ready);
   _curr->node()->ready = true;
+  _curr->node()->trace = Trace::getEmpty(_ord);
 }
 
 const OrderingComparator::Trace* OrderingComparator::getCurrentTrace()
@@ -418,8 +419,10 @@ OrderingComparator::Branch& OrderingComparator::Node::getBranch(Ordering::Result
   switch (r) {
     case Ordering::EQUAL: return eqBranch;
     case Ordering::GREATER: return gtBranch;
-    case Ordering::INCOMPARABLE: return ngeBranch;
-    case Ordering::LESS: break; // no distinction between less and incomparable
+    case Ordering::INCOMPARABLE:
+    case Ordering::LESS:
+      // no distinction between less and incomparable
+      return ngeBranch;
   }
   ASSERTION_VIOLATION;
 }


### PR DESCRIPTION
As @joe-hauns pointed out, calling `OrderingComparator` for a term ordering that does not specialize this class or  `compareUnidirectional` results in some assertion violations. This PR attempts at rooting these out.