### PR TITLE
allow clauses to be iterators

### DIFF
--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -130,7 +130,9 @@ public:
   Literal** literals() { return _literals; }
   // support use of clauses as an iterator
   Literal **begin() { return _literals; }
+  Literal *const *begin() const { return _literals; }
   Literal **end() { return _literals + _length; }
+  Literal *const *end() const { return _literals + _length; }
 
   /** True if the clause is empty */
   bool isEmpty() const { return _length == 0; }

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -128,6 +128,9 @@ public:
    * Caller should not manipulate literals, with the exception of
    * clause construction and literal selection. */
   Literal** literals() { return _literals; }
+  // support use of clauses as an iterator
+  Literal **begin() { return _literals; }
+  Literal **end() { return _literals + _length; }
 
   /** True if the clause is empty */
   bool isEmpty() const { return _length == 0; }


### PR DESCRIPTION
A minor irritation used to be that one cannot iterate over a clause with range-for. We now have `iterLits()`, which is a big improvement, but it's still nice to be able to write

```c++
// Clause *cl;
for(Literal *l : *cl)
  ;
```

Allow this.