### PR TITLE
allow defining numerals as non-number sorts in SMT-LIB

### DIFF
--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -2793,11 +2793,11 @@ SMTLIB2::ParseResult SMTLIB2::parseTermOrFormula(LExpr* body, bool isSort)
           continue;
         }
 
-        if (parseAsSpecConstant(id)) {
+        if (parseAsUserDefinedSymbol(id,exp,false/*isSort*/)) {
           continue;
         }
 
-        if (parseAsUserDefinedSymbol(id,exp,false/*isSort*/)) {
+        if (parseAsSpecConstant(id)) {
           continue;
         }
 


### PR DESCRIPTION
Fixes #646, I hope. According to the standard, users can declare e.g. `123` to be a constant (or even a function) of non-number sort and we just have to deal with that.

However, it seems to actually be quite easy to fix. Just try to look up strings as user-defined symbols before trying to parse them as numeric constants.