### PR TITLE
more proof extra

### DIFF
--- a/Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
+++ b/Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
@@ -15,7 +15,8 @@
 #include "Saturation/SaturationAlgorithm.hpp"
 #include "Shell/Statistics.hpp"
 
-#include "Inferences/CodeTreeForwardSubsumptionAndResolution.hpp"
+#include "ProofExtra.hpp"
+#include "CodeTreeForwardSubsumptionAndResolution.hpp"
 
 namespace Inferences {
 
@@ -65,6 +66,8 @@ bool CodeTreeForwardSubsumptionAndResolution::perform(Clause *cl, Clause *&repla
       res.push((*cl)[i]);
     }
     replacement = Clause::fromStack(res, SimplifyingInference2(InferenceRule::SUBSUMPTION_RESOLUTION, cl, premise));
+    if(env.options->proofExtra() == Options::ProofExtra::FULL)
+      env.proofExtra.insert(replacement, new LiteralInferenceExtra((*cl)[resolvedQueryLit]));
     premises = pvi(getSingletonIterator(premise));
     env.statistics->forwardSubsumptionResolution++;
     cm.reset();

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -257,6 +257,15 @@ protected:
         out << prem->number();
         first=false;
       }
+
+      if(env.options->proofExtra() == Options::ProofExtra::FULL) {
+        auto *extra = env.proofExtra.find(cs);
+        if(extra)
+          out
+            << (first ? ' ' : ',')
+            << *extra;
+      }
+
       out << "]" << endl;
     }
   }

--- a/Lib/ProofExtra.hpp
+++ b/Lib/ProofExtra.hpp
@@ -65,8 +65,11 @@ public:
   }
 
   // associated InferenceExtra: must be present
-  const InferenceExtra &get(const Kernel::Unit *unit) {
-    return *extras.get(const_cast<Kernel::Unit *>(unit));
+  template<typename T>
+  T &get(Kernel::Unit *unit) {
+    auto &found = extras.get(unit);
+    ASS(found)
+    return static_cast<T &>(*found);
   }
 };
 }

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -57,6 +57,14 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
+void SplitClauseExtra::output(std::ostream &out) const {
+  out << "sat_clause_recorded";
+}
+
+void SplitDefinitionExtra::output(std::ostream &out) const {
+  out << component->number();
+}
+
 /////////////////////////////
 // SplittingBranchSelector
 //
@@ -962,6 +970,8 @@ bool Splitter::handleNonSplittable(Clause* cl)
 
     Formula* f = JunctionFormula::generalJunction(OR,resLst);
     FormulaUnit* scl = new FormulaUnit(f,NonspecificInferenceMany(InferenceRule::AVATAR_SPLIT_CLAUSE,ps));
+    if(env.options->proofExtra() == Options::ProofExtra::FULL)
+      env.proofExtra.insert(scl, new SplitClauseExtra(nsClause));
 
     nsClause->setInference(new FOConversionInference(scl));
 
@@ -1149,6 +1159,8 @@ bool Splitter::doSplitting(Clause* cl)
 
   Formula* f = JunctionFormula::generalJunction(OR,resLst);
   FormulaUnit* scl = new FormulaUnit(f,NonspecificInferenceMany(InferenceRule::AVATAR_SPLIT_CLAUSE,ps));
+  if(env.options->proofExtra() == Options::ProofExtra::FULL)
+    env.proofExtra.insert(scl, new SplitClauseExtra(splitClause));
 
   splitClause->setInference(new FOConversionInference(scl));
 
@@ -1243,6 +1255,9 @@ Clause* Splitter::buildAndInsertComponentClause(SplitLevel name, unsigned size, 
 
   Clause* compCl = Clause::fromIterator(arrayIter(lits, size),
           NonspecificInference1(InferenceRule::AVATAR_COMPONENT,def_u));
+
+  if(posName == name && env.options->proofExtra() == Options::ProofExtra::FULL)
+    env.proofExtra.insert(def_u, new SplitDefinitionExtra(compCl));
 
   // propagate running sums:
   // - we have certain values we propagate from the parents of a clause d to d. These values are mainly used to guide saturation.

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -50,6 +50,20 @@ using namespace Indexing;
 
 typedef Stack<SplitLevel> SplitLevelStack;
 
+struct SplitClauseExtra : public InferenceExtra {
+  SATClause *clause;
+  SplitClauseExtra(SATClause *clause) : clause(clause) {}
+  void output(std::ostream &out) const override;
+};
+
+struct SplitDefinitionExtra : public InferenceExtra {
+  Clause *component;
+  SplitDefinitionExtra(Clause *component) : component(component) {
+    component->incRefCnt();
+  }
+  void output(std::ostream &out) const override;
+};
+
 class Splitter;
 
 /**

--- a/Shell/EqResWithDeletion.hpp
+++ b/Shell/EqResWithDeletion.hpp
@@ -19,8 +19,11 @@
 #include "Forwards.hpp"
 
 #include "Lib/DHMap.hpp"
+#include "Lib/ProofExtra.hpp"
 
 #include "Kernel/Term.hpp"
+
+#include <unordered_set>
 
 namespace Shell {
 
@@ -44,6 +47,12 @@ private:
    * (It is reset with each clause). */
   DHMap<unsigned, TermList, IdentityHash, DefaultHash> _subst;
   Literal* _ansLit = nullptr;
+};
+
+struct EqResWithDeletionExtra : public InferenceExtra {
+  std::unordered_set<Literal *> resolved;
+  EqResWithDeletionExtra(std::unordered_set<Literal *> resolved) : resolved(resolved) {}
+  void output(std::ostream &out) const override;
 };
 
 };

--- a/Shell/FunctionDefinition.hpp
+++ b/Shell/FunctionDefinition.hpp
@@ -29,6 +29,7 @@
 
 #include "Lib/DHMap.hpp"
 #include "Lib/MultiCounter.hpp"
+#include "Lib/ProofExtra.hpp"
 #include "Lib/Stack.hpp"
 #include "Kernel/Unit.hpp"
 
@@ -114,6 +115,11 @@ private:
   Problem* _processedProblem;
 }; // class FunctionDefinition
 
+struct FunctionDefinitionExtra : public InferenceExtra {
+  std::vector<Term *> lhs;
+  FunctionDefinitionExtra(std::vector<Term *> lhs) : lhs(lhs) {}
+  void output(std::ostream &out) const override;
+};
 
 }
 


### PR DESCRIPTION
Synchronise usability improvements and more inferences from the Dedukti efforts:
- forward subsumption (resolution)
- AVATAR (except the dreaded `avatar_sat_refutation`)
- equality resolution with deletion
- function definition elimination