### PR TITLE
Fix precedences for interpreted functions

### DIFF
--- a/Inferences/ForwardDemodulation.cpp
+++ b/Inferences/ForwardDemodulation.cpp
@@ -172,6 +172,8 @@ bool ForwardDemodulationImpl<combinatorySupSupport>::perform(Clause* cl, Clause*
         AppliedTerm rhsApplied(qr.data->rhs,appl,true);
         bool preordered = qr.data->preordered;
 
+        ASS_EQ(ordering.compare(trm,rhsApplied),Ordering::reverse(ordering.compare(rhsApplied,trm)));
+
         if (_precompiledComparison) {
 #if VDEBUG
           auto dcomp = ordering.compareUnidirectional(trm,rhsApplied);

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -326,12 +326,14 @@ Ordering::Result PrecedenceOrdering::compareFunctionPrecedences(unsigned fun1, u
     return EQUAL;
 
   // unary minus is the biggest
+  // CAREFUL: changing the relative order might cause non-well-foundedness
   if (theory->isInterpretedFunction(fun1, IntTraits::minusI)) { return GREATER; }
-  if (theory->isInterpretedFunction(fun1, RatTraits::minusI)) { return GREATER; }
-  if (theory->isInterpretedFunction(fun1, RealTraits::minusI)) { return GREATER; }
-
   if (theory->isInterpretedFunction(fun2, IntTraits::minusI)) { return LESS; }
+
+  if (theory->isInterpretedFunction(fun1, RatTraits::minusI)) { return GREATER; }
   if (theory->isInterpretedFunction(fun2, RatTraits::minusI)) { return LESS; }
+
+  if (theory->isInterpretedFunction(fun1, RealTraits::minusI)) { return GREATER; }
   if (theory->isInterpretedFunction(fun2, RealTraits::minusI)) { return LESS; }
 
   // $$false is the smallest

--- a/Test/SyntaxSugar.hpp
+++ b/Test/SyntaxSugar.hpp
@@ -174,6 +174,7 @@
     auto minus = FuncSugar(NumTraits::minusF());                                          \
     auto floor = FuncSugar(NumTraits::floorF());                                          \
     auto ceil = [&](auto t) { return minus(floor(minus(t))); };                           \
+    auto toReal = FuncSugar(NumTraits::toRealF());                                        \
     auto Sort = SortSugar(NumTraits::sort());                                             \
   )                                                                                       \
 

--- a/UnitTests/tLPO.cpp
+++ b/UnitTests/tLPO.cpp
@@ -94,3 +94,20 @@ TEST_FUN(lpo_test05) {
   ASS_EQ(ord.compare(f(x,y), z),           Ordering::Result::INCOMPARABLE);
   ASS_EQ(ord.compare(g(x,y), f(f(z,z),z)), Ordering::Result::INCOMPARABLE);
 }
+
+TEST_FUN(lpo_test06) {
+  DECL_DEFAULT_VARS
+  NUMBER_SUGAR(Int)
+  DECL_FUNC(f, {Int}, Int)
+  auto minusR = FuncSugar(RealTraits::minusF());
+
+  auto ord = lpo();
+
+  auto t1 = minus(f(x));
+  auto t2 = minusR(toReal(f(x)));
+  auto t3 = toReal(minus(f(x)));
+
+  compareTwoWays(ord, t3, t1);
+  compareTwoWays(ord, t3, t2);
+  compareTwoWays(ord, t1, t2);
+}


### PR DESCRIPTION
This bug has already been fixed, but the fix must have got lost in some merge, so now I added a unit test, which is not much but better than nothing.

The bug could be reproduced by comparing the two terms in both directions which gives inconsistent results, so I suggest a debug check for this. For now I added this to forward demodulation since we are comparing pairs of terms there anyways, but I am open to putting it somewhere else.

I will run the entire TPTP with this check to see if there's any more such bugs.