### PR TITLE
update CI image to 24.04

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Tree
       uses: actions/checkout@v4

--- a/Kernel/PartialOrdering.hpp
+++ b/Kernel/PartialOrdering.hpp
@@ -14,6 +14,7 @@
 #ifndef __PartialOrdering__
 #define __PartialOrdering__
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -22,7 +23,7 @@ namespace Kernel {
 /** This corresponds to the values we can handle between two elements.
  *  Note that incomparability is also possible, namely ≱ (NGEQ),
  *  ≰ (NLEQ) and their conjunction (INCOMPARABLE). */
-enum class PoComp : uint8_t {
+enum class PoComp : std::uint8_t {
   UNKNOWN,
   GREATER,
   EQUAL,

--- a/Kernel/Theory.hpp
+++ b/Kernel/Theory.hpp
@@ -16,6 +16,7 @@
 #define __Theory__
 
 #include <cmath>
+#include <cstdint>
 
 #include "Forwards.hpp"
 
@@ -72,7 +73,7 @@ public:
   DivByZeroException() : Exception("divided by zero"){} 
 };
 
-enum class Sign : uint8_t {
+enum class Sign : std::uint8_t {
   Zero = 0,
   Pos = 1,
   Neg = 2,

--- a/SATSubsumption/SATSubsumptionAndResolution.hpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.hpp
@@ -14,6 +14,8 @@
 #ifndef SAT_SUBSUMPTION_RESOLUTION_HPP
 #define SAT_SUBSUMPTION_RESOLUTION_HPP
 
+#include <cstdint>
+
 #include "Kernel/Clause.hpp"
 #include "Lib/Slice.hpp"
 
@@ -125,7 +127,7 @@ private:
     /// After shifting 4 bits to the right (>> (2 * (j % 4)))
     /// 0b 00 00 00 10
     /// We know that m_2 does not have a positive match, but has a negative match
-    std::vector<uint8_t> _jStates;
+    std::vector<std::uint8_t> _jStates;
 
     /// @brief number of literals in L
     unsigned _m;


### PR DESCRIPTION
I got e-mail saying that GitHub are sunsetting the 20.04 image we use for the CI script. Update to 24.04 and hope we don't break anything.