### PR TITLE
Qa auto for Geoff - version 2

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -577,7 +577,7 @@ void PortfolioMode::runSlice(std::string sliceCode, int timeLimitInDeciseconds)
   ASS_GE(sliceTime,0);
   try
   {
-    Options opt = *env.options;
+    Options& opt = *env.options;
 
     // opt.randomSeed() would normally be inherited from the parent
     // addCommentSignForSZS(cout) << "runSlice - seed before setting: " << opt.randomSeed() << endl;    
@@ -608,17 +608,15 @@ void PortfolioMode::runSlice(std::string sliceCode, int timeLimitInDeciseconds)
 /**
  * Run a slice given by its options
  */
-void PortfolioMode::runSlice(Options& strategyOpt)
+void PortfolioMode::runSlice(Options& opt)
 {
   System::registerForSIGHUPOnParentDeath();
   UIHelper::portfolioParent=false;
 
-  Options opt = strategyOpt;
   //we have already performed the normalization (or don't care about it)
   opt.setNormalize(false);
   opt.setForcedOptionValues();
   opt.checkGlobalOptionConstraints();
-  *env.options = opt; //just temporarily until we get rid of dependencies on env.options in solving
 
   if (outputAllowed()) {
     addCommentSignForSZS(cout) << opt.testId() << " on " << opt.problemName() <<

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2228,7 +2228,8 @@ void Options::init()
                                                                   {"auto","plain","synthesis","off"});
     _questionAnswering.description= "Determines whether (and how) we attempt to answer questions:"
        " plain - answer-literal-based, supports disjunctive answers; synthesis - designed for sythesising programs from proofs.";
-    _questionAnswering.addHardConstraint(If(notEqual(QuestionAnsweringMode::OFF)).then(ProperSaturationAlgorithm()));
+    _questionAnswering.addHardConstraint(If(equal(QuestionAnsweringMode::PLAIN)).then(ProperSaturationAlgorithm()));
+    _questionAnswering.addHardConstraint(If(equal(QuestionAnsweringMode::SYNTHESIS)).then(ProperSaturationAlgorithm()));
     _lookup.insert(&_questionAnswering);
     _questionAnswering.tag(OptionTag::OTHER);
 

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -92,7 +92,9 @@ void Preprocess::preprocess(Problem& prb)
 
   // resolve away auto value before accessing it
   if (_options.questionAnswering() == Options::QuestionAnsweringMode::AUTO) {
-    env.options->setQuestionAnswering(Parse::TPTP::seenQuestions() ? Options::QuestionAnsweringMode::PLAIN : Options::QuestionAnsweringMode::OFF);
+    env.options->setQuestionAnswering(
+        (Parse::TPTP::seenQuestions() && env.options->saturationAlgorithm() != Options::SaturationAlgorithm::FINITE_MODEL_BUILDING ) ?
+          Options::QuestionAnsweringMode::PLAIN : Options::QuestionAnsweringMode::OFF);
   }
 
   if (_options.questionAnswering()!=Options::QuestionAnsweringMode::OFF) {


### PR DESCRIPTION
The major change (which could have consequences) is that in portfolio mode, we start modifying `env.options` in the child, while previously there was a copy (actually two). In my head, there is just one global Options object in vampire (for now), so I hope the change is only to the better (no copying needed).

Also, there is going to be a better place (in Options.cpp) for the
`// resolve away auto value before accessing it`
bit (now in Preprocess.cpp for `-qa`), once we merge the `alasca` PR.