### PR TITLE
foolp plus ins incomplete

### DIFF
--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3549,6 +3549,12 @@ bool Options::complete(const Problem& prb) const
     return false;
   }
 
+  if (prb.hasFOOL() && // careful: will this always be true after FOOLElimination?
+    _FOOLParamodulation.actualValue && _inequalitySplitting.actualValue > 0) {
+    // as currently done in the preprocessing pipeline, "ins" will destroy the abstracted normal for that "foolp" needs for completeness
+    return false;
+  }
+
   if (!unitEquality) {
     if (_selection.actualValue <= -1000 || _selection.actualValue >= 1000) return false;
     if (_literalComparisonMode.actualValue == LiteralComparisonMode::REVERSE) return false;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1733,7 +1733,7 @@ bool _hard;
         ASS(p)
         return (p->equalityAtoms() != 0) ||
           // theories may introduce equality at various places of the pipeline!
-          HasTheories::actualCheck(p);
+          HasTheories::actualCheck(p) || p->hasFOOL();
       }
       std::string msg(){ return " only useful with equality"; }
     };
@@ -1776,8 +1776,8 @@ bool _hard;
       bool check(Property*p){
         return greater ? p->atoms()>atoms : p->atoms()<atoms;
       }
-          
-      std::string msg(){ 
+
+      std::string msg(){
         std::string m = " not with ";
         if(greater){ m+="more";}else{m+="less";}
         return m+" than "+Lib::Int::toString(atoms)+" atoms";


### PR DESCRIPTION
The falsely saturated example was
```
./vampire -ins 1 -foolp on Problems/SYO/SYO078^5.p 
```
discovered by Marton