### PR TITLE
Capitalized CMAKE_BUILD_HOL value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -808,7 +808,7 @@ elseif(CMAKE_BUILD_TYPE STREQUAL Release)
   add_compile_definitions(VDEBUG=0)
 endif()
 
-if(CMAKE_BUILD_HOL STREQUAL On)
+if(CMAKE_BUILD_HOL STREQUAL ON)
   message(STATUS "Building with HOL support")
   add_compile_definitions(VHOL=1)
 else()


### PR DESCRIPTION
Hello!

The release notes say to use `CMAKE_BUILD_HOL=ON` but `CMakeLists.txt` only supports `CMAKE_BUILD_HOL=On` (note the lowercase "n") with a string comparison ([here](https://github.com/vprover/vampire/blob/hol/CMakeLists.txt#L811)).  In order to keep the values consistent with other CMake arguments I propose changing it to `ON`.

Thanks!
~Tyler