### PR TITLE
save/restore logic for line numbers in TPTP parser

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -1229,6 +1229,7 @@ void TPTP::unitList()
     resetChars();
     delete _in;
     _in = _inputs.pop();
+    _lineNumber = _lineNumbers.pop();
     _includeDirectory = _includeDirectories.pop();
     delete _allowedNames;
     _allowedNames = _allowedNamesStack.pop();
@@ -2079,6 +2080,8 @@ void TPTP::include()
     _allowedNamesStack.push(_allowedNames);
     _allowedNames = 0;
     _inputs.push(_in);
+    _lineNumbers.push(_lineNumber);
+    _lineNumber = 1;
     _includeDirectories.push(_includeDirectory);
   }
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -557,6 +557,8 @@ private:
   int _tend;
   /** line number */
   unsigned _lineNumber;
+  /** stack of line numbers when processing include directives */
+  Stack<unsigned> _lineNumbers;
   /** The list of units read (with additions directed to the end) */
   UnitList::FIFO _units;
   /** stack of unprocessed states */


### PR DESCRIPTION
Fixes #670. There is also the ...byte offset? in e.g.

```
% Parsing Error on line 2: , expected at position 3867 (text: ))
```

but I'd be inclined to say that's useless and remove it.