### PR TITLE
fix TPTP `include()` logic, report paths in errors

### DIFF
--- a/Lib/Exception.cpp
+++ b/Lib/Exception.cpp
@@ -42,8 +42,13 @@ void Exception::cry (std::ostream& str) const
 void UserErrorException::cry (std::ostream& str) const
 {
   str << "User error: " << _message;
-  if(line)
-    str << " (detected at or around line " << line << ")";
+  if(line) {
+    str << " (detected at or around line " << line;
+    if (!filename.empty()) {
+      str << " in file " << filename;
+    }
+    str << ")";
+  }
   str << endl;
 } // UserErrorException::cry
 

--- a/Lib/Exception.hpp
+++ b/Lib/Exception.hpp
@@ -20,6 +20,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <string>
 
 namespace Lib {
 
@@ -102,6 +103,7 @@ class UserErrorException
 
   // input line related to the error: non-zero if set
   unsigned line = 0;
+  std::string filename;
   void cry (std::ostream&) const;
 }; // UserErrorException
 

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -2061,7 +2061,7 @@ fs::path TPTP::resolveInclude(const fs::path included)
     return included;
 
   // 2
-  auto relativeToCurrentFileDirectory = currentFile.path.remove_filename() / included;
+  auto relativeToCurrentFileDirectory = currentFile.path.parent_path() / included;
   if(fs::exists(relativeToCurrentFileDirectory))
     return relativeToCurrentFileDirectory;
 

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -120,12 +120,13 @@ void TPTP::parse()
     parseImpl();
   } catch (UserErrorException &e) {
     e.line = lineNumber();
+    e.filename = currentPath();
     throw;
   }
 }
 
 /**
- * Read all tokens one by one 
+ * Read all tokens one by one
  * @since 08/04/2011 Manchester
  */
 void TPTP::parseImpl(State initialState)

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -350,6 +350,7 @@ public:
   //this function is used also by the API
   static void assignAxiomName(const Unit* unit, std::string& name);
   unsigned lineNumber(){ return currentFile.lineNumber; }
+  std::string currentPath(){ return currentFile.path; }
 
   static Map<int,std::string>* findQuestionVars(unsigned questionNumber) {
     auto res = _questionVariableNames.findPtr(questionNumber);

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -17,11 +17,12 @@
 #ifndef __Parser_TPTP__
 #define __Parser_TPTP__
 
+#include <filesystem>
 #include <iostream>
+#include <unordered_set>
 
 #include "Forwards.hpp"
 #include "Lib/Array.hpp"
-#include "Lib/Set.hpp"
 #include "Lib/Stack.hpp"
 #include "Lib/Exception.hpp"
 #include "Lib/IntNameTable.hpp"
@@ -300,19 +301,22 @@ public:
     : public ParsingRelatedException
   {
   public:
-    ParseErrorException(std::string message,unsigned ln) : _message(message), _ln(ln) {}
-    ParseErrorException(std::string message,Token& tok,unsigned ln);
+    ParseErrorException(std::string message, std::filesystem::path path, unsigned ln)
+      : _message(message), _path(path), _ln(ln) {}
+    ParseErrorException(std::string message, Token& tok, std::filesystem::path path, unsigned ln)
+      : ParseErrorException(message + " (text: " + tok.toString() + ')', path, ln) {}
     void cry(std::ostream&) const;
     ~ParseErrorException() {}
   protected:
     std::string _message;
+    std::filesystem::path _path;
     unsigned _ln = 0;
   }; // TPTP::ParseErrorException
 
 #define PARSE_ERROR_TOK(msg,tok) \
-  throw ParseErrorException(msg,tok,_lineNumber)
+  throw ParseErrorException(msg,tok,currentFile.path,currentFile.lineNumber)
 #define PARSE_ERROR(msg) \
-  throw ParseErrorException(msg,_lineNumber)
+  throw ParseErrorException(msg,currentFile.path,currentFile.lineNumber)
 
   /**
    * @brief Construct a new TPTP parser.
@@ -325,7 +329,7 @@ public:
    *  (use this default behaviour if you do not want to collect formulas
    *   from multiple parser calls)
    */
-  TPTP(std::istream& in, UnitList::FIFO unitBuffer = UnitList::FIFO());
+  TPTP(std::istream &in, UnitList::FIFO unitBuffer = UnitList::FIFO());
   ~TPTP();
   void parse();
   static UnitList* parse(std::istream& str);
@@ -342,11 +346,10 @@ public:
    * based on this value.
    */
   bool containsConjecture() const { return _containsConjecture; }
-  void addForbiddenInclude(std::string file);
   static bool findAxiomName(const Unit* unit, std::string& result);
   //this function is used also by the API
   static void assignAxiomName(const Unit* unit, std::string& name);
-  unsigned lineNumber(){ return _lineNumber; }
+  unsigned lineNumber(){ return currentFile.lineNumber; }
 
   static Map<int,std::string>* findQuestionVars(unsigned questionNumber) {
     auto res = _questionVariableNames.findPtr(questionNumber);
@@ -523,27 +526,23 @@ private:
 
   /** true if the input contains a conjecture */
   bool _containsConjecture;
-  /** Allowed names of formulas.
-   * If non-null, ignore formulas not included in _allowedNames.
-   * This is to support the feature formula_selection of the include
-   * directive of the TPTP format.
- */
-  Set<std::string>* _allowedNames;
-  /** stacks of allowed names when include is used */
-  Stack<Set<std::string>*> _allowedNamesStack;
-  /** set of files whose inclusion should be ignored */
-  Set<std::string> _forbiddenIncludes;
-  /** the input stream */
-  std::istream* _in;
-  /** in the case include() is used, previous streams will be saved here */
-  Stack<std::istream*> _inputs;
-  /** the current include directory */
-  std::string _includeDirectory;
-  /** in the case include() is used, previous sequence of directories will be
-   * saved here, this is required since TPTP requires the directory to be
-   * relative to the "current directory, that is, the directory used by the last include()
-   */
-  Stack<std::string> _includeDirectories;
+
+  // all the state associated with parsing a single file
+  struct FileState {
+    // the input stream: raw pointer because UIHelper might own it
+    // TODO fix ownership of streams
+    std::istream *in = nullptr;
+    // include() can optionally give a formula_selection list of names to import: the rest should be ignored
+    std::unordered_set<std::string> allowedNames;
+
+    // name of the file for error reporting
+    std::filesystem::path path;
+    // current line number for parse errors
+    unsigned lineNumber;
+  } currentFile;
+  // stack of states to restore after finishing an include() directive
+  std::vector<FileState> restoreFiles;
+
   /** input characters */
   Array<char> _chars;
   /** the position beyond the last read characters */
@@ -552,10 +551,6 @@ private:
   Array<Token> _tokens;
   /** the position beyond the last processed token */
   int _tend;
-  /** line number */
-  unsigned _lineNumber;
-  /** stack of line numbers when processing include directives */
-  Stack<unsigned> _lineNumbers;
   /** The list of units read (with additions directed to the end) */
   UnitList::FIFO _units;
   /** stack of unprocessed states */
@@ -648,7 +643,7 @@ private:
   inline char getChar(int pos)
   {
     while (_cend <= pos) {
-      int c = _in->get();
+      int c = currentFile.in->get();
       //      if (c == -1) { std::cout << "<EOF>"; } else {std::cout << char(c);}
       _chars[_cend++] = c == -1 ? 0 : c;
     }
@@ -760,6 +755,7 @@ private:
   void tag();
   void endFof();
   void endTff();
+  std::filesystem::path resolveInclude(const std::filesystem::path included);
   void include();
   void type();
   void endIte();

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2621,62 +2621,6 @@ bool Options::HasTheories::check(Property*p) {
 }
 
 /**
- * Return the include file name using its relative name.
- *
- * @param relativeName the relative name, must begin and end with "'"
- *        because of the TPTP syntax
- * @since 16/10/2003 Manchester, relativeName changed to string from char*
- * @since 07/08/2014 Manchester, relativeName changed to std::string
- */
-// TODO this behaviour isn't quite right, at least:
-// 1. we use the *root* file to resolve relative paths, which won't work if we have an axiom file that includes another
-// 2. checks current directory, which spec doesn't ask for
-// 3. checks our "-include" option, which isn't in the spec either (OK if someone relies on it, I guess)
-// cf https://tptp.org/TPTP/TR/TPTPTR.shtml#IncludeSection
-// probable solution: move all this logic into TPTP parser and do it properly there
-
-std::string Options::includeFileName (const std::string& relativeName)
-{
-  if (relativeName[0] == '/') { // absolute name
-    return relativeName;
-  }
-
-  if (std::filesystem::exists(relativeName)) {
-    return relativeName;
-  }
-
-  // truncatedRelativeName is relative.
-  // Use the conventions of Vampire:
-  // (a) first search the value of "include"
-  std::string dir = include();
-
-  if (dir == "") { // include undefined
-    // (b) search in the directory of the 'current file'
-    // i.e. the input file
-    std::filesystem::path currentFile(inputFile());
-    dir = currentFile.parent_path().string();
-    if(std::filesystem::exists(dir+"/"+relativeName)){
-      return dir + "/" + relativeName;
-    }
-
-    // (c) search the value of the environment variable TPTP_DIR
-    char* env = getenv("TPTP");
-    if (env) {
-      dir = env;
-    }
-    else {
-    // (d) use the current directory
-      dir = ".";
-    }
-    // we do not check (c) or (d) - an error will occur later
-    // if the file does not exist here
-  }
-  // now dir is the directory to search
-  return dir + "/" + relativeName;
-} // Options::includeFileName
-
-
-/**
  * Output options to a stream.
  *
  * @param str the stream

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -146,7 +146,6 @@ public:
     void setProblemName(std::string str) { _problemName.actualValue = str; }
 
     void setInputFile(const std::string& newVal){ _inputFile.set(newVal); }
-    std::string includeFileName (const std::string& relativeName);
 
     // standard ways of creating options
     void set(const std::string& name, const std::string& value); // implicitly the long version used here


### PR DESCRIPTION
- Group various save/restore TPTP logic into one struct.
- Finally move the resolve-include-file logic out from `Options` into `TPTP`.
- Fix it to conform with the TPTP standard, and only then with Vampire extensions.
- Report paths in TPTP parse errors.