### PR TITLE
Unsoundness fix in evaluation for non-linear terms

### DIFF
--- a/Inferences/PolynomialEvaluation.cpp
+++ b/Inferences/PolynomialEvaluation.cpp
@@ -298,6 +298,7 @@ PolyNf simplifyPoly(Polynom<Number> const& in, PolyNf* simplifiedArgs, bool remo
 {
   using Monom   = Monom<Number>;
 
+
   // first we simplify all the monoms containted in this polynom
   Stack<Monom> sum;
   {
@@ -353,15 +354,18 @@ Monom<Number> simplifyMonom(Monom<Number> const& in, PolyNf* simplifiedArgs, boo
   auto numeral = in.numeral;
   Stack<MonomFactor> args(facs.nFactors());
   for (unsigned i = 0; i < facs.nFactors(); i++) {
+    auto power = facs.factorAt(i).power;
     if (auto poly_ = simplifiedArgs[i].downcast<Number>()) {
       auto& poly = **poly_;
       if (poly.nSummands() == 1) {
-        numeral *= poly.summandAt(0).numeral;
-        args.loadFromIterator(poly.summandAt(0).factors->iter());
+        numeral *= pow(poly.summandAt(0).numeral, power);
+        args.loadFromIterator(
+            poly.summandAt(0).factors->iter()
+            .map([&](auto fac) { fac.power *= power; return fac; }));
         continue;
       }
     }
-    args.push(MonomFactor(simplifiedArgs[i], facs.factorAt(i).power));
+    args.push(MonomFactor(simplifiedArgs[i], power));
   }
 
   std::sort(args.begin(), args.end());

--- a/UnitTests/tInterpretedFunctions.cpp
+++ b/UnitTests/tInterpretedFunctions.cpp
@@ -625,6 +625,28 @@ ALL_NUMBERS_TEST(NUM_IS_NUM_08,
      false
     )
 
+
+ALL_NUMBERS_TEST(bug_10,
+     ((num(2) + 2) * ((num(2) + 2) + (num(2) + 2))) == (num(2) + 2) * (num(2) + 2) + (num(2) + 2) * (num(2) + 2),
+     true
+    )
+
+ALL_NUMBERS_TEST(bug_10a,
+     p((num(2) + 2) * ((num(2) + 2) + (num(2) + 2))),
+     p(32)
+    )
+
+ALL_NUMBERS_TEST(bug_10b,
+     p((num(2) + 2) * (num(2) + 2) + (num(2) + 2) * (num(2) + 2)),
+     p(32)
+    )
+
+ALL_NUMBERS_TEST(bug_10c,
+     // p(a * a + (-a) * (-a)),
+     p((num(2) - 2 + a) * (num(2) - 2 + a) + (num(2) - 2 - a) * (num(2) - 2 - a)),
+     p(2 * ( a * a ))
+    )
+
 // FRACTIONAL_TEST(eval_div_1,
 //     p(floor(frac(7,2))),
 //     p(3)


### PR DESCRIPTION
Fixes the bug that was forwarded to me by @quicquid . Must have been there for 2 years+. I think it might just be showing up now because we updated z3 recently which gives us other terms in instantiation.