### PR TITLE
Fix HOL-UWA use after free

### DIFF
--- a/Kernel/UnificationWithAbstraction.cpp
+++ b/Kernel/UnificationWithAbstraction.cpp
@@ -275,8 +275,8 @@ Option<AbstractionOracle::AbstractionResult> funcExt(
        || env.signature->isBoolCon(argSort1.functor())
        || env.signature->isBoolCon(argSort2.functor())
        ) {
-        auto& arg1 = au->subs().derefBound(t1.termArg(1));
-        auto& arg2 = au->subs().derefBound(t2.termArg(1));
+        auto arg1 = au->subs().derefBound(t1.termArg(1));
+        auto arg2 = au->subs().derefBound(t2.termArg(1));
         auto out = AbstractionOracle::EqualIf()
               .unify (UnificationConstraint(t1.typeArg(0), t2.typeArg(0), TermSpec(AtomicSort::superSort(), 0)),
                       UnificationConstraint(t1.typeArg(1), t2.typeArg(1), TermSpec(AtomicSort::superSort(), 0)),


### PR DESCRIPTION
This commit probably fixes #590. I can't confirm it 100% because i didn't manage to reproduce the issue with gcc, but with clang + address sanitizer.
