### PR TITLE
Fix compilation under g++15

### DIFF
--- a/Lib/Hash.hpp
+++ b/Lib/Hash.hpp
@@ -18,6 +18,7 @@
 #include <utility>
 #include <functional>
 #include <type_traits>
+#include <cstdint>
 
 #include "Forwards.hpp"
 #include "Kernel/Unit.hpp"


### PR DESCRIPTION
When building with g++ 15 I get an error that the type `uintptr_t` is not known.
The issue was that since g++ 15 the header `<cstdint>` is no longer automatically included and has to be explicitly included (see [https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes](https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes))