### PR TITLE
Bug fix: avoid double answer literal in Sup

### DIFF
--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -466,7 +466,7 @@ Clause* Superposition::performSuperposition(
 
     for(unsigned i=0;i<eqLength;i++) {
       Literal* curr=(*eqClause)[i];
-      if(curr!=eqLit) {
+      if(curr!=eqLit && (!bothHaveAnsLit || curr!=eqAnsLit)) {
         Literal* currAfter = subst->apply(curr, eqIsResult);
 
         if(EqHelper::isEqTautology(currAfter)) {


### PR DESCRIPTION
If both premises op Sup have an answer literal, we should not copy it from both, rather construct a new one.
(In the recent master versions this bug was masked by `MultipleAnswerLiteralRemoval`, which deleted the resulting clauses.)
The change only applies to `-qa synthesis`.