### PR TITLE
Precedence generation mini update

### DIFF
--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -579,13 +579,13 @@ struct BoostWrapper : public SymbolComparator
   }
 };
 
-struct OccurenceTiebreak {
-  OccurenceTiebreak(SymbolType) {} // here the SymbolType is a dummy argument, required by the template recursion convention
+struct IncomaparableTiebreak {
+  IncomaparableTiebreak(SymbolType) {} // here the SymbolType is a dummy argument, required by the template recursion convention
 
-  Comparison compare(unsigned s1, unsigned s2) {  return Int::compare(s1,s2); }
+  Comparison compare(unsigned s1, unsigned s2) { return Comparison::EQUAL; }
 };
 
-template<bool revert = false, typename InnerComparator = OccurenceTiebreak>
+template<bool revert = false, typename InnerComparator = IncomaparableTiebreak>
 struct FreqComparator : public SymbolComparator
 {
   FreqComparator(SymbolType symType) : SymbolComparator(symType) {}
@@ -604,7 +604,7 @@ struct FreqComparator : public SymbolComparator
   }
 };
 
-template<bool revert = false, typename InnerComparator = OccurenceTiebreak>
+template<bool revert = false, typename InnerComparator = IncomaparableTiebreak>
 struct ArityComparator : public SymbolComparator
 {
   ArityComparator(SymbolType symType) : SymbolComparator(symType) {}
@@ -616,14 +616,14 @@ struct ArityComparator : public SymbolComparator
       res = Lib::revert(res);
     }
     if(res==EQUAL) {
-      // fallback to Inner 
+      // fallback to Inner
       res = InnerComparator(_symType).compare(u1,u2);
     }
     return res;
   }
 };
 
-template<int spc, bool revert = false, typename InnerComparator = OccurenceTiebreak>
+template<int spc, bool revert = false, typename InnerComparator = IncomaparableTiebreak>
 struct SpecAriFirstComparator : public SymbolComparator
 {
   SpecAriFirstComparator(SymbolType symType) : SymbolComparator(symType) {}
@@ -642,10 +642,10 @@ struct SpecAriFirstComparator : public SymbolComparator
   }
 };
 
-template<bool revert = false, typename InnerComparator = OccurenceTiebreak>
+template<bool revert = false, typename InnerComparator = IncomaparableTiebreak>
 using UnaryFirstComparator = SpecAriFirstComparator<1,revert,InnerComparator>;
 
-template<bool revert = false, typename InnerComparator = OccurenceTiebreak>
+template<bool revert = false, typename InnerComparator = IncomaparableTiebreak>
 using ConstFirstComparator = SpecAriFirstComparator<0,revert,InnerComparator>;
 
 static void loadPermutationFromString(DArray<unsigned>& p, const std::string& str) {
@@ -742,7 +742,7 @@ PrecedenceOrdering::PrecedenceOrdering(Problem& prb, const Options& opt, bool qk
 }
 
 static void sortAuxBySymbolPrecedence(DArray<unsigned>& aux, const Options& opt, SymbolType symType) {
-  // since the below sorts are stable, a proper input shuffling manifests itself (also) by initializing aux with a random permutation rather then the identity one
+  // a proper input shuffling manifests itself (also) by initializing aux with a random permutation rather then the identity one
   if (opt.shuffleInput()) {
     // in particular shuffleInput causes OCCURRENCE to be also random
     Shuffling::shuffleArray(aux,aux.size());

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -584,6 +584,8 @@ struct OccurenceTiebreak {
   OccurenceTiebreak(SymbolType, // here the SymbolType is a dummy argument, required by the template recursion convention
     bool noTiebreak) : _noTiebreak(noTiebreak) {}
 
+  // normally, OccurenceTiebreak resorts to comparing the plain symbol IDs,
+  // but under shuffling (=> noTiebreak), we want to ignore this and use whatever was in the array before (which was a random permutation)
   Comparison compare(unsigned s1, unsigned s2) { return _noTiebreak ? Comparison::EQUAL : Int::compare(s1,s2); }
 private:
   bool _noTiebreak;

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -743,9 +743,13 @@ PrecedenceOrdering::PrecedenceOrdering(Problem& prb, const Options& opt, bool qk
 
 static void sortAuxBySymbolPrecedence(DArray<unsigned>& aux, const Options& opt, SymbolType symType) {
   // since the below sorts are stable, a proper input shuffling manifests itself (also) by initializing aux with a random permutation rather then the identity one
-  if (opt.shuffleInput() && opt.symbolPrecedence() != Shell::Options::SymbolPrecedence::SCRAMBLE) {
-    Shuffling::shuffleArray(aux,aux.size());
+  if (opt.shuffleInput()) {
     // in particular shuffleInput causes OCCURRENCE to be also random
+    Shuffling::shuffleArray(aux,aux.size());
+    if (opt.symbolPrecedence() == Shell::Options::SymbolPrecedence::SCRAMBLE) {
+      // no need to go and shuffle one more time below
+      return;
+    }
   }
 
   switch(opt.symbolPrecedence()) {
@@ -782,13 +786,7 @@ static void sortAuxBySymbolPrecedence(DArray<unsigned>& aux, const Options& opt,
       // already sorted by occurrence
       break;
     case Shell::Options::SymbolPrecedence::SCRAMBLE:
-      unsigned sz = aux.size();
-      for(unsigned i=0;i<sz;i++){
-        unsigned j = Random::getInteger(sz-i)+i;
-        unsigned tmp = aux[j];
-        aux[j]=aux[i];
-        aux[i]=tmp;
-      }
+      Shuffling::shuffleArray(aux,aux.size());
       break;
   }
 }

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -483,7 +483,7 @@ Ordering::Result PrecedenceOrdering::compareFunctionPrecedences(unsigned fun1, u
 /**
  * Compare precedences of two type constructor symbols
  * At the moment, completely non-optimised
- */ 
+ */
 Ordering::Result PrecedenceOrdering::compareTypeConPrecedences(unsigned tyc1, unsigned tyc2) const
 {
   auto size = _typeConPrecedences.size();
@@ -521,11 +521,11 @@ struct SymbolComparator {
     if(_symType == SymbolType::FUNC){
       return env.signature->getFunction(s);
     } else if (_symType == SymbolType::PRED){
-      return env.signature->getPredicate(s);      
+      return env.signature->getPredicate(s);
     } else {
-      return env.signature->getTypeCon(s);            
+      return env.signature->getTypeCon(s);
     }
-  }  
+  }
 };
 
 template<typename InnerComparator>
@@ -539,8 +539,8 @@ struct BoostWrapper : public SymbolComparator
     Comparison res = EQUAL;
     auto sym1 = getSymbol(s1);
     auto sym2 = getSymbol(s2);
-    bool u1 = sym1->inUnit(); 
-    bool u2 = sym2->inUnit(); 
+    bool u1 = sym1->inUnit();
+    bool u2 = sym2->inUnit();
     bool g1 = sym1->inGoal();
     bool g2 = sym2->inGoal();
     bool i1 = sym1->introduced();
@@ -670,7 +670,7 @@ static void loadPermutationFromString(DArray<unsigned>& p, const std::string& st
 }
 
 bool isPermutation(const DArray<int>& xs) {
-  DArray<int> cnts(xs.size()); 
+  DArray<int> cnts(xs.size());
   cnts.init(xs.size(), 0);
   for (unsigned i = 0; i < xs.size(); i++) {
     cnts[xs[i]] += 1;
@@ -686,10 +686,10 @@ bool isPermutation(const DArray<int>& xs) {
 /**
  * Create a PrecedenceOrdering object.
  */
-PrecedenceOrdering::PrecedenceOrdering(const DArray<int>& funcPrec, 
-                                       const DArray<int>& typeConPrec,   
-                                       const DArray<int>& predPrec, 
-                                       const DArray<int>& predLevels, 
+PrecedenceOrdering::PrecedenceOrdering(const DArray<int>& funcPrec,
+                                       const DArray<int>& typeConPrec,
+                                       const DArray<int>& predPrec,
+                                       const DArray<int>& predLevels,
                                        bool reverseLCM,
                                        bool qkboPrecedence)
   : _predicates(predPrec.size()),
@@ -716,7 +716,7 @@ PrecedenceOrdering::PrecedenceOrdering(const DArray<int>& funcPrec,
 PrecedenceOrdering::PrecedenceOrdering(Problem& prb, const Options& opt, const DArray<int>& predPrec, bool qkboPrecedence)
 : PrecedenceOrdering(
     funcPrecFromOpts(prb,opt),
-    typeConPrecFromOpts(prb,opt),    
+    typeConPrecFromOpts(prb,opt),
     predPrec,
     predLevelsFromOptsAndPrec(prb,opt,predPrec),
     opt.literalComparisonMode()==Shell::Options::LiteralComparisonMode::REVERSE,
@@ -935,7 +935,7 @@ void PrecedenceOrdering::checkLevelAssumptions(DArray<int> const& levels)
 #endif // VDEBUG
 }
 
-void PrecedenceOrdering::show(std::ostream& out) const 
+void PrecedenceOrdering::show(std::ostream& out) const
 {
   auto _show = [&](const char* precKind, unsigned cntFunctors, auto getSymbol, auto compareFunctors)
     {
@@ -955,18 +955,18 @@ void PrecedenceOrdering::show(std::ostream& out) const
       out << "%" << std::endl;
     };
 
-  _show("type constructor", 
-      env.signature->typeCons(), 
+  _show("type constructor",
+      env.signature->typeCons(),
       [](unsigned f) { return env.signature->getTypeCon(f); },
       [&](unsigned l, unsigned r){ return intoComparison(compareTypeConPrecedences(l,r)); });
 
-  _show("function", 
+  _show("function",
       env.signature->functions(),
       [](unsigned f) { return env.signature->getFunction(f); },
       [&](unsigned l, unsigned r){ return intoComparison(compareFunctionPrecedences(l,r)); }
       );
 
-  _show("predicate", 
+  _show("predicate",
       env.signature->predicates(),
       [](unsigned f) { return env.signature->getPredicate(f); },
       [&](unsigned l, unsigned r) { return intoComparison(comparePredicatePrecedences(l,r)); });
@@ -993,7 +993,7 @@ void PrecedenceOrdering::show(std::ostream& out) const
   showConcrete(out);
 }
 
-DArray<int> PrecedenceOrdering::testLevels() 
+DArray<int> PrecedenceOrdering::testLevels()
 {
   DArray<int> levels(env.signature->predicates());
   for (unsigned i = 0; i < levels.size(); i++) {

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1893,7 +1893,7 @@ bool SMTLIB2::parseAsUserDefinedSymbol(const std::string& id,LExpr* exp,bool isS
       _todo.pop();
       ASS(!isSort);
       TermList resSort;
-      auto sort = _results.pop().asTerm(resSort);
+      DEBUG_CODE(auto sort =) _results.pop().asTerm(resSort);
       ASS_EQ(sort, AtomicSort::superSort());
       if (!MatchingUtils::matchTerms(type->result(), resSort, subst)) {
         complainAboutArgShortageOrWrongSorts("user defined symbol",exp);


### PR DESCRIPTION
* don't shuffle twice for `si=on:sp=scramble`; reuse `shuffleArray` for `SCRAMBLE`
* don't tiebreak on `Occurrence` (it defeats the purpose of pre-Shuffling under `si=on`); but no: randomized quicksort is not stable, but that should not matter
