### PR TITLE
Fix UB in SATSubsumptionAndResolution::get(I|J)Matches

### DIFF
--- a/SATSubsumption/SATSubsumptionAndResolution.hpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.hpp
@@ -166,9 +166,8 @@ private:
     Slice<Match> getIMatches(unsigned i)
     {
       ASS_L(i, _indexI.size())
-      return Slice<Match>(
-          &_matchesByI[_indexI[i]],
-          &_matchesByI[_indexI[i + 1]]);
+      return Slice(_matchesByI.data() + _indexI[i],
+                   _matchesByI.data() + _indexI[i + 1]);
     }
 
     /**
@@ -179,9 +178,8 @@ private:
     Slice<Match> getJMatches(unsigned j)
     {
       ASS_L(j, _indexJ.size())
-      return Slice<Match>(
-          &_matchesByJ[_indexJ[j]],
-          &_matchesByJ[_indexJ[j + 1]]);
+      return Slice(_matchesByJ.data() + _indexJ[j],
+                   _matchesByJ.data() + _indexJ[j + 1]);
     }
 
     /**

--- a/checks/sanity
+++ b/checks/sanity
@@ -28,7 +28,7 @@ check_szs_status() {
 	shift
 	echo $@
 	out=`cd checks && $vampire $@`
-	szs=`echo "$out" | egrep "^% SZS status $status for .+$"`
+	szs=`echo "$out" | grep -E "^% SZS status $status for .+$"`
 	if test -z "$szs"
 	then
 		echo "SZS check failed: should have been SZS $status"
@@ -43,7 +43,7 @@ check_smtcomp_status() {
 	shift
 	echo $@
 	out=`cd checks && $vampire $@`
-	result=`echo "$out" | egrep "^$status$"`
+	result=`echo "$out" | grep -E "^$status$"`
 	if test -z "$result"
 	then
 		echo "$SMT check failed: should have been $status"


### PR DESCRIPTION
Before this commit, the code relied on UB because the indices in `_indexI` and `_indexJ` sometimes point to `_matchesByI.end()` and `_matchesByJ.end()`, respectively.
When running the vampire using a debug build, an assertion in the STL vector is violated because we try to access out of bounds.
But since we only need the pointer of the elements we can remove the dereferencing and just access the `vector::data()` pointer and add the desired offsets.

Moreover, `checks/sanity` the obsolete `egrep` is replaced by `grep -E` to remove all the warnings.
