### PR TITLE
bitfield-generating macro

### DIFF
--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -162,6 +162,8 @@ public:
     CHECK_VAR = 5,
     SEARCH_STRUCT = 6,
   };
+  static const unsigned INSTRUCTION_BITS = 3;
+  static_assert(SEARCH_STRUCT < 1 << INSTRUCTION_BITS, "Instruction should fit within INSTRUCTION_BITS");
 
   /** Structure containing a single instruction and its arguments */
   struct CodeOp
@@ -220,16 +222,15 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const CodeOp& op);
 
     BITFIELD(64,
-      BITFIELD_MEMBER(unsigned, _arg, _setArg, 61,
-      BITFIELD_MEMBER(unsigned, _instruction, _setInstruction, 3,
+      BITFIELD_MEMBER(unsigned, _arg, _setArg, CHAR_BIT * sizeof(unsigned) - INSTRUCTION_BITS,
+      BITFIELD_MEMBER(unsigned, _instruction, _setInstruction, INSTRUCTION_BITS,
       END_BITFIELD
     )))
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
-    static_assert(SEARCH_STRUCT < 8, "must be able to squash instructions into 3 bits");
     template<class T>
-    BITFIELD_PTR_GET(T, _data, 3)
+    BITFIELD_PTR_GET(T, _data, INSTRUCTION_BITS)
     template<class T>
-    BITFIELD_PTR_SET(T, _setData, 3)
+    BITFIELD_PTR_SET(T, _setData, INSTRUCTION_BITS)
 
   private:
     // bitfield

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -219,31 +219,20 @@ public:
 
     friend std::ostream& operator<<(std::ostream& out, const CodeOp& op);
 
-    static constexpr unsigned
-      INSTRUCTION_BITS_START = 0,
-      INSTRUCTION_BITS_END = INSTRUCTION_BITS_START + 3,
-      ARG_BITS_START = INSTRUCTION_BITS_END,
-      ARG_BITS_END = CHAR_BIT * sizeof(uint64_t),
-      DATA_BITS_START = INSTRUCTION_BITS_END,
-      DATA_BITS_END = CHAR_BIT * sizeof(void *);
-
+    BITFIELD(64,
+      BITFIELD_MEMBER(unsigned, _arg, _setArg, 61,
+      BITFIELD_MEMBER(unsigned, _instruction, _setInstruction, 3,
+      END_BITFIELD
+    )))
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
     static_assert(SEARCH_STRUCT < 8, "must be able to squash instructions into 3 bits");
-
-    // getters and setters
-    BITFIELD64_GET_AND_SET(unsigned, instruction, Instruction, INSTRUCTION)
-    BITFIELD64_GET_AND_SET(unsigned, arg, Arg, ARG)
-    template<class T> T* _data() const {
-      static_assert(alignof(T)>SEARCH_STRUCT);
-      return reinterpret_cast<T*>(BitUtils::getBits<DATA_BITS_START, DATA_BITS_END>(this->_content));
-    }
-    template<class T> void _setData(T* data) {
-      static_assert(alignof(T)>SEARCH_STRUCT);
-      BitUtils::setBits<DATA_BITS_START, DATA_BITS_END>(this->_content, reinterpret_cast<uint64_t>(data));
-    }
-    // end bitfield
+    template<class T>
+    BITFIELD_PTR_GET(T, _data, 3)
+    template<class T>
+    BITFIELD_PTR_SET(T, _setData, 3)
 
   private:
+    // bitfield
     uint64_t _content;
 
     /**

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -53,6 +53,8 @@ public:
     FUN_RIGHT_OFS = 3,
     FUN_UNEXPANDED = 4,
   };
+  static const unsigned ENTRY_TAG_BITS = 3;
+  static_assert(FUN_UNEXPANDED < 1 << ENTRY_TAG_BITS, "EntryTag should fit within ENTRY_TAG_BITS");
 
   struct Entry
   {
@@ -73,14 +75,13 @@ public:
 
     uint64_t _content;
     BITFIELD(64,
-      BITFIELD_MEMBER(unsigned, _number, _setNumber, 27,
-      BITFIELD_MEMBER(unsigned, _tag, _setTag, 3,
+      BITFIELD_MEMBER(unsigned, _number, _setNumber, CHAR_BIT * sizeof(unsigned) - ENTRY_TAG_BITS,
+      BITFIELD_MEMBER(unsigned, _tag, _setTag, ENTRY_TAG_BITS,
       END_BITFIELD
     )))
     BITFIELD_PTR_GET(Term, _term, 0)
     BITFIELD_PTR_SET(Term, _setTerm, 0)
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
-    static_assert(FUN_UNEXPANDED < 8, "must be able to squash tags into 3 bits");
   };
 
   inline Entry& operator[](size_t i) { ASS_L(i,_length); return _data[i]; }

--- a/Kernel/FlatTerm.hpp
+++ b/Kernel/FlatTerm.hpp
@@ -72,26 +72,15 @@ public:
     void expand();
 
     uint64_t _content;
-
-    static constexpr unsigned
-      TAG_BITS_START = 0,
-      TAG_BITS_END = TAG_BITS_START + 3,
-      NUMBER_BITS_START = TAG_BITS_END,
-      NUMBER_BITS_END = NUMBER_BITS_START + 27,
-      TERM_BITS_START = 0,
-      TERM_BITS_END = CHAR_BIT * sizeof(Term *);
-
-    // various properties we want to check
-    static_assert(TAG_BITS_START == 0, "tag must be the least significant bits");
-    static_assert(TERM_BITS_START == 0, "term must be the least significant bits");
+    BITFIELD(64,
+      BITFIELD_MEMBER(unsigned, _number, _setNumber, 27,
+      BITFIELD_MEMBER(unsigned, _tag, _setTag, 3,
+      END_BITFIELD
+    )))
+    BITFIELD_PTR_GET(Term, _term, 0)
+    BITFIELD_PTR_SET(Term, _setTerm, 0)
     static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
     static_assert(FUN_UNEXPANDED < 8, "must be able to squash tags into 3 bits");
-
-    // getters and setters
-    BITFIELD64_GET_AND_SET(unsigned, tag, Tag, TAG)
-    BITFIELD64_GET_AND_SET(unsigned, number, Number, NUMBER)
-    BITFIELD64_GET_AND_SET_PTR(Term*, term, Term, TERM)
-    // end bitfield
   };
 
   inline Entry& operator[](size_t i) { ASS_L(i,_length); return _data[i]; }

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -70,6 +70,9 @@ enum TermTag {
   /** special variable */
   SPEC_VAR = 3u,
 };
+// number of bits occupied by a TermTag
+const unsigned TERM_TAG_BITS = 2;
+static_assert(SPEC_VAR < 1 << TERM_TAG_BITS, "TermTag must fit within TERM_TAG_BITS");
 
 enum ArgumentOrderVals {
   /**
@@ -90,9 +93,11 @@ enum ArgumentOrderVals {
   AO_EQUAL=3,
   AO_INCOMPARABLE=4,
 };
+const unsigned ARGUMENT_ORDER_BITS = 3;
+static_assert(AO_INCOMPARABLE < 1 << ARGUMENT_ORDER_BITS, "ArgumentOrderVals must fit within ARGUMENT_ORDER_BITS");
 
 inline std::ostream& operator<<(std::ostream& out, ArgumentOrderVals const& self)
-{ 
+{
   switch(self) {
     case AO_UNKNOWN: return out << "UNKNOWN";
     case AO_GREATER: return out << "GREATER";
@@ -357,7 +362,7 @@ private:
   BITFIELD(64,
     BITFIELD_MEMBER(uint32_t, _id, _setId, 32,
     BITFIELD_MEMBER(uint32_t, _distinctVars, _setDistinctVars, TERM_DIST_VAR_BITS,
-    BITFIELD_MEMBER(unsigned, _order, _setOrder, 3,
+    BITFIELD_MEMBER(unsigned, _order, _setOrder, ARGUMENT_ORDER_BITS,
     BITFIELD_MEMBER(bool, _hasLambda, _setHasLambda, 1,
     BITFIELD_MEMBER(bool, _hasRedex, _setHasRedex, 1,
     BITFIELD_MEMBER(bool, _hasDeBruijnIndex, _setHasDeBruijnIndex, 1,
@@ -366,14 +371,13 @@ private:
     BITFIELD_MEMBER(bool, _literal, _setLiteral, 1,
     BITFIELD_MEMBER(bool, _shared, _setShared, 1,
     BITFIELD_MEMBER(bool, _polarity, _setPolarity, 1,
-    BITFIELD_MEMBER(unsigned, _tag, _setTag, 2,
+    BITFIELD_MEMBER(unsigned, _tag, _setTag, TERM_TAG_BITS,
     END_BITFIELD
   )))))))))))))
   BITFIELD_PTR_GET(Term, _term, 0)
   BITFIELD_PTR_SET(Term, _setTerm, 0)
 
   static_assert(sizeof(void *) <= sizeof(uint64_t), "must be able to fit a pointer into a 64-bit integer");
-  static_assert(AO_INCOMPARABLE < 8, "must be able to squash orderings into 3 bits");
 
   friend class Indexing::TermSharing;
   friend class Term;

--- a/Lib/MacroUtils.hpp
+++ b/Lib/MacroUtils.hpp
@@ -15,4 +15,7 @@
 #define __CONCAT_IDENTS(A, B) A ## B
 #define CONCAT_IDENTS(A, B) __EXPAND(__CONCAT_IDENTS)(A, B)
 
+#define CAR(x, ...) x
+#define CDR(x, ...) __VA_ARGS__
+
 #endif // __MacroUtils__


### PR DESCRIPTION
I nerd-sniped myself a bit yesterday afternoon. We currently have some mostly-manual bitfield stuff to do pointer tagging. In particular it requires a particular pattern with `_BITS_START` and `_BITS_END` which is quite annoying/fragile.

Implement this with a slightly odd-looking macro instead that works out the bit positions for you.

If you like it, great. If you think this is dark magic that should be banished, also fair enough.