### PR TITLE
Some new option defaults

### DIFF
--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -5021,155 +5021,155 @@ void Schedules::getCascSat2024Schedule(const Property& property, Schedule& quick
 void Schedules::getAlascaAwareAriSchedule(const Shell::Property& property, Schedule& quick) {
   // alasca/problemsARIuns.txt
   // Sub-schedule for 2000Mi strat cap / 2000Mi overall limit
-  quick.push("lrs+10_1:1_asg=force:gtg=exists_top:sil=64000:thi=all:to=kbo:i=14:si=on:rtra=on:alasca=on_0");
-  quick.push("lrs+1010_1:1_canc=force:doe=on:drc=off:nwc=5.0:prc=on:prlc=on:sil=128000:sp=const_max:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=8,1:to=lpo:i=74:si=on:rtra=on_0");
-  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:nwc=10.0:rp=on:s2a=on:sas=z3:sil=128000:sp=frequency:tha=off:thi=all:to=kbo:i=96:si=on:rtra=on_0");
-  quick.push("lrs+10_1:2_ep=RST:gve=force:ins=2:lcm=reverse:sil=64000:sos=on:to=lpo:uwa=one_side_interpreted:i=5:si=on:rtra=on_0");
-  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:sp=frequency:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=10:si=on:rtra=on_0");
-  quick.push("dis+1011_1:1_canc=force:drc=off:prc=on:sac=on:i=21:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_ep=RSTC:fs=off:fsr=off:gtg=position:s2a=on:sas=z3:slsq=on:to=lpo:i=33:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+11_1:1_add=large:pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=141:si=on:rtra=on_0");
-  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=20:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+1011_1:5_av=off:bd=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=3:si=on:rtra=on_0");
-  quick.push("lrs+21_4:1_nm=2:s2a=on:sac=on:sil=64000:sos=on:sp=weighted_frequency:to=lpo:i=72:si=on:rtra=on_0");
-  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=7:si=on:rtra=on_0");
-  quick.push("lrs+1002_4:1_br=off:inst=on:s2a=on:sil=64000:to=lpo:i=11:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=20:si=on:rtra=on_0");
-  quick.push("dis+1010_1:128_ev=force:fd=preordered:isp=bottom:prc=on:sas=z3:thi=overlap:thsq=on:thsqc=16:thsqd=64:to=lpo:i=59:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1024_fde=unused:nm=16:norm_ineq=on:sas=z3:sil=128000:sos=on:tha=off:to=kbo:i=74:si=on:rtra=on_0");
-  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=243:si=on:rtra=on_0");
-  quick.push("dis+1011_1:1_gtg=position:lsd=20:nwc=3.0:sas=z3:sil=64000:sp=const_frequency:tgt=ground:to=kbo:i=237:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_doe=on:ev=cautious:gtg=exists_sym:nm=0:ss=axioms:to=kbo:i=226:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_sas=z3:tha=off:to=lpo:i=37:si=on:rtra=on_0");
-  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=444:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_gtg=all:gtgl=2:nwc=5.0:sas=z3:sil=128000:to=lpo:i=44:si=on:rtra=on_0");
-  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=16:si=on:rtra=on_0");
-  quick.push("lrs+1002_1:1_gtg=exists_top:sas=z3:sp=const_frequency:tha=off:thi=strong:to=lpo:i=78:si=on:rtra=on_0");
-  quick.push("dis+1002_16:1_doe=on:gtg=exists_top:gve=force:norm_ineq=on:sas=z3:sil=64000:ss=axioms:to=lpo:uwa=one_side_constant:i=15:si=on:rtra=on_0");
-  // Improves by expected 999.4749066268228 probs costing 1975 Mi
+  quick.push("lrs+10_1:1_asg=force:gtg=exists_top:sil=64000:thi=all:to=kbo:i=14:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1010_1:1_canc=force:doe=on:drc=off:nwc=5.0:prc=on:prlc=on:sil=128000:sp=const_max:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=8,1:to=lpo:i=74:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
+  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:rp=on:s2a=on:sas=z3:sil=128000:tha=off:thi=all:to=kbo:i=96:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
+  quick.push("lrs+10_1:2_ep=RST:gve=force:ins=2:lcm=reverse:sil=64000:sos=on:to=lpo:uwa=one_side_interpreted:i=5:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=10:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+1011_1:1_canc=force:drc=off:prc=on:sac=on:i=21:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_ep=RSTC:fs=off:fsr=off:gtg=position:s2a=on:sas=z3:slsq=on:to=lpo:i=33:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=141:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=20:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_1:5_av=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=3:si=on:rtra=on:lma=off:uhcvi=off:sp=arity_0");
+  quick.push("lrs+21_4:1_nm=2:s2a=on:sac=on:sil=64000:sos=on:sp=weighted_frequency:to=lpo:i=72:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=7:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1002_4:1_br=off:inst=on:s2a=on:sil=64000:to=lpo:i=11:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=20:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:128_ev=force:fd=preordered:isp=bottom:prc=on:sas=z3:thi=overlap:thsq=on:thsqc=16:thsqd=64:to=lpo:i=59:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1024_fde=unused:nm=16:norm_ineq=on:sas=z3:sil=128000:sos=on:tha=off:to=kbo:i=74:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=243:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_1:1_gtg=position:lsd=20:nwc=3.0:sas=z3:sil=64000:sp=const_frequency:tgt=ground:to=kbo:i=237:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
+  quick.push("dis+1010_1:1_doe=on:ev=cautious:gtg=exists_sym:nm=0:ss=axioms:to=kbo:i=226:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_sas=z3:tha=off:to=lpo:i=37:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=444:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:1_gtg=all:gtgl=2:nwc=5.0:sas=z3:sil=128000:to=lpo:i=44:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=16:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("lrs+1002_1:1_gtg=exists_top:sas=z3:sp=const_frequency:tha=off:thi=strong:to=lpo:i=78:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+1002_16:1_doe=on:gtg=exists_top:gve=force:norm_ineq=on:sas=z3:sil=64000:ss=axioms:to=lpo:uwa=one_side_constant:i=15:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  // Improves by expected 999.474906626823 probs costing 1975 Mi
   // Sub-schedule for 4000Mi strat cap / 4000Mi overall limit
-  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:sp=frequency:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=85:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_doe=on:norm_ineq=on:nwc=10.0:sil=64000:sp=unary_frequency:to=kbo:i=126:si=on:rtra=on_0");
-  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:uhcvi=on:i=116:si=on:rtra=on_0");
-  quick.push("lrs-1011_1:64_av=off:br=off:canc=cautious:sos=on:sp=unary_first:to=lpo:i=92:si=on:rtra=on_0");
-  quick.push("dis+1002_1:1_acc=on:canc=force:fdi=10:fsr=off:sil=64000:tha=off:to=lpo:i=92:si=on:rtra=on_0");
-  quick.push("lrs+1010_1:1_bd=off:fde=unused:gve=force:kws=precedence:sas=z3:sp=unary_frequency:spb=goal:tgt=ground:tha=off:thf=on:to=kbo:uace=off:i=693:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=all:to=kbo:i=54:si=on:rtra=on_0");
-  quick.push("dis+10_1:1_fde=unused:nm=16:nwc=10.0:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=110:si=on:rtra=on_0");
-  quick.push("dis+10_1:1_gtg=exists_sym:gtgl=5:nwc=5.0:sil=128000:ss=axioms:tha=off:to=kbo:i=999:si=on:rtra=on_0");
-  quick.push("ott+1010_3:1_bs=on:canc=cautious:doe=on:fsr=off:s2a=on:s2agt=32:sas=z3:sil=128000:tha=off:thi=overlap:to=kbo:urr=on:i=606:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=61:si=on:rtra=on_0");
-  quick.push("dis+1011_2:1_ev=off:fde=none:nm=0:norm_ineq=on:nwc=2.0:sac=on:sil=128000:spb=goal_then_units:tgt=full:tha=some:thsq=on:thsqc=8:thsqd=64:to=kbo:i=363:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=125:si=on:rtra=on_0");
-  quick.push("lrs-1002_1:1_norm_ineq=on:sas=z3:sos=on:tha=some:to=kbo:i=72:si=on:rtra=on_0");
-  quick.push("ott+21_1:1_gtg=exists_all:kws=inv_frequency:nm=0:sas=z3:tgt=full:tha=off:to=kbo:i=268:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=on:tgt=ground:to=lakbo:i=102:si=on:rtra=on:alasca=on_0");
+  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=85:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+10_1:1_doe=on:norm_ineq=on:sil=64000:sp=unary_frequency:to=kbo:i=126:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
+  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:i=116:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs-1011_1:64_av=off:br=off:canc=cautious:sos=on:sp=unary_first:to=lpo:i=92:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
+  quick.push("dis+1002_1:1_acc=on:canc=force:fdi=10:fsr=off:sil=64000:tha=off:to=lpo:i=92:si=on:rtra=on:lma=off:bd=all:uhcvi=off:ccuc=all:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1010_1:1_fde=unused:gve=force:kws=precedence:sas=z3:sp=unary_frequency:spb=goal:tgt=ground:tha=off:thf=on:to=kbo:uace=off:i=693:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=all:to=kbo:i=54:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+10_1:1_fde=unused:nm=16:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=110:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+10_1:1_gtg=exists_sym:gtgl=5:nwc=5.0:sil=128000:ss=axioms:tha=off:to=kbo:i=999:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("ott+1010_3:1_bs=on:canc=cautious:doe=on:fsr=off:s2a=on:s2agt=32:sas=z3:sil=128000:tha=off:thi=overlap:to=kbo:urr=on:i=606:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=61:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_2:1_ev=off:fde=none:nm=0:norm_ineq=on:nwc=2.0:sac=on:sil=128000:spb=goal_then_units:tgt=full:tha=some:thsq=on:thsqc=8:thsqd=64:to=kbo:i=363:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=125:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs-1002_1:1_norm_ineq=on:sas=z3:sos=on:tha=some:to=kbo:i=72:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+21_1:1_gtg=exists_all:kws=inv_frequency:nm=0:sas=z3:tgt=full:tha=off:to=kbo:i=268:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=on:tgt=ground:to=lakbo:i=102:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   // Improves by expected 57.82589341972467 probs costing 3948 Mi
   // Sub-schedule for 4000Mi strat cap / 4000Mi overall limit
-  quick.push("lrs+10_1:1_gtg=exists_top:sil=64000:sos=on:sp=frequency:to=lpo:urr=on:i=329:si=on:rtra=on_0");
-  quick.push("lrs+1010_1:1_av=off:doe=on:nm=0:sil=128000:sos=on:ss=axioms:to=kbo:urr=on:uwa=alasca_main:i=491:si=on:rtra=on_0");
-  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=237:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=443:si=on:rtra=on_0");
-  quick.push("lrs+1011_1:12_acc=on:gtg=exists_sym:gve=force:kws=inv_arity_squared:sp=frequency:tgt=ground:tha=off:to=kbo:i=187:si=on:rtra=on_0");
-  quick.push("lrs+21_1:1_abs=on:nwc=3.0:sas=z3:sil=64000:spb=goal_then_units:tha=off:thi=all:to=kbo:i=135:si=on:rtra=on_0");
-  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=152:si=on:rtra=on_0");
-  quick.push("dis+1011_1:5_av=off:bd=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=161:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=250:si=on:rtra=on_0");
-  quick.push("lrs+10_1:40_anc=all:ev=force:nm=0:sas=z3:tgt=ground:thi=overlap:thigen=on:thitd=on:to=kbo:i=216:si=on:rtra=on_0");
-  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=65:si=on:rtra=on_0");
-  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=523:si=on:rtra=on_0");
-  quick.push("lrs+1011_5:1_br=off:canc=cautious:fsr=off:sil=64000:thi=all:to=kbo:uwa=ground:i=138:si=on:rtra=on_0");
-  quick.push("lrs-2_1:1_kws=precedence:sas=z3:sd=1:sil=64000:sp=const_max:ss=axioms:st=1.5:tgt=ground:tha=off:to=kbo:i=381:si=on:rtra=on_0");
-  quick.push("lrs+1011_1:3_bsr=on:canc=force:ev=off:gtg=all:plsq=on:plsqr=1,32:s2a=on:s2at=2.0:sas=z3:sp=reverse_arity:tha=off:thsq=on:thsqc=64:to=kbo:i=257:si=on:rtra=on_0");
-  // Improves by expected 21.96302462786303 probs costing 3950 Mi
+  quick.push("lrs+10_1:1_gtg=exists_top:sil=64000:sos=on:to=lpo:urr=on:i=329:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+1010_1:1_av=off:doe=on:nm=0:sil=128000:sos=on:ss=axioms:to=kbo:urr=on:uwa=alasca_main:i=491:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=237:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=443:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1011_1:12_acc=on:gtg=exists_sym:gve=force:kws=inv_arity_squared:tgt=ground:tha=off:to=kbo:i=187:si=on:rtra=on:lma=off:bd=all:uhcvi=off:ccuc=all:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+21_1:1_abs=on:nwc=3.0:sas=z3:sil=64000:spb=goal_then_units:tha=off:thi=all:to=kbo:i=135:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=152:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_1:5_av=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=161:si=on:rtra=on:lma=off:uhcvi=off:sp=arity_0");
+  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=250:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:40_anc=all:ev=force:nm=0:sas=z3:tgt=ground:thi=overlap:thigen=on:thitd=on:to=kbo:i=216:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=65:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=523:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1011_5:1_br=off:canc=cautious:fsr=off:sil=64000:thi=all:to=kbo:uwa=ground:i=138:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs-2_1:1_kws=precedence:sas=z3:sd=1:sil=64000:sp=const_max:ss=axioms:st=1.5:tgt=ground:tha=off:to=kbo:i=381:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+1011_1:3_bsr=on:canc=force:ev=off:gtg=all:plsq=on:plsqr=1,32:s2a=on:s2at=2.0:sas=z3:sp=reverse_arity:tha=off:thsq=on:thsqc=64:to=kbo:i=257:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  // Improves by expected 21.963024627863028 probs costing 3950 Mi
   // Sub-schedule for 8000Mi strat cap / 8000Mi overall limit
-  quick.push("dis+1010_1:1_bd=off:gsp=on:sos=on:sp=weighted_frequency:spb=goal:uhcvi=on:i=376:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+1002_8:1_gve=cautious:sac=on:sas=z3:sos=all:sp=occurrence:spb=goal:ss=axioms:to=kbo:i=421:si=on:rtra=on_0");
-  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:uhcvi=on:i=98:si=on:rtra=on_0");
-  quick.push("dis+11_1:1_add=large:pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on_0");
-  quick.push("lrs+1011_5:1_bd=off:norm_ineq=on:sas=z3:sil=128000:tha=some:to=lpo:i=387:si=on:rtra=on_0");
-  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=5491:si=on:rtra=on_0");
-  quick.push("lrs+1011_16:1_doe=on:erd=off:sas=z3:sil=128000:sos=theory:to=kbo:urr=full:i=329:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_sil=64000:spb=goal_then_units:to=lpo:i=275:si=on:rtra=on_0");
-  quick.push("ott+1011_1:1_drc=off:ep=RST:gtg=exists_top:nm=16:plsq=on:plsqr=32,1:sac=on:sos=all:sp=const_frequency:to=kbo:uwa=one_side_interpreted:i=383:si=on:rtra=on_0");
-  // Improves by expected 32.29023819027194 probs costing 7951 Mi
+  quick.push("dis+1010_1:1_gsp=on:sos=on:sp=weighted_frequency:spb=goal:i=376:si=on:rtra=on:alasca=on:lma=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+1002_8:1_gve=cautious:sac=on:sas=z3:sos=all:sp=occurrence:spb=goal:ss=axioms:to=kbo:i=421:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:i=98:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("lrs+1011_5:1_norm_ineq=on:sas=z3:sil=128000:tha=some:to=lpo:i=387:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=5491:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1011_16:1_doe=on:erd=off:sas=z3:sil=128000:sos=theory:to=kbo:urr=full:i=329:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_sil=64000:spb=goal_then_units:to=lpo:i=275:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+1011_1:1_drc=off:ep=RST:gtg=exists_top:nm=16:plsq=on:plsqr=32,1:sac=on:sos=all:sp=const_frequency:to=kbo:uwa=one_side_interpreted:i=383:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  // Improves by expected 32.29023819027196 probs costing 7951 Mi
   // Sub-schedule for 20000Mi strat cap / 20000Mi overall limit
-  quick.push("dis+21_2:1_bd=off:erd=off:gtg=exists_all:gtgl=3:prc=on:sas=z3:sos=all:to=lakbo:i=759:si=on:rtra=on:alasca=on_0");
-  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:nwc=10.0:rp=on:s2a=on:sas=z3:sil=128000:sp=frequency:tha=off:thi=all:to=kbo:i=467:si=on:rtra=on_0");
-  quick.push("lrs-1011_1:1_afr=on:bd=off:cond=fast:fde=none:gtg=all:lcm=predicate:nm=30:nwc=10.0:sil=128000:slsq=on:sp=frequency:spb=non_intro:tac=axiom:thi=overlap:thitd=on:to=lpo:uwa=func_ext:i=681:si=on:rtra=on_0");
-  quick.push("dis+10_1:1_fde=unused:nm=16:nwc=10.0:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=122:si=on:rtra=on_0");
-  quick.push("ott+1011_4:1_s2a=on:s2at=2.0:sil=64000:spb=intro:to=lpo:i=522:si=on:rtra=on_0");
-  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=15642:si=on:rtra=on_0");
-  quick.push("lrs+21_1:1_lma=on:s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:nwc=10.0:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:uhcvi=on:i=198:si=on:rtra=on_0");
-  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=198:si=on:rtra=on_0");
-  // Improves by expected 25.347046011495706 probs costing 19915 Mi
+  quick.push("dis+21_2:1_erd=off:gtg=exists_all:gtgl=3:prc=on:sas=z3:sos=all:to=lakbo:i=759:si=on:rtra=on:alasca=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:rp=on:s2a=on:sas=z3:sil=128000:tha=off:thi=all:to=kbo:i=467:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
+  quick.push("lrs-1011_1:1_afr=on:cond=fast:fde=none:gtg=all:lcm=predicate:nm=30:sil=128000:slsq=on:spb=non_intro:tac=axiom:thi=overlap:thitd=on:to=lpo:uwa=func_ext:i=681:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on_0");
+  quick.push("dis+10_1:1_fde=unused:nm=16:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=122:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("ott+1011_4:1_s2a=on:s2at=2.0:sil=64000:spb=intro:to=lpo:i=522:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=15642:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
+  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=198:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  // Improves by expected 25.34704601149571 probs costing 19915 Mi
   // Sub-schedule for 40000Mi strat cap / 40000Mi overall limit
-  quick.push("dis+1011_1:1_fd=preordered:lsd=50:sac=on:sil=128000:spb=intro:tgt=full:tha=some:to=kbo:i=1271:si=on:rtra=on_0");
-  quick.push("dis+1011_1:14_av=off:drc=ordering:ev=cautious:fde=none:nm=32:ss=axioms:st=5.0:tgt=ground:tha=off:to=kbo:uwa=func_ext:i=1147:si=on:rtra=on_0");
-  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:nwc=10.0:rp=on:s2a=on:sas=z3:sil=128000:sp=frequency:tha=off:thi=all:to=kbo:i=467:si=on:rtra=on_0");
-  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=1107:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_gtg=position:sd=10:ss=axioms:st=5.0:to=kbo:i=17184:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+11_1:1_add=large:pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=1446:si=on:rtra=on_0");
-  quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_nm=0:norm_ineq=on:sas=z3:tgt=full:to=kbo:i=1903:si=on:rtra=on_0");
-  quick.push("dis+2_1:32_nm=30:s2a=on:s2agt=20:sil=64000:to=lpo:i=915:si=on:rtra=on_0");
-  quick.push("dis+1011_1:2_bd=off:canc=cautious:gve=cautious:irw=on:kws=precedence:nm=10:nwc=5.53:rawr=on:sil=128000:sp=unary_frequency:tar=off:tgt=full:to=kbo:i=645:si=on:rtra=on_0");
-  quick.push("dis+10_1:1024_cond=on:ep=R:gtg=exists_all:newcnf=on:sil=128000:sos=on:to=lakbo:uwa=alasca_main_floor:i=2401:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:nwc=10.0:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:uhcvi=on:i=198:si=on:rtra=on_0");
-  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=7196:si=on:rtra=on_0");
-  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on_0");
-  quick.push("ott+10_1:1_asg=cautious:er=filter:nm=0:rawr=on:sas=z3:tgt=full:thi=neg_eq:thitd=on:to=lpo:uhcvi=on:i=1434:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=744:si=on:rtra=on_0");
-  // Improves by expected 26.250114692993552 probs costing 39799 Mi
+  quick.push("dis+1011_1:1_fd=preordered:lsd=50:sac=on:sil=128000:spb=intro:tgt=full:tha=some:to=kbo:i=1271:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_1:14_av=off:drc=ordering:ev=cautious:fde=none:nm=32:ss=axioms:st=5.0:tgt=ground:tha=off:to=kbo:uwa=func_ext:i=1147:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=1107:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+1010_1:1_aac=none:abs=on:drc=ordering:fd=off:nm=0:rawr=on:sas=z3:sims=off:tha=off:to=lpo:i=993:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_gtg=position:sd=10:ss=axioms:st=5.0:to=kbo:i=17184:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=1446:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+2_1:32_nm=30:s2a=on:s2agt=20:sil=64000:to=lpo:i=915:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1011_1:2_canc=cautious:gve=cautious:irw=on:kws=precedence:nm=10:nwc=5.53:rawr=on:sil=128000:sp=unary_frequency:tar=off:tgt=full:to=kbo:i=645:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on_0");
+  quick.push("dis+10_1:1024_cond=on:ep=R:gtg=exists_all:newcnf=on:sil=128000:sos=on:to=lakbo:uwa=alasca_main_floor:i=2401:si=on:rtra=on:alasca=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
+  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=7196:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("ott+10_1:1_asg=cautious:er=filter:nm=0:rawr=on:sas=z3:tgt=full:thi=neg_eq:thitd=on:to=lpo:i=1434:si=on:rtra=on:alasca=on:lma=off:bd=all:erape=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  // Improves by expected 26.73542158755427 probs costing 39976 Mi
   // Sub-schedule for 120000Mi strat cap / 120000Mi overall limit
-  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=4498:si=on:rtra=on_0");
-  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4214:si=on:rtra=on_0");
-  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on_0");
-  quick.push("lrs+10_1:12_add=large:gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=16031:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+11_1:1_add=large:pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=4723:si=on:rtra=on_0");
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on_0");
-  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=3845:si=on:rtra=on_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=4777:si=on:rtra=on_0");
-  quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on_0");
-  quick.push("dis+10_1:1_aac=none:abs=on:amm=off:doe=on:gtg=position:nm=0:norm_ineq=on:plsq=on:plsqc=2:plsqr=2,1:sas=z3:sil=128000:tgt=ground:to=kbo:i=6072:si=on:rtra=on_0");
-  quick.push("lrs+11_1:1_avsq=on:avsqr=17,4:bd=off:canc=force:er=filter:fd=off:gtg=exists_top:lma=on:sac=on:sas=z3:slsq=on:thi=all:to=lpo:i=10547:si=on:rtra=on_0");
-  quick.push("dis+1011_1:2_bd=off:canc=cautious:gve=cautious:irw=on:kws=precedence:nm=10:nwc=5.53:rawr=on:sil=128000:sp=unary_frequency:tar=off:tgt=full:to=kbo:i=645:si=on:rtra=on_0");
-  quick.push("lrs+21_1:1_lma=on:s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on_0");
-  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:nwc=10.0:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=4352:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:nwc=10.0:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:uhcvi=on:i=198:si=on:rtra=on_0");
-  quick.push("dis+10_1:1_add=off:alasca_sn=on:nm=0:prc=on:sas=z3:tac=light:tar=off:tgt=full:to=lakbo:viras=off:i=3153:si=on:rtra=on:alasca=on_0");
-  quick.push("lrs+35_1:1_aac=none:abs=on:amm=off:drc=ordering:norm_ineq=on:rawr=on:s2a=on:s2at=3.0:tha=off:i=44197:si=on:rtra=on_0");
-  // Improves by expected 27.369185118492503 probs costing 119696 Mi
+  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=4498:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4214:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:12_gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=16031:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=2521:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
+  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=4777:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+10_1:1_aac=none:abs=on:amm=off:doe=on:gtg=position:nm=0:norm_ineq=on:plsq=on:plsqc=2:plsqr=2,1:sas=z3:sil=128000:tgt=ground:to=kbo:i=6072:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+11_1:1_avsq=on:avsqr=17,4:canc=force:er=filter:fd=off:gtg=exists_top:sac=on:sas=z3:slsq=on:thi=all:to=lpo:i=10547:si=on:rtra=on:erape=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=2633:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
+  quick.push("dis+10_1:1_add=off:alasca_sn=on:nm=0:prc=on:sas=z3:tac=light:tar=off:tgt=full:to=lakbo:viras=off:i=3153:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+35_1:1_aac=none:abs=on:amm=off:drc=ordering:norm_ineq=on:rawr=on:s2a=on:s2at=3.0:tha=off:i=44197:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  // Improves by expected 27.03742746157508 probs costing 117573 Mi
   // Sub-schedule for 240000Mi strat cap / 240000Mi overall limit
-  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4200:si=on:rtra=on_0");
-  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on_0");
-  quick.push("dis+21_1:1_abs=on:bd=off:doe=on:kws=inv_precedence:s2a=on:s2agt=16:sil=128000:sp=weighted_frequency:to=kbo:uwa=off:i=67352:si=on:rtra=on_0");
-  quick.push("lrs+10_1:12_add=large:gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=33347:si=on:rtra=on:alasca=on_0");
-  quick.push("dis+11_1:1_add=large:pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on_0");
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on_0");
-  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on_0");
-  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=60504:si=on:rtra=on:alasca=on_0");
-  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=18871:si=on:rtra=on_0");
-  quick.push("lrs+21_1:1_lma=on:s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on_0");
-  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:nwc=10.0:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on_0");
-  quick.push("dis+11_1:3_afp=4000:anc=none:bce=on:bd=off:drc=ordering:rawr=on:sac=on:sd=10:ss=axioms:st=5.0:tha=off:urr=ec_only:i=20544:si=on:rtra=on_0");
-  quick.push("ott+1010_16:1_ev=cautious:nm=0:prc=on:sas=z3:sil=64000:sp=const_max:ss=axioms:thi=strong:to=lpo:i=9709:si=on:rtra=on_0");
-  // Improves by expected 7.437715539461791 probs costing 235560 Mi
+  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+21_1:1_abs=on:doe=on:kws=inv_precedence:s2a=on:s2agt=16:sil=128000:sp=weighted_frequency:to=kbo:uwa=off:i=67352:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+10_1:12_gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=33347:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
+  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=60504:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=18871:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+11_1:3_afp=4000:anc=none:bce=on:drc=ordering:rawr=on:sac=on:sd=10:ss=axioms:st=5.0:tha=off:urr=ec_only:i=20544:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+1010_16:1_ev=cautious:nm=0:prc=on:sas=z3:sil=64000:sp=const_max:ss=axioms:thi=strong:to=lpo:i=9709:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  // Improves by expected 7.397894980762539 probs costing 235560 Mi
   // Sub-schedule for 480000Mi strat cap / 480000Mi overall limit
-  quick.push("dis+11_1:1_add=large:pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on_0");
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=29781:si=on:rtra=on_0");
-  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=14001:si=on:rtra=on_0");
-  // Improves by expected 0.6603902532694651 probs costing 51665 Mi
-  // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=29781:si=on:rtra=on_0");
-  // Improves by expected 0.11118668387392719 probs costing 29780 Mi
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=29781:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
+  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=5593:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=14001:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  // Improves by expected 0.6801530887812606 probs costing 57257 Mi
   // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
   // Improves by expected 0.0 probs costing 0 Mi
   // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
   // Improves by expected 0.0 probs costing 0 Mi
-  // Overall score 1198.7297011642693 probs on average / budget 514239 Mi
+  // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
+  // Improves by expected 0.0 probs costing 0 Mi
+  // Overall score 1198.7520059948515 probs on average / budget 488105 Mi
 }

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -5021,155 +5021,155 @@ void Schedules::getCascSat2024Schedule(const Property& property, Schedule& quick
 void Schedules::getAlascaAwareAriSchedule(const Shell::Property& property, Schedule& quick) {
   // alasca/problemsARIuns.txt
   // Sub-schedule for 2000Mi strat cap / 2000Mi overall limit
-  quick.push("lrs+10_1:1_asg=force:gtg=exists_top:sil=64000:thi=all:to=kbo:i=14:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1010_1:1_canc=force:doe=on:drc=off:nwc=5.0:prc=on:prlc=on:sil=128000:sp=const_max:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=8,1:to=lpo:i=74:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
-  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:rp=on:s2a=on:sas=z3:sil=128000:tha=off:thi=all:to=kbo:i=96:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
-  quick.push("lrs+10_1:2_ep=RST:gve=force:ins=2:lcm=reverse:sil=64000:sos=on:to=lpo:uwa=one_side_interpreted:i=5:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=10:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("dis+1011_1:1_canc=force:drc=off:prc=on:sac=on:i=21:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_ep=RSTC:fs=off:fsr=off:gtg=position:s2a=on:sas=z3:slsq=on:to=lpo:i=33:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=141:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=20:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_1:5_av=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=3:si=on:rtra=on:lma=off:uhcvi=off:sp=arity_0");
-  quick.push("lrs+21_4:1_nm=2:s2a=on:sac=on:sil=64000:sos=on:sp=weighted_frequency:to=lpo:i=72:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=7:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1002_4:1_br=off:inst=on:s2a=on:sil=64000:to=lpo:i=11:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=20:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:128_ev=force:fd=preordered:isp=bottom:prc=on:sas=z3:thi=overlap:thsq=on:thsqc=16:thsqd=64:to=lpo:i=59:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1024_fde=unused:nm=16:norm_ineq=on:sas=z3:sil=128000:sos=on:tha=off:to=kbo:i=74:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=243:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_1:1_gtg=position:lsd=20:nwc=3.0:sas=z3:sil=64000:sp=const_frequency:tgt=ground:to=kbo:i=237:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
-  quick.push("dis+1010_1:1_doe=on:ev=cautious:gtg=exists_sym:nm=0:ss=axioms:to=kbo:i=226:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_sas=z3:tha=off:to=lpo:i=37:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=444:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:1_gtg=all:gtgl=2:nwc=5.0:sas=z3:sil=128000:to=lpo:i=44:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=16:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("lrs+1002_1:1_gtg=exists_top:sas=z3:sp=const_frequency:tha=off:thi=strong:to=lpo:i=78:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("dis+1002_16:1_doe=on:gtg=exists_top:gve=force:norm_ineq=on:sas=z3:sil=64000:ss=axioms:to=lpo:uwa=one_side_constant:i=15:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  // Improves by expected 999.474906626823 probs costing 1975 Mi
+  quick.push("lrs+10_1:1_asg=force:gtg=exists_top:sil=64000:thi=all:to=kbo:i=14:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1010_1:1_canc=force:doe=on:drc=off:nwc=5.0:prc=on:prlc=on:sil=128000:sp=const_max:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=8,1:to=lpo:i=74:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:rp=on:s2a=on:sas=z3:sil=128000:tha=off:thi=all:to=kbo:i=96:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("lrs+10_1:2_ep=RST:gve=force:ins=2:lcm=reverse:sil=64000:sos=on:to=lpo:uwa=one_side_interpreted:i=5:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=10:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("dis+1011_1:1_canc=force:drc=off:prc=on:sac=on:i=21:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:1_ep=RSTC:fs=off:fsr=off:gtg=position:s2a=on:sas=z3:slsq=on:to=lpo:i=33:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=141:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:fdtod=off_0");
+  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=20:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_1:5_av=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=3:si=on:rtra=on:lma=off:uhcvi=off:sp=arity:fdtod=off_0");
+  quick.push("lrs+21_4:1_nm=2:s2a=on:sac=on:sil=64000:sos=on:sp=weighted_frequency:to=lpo:i=72:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=7:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1002_4:1_br=off:inst=on:s2a=on:sil=64000:to=lpo:i=11:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=20:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:128_ev=force:fd=preordered:isp=bottom:prc=on:sas=z3:thi=overlap:thsq=on:thsqc=16:thsqd=64:to=lpo:i=59:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:1024_fde=unused:nm=16:norm_ineq=on:sas=z3:sil=128000:sos=on:tha=off:to=kbo:i=74:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=243:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_1:1_gtg=position:lsd=20:nwc=3.0:sas=z3:sil=64000:sp=const_frequency:tgt=ground:to=kbo:i=237:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("dis+1010_1:1_doe=on:ev=cautious:gtg=exists_sym:nm=0:ss=axioms:to=kbo:i=226:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:1_sas=z3:tha=off:to=lpo:i=37:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=444:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_gtg=all:gtgl=2:nwc=5.0:sas=z3:sil=128000:to=lpo:i=44:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=16:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("lrs+1002_1:1_gtg=exists_top:sas=z3:sp=const_frequency:tha=off:thi=strong:to=lpo:i=78:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("dis+1002_16:1_doe=on:gtg=exists_top:gve=force:norm_ineq=on:sas=z3:sil=64000:ss=axioms:to=lpo:uwa=one_side_constant:i=15:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  // Improves by expected 999.4749066268228 probs costing 1975 Mi
   // Sub-schedule for 4000Mi strat cap / 4000Mi overall limit
-  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=85:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+10_1:1_doe=on:norm_ineq=on:sil=64000:sp=unary_frequency:to=kbo:i=126:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
-  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:i=116:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs-1011_1:64_av=off:br=off:canc=cautious:sos=on:sp=unary_first:to=lpo:i=92:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
-  quick.push("dis+1002_1:1_acc=on:canc=force:fdi=10:fsr=off:sil=64000:tha=off:to=lpo:i=92:si=on:rtra=on:lma=off:bd=all:uhcvi=off:ccuc=all:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1010_1:1_fde=unused:gve=force:kws=precedence:sas=z3:sp=unary_frequency:spb=goal:tgt=ground:tha=off:thf=on:to=kbo:uace=off:i=693:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=all:to=kbo:i=54:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+10_1:1_fde=unused:nm=16:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=110:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+10_1:1_gtg=exists_sym:gtgl=5:nwc=5.0:sil=128000:ss=axioms:tha=off:to=kbo:i=999:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("ott+1010_3:1_bs=on:canc=cautious:doe=on:fsr=off:s2a=on:s2agt=32:sas=z3:sil=128000:tha=off:thi=overlap:to=kbo:urr=on:i=606:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=61:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_2:1_ev=off:fde=none:nm=0:norm_ineq=on:nwc=2.0:sac=on:sil=128000:spb=goal_then_units:tgt=full:tha=some:thsq=on:thsqc=8:thsqd=64:to=kbo:i=363:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=125:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs-1002_1:1_norm_ineq=on:sas=z3:sos=on:tha=some:to=kbo:i=72:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+21_1:1_gtg=exists_all:kws=inv_frequency:nm=0:sas=z3:tgt=full:tha=off:to=kbo:i=268:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=on:tgt=ground:to=lakbo:i=102:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+21_1:1_canc=force:ev=force:sil=128000:ss=axioms:tac=axiom:thi=neg_eq:to=kbo:i=85:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+10_1:1_doe=on:norm_ineq=on:sil=64000:sp=unary_frequency:to=kbo:i=126:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:i=116:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs-1011_1:64_av=off:br=off:canc=cautious:sos=on:sp=unary_first:to=lpo:i=92:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:fdtod=off_0");
+  quick.push("dis+1002_1:1_acc=on:canc=force:fdi=10:fsr=off:sil=64000:tha=off:to=lpo:i=92:si=on:rtra=on:lma=off:bd=all:uhcvi=off:ccuc=all:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1010_1:1_fde=unused:gve=force:kws=precedence:sas=z3:sp=unary_frequency:spb=goal:tgt=ground:tha=off:thf=on:to=kbo:uace=off:i=693:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=all:to=kbo:i=54:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+10_1:1_fde=unused:nm=16:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=110:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+10_1:1_gtg=exists_sym:gtgl=5:nwc=5.0:sil=128000:ss=axioms:tha=off:to=kbo:i=999:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("ott+1010_3:1_bs=on:canc=cautious:doe=on:fsr=off:s2a=on:s2agt=32:sas=z3:sil=128000:tha=off:thi=overlap:to=kbo:urr=on:i=606:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=61:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_2:1_ev=off:fde=none:nm=0:norm_ineq=on:nwc=2.0:sac=on:sil=128000:spb=goal_then_units:tgt=full:tha=some:thsq=on:thsqc=8:thsqd=64:to=kbo:i=363:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_anc=none:gve=force:ins=3:s2a=on:s2at=5.0:sas=z3:sil=128000:sos=on:to=kbo:urr=on:uwa=one_side_interpreted:i=125:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs-1002_1:1_norm_ineq=on:sas=z3:sos=on:tha=some:to=kbo:i=72:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+21_1:1_gtg=exists_all:kws=inv_frequency:nm=0:sas=z3:tgt=full:tha=off:to=kbo:i=268:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:1_sas=z3:sil=64000:sos=on:tgt=ground:to=lakbo:i=102:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
   // Improves by expected 57.82589341972467 probs costing 3948 Mi
   // Sub-schedule for 4000Mi strat cap / 4000Mi overall limit
-  quick.push("lrs+10_1:1_gtg=exists_top:sil=64000:sos=on:to=lpo:urr=on:i=329:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+1010_1:1_av=off:doe=on:nm=0:sil=128000:sos=on:ss=axioms:to=kbo:urr=on:uwa=alasca_main:i=491:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=237:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=443:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1011_1:12_acc=on:gtg=exists_sym:gve=force:kws=inv_arity_squared:tgt=ground:tha=off:to=kbo:i=187:si=on:rtra=on:lma=off:bd=all:uhcvi=off:ccuc=all:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+21_1:1_abs=on:nwc=3.0:sas=z3:sil=64000:spb=goal_then_units:tha=off:thi=all:to=kbo:i=135:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=152:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_1:5_av=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=161:si=on:rtra=on:lma=off:uhcvi=off:sp=arity_0");
-  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=250:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:40_anc=all:ev=force:nm=0:sas=z3:tgt=ground:thi=overlap:thigen=on:thitd=on:to=kbo:i=216:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=65:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=523:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1011_5:1_br=off:canc=cautious:fsr=off:sil=64000:thi=all:to=kbo:uwa=ground:i=138:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs-2_1:1_kws=precedence:sas=z3:sd=1:sil=64000:sp=const_max:ss=axioms:st=1.5:tgt=ground:tha=off:to=kbo:i=381:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+1011_1:3_bsr=on:canc=force:ev=off:gtg=all:plsq=on:plsqr=1,32:s2a=on:s2at=2.0:sas=z3:sp=reverse_arity:tha=off:thsq=on:thsqc=64:to=kbo:i=257:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("lrs+10_1:1_gtg=exists_top:sil=64000:sos=on:to=lpo:urr=on:i=329:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1010_1:1_av=off:doe=on:nm=0:sil=128000:sos=on:ss=axioms:to=kbo:urr=on:uwa=alasca_main:i=491:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=237:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=443:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1011_1:12_acc=on:gtg=exists_sym:gve=force:kws=inv_arity_squared:tgt=ground:tha=off:to=kbo:i=187:si=on:rtra=on:lma=off:bd=all:uhcvi=off:ccuc=all:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+21_1:1_abs=on:nwc=3.0:sas=z3:sil=64000:spb=goal_then_units:tha=off:thi=all:to=kbo:i=135:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=152:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_1:5_av=off:drc=off:nm=30:nwc=7.0:prc=on:s2a=on:sil=128000:spb=units:to=lpo:i=161:si=on:rtra=on:lma=off:uhcvi=off:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_ev=cautious:sil=128000:ss=axioms:tgt=full:tha=off:to=kbo:i=250:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:40_anc=all:ev=force:nm=0:sas=z3:tgt=ground:thi=overlap:thigen=on:thitd=on:to=kbo:i=216:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1010_4:1_gtg=exists_top:newcnf=on:tha=off:to=lpo:i=65:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1002_1:1_gtg=position:sas=z3:sil=128000:sos=on:ss=axioms:tha=off:to=lpo:urr=on:i=523:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1011_5:1_br=off:canc=cautious:fsr=off:sil=64000:thi=all:to=kbo:uwa=ground:i=138:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs-2_1:1_kws=precedence:sas=z3:sd=1:sil=64000:sp=const_max:ss=axioms:st=1.5:tgt=ground:tha=off:to=kbo:i=381:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1011_1:3_bsr=on:canc=force:ev=off:gtg=all:plsq=on:plsqr=1,32:s2a=on:s2at=2.0:sas=z3:sp=reverse_arity:tha=off:thsq=on:thsqc=64:to=kbo:i=257:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
   // Improves by expected 21.963024627863028 probs costing 3950 Mi
   // Sub-schedule for 8000Mi strat cap / 8000Mi overall limit
-  quick.push("dis+1010_1:1_gsp=on:sos=on:sp=weighted_frequency:spb=goal:i=376:si=on:rtra=on:alasca=on:lma=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("dis+1002_8:1_gve=cautious:sac=on:sas=z3:sos=all:sp=occurrence:spb=goal:ss=axioms:to=kbo:i=421:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:i=98:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:nwc=1.0_0");
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("lrs+1011_5:1_norm_ineq=on:sas=z3:sil=128000:tha=some:to=lpo:i=387:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=5491:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1011_16:1_doe=on:erd=off:sas=z3:sil=128000:sos=theory:to=kbo:urr=full:i=329:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_sil=64000:spb=goal_then_units:to=lpo:i=275:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+1011_1:1_drc=off:ep=RST:gtg=exists_top:nm=16:plsq=on:plsqr=32,1:sac=on:sos=all:sp=const_frequency:to=kbo:uwa=one_side_interpreted:i=383:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  // Improves by expected 32.29023819027196 probs costing 7951 Mi
+  quick.push("dis+1010_1:1_gsp=on:sos=on:sp=weighted_frequency:spb=goal:i=376:si=on:rtra=on:alasca=on:lma=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("dis+1002_8:1_gve=cautious:sac=on:sas=z3:sos=all:sp=occurrence:spb=goal:ss=axioms:to=kbo:i=421:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+32_1:1_asg=cautious:fsr=off:nm=6:sas=z3:sil=64000:sos=on:sp=const_max:tac=light:tgt=ground:tha=some:thi=neg_eq:to=kbo:i=98:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1011_5:1_norm_ineq=on:sas=z3:sil=128000:tha=some:to=lpo:i=387:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:1_doe=on:fsr=off:norm_ineq=on:plsq=on:slsq=on:slsqr=1,2:to=lpo:i=5491:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1011_16:1_doe=on:erd=off:sas=z3:sil=128000:sos=theory:to=kbo:urr=full:i=329:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:1_sil=64000:spb=goal_then_units:to=lpo:i=275:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+1011_1:1_drc=off:ep=RST:gtg=exists_top:nm=16:plsq=on:plsqr=32,1:sac=on:sos=all:sp=const_frequency:to=kbo:uwa=one_side_interpreted:i=383:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  // Improves by expected 32.29023819027195 probs costing 7951 Mi
   // Sub-schedule for 20000Mi strat cap / 20000Mi overall limit
-  quick.push("dis+21_2:1_erd=off:gtg=exists_all:gtgl=3:prc=on:sas=z3:sos=all:to=lakbo:i=759:si=on:rtra=on:alasca=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:rp=on:s2a=on:sas=z3:sil=128000:tha=off:thi=all:to=kbo:i=467:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on_0");
-  quick.push("lrs-1011_1:1_afr=on:cond=fast:fde=none:gtg=all:lcm=predicate:nm=30:sil=128000:slsq=on:spb=non_intro:tac=axiom:thi=overlap:thitd=on:to=lpo:uwa=func_ext:i=681:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on_0");
-  quick.push("dis+10_1:1_fde=unused:nm=16:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=122:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("ott+1011_4:1_s2a=on:s2at=2.0:sil=64000:spb=intro:to=lpo:i=522:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=15642:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
-  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=198:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
+  quick.push("dis+21_2:1_erd=off:gtg=exists_all:gtgl=3:prc=on:sas=z3:sos=all:to=lakbo:i=759:si=on:rtra=on:alasca=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1002_1:8_doe=on:drc=ordering:nm=32:rp=on:s2a=on:sas=z3:sil=128000:tha=off:thi=all:to=kbo:i=467:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("lrs-1011_1:1_afr=on:cond=fast:fde=none:gtg=all:lcm=predicate:nm=30:sil=128000:slsq=on:spb=non_intro:tac=axiom:thi=overlap:thitd=on:to=lpo:uwa=func_ext:i=681:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("dis+10_1:1_fde=unused:nm=16:sac=on:sil=128000:tgt=ground:tha=some:to=kbo:i=122:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("ott+1011_4:1_s2a=on:s2at=2.0:sil=64000:spb=intro:to=lpo:i=522:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=15642:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:fdtod=off_0");
+  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=198:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
   // Improves by expected 25.34704601149571 probs costing 19915 Mi
   // Sub-schedule for 40000Mi strat cap / 40000Mi overall limit
-  quick.push("dis+1011_1:1_fd=preordered:lsd=50:sac=on:sil=128000:spb=intro:tgt=full:tha=some:to=kbo:i=1271:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_1:14_av=off:drc=ordering:ev=cautious:fde=none:nm=32:ss=axioms:st=5.0:tgt=ground:tha=off:to=kbo:uwa=func_ext:i=1147:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=1107:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+1010_1:1_aac=none:abs=on:drc=ordering:fd=off:nm=0:rawr=on:sas=z3:sims=off:tha=off:to=lpo:i=993:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_gtg=position:sd=10:ss=axioms:st=5.0:to=kbo:i=17184:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=1446:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("dis+2_1:32_nm=30:s2a=on:s2agt=20:sil=64000:to=lpo:i=915:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1011_1:2_canc=cautious:gve=cautious:irw=on:kws=precedence:nm=10:nwc=5.53:rawr=on:sil=128000:sp=unary_frequency:tar=off:tgt=full:to=kbo:i=645:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on_0");
-  quick.push("dis+10_1:1024_cond=on:ep=R:gtg=exists_all:newcnf=on:sil=128000:sos=on:to=lakbo:uwa=alasca_main_floor:i=2401:si=on:rtra=on:alasca=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
-  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=7196:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("ott+10_1:1_asg=cautious:er=filter:nm=0:rawr=on:sas=z3:tgt=full:thi=neg_eq:thitd=on:to=lpo:i=1434:si=on:rtra=on:alasca=on:lma=off:bd=all:eape=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  // Improves by expected 26.73542158755427 probs costing 39976 Mi
+  quick.push("dis+1011_1:1_fd=preordered:lsd=50:sac=on:sil=128000:spb=intro:tgt=full:tha=some:to=kbo:i=1271:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_1:14_av=off:drc=ordering:ev=cautious:fde=none:nm=32:ss=axioms:st=5.0:tgt=ground:tha=off:to=kbo:uwa=func_ext:i=1147:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=1107:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1010_1:1_aac=none:abs=on:drc=ordering:fd=off:nm=0:rawr=on:sas=z3:sims=off:tha=off:to=lpo:i=1000:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_gtg=position:sd=10:ss=axioms:st=5.0:to=kbo:i=17184:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=1446:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+1011_4:1_drc=off:ev=off:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+2_1:32_nm=30:s2a=on:s2agt=20:sil=64000:to=lpo:i=915:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1011_1:2_canc=cautious:gve=cautious:irw=on:kws=precedence:nm=10:nwc=5.53:rawr=on:sil=128000:sp=unary_frequency:tar=off:tgt=full:to=kbo:i=645:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:fdtod=off_0");
+  quick.push("dis+10_1:1024_cond=on:ep=R:gtg=exists_all:newcnf=on:sil=128000:sos=on:to=lakbo:uwa=alasca_main_floor:i=2401:si=on:rtra=on:alasca=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:fdtod=off_0");
+  quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=7196:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("ott+10_1:1_asg=cautious:er=filter:nm=0:rawr=on:sas=z3:tgt=full:thi=neg_eq:thitd=on:to=lpo:i=1434:si=on:rtra=on:alasca=on:lma=off:bd=all:erape=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  // Improves by expected 26.73423111292651 probs costing 39983 Mi
   // Sub-schedule for 120000Mi strat cap / 120000Mi overall limit
-  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=4498:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4214:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:12_gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=16031:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=2521:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
-  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=4777:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("dis+10_1:1_aac=none:abs=on:amm=off:doe=on:gtg=position:nm=0:norm_ineq=on:plsq=on:plsqc=2:plsqr=2,1:sas=z3:sil=128000:tgt=ground:to=kbo:i=6072:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+11_1:1_avsq=on:avsqr=17,4:canc=force:er=filter:fd=off:gtg=exists_top:sac=on:sas=z3:slsq=on:thi=all:to=lpo:i=10547:si=on:rtra=on:eape=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=2633:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
-  quick.push("dis+10_1:1_add=off:alasca_sn=on:nm=0:prc=on:sas=z3:tac=light:tar=off:tgt=full:to=lakbo:viras=off:i=3153:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+35_1:1_aac=none:abs=on:amm=off:drc=ordering:norm_ineq=on:rawr=on:s2a=on:s2at=3.0:tha=off:i=44197:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  // Improves by expected 27.03742746157508 probs costing 117573 Mi
+  quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=4498:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4214:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+10_1:12_gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=16031:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=2521:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=4777:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+1011_4:1_drc=off:ev=off:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
+  quick.push("dis+10_1:1_aac=none:abs=on:amm=off:doe=on:gtg=position:nm=0:norm_ineq=on:plsq=on:plsqc=2:plsqr=2,1:sas=z3:sil=128000:tgt=ground:to=kbo:i=6072:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+11_1:1_avsq=on:avsqr=17,4:canc=force:er=filter:fd=off:gtg=exists_top:sac=on:sas=z3:slsq=on:thi=all:to=lpo:i=10547:si=on:rtra=on:erape=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=2633:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on:fdtod=off_0");
+  quick.push("dis+10_1:1_add=off:alasca_sn=on:nm=0:prc=on:sas=z3:tac=light:tar=off:tgt=full:to=lakbo:viras=off:i=3153:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+35_1:1_aac=none:abs=on:amm=off:drc=ordering:norm_ineq=on:rawr=on:s2a=on:s2at=3.0:tha=off:i=44197:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  // Improves by expected 27.03861794728659 probs costing 117573 Mi
   // Sub-schedule for 240000Mi strat cap / 240000Mi overall limit
-  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+21_1:1_abs=on:doe=on:kws=inv_precedence:s2a=on:s2agt=16:sil=128000:sp=weighted_frequency:to=kbo:uwa=off:i=67352:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+10_1:12_gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=33347:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity_0");
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
-  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=60504:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=18871:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+11_1:3_afp=4000:anc=none:bce=on:drc=ordering:rawr=on:sac=on:sd=10:ss=axioms:st=5.0:tha=off:urr=ec_only:i=20544:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("ott+1010_16:1_ev=cautious:nm=0:prc=on:sas=z3:sil=64000:sp=const_max:ss=axioms:thi=strong:to=lpo:i=9709:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  // Improves by expected 7.397894980762539 probs costing 235560 Mi
+  quick.push("lrs+1010_1:1_bce=on:gtg=exists_top:sas=cadical:sil=64000:sos=on:ss=axioms:to=kbo:i=4200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+1010_1:1_newcnf=on:nm=0:s2a=on:sil=128000:to=kbo:i=3643:si=on:rtra=on:ile=off:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+21_1:1_abs=on:doe=on:kws=inv_precedence:s2a=on:s2agt=16:sil=128000:sp=weighted_frequency:to=kbo:uwa=off:i=67352:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+10_1:12_gtg=all:gtgl=5:nicw=on:s2a=on:s2at=3.0:spb=units:to=lpo:i=33347:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=6634:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("ott+10_8:1_fs=off:fsr=off:inst=on:sil=128000:spb=goal_then_units:to=lpo:uwa=alasca_main:i=60504:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=18871:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+11_1:3_afp=4000:anc=none:bce=on:drc=ordering:rawr=on:sac=on:sd=10:ss=axioms:st=5.0:tha=off:urr=ec_only:i=20544:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity:fdtod=off_0");
+  quick.push("ott+1010_16:1_ev=cautious:nm=0:prc=on:sas=z3:sil=64000:sp=const_max:ss=axioms:thi=strong:to=lpo:i=9709:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  // Improves by expected 7.39789498076528 probs costing 235560 Mi
   // Sub-schedule for 480000Mi strat cap / 480000Mi overall limit
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=29781:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
-  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
-  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=5593:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=14001:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  // Improves by expected 0.6801530887812606 probs costing 57257 Mi
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=29781:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:fdtod=off_0");
+  quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=5593:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=14001:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity:fdtod=off_0");
+  // Improves by expected 0.6801530887812228 probs costing 57257 Mi
   // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
   // Improves by expected 0.0 probs costing 0 Mi
   // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
   // Improves by expected 0.0 probs costing 0 Mi
   // Sub-schedule for 960000Mi strat cap / 960000Mi overall limit
   // Improves by expected 0.0 probs costing 0 Mi
-  // Overall score 1198.7520059948515 probs on average / budget 488105 Mi
+  // Overall score 1198.7520060059378 probs on average / budget 488112 Mi
 }

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -5110,9 +5110,9 @@ void Schedules::getAlascaAwareAriSchedule(const Shell::Property& property, Sched
   quick.push("dis+1011_1:14_av=off:drc=ordering:ev=cautious:fde=none:nm=32:ss=axioms:st=5.0:tgt=ground:tha=off:to=kbo:uwa=func_ext:i=1147:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0:sp=arity_0");
   quick.push("dis+1011_12:1_abs=on:doe=on:gtg=exists_sym:nm=0:sas=z3:sil=128000:slsq=on:slsqc=5:sp=const_frequency:tgt=full:tha=off:to=lpo:i=1107:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
   quick.push("lrs+1010_1:1_aac=none:abs=on:drc=ordering:fd=off:nm=0:rawr=on:sas=z3:sims=off:tha=off:to=lpo:i=993:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+10_1:1_gtg=position:sd=10:ss=axioms:st=5.0:to=kbo:i=17184:si=on:rtra=on:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_gtg=position:sd=10:ss=axioms:st=5.0:to=kbo:i=17184:alasca=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=200:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
-  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=1446:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=1446:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
   quick.push("dis+2_1:32_nm=30:s2a=on:s2agt=20:sil=64000:to=lpo:i=915:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("dis+1011_1:2_canc=cautious:gve=cautious:irw=on:kws=precedence:nm=10:nwc=5.53:rawr=on:sil=128000:sp=unary_frequency:tar=off:tgt=full:to=kbo:i=645:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on_0");
@@ -5155,11 +5155,11 @@ void Schedules::getAlascaAwareAriSchedule(const Shell::Property& property, Sched
   quick.push("ott+1011_1:195_aac=none:abs=on:bce=on:bs=unit_only:bsr=unit_only:cond=fast:lsd=100:sac=on:taea=off:thi=strong:thigen=on:to=lpo:urr=on:i=18871:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=1901:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("dis+11_1:3_afp=4000:anc=none:bce=on:drc=ordering:rawr=on:sac=on:sd=10:ss=axioms:st=5.0:tha=off:urr=ec_only:i=20544:si=on:rtra=on:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("dis+11_1:3_afp=4000:anc=none:bce=on:drc=ordering:rawr=on:sac=on:sd=10:ss=axioms:st=5.0:tha=off:urr=ec_only:i=20544:lma=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("ott+1010_16:1_ev=cautious:nm=0:prc=on:sas=z3:sil=64000:sp=const_max:ss=axioms:thi=strong:to=lpo:i=9709:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
   // Improves by expected 7.397894980762539 probs costing 235560 Mi
   // Sub-schedule for 480000Mi strat cap / 480000Mi overall limit
-  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
+  quick.push("dis+11_1:1_pum=on:s2agt=20:s2pl=no:sas=z3:sd=10:sos=theory:sp=reverse_arity:ss=axioms:tha=some:thsq=on:thsqc=64:thsqd=64:thsqr=2,1:to=lpo:i=1996:lma=off:bd=all:uhcvi=off:aer=on:nwc=1.0_0");
   quick.push("lrs+1011_4:1_asg=cautious:av=off:bsr=on:kws=precedence:sil=128000:sp=weighted_frequency:tgt=ground:thi=neg_eq:to=kbo:i=29781:si=on:rtra=on:lma=off:bd=all:uhcvi=off:nwc=1.0_0");
   quick.push("lrs+666_16:1_aac=none:gtg=all:gtgl=2:norm_ineq=on:sas=z3:sil=128000:sp=reverse_arity:spb=goal_then_units:tac=axiom:tha=some:to=kbo:urr=on:uwa=off:i=5891:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
   quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=5593:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");

--- a/CASC/Schedules.cpp
+++ b/CASC/Schedules.cpp
@@ -4120,7 +4120,7 @@ void Schedules::getCasc2024Schedule(const Property& property, Schedule& quick, S
     propNZbig14.push("lrs+10_8:1_sil=256000:st=3.0:s2a=on:i=3083:s2at=1.2:ss=axioms:sd=15_0");
     propNZbig14.push("lrs+10_1:64_sil=16000:tgt=full:sp=reverse_frequency:slsq=on:i=4105:kws=precedence:slsql=off:ss=axioms:bs=unit_only:prc=on:spb=goal_0");
     propNZbig14.push("lrs+10_1:4_sil=32000:tgt=full:fde=unused:sp=const_frequency:nwc=10.0:i=9762:fdtod=on:rawr=on:bd=preordered:to=lpo_0");
-    propNZbig14.push("lrs+10_1:27_bsr=unit_only:to=lpo:sil=128000:fde=unused:sp=const_min:spb=goal:fd=preordered:i=9874:bs=on:fdtod=on:uhcvi=on:rawr=on:prc=on:er=filter:erape=on:erml=3_0");
+    propNZbig14.push("lrs+10_1:27_bsr=unit_only:to=lpo:sil=128000:fde=unused:sp=const_min:spb=goal:fd=preordered:i=9874:bs=on:fdtod=on:uhcvi=on:rawr=on:prc=on:er=filter:eape=on:erml=3_0");
     propNZbig14.push("lrs+10_1:4_sil=16000:tgt=ground:lwlo=on:s2a=on:i=7263:s2at=2.0_0");
     propNZbig14.push("lrs+10_2:3_drc=ordering:sil=128000:fde=none:s2a=on:i=13654:s2at=3.0:lwlo=on:bd=off_0");
     propNZbig14.push("lrs+10_1:16_sil=256000:tgt=full:spb=intro:i=41528:kws=precedence:ss=axioms:prc=on:proc=on:st=3.0:sp=const_frequency_0");
@@ -4128,7 +4128,7 @@ void Schedules::getCasc2024Schedule(const Property& property, Schedule& quick, S
     propNZbig14.push("ott+10_1:6_sil=512000:tgt=ground:fde=unused:sp=const_min:spb=goal:nwc=1.1:i=95210:kws=precedence:fdtod=on_0");
     propNZbig14.push("lrs+10_1:32_drc=ordering:sil=64000:tgt=full:sp=frequency:lwlo=on:i=51758:prc=on:proc=on_0");
     propNZbig14.push("lrs+10_2:23_sil=256000:tgt=full:s2a=on:i=126830:s2at=2.0:prc=on:fdtod=on_0");
-    propNZbig14.push("lrs+10_1:24_bsr=unit_only:to=lpo:sil=128000:fde=unused:sp=const_min:spb=goal:fd=preordered:i=67476:bs=on:fdtod=on:rawr=on:prc=on:er=filter:erape=on:nwc=3.0:ss=axioms:st=6.0:urr=ec_only_0");
+    propNZbig14.push("lrs+10_1:24_bsr=unit_only:to=lpo:sil=128000:fde=unused:sp=const_min:spb=goal:fd=preordered:i=67476:bs=on:fdtod=on:rawr=on:prc=on:er=filter:eape=on:nwc=3.0:ss=axioms:st=6.0:urr=ec_only_0");
     propNZbig14.push("lrs+10_1:3_sil=256000:tgt=full:fd=preordered:s2a=on:i=85601:s2at=4.0_0");
 
     // total_instr 925697
@@ -4310,7 +4310,7 @@ void Schedules::getCasc2024Schedule(const Property& property, Schedule& quick, S
     feqAtomsG2800.push("dis+1010_16550053:1048576_drc=ordering:to=lpo:ccuc=small_ones:sil=4000:fde=none:plsq=on:avsql=on:plsqr=34063,1048576:sp=const_min:sos=on:acc=on:plsql=on:nwc=10.3787:avsq=on:i=349:sd=1:avsqr=1084175,1048576:nm=0:amm=off:ss=axioms:bce=on:rawr=on:sup=off:bd=off_0");
     feqAtomsG2800.push("lrs+2_1:1_drc=ordering:sil=2000:sos=all:st=5.0:i=193:bd=off:av=off:ss=axioms:sd=2:sup=off_0");
     feqAtomsG2800.push("lrs+1002_1:1_drc=ordering:sil=64000:sos=on:urr=ec_only:flr=on:st=3.0:i=632:sd=1:ep=RS:nm=16:ss=axioms_0");
-    feqAtomsG2800.push("lrs+1011_4801913:1048576_drc=ordering:sfv=off:sil=2000:plsqc=1:plsq=on:plsqr=98277,1048576:etr=on:sp=const_max:lma=on:erape=on:urr=full:rp=on:nwc=23.4614:lwlo=on:st=2.5:i=440:add=large:bs=unit_only:sd=2:kws=inv_arity_squared:nm=17:amm=sco:ss=axioms:er=filter:sgt=50:rawr=on:anc=none_0");
+    feqAtomsG2800.push("lrs+1011_4801913:1048576_drc=ordering:sfv=off:sil=2000:plsqc=1:plsq=on:plsqr=98277,1048576:etr=on:sp=const_max:lma=on:eape=on:urr=full:rp=on:nwc=23.4614:lwlo=on:st=2.5:i=440:add=large:bs=unit_only:sd=2:kws=inv_arity_squared:nm=17:amm=sco:ss=axioms:er=filter:sgt=50:rawr=on:anc=none_0");
     feqAtomsG2800.push("lrs-1011_4:1_drc=ordering:bsr=unit_only:sil=4000:sp=occurrence:lsd=20:newcnf=on:i=730:kws=inv_arity_squared:rawr=on:rp=on:alpa=false:nwc=3.0_0");
     feqAtomsG2800.push("lrs+1002_8:1_drc=ordering:sil=16000:plsq=on:sos=on:urr=on:plsql=on:st=1.2:i=228:sd=2:ss=axioms_0");
     feqAtomsG2800.push("lrs+10_8:1_to=lpo:sil=4000:sos=on:urr=on:newcnf=on:i=1008:sd=2:nm=2:ss=axioms:sgt=32:sup=off:bd=off_0");
@@ -4425,7 +4425,7 @@ void Schedules::getCasc2024Schedule(const Property& property, Schedule& quick, S
 
     feqAtomsG180.push("dis+1011_3:1_drc=ordering:sil=256000:tgt=ground:sac=on:i=109:sd=1:ss=included_0");
     feqAtomsG180.push("dis+1010_1:1_drc=ordering:sil=2000:nwc=3.0:s2a=on:i=132:ins=5:fsr=off:ss=axioms:sd=2:fd=off_0");
-    feqAtomsG180.push("dis+1010_159245:1048576_to=lpo:sil=2000:etr=on:sp=unary_frequency:spb=goal:rnwc=on:nwc=10.9066:st=2:i=124:sd=1:nm=3:av=off:ss=axioms:rawr=on:foolp=on:sgt=5:cond=fast:er=filter:erape=on:erml=2:s2a=on_0");
+    feqAtomsG180.push("dis+1010_159245:1048576_to=lpo:sil=2000:etr=on:sp=unary_frequency:spb=goal:rnwc=on:nwc=10.9066:st=2:i=124:sd=1:nm=3:av=off:ss=axioms:rawr=on:foolp=on:sgt=5:cond=fast:er=filter:eape=on:erml=2:s2a=on_0");
     feqAtomsG180.push("lrs+1011_1:1_drc=ordering:sil=16000:sos=on:erd=off:i=126:nm=2:ep=RST_0");
     feqAtomsG180.push("lrs+1011_1:1_drc=ordering:sil=8000:sp=occurrence:nwc=10.0:st=1.5:i=145:ss=axioms:sgt=4_0");
     feqAtomsG180.push("ott+1002_2835555:1048576_drc=ordering:to=lpo:sil=2000:sos=on:fs=off:nwc=10.3801:avsqc=3:updr=off:avsq=on:st=2:s2a=on:i=173:s2at=3:afp=10000:aac=none:avsqr=13357983,1048576:bd=off:nm=13:ins=2:fsr=off:amm=sco:afq=1.16719:ss=axioms:rawr=on:fd=off_0");
@@ -5121,7 +5121,7 @@ void Schedules::getAlascaAwareAriSchedule(const Shell::Property& property, Sched
   quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");
   quick.push("lrs-1011_1:1_ep=RS:fs=off:fsr=off:prc=on:sil=128000:tha=off:to=kbo:i=7196:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("dis+666_1:5_ins=2:nwc=2.0:s2a=on:s2agt=20:sil=128000:spb=non_intro:ss=axioms:st=2.0:thi=all:to=lpo:i=355:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
-  quick.push("ott+10_1:1_asg=cautious:er=filter:nm=0:rawr=on:sas=z3:tgt=full:thi=neg_eq:thitd=on:to=lpo:i=1434:si=on:rtra=on:alasca=on:lma=off:bd=all:erape=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("ott+10_1:1_asg=cautious:er=filter:nm=0:rawr=on:sas=z3:tgt=full:thi=neg_eq:thitd=on:to=lpo:i=1434:si=on:rtra=on:alasca=on:lma=off:bd=all:eape=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("dis+1010_1:1_abs=on:br=off:drc=ordering:kws=inv_frequency:nm=20:nwc=5.0:sas=z3:sil=128000:spb=goal:tgt=ground:to=kbo:i=397:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
   // Improves by expected 26.73542158755427 probs costing 39976 Mi
   // Sub-schedule for 120000Mi strat cap / 120000Mi overall limit
@@ -5135,7 +5135,7 @@ void Schedules::getAlascaAwareAriSchedule(const Shell::Property& property, Sched
   quick.push("lrs+10_1:1_ep=R:norm_ineq=on:sd=12:sil=128000:ss=axioms:st=2.0:to=kbo:i=4777:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("ott+1011_4:1_drc=off:ev=off:fdtod=on:nicw=on:sil=128000:sp=weighted_frequency:tgt=ground:thi=overlap:thitd=on:to=lpo:i=1203:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0_0");
   quick.push("dis+10_1:1_aac=none:abs=on:amm=off:doe=on:gtg=position:nm=0:norm_ineq=on:plsq=on:plsqc=2:plsqr=2,1:sas=z3:sil=128000:tgt=ground:to=kbo:i=6072:si=on:rtra=on:lma=off:bd=all:uhcvi=off:add=on:nwc=1.0:sp=arity_0");
-  quick.push("lrs+11_1:1_avsq=on:avsqr=17,4:canc=force:er=filter:fd=off:gtg=exists_top:sac=on:sas=z3:slsq=on:thi=all:to=lpo:i=10547:si=on:rtra=on:erape=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
+  quick.push("lrs+11_1:1_avsq=on:avsqr=17,4:canc=force:er=filter:fd=off:gtg=exists_top:sac=on:sas=z3:slsq=on:thi=all:to=lpo:i=10547:si=on:rtra=on:eape=off:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("lrs+21_1:1_s2a=on:s2at=5.0:sil=128000:spb=goal:taea=off:thi=overlap:to=kbo:urr=on:i=981:si=on:rtra=on:bd=all:uhcvi=off:aer=on:add=on:nwc=1.0:sp=arity_0");
   quick.push("lrs+11_1:1_avsq=on:avsql=on:avsqr=1,16:drc=ordering:norm_ineq=on:plsq=on:rawr=on:sas=z3:tha=off:urr=on:i=2633:si=on:rtra=on:lma=off:bd=all:uhcvi=off:aer=on:add=on:sp=arity_0");
   quick.push("dis+1010_1:1_ev=force:fde=unused:fsd=on:fsdmm=1:gtg=exists_sym:gtgl=2:sil=128000:sp=reverse_arity:tha=off:thi=all:to=lpo:i=198:si=on:rtra=on:lma=off:bd=all:aer=on:add=on_0");

--- a/Kernel/Ordering.cpp
+++ b/Kernel/Ordering.cpp
@@ -548,11 +548,11 @@ struct BoostWrapper : public SymbolComparator
         if(g1 && !g2){ res = GREATER; }
         else if(!g1 && g2){ res = LESS; }
         break;
-      case Options::SymbolPrecedenceBoost::UNIT:
+      case Options::SymbolPrecedenceBoost::UNITS:
         if(u1 && !u2){ res = GREATER; }
         else if(!u1 && u2){ res = LESS; }
         break;
-      case Options::SymbolPrecedenceBoost::GOAL_UNIT:
+      case Options::SymbolPrecedenceBoost::GOAL_THEN_UNITS:
         if(g1 && !g2){ res = GREATER; }
         else if(!g1 && g2){ res = LESS; }
         else if(u1 && !u2){ res = GREATER; }

--- a/Lib/DHMap.hpp
+++ b/Lib/DHMap.hpp
@@ -58,7 +58,7 @@ class DHMap
 {
 public:
   USE_ALLOCATOR(DHMap);
-  
+
   /** Create a new DHMap */
   DHMap()
   : _timestamp(1), _size(0), _deleted(0), _capacityIndex(0), _capacity(0),
@@ -236,7 +236,7 @@ public:
 
   /**
    * If there is no value stored under @b key in the map,
-   * insert pair (key,value) and return true. Otherwise, 
+   * insert pair (key,value) and return true. Otherwise,
    * return false.
    */
   bool insert(Key key, Val val)
@@ -877,13 +877,14 @@ public:
   friend std::ostream& operator<<(std::ostream& out, DHMap const& self) 
   {
     auto iter = self.items();
-    auto write = [&](auto itm) { out << itm.first << " -> " << itm.second; };
+    // auto write = [&](auto itm) { out << itm.first << " -> " << itm.second; };
+    auto write_pythonic = [&](auto itm) { out << '"' << itm.first << '"' << " : "  << '"' << itm.second  << '"'; };
     out << "{ ";
     if (iter.hasNext()) {
-      write(iter.next());
+      write_pythonic(iter.next());
       while (iter.hasNext()) {
         out << ", ";
-        write(iter.next());
+        write_pythonic(iter.next());
       }
     }
     return out << " }";

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -73,10 +73,12 @@ void SplitDefinitionExtra::output(std::ostream &out) const {
 
 void SplittingBranchSelector::init()
 {
-  _eagerRemoval = _parent.getOptions().splittingEagerRemoval() &&
-    // if minimize is off then makes no difference; if minimize is sco then we could completeness issues
-    // (Problems/SWV/SWV608-1.p --decode Problems/SWV/SWV608-1.p --decode ott-1_1:40_tgt=full:plsq=on:sp=frequency:lcm=predicate:gs=on:bd=off:rawr=on:afp=1000:afq=2.0:irw=on:fsd=on:aer=off:si=on:rtra=on:amm=sco_30 --random_seed XXX)
-    (_parent.getOptions().splittingMinimizeModel() == Options::SplittingMinimizeModel::ALL);
+  // we need _eagerRemoval (aer) true, unless SplittingMinimizeModel is ALL
+  // if minimize is off then aer makes no difference;
+  // if minimize is sco then we could completeness issues
+  // (Problems/SWV/SWV608-1.p --decode Problems/SWV/SWV608-1.p --decode ott-1_1:40_tgt=full:plsq=on:sp=frequency:lcm=predicate:gs=on:bd=off:rawr=on:afp=1000:afq=2.0:irw=on:fsd=on:aer=off:si=on:rtra=on:amm=sco_30 --random_seed XXX)
+  _eagerRemoval = _parent.getOptions().splittingEagerRemoval() ||
+    (_parent.getOptions().splittingMinimizeModel() != Options::SplittingMinimizeModel::ALL);
   _literalPolarityAdvice = _parent.getOptions().splittingLiteralPolarityAdvice();
 
   switch(_parent.getOptions().satSolver()){

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -73,7 +73,10 @@ void SplitDefinitionExtra::output(std::ostream &out) const {
 
 void SplittingBranchSelector::init()
 {
-  _eagerRemoval = _parent.getOptions().splittingEagerRemoval();
+  _eagerRemoval = _parent.getOptions().splittingEagerRemoval() &&
+    // if minimize is off then makes no difference; if minimize is sco then we could completeness issues
+    // (Problems/SWV/SWV608-1.p --decode Problems/SWV/SWV608-1.p --decode ott-1_1:40_tgt=full:plsq=on:sp=frequency:lcm=predicate:gs=on:bd=off:rawr=on:afp=1000:afq=2.0:irw=on:fsd=on:aer=off:si=on:rtra=on:amm=sco_30 --random_seed XXX)
+    (_parent.getOptions().splittingMinimizeModel() == Options::SplittingMinimizeModel::ALL);
   _literalPolarityAdvice = _parent.getOptions().splittingLiteralPolarityAdvice();
 
   switch(_parent.getOptions().satSolver()){

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1702,7 +1702,7 @@ void Options::init()
     _demodulationOnlyEquational.onlyUsefulWith(Or(_forwardDemodulation.is(notEqual(Demodulation::OFF)),_backwardDemodulation.is(notEqual(Demodulation::OFF))));
     _demodulationOnlyEquational.addProblemConstraint(hasEquality());
 
-    _extensionalityAllowPosEq = BoolOptionValue( "extensionality_allow_pos_eq","erape",true);
+    _extensionalityAllowPosEq = BoolOptionValue( "extensionality_allow_pos_eq","eape",true);
     _extensionalityAllowPosEq.description="If extensionality resolution equals filter, this dictates"
       " whether we allow other positive equalities when recognising extensionality clauses";
     _lookup.insert(&_extensionalityAllowPosEq);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2273,6 +2273,13 @@ void Options::init()
     _lookup.insert(&_activationLimit);
     _activationLimit.tag(OptionTag::SATURATION);
 
+    // Even if AUTO_KBO resolves to "qkbo" or "lakbo", we still allow KBO suboptions (and possible ignore them)
+    // this is better than the default (to=auto_kbo) warning whenever we touch "kws" or "kmz" ...
+    auto KboLike = [this] {
+      return Or(_termOrdering.is(equal(TermOrdering::KBO)),
+                _termOrdering.is(equal(TermOrdering::AUTO_KBO)));
+    };
+
     _termOrdering = ChoiceOptionValue<TermOrdering>("term_ordering","to", TermOrdering::AUTO_KBO,
                                                     {"auto_kbo","kbo","qkbo","lakbo","lpo","incomp"});
     _termOrdering.description="The term ordering used by Vampire to orient equations and order literals.\n"
@@ -2321,13 +2328,13 @@ void Options::init()
                                           "precedence","inv_precedence","frequency","inv_frequency"});
     _kboWeightGenerationScheme.description = "Weight generation schemes from KBO inspired by E. This gets overridden by the function_weights option if used.";
     _kboWeightGenerationScheme.setExperimental();
-    _kboWeightGenerationScheme.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
+    _kboWeightGenerationScheme.onlyUsefulWith(KboLike());
     _kboWeightGenerationScheme.tag(OptionTag::SATURATION);
     _lookup.insert(&_kboWeightGenerationScheme);
 
     _kboMaxZero = BoolOptionValue("kbo_max_zero","kmz",false);
     _kboMaxZero.setExperimental();
-    _kboMaxZero.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
+    _kboMaxZero.onlyUsefulWith(KboLike());
     _kboMaxZero.tag(OptionTag::SATURATION);
     _kboMaxZero.description="Modifies any kbo_weight_scheme by setting the maximal (by the precedence) function symbol to have weight 0.";
     _lookup.insert(&_kboMaxZero);
@@ -2337,7 +2344,7 @@ void Options::init()
                                      {"error","warning" });
     _kboAdmissabilityCheck.description = "Choose to emit a warning instead of throwing an exception if the weight function and precedence ordering for kbo are not compatible.";
     _kboAdmissabilityCheck.setExperimental();
-    _kboAdmissabilityCheck.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
+    _kboAdmissabilityCheck.onlyUsefulWith(KboLike());
     _kboAdmissabilityCheck.tag(OptionTag::SATURATION);
     _lookup.insert(&_kboAdmissabilityCheck);
 
@@ -2368,7 +2375,7 @@ void Options::init()
       "If this option is empty all weights default to 1.\n"
       ;
     _functionWeights.setExperimental();
-    _functionWeights.onlyUsefulWith(_termOrdering.is(equal(TermOrdering::KBO)));
+    _functionWeights.onlyUsefulWith(KboLike());
     _lookup.insert(&_functionWeights);
 
     _typeConPrecedence = StringOptionValue("type_con_precedence","tcp","");

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -613,7 +613,7 @@ void Options::init()
     _newCNF.addProblemConstraint(onlyFirstOrder());
     _newCNF.tag(OptionTag::PREPROCESSING);
 
-    _inlineLet = BoolOptionValue("inline_let","ile",false);
+    _inlineLet = BoolOptionValue("inline_let","ile",true);
     _inlineLet.description="Always inline let-expressions.";
     _lookup.insert(&_inlineLet);
     _inlineLet.onlyUsefulWith(_newCNF.is(equal(true)));
@@ -1063,7 +1063,7 @@ void Options::init()
     _positiveLiteralSplitQueueLayeredArrangement.onlyUsefulWith(_usePositiveLiteralSplitQueues.is(equal(true)));
     _positiveLiteralSplitQueueLayeredArrangement.tag(OptionTag::SATURATION);
 
-    _literalMaximalityAftercheck = BoolOptionValue("literal_maximality_aftercheck","lma",false);
+    _literalMaximalityAftercheck = BoolOptionValue("literal_maximality_aftercheck","lma",true);
     _literalMaximalityAftercheck.description =
                                    "For efficiency we perform maximality checks before applying substitutions. Sometimes this can "
                                    "lead to generating more clauses than needed for completeness. Set this on to add the checks "
@@ -1589,7 +1589,7 @@ void Options::init()
     _lookup.insert(&_instantiation);
 
     _backwardDemodulation = ChoiceOptionValue<Demodulation>("backward_demodulation","bd",
-                  Demodulation::ALL,
+                  Demodulation::OFF,
                   {"all","off","preordered"});
     _backwardDemodulation.description=
        "Oriented rewriting of kept clauses by newly derived unit equalities\n"
@@ -1696,7 +1696,7 @@ void Options::init()
     _demodulationOnlyEquational.onlyUsefulWith(Or(_forwardDemodulation.is(notEqual(Demodulation::OFF)),_backwardDemodulation.is(notEqual(Demodulation::OFF))));
     _demodulationOnlyEquational.addProblemConstraint(hasEquality());
 
-    _extensionalityAllowPosEq = BoolOptionValue( "extensionality_allow_pos_eq","erape",false);
+    _extensionalityAllowPosEq = BoolOptionValue( "extensionality_allow_pos_eq","erape",true);
     _extensionalityAllowPosEq.description="If extensionality resolution equals filter, this dictates"
       " whether we allow other positive equalities when recognising extensionality clauses";
     _lookup.insert(&_extensionalityAllowPosEq);
@@ -2003,7 +2003,7 @@ void Options::init()
     _globalSubsumptionSatSolverPower.onlyUsefulWith(_globalSubsumption.is(equal(true)));
 
     _globalSubsumptionExplicitMinim = ChoiceOptionValue<GlobalSubsumptionExplicitMinim>("global_subsumption_explicit_minim","gsem",
-        GlobalSubsumptionExplicitMinim::RANDOMIZED,{"off","on","randomized"});
+        GlobalSubsumptionExplicitMinim::ON,{"off","on","randomized"});
     _globalSubsumptionSatSolverPower.description="Explicitly minimize the result of global subsumption reduction.";
     _lookup.insert(&_globalSubsumptionExplicitMinim);
     _globalSubsumptionExplicitMinim.tag(OptionTag::INFERENCES);
@@ -2020,7 +2020,7 @@ void Options::init()
     _globalSubsumptionAvatarAssumptions.onlyUsefulWith(_globalSubsumption.is(equal(true)));
     _globalSubsumptionAvatarAssumptions.onlyUsefulWith(_splitting.is(equal(true)));
 
-    _useHashingVariantIndex = BoolOptionValue("use_hashing_clause_variant_index","uhcvi",false);
+    _useHashingVariantIndex = BoolOptionValue("use_hashing_clause_variant_index","uhcvi",true);
     _useHashingVariantIndex.description= "Use clause variant index based on hashing for clause variant detection (affects avatar).";
     _lookup.insert(&_useHashingVariantIndex);
     _useHashingVariantIndex.tag(OptionTag::OTHER);
@@ -2057,7 +2057,7 @@ void Options::init()
 #endif
     // _splittingCongruenceClosure.addProblemConstraint(hasEquality()); -- not a good constraint for the minimizer
 
-    _ccUnsatCores = ChoiceOptionValue<CCUnsatCores>("cc_unsat_cores","ccuc",CCUnsatCores::ALL,
+    _ccUnsatCores = ChoiceOptionValue<CCUnsatCores>("cc_unsat_cores","ccuc",CCUnsatCores::SMALL_ONES,
                                                      {"first", "small_ones", "all"});
     _ccUnsatCores.description="";
     _lookup.insert(&_ccUnsatCores);
@@ -2082,7 +2082,7 @@ void Options::init()
     _splittingMinimizeModel.tag(OptionTag::AVATAR);
     _splittingMinimizeModel.onlyUsefulWith(_splitting.is(equal(true)));
 
-    _splittingEagerRemoval = BoolOptionValue("avatar_eager_removal","aer",true);
+    _splittingEagerRemoval = BoolOptionValue("avatar_eager_removal","aer",false);
     _splittingEagerRemoval.description="If a component was in the model and then becomes 'don't care' eagerly remove that component from the first-order solver. Note: only has any impact when amm is used.";
     _lookup.insert(&_splittingEagerRemoval);
     _splittingEagerRemoval.tag(OptionTag::AVATAR);
@@ -2107,7 +2107,7 @@ void Options::init()
     _splittingBufferedSolver.onlyUsefulWith(_splitting.is(equal(true)));
 
     _splittingDeleteDeactivated = ChoiceOptionValue<SplittingDeleteDeactivated>("avatar_delete_deactivated","add",
-                                                                        SplittingDeleteDeactivated::ON,{"on","large","off"});
+                                                                        SplittingDeleteDeactivated::LARGE_ONLY,{"on","large","off"});
 
     _splittingDeleteDeactivated.description="";
     _lookup.insert(&_splittingDeleteDeactivated);
@@ -2293,7 +2293,7 @@ void Options::init()
           .then(_alasca.is(equal(true)))); // <- alasca must be enabled, because the orderings rely on AlascaState to be set
     _lookup.insert(&_termOrdering);
 
-    _symbolPrecedence = ChoiceOptionValue<SymbolPrecedence>("symbol_precedence","sp",SymbolPrecedence::ARITY,
+    _symbolPrecedence = ChoiceOptionValue<SymbolPrecedence>("symbol_precedence","sp",SymbolPrecedence::FREQUENCY,
                                                             {"arity","occurrence","reverse_arity","unary_first",
                                                             "const_max", "const_min",
                                                             "scramble","frequency","unary_frequency","const_frequency",

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -759,6 +759,12 @@ void Options::init()
     _lookup.insert(&_showSimplOrdering);
     _showSimplOrdering.tag(OptionTag::OUTPUT);
 
+    _showPropDict = BoolOptionValue("show_property_dict","",false);
+    _showPropDict.description = "Display a (python-formatted) dictionary summing up the main properties of the parsed problem.";
+    _lookup.insert(&_showPropDict);
+    _showPropDict.setExperimental();
+    _showPropDict.tag(OptionTag::OUTPUT);
+
 #if VAMPIRE_CLAUSE_TRACING
 
     _traceBackward = IntOptionValue("trace_bwd","",0);
@@ -2990,7 +2996,7 @@ std::string Options::strategySamplingLookup(std::string optname, DHMap<std::stri
   return "";
 }
 
-void Options::sampleStrategy(const std::string& strategySamplerFilename, Shell::Property* prop)
+void Options::sampleStrategy(const std::string& strategySamplerFilename, DHMap<std::string,std::string> fakes)
 {
   std::ifstream input(strategySamplerFilename.c_str());
 
@@ -3002,14 +3008,6 @@ void Options::sampleStrategy(const std::string& strategySamplerFilename, Shell::
   auto rng = _randomStrategySeed.actualValue == 0
     ? std::mt19937((std::random_device())())
     : std::mt19937(_randomStrategySeed.actualValue);
-  // map of local variables (fake options)
-  DHMap<std::string,std::string> fakes;
-
-  // fill the fakes with some builtins - used for conditional sampling based on prop
-  fakes.set("@cat",prop->categoryString());
-  for (unsigned i = 1, n = 2; i <= 25; i++, n *= 2){
-    fakes.set("@atoms_leq_2^"+Int::toString(i),Int::toString(unsigned(prop->atoms() <= n)));
-  }
 
   std::string line; // parsed lines
   Stack<std::string> pieces; // temp stack used for splitting

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -48,6 +48,7 @@
 
 #include "Shell/UIHelper.hpp"
 #include "Shell/Statistics.hpp"
+#include "Shell/Property.hpp"
 
 #include "Kernel/Problem.hpp"
 #include "Kernel/Signature.hpp"
@@ -2982,7 +2983,7 @@ std::string Options::strategySamplingLookup(std::string optname, DHMap<std::stri
   return "";
 }
 
-void Options::sampleStrategy(const std::string& strategySamplerFilename)
+void Options::sampleStrategy(const std::string& strategySamplerFilename, Shell::Property* prop)
 {
   std::ifstream input(strategySamplerFilename.c_str());
 
@@ -2996,6 +2997,12 @@ void Options::sampleStrategy(const std::string& strategySamplerFilename)
     : std::mt19937(_randomStrategySeed.actualValue);
   // map of local variables (fake options)
   DHMap<std::string,std::string> fakes;
+
+  // fill the fakes with some builtins - used for conditional sampling based on prop
+  fakes.set("@cat",prop->categoryString());
+  for (unsigned i = 1, n = 2; i <= 25; i++, n *= 2){
+    fakes.set("@atoms_leq_2^"+Int::toString(i),Int::toString(unsigned(prop->atoms() <= n)));
+  }
 
   std::string line; // parsed lines
   Stack<std::string> pieces; // temp stack used for splitting

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2209,9 +2209,9 @@ void Options::init()
     _literalComparisonMode.addProblemConstraint(mayHaveNonUnits());
     _literalComparisonMode.addProblemConstraint(notJustEquality());
 
-    _nonGoalWeightCoefficient = NonGoalWeightOptionValue("nongoal_weight_coefficient","nwc",1.0);
+    _nonGoalWeightCoefficient = NonGoalWeightOptionValue("nongoal_weight_coefficient","nwc"); // default 10.0 is hard-wired to the constructor
     _nonGoalWeightCoefficient.description=
-             "coefficient that will multiply the weight of theory clauses (those marked as 'axiom' in TPTP)";
+             "coefficient that will multiply the weight of non-conjecture clauses (those marked as 'axiom' in TPTP)";
     _lookup.insert(&_nonGoalWeightCoefficient);
     _nonGoalWeightCoefficient.onlyUsefulWith(ProperSaturationAlgorithm());
     _nonGoalWeightCoefficient.tag(OptionTag::SATURATION);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1683,7 +1683,7 @@ void Options::init()
     _demodulationRedundancyCheck.onlyUsefulWith(Or(_forwardDemodulation.is(notEqual(Demodulation::OFF)),_backwardDemodulation.is(notEqual(Demodulation::OFF))));
     _demodulationRedundancyCheck.addProblemConstraint(hasEquality());
 
-    _forwardDemodulationTermOrderingDiagrams = BoolOptionValue("forward_demodulation_term_ordering_diagrams","fdtod",false);
+    _forwardDemodulationTermOrderingDiagrams = BoolOptionValue("forward_demodulation_term_ordering_diagrams","fdtod",true);
     _forwardDemodulationTermOrderingDiagrams.description=
        "Use term ordering diagrams (TODs) to runtime specialize post-ordering checks in forward demodulation.";
     _lookup.insert(&_forwardDemodulationTermOrderingDiagrams);
@@ -2279,7 +2279,7 @@ void Options::init()
     _lookup.insert(&_activationLimit);
     _activationLimit.tag(OptionTag::SATURATION);
 
-    // Even if AUTO_KBO resolves to "qkbo" or "lakbo", we still allow KBO suboptions (and possible ignore them)
+    // Even if AUTO_KBO resolves to "qkbo" or "lakbo", we still allow KBO suboptions (and possibly ignore them)
     // this is better than the default (to=auto_kbo) warning whenever we touch "kws" or "kmz" ...
     auto KboLike = [this] {
       return Or(_termOrdering.is(equal(TermOrdering::KBO)),

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1065,9 +1065,8 @@ void Options::init()
 
     _literalMaximalityAftercheck = BoolOptionValue("literal_maximality_aftercheck","lma",true);
     _literalMaximalityAftercheck.description =
-                                   "For efficiency we perform maximality checks before applying substitutions. Sometimes this can "
-                                   "lead to generating more clauses than needed for completeness. Set this on to add the checks "
-                                   "afterwards as well.";
+                                   "Allows to disable a secondary (literal maximality) ordering check (in the superposition calculus) after a substitution is applied."
+                                   " The check costs something but sometimes helps to skip some generating inferences";
     _lookup.insert(&_literalMaximalityAftercheck);
     _literalMaximalityAftercheck.onlyUsefulWith(ProperSaturationAlgorithm());
     _literalMaximalityAftercheck.tag(OptionTag::SATURATION);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2086,8 +2086,9 @@ void Options::init()
     _lookup.insert(&_splittingEagerRemoval);
     _splittingEagerRemoval.tag(OptionTag::AVATAR);
     _splittingEagerRemoval.onlyUsefulWith(_splitting.is(equal(true)));
-    // if minimize is off then makes no difference
-    // if minimize is sco then we could have a conflict clause added infinitely often (we actually protect against this in Splitter, be ignoring aer even if turned on)
+    // if minimize is off then aer makes no difference
+    // if minimize is sco then aer=off could lead to a conflict clause added infinitely often
+    // (we actually protect against the problematic combination in Splitter, by ignoring aer=off even if requested)
     _splittingEagerRemoval.onlyUsefulWith(_splittingMinimizeModel.is(equal(SplittingMinimizeModel::ALL)));
 
     _splittingFastRestart = BoolOptionValue("avatar_fast_restart","afr",false);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2088,11 +2088,8 @@ void Options::init()
     _splittingEagerRemoval.tag(OptionTag::AVATAR);
     _splittingEagerRemoval.onlyUsefulWith(_splitting.is(equal(true)));
     // if minimize is off then makes no difference
-    // if minimize is sco then we could have a conflict clause added infinitely often
+    // if minimize is sco then we could have a conflict clause added infinitely often (we actually protect against this in Splitter, be ignoring aer even if turned on)
     _splittingEagerRemoval.onlyUsefulWith(_splittingMinimizeModel.is(equal(SplittingMinimizeModel::ALL)));
-    // actually, with amm=sco:aer=off, we can also (wrongly) saturate finitely - let's make this part of the constraint hard
-    // (Problems/SWV/SWV608-1.p --decode Problems/SWV/SWV608-1.p --decode ott-1_1:40_tgt=full:plsq=on:sp=frequency:lcm=predicate:gs=on:bd=off:rawr=on:afp=1000:afq=2.0:irw=on:fsd=on:aer=off:si=on:rtra=on:amm=sco_30 --random_seed XXX)
-    _splittingEagerRemoval.addHardConstraint(If(equal(false)).then(_splittingMinimizeModel.is(notEqual(SplittingMinimizeModel::SCO))));
 
     _splittingFastRestart = BoolOptionValue("avatar_fast_restart","afr",false);
     _splittingFastRestart.description="";

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -132,7 +132,7 @@ public:
      * and if $nm is set to NZ, samples from a shifted geometric distribution with p=0.07 and a shift=2. (So 2 gets selected with a probability p,
      * 3 with a probability p(1-p), ... and 2+i with a probability p(1-p)^i).
      */
-    void sampleStrategy(const std::string& samplerFileName, Property* prop);
+    void sampleStrategy(const std::string& samplerFileName, DHMap<std::string,std::string> fakes = DHMap<std::string,std::string>());
 
     /**
      * Return the problem name
@@ -2036,6 +2036,8 @@ public:
   bool showFMBsortInfo() const { return showAll() || _showFMBsortInfo.actualValue; }
   bool showInduction() const { return showAll() || _showInduction.actualValue; }
   bool showSimplOrdering() const { return showAll() || _showSimplOrdering.actualValue; }
+  bool showPropDict() const { return _showPropDict.actualValue; }
+
 #if VAMPIRE_CLAUSE_TRACING
   int traceBackward() { return _traceBackward.actualValue; }
   int traceForward() { return _traceForward.actualValue; }
@@ -2633,6 +2635,7 @@ private:
   BoolOptionValue _showFMBsortInfo;
   BoolOptionValue _showInduction;
   BoolOptionValue _showSimplOrdering;
+  BoolOptionValue _showPropDict;
 #if VAMPIRE_CLAUSE_TRACING
   // TODO make unsigned option value
   IntOptionValue _traceBackward;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -132,7 +132,7 @@ public:
      * and if $nm is set to NZ, samples from a shifted geometric distribution with p=0.07 and a shift=2. (So 2 gets selected with a probability p,
      * 3 with a probability p(1-p), ... and 2+i with a probability p(1-p)^i).
      */
-    void sampleStrategy(const std::string& samplerFileName);
+    void sampleStrategy(const std::string& samplerFileName, Property* prop);
 
     /**
      * Return the problem name

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -553,8 +553,8 @@ public:
   enum class SymbolPrecedenceBoost : unsigned int {
     NONE = 0,
     GOAL = 1,
-    UNIT = 2,
-    GOAL_UNIT = 3,
+    UNITS = 2,
+    GOAL_THEN_UNITS = 3,
     NON_INTRO = 4,
     INTRO = 5,
   };

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -1228,8 +1228,8 @@ virtual std::string getStringOfActual() const override {
 */
 struct NonGoalWeightOptionValue : public OptionValue<float>{
 NonGoalWeightOptionValue(){}
-NonGoalWeightOptionValue(std::string l, std::string s, float def) :
-OptionValue(l,s,def), numerator(1), denominator(1) {};
+NonGoalWeightOptionValue(std::string l, std::string s) :
+OptionValue(l,s,10.0), numerator(10), denominator(1) {};
 
 bool setValue(const std::string& value);
 

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -1077,4 +1077,24 @@ std::string Property::toSpider(const std::string& problemName) const
     + "';";
 } // Property::toSpider
 
+/**
+ * Reflect the state of Property into a "python-style" representation
+ * as a dictionary of key-valey (string) pairs. In particular,
+ * Options::sampleStrategy is eagerly waiting for this to be able to do property-conditioned sampling.
+ */
+DHMap<std::string,std::string> Property::toDict() const
+{
+  DHMap<std::string,std::string> result;
+  result.set("@hasFormulas",Int::toString(hasFormulas()));
+  result.set("@hasEquality",Int::toString(equalityAtoms()>0));
+  result.set("@hasFOOL",Int::toString(hasFOOL()));
+  result.set("@hasGoal",Int::toString(hasGoal()));
+
+  result.set("@cat",categoryString());
+  for (unsigned i = 1, n = 2; i <= 25; i++, n *= 2){
+    result.set("@atoms_leq_2^"+Int::toString(i),Int::toString(unsigned(atoms() <= n)));
+  }
+  return result;
+} // Property::toDict
+
 } // namespace Shell

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -164,6 +164,8 @@ public:
   std::string toString() const;
   std::string toSpider(const std::string& problemName) const;
 
+  DHMap<std::string,std::string> toDict() const;
+
   /** Total number of clauses in the problem. */
   int clauses() const { return _goalClauses + _axiomClauses; }
   /** Total number of formulas in the problem */

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -207,7 +207,7 @@ public:
 
   bool hasInterpretedOperation(Interpretation i) const {
     if(i >= _interpretationPresence.size()){ return false; }
-    return _interpretationPresence[i]; 
+    return _interpretationPresence[i];
   }
   bool hasInterpretedOperation(Interpretation i, OperatorType* type) const {
     return _polymorphicInterpretations.find(std::make_pair(i,type));
@@ -238,12 +238,12 @@ public:
   unsigned sortsUsed() const { return _sortsUsed; }
   bool onlyFiniteDomainDatatypes() const { return _onlyFiniteDomainDatatypes; }
   bool knownInfiniteDomain() const { return _knownInfiniteDomain; }
-  
-  void setSMTLIBLogic(SMTLIBLogic smtLibLogic) { 
-    _smtlibLogic = smtLibLogic; 
+
+  void setSMTLIBLogic(SMTLIBLogic smtLibLogic) {
+    _smtlibLogic = smtLibLogic;
   }
-  SMTLIBLogic getSMTLIBLogic() const { 
-    return _smtlibLogic; 
+  SMTLIBLogic getSMTLIBLogic() const {
+    return _smtlibLogic;
   }
 
   bool allNonTheoryClausesGround(){ return _allNonTheoryClausesGround; }
@@ -302,7 +302,7 @@ public:
   int _totalNumberOfVariables;
   /** Maximal number of variables in a clause */
   int _maxVariablesInClause;
-  /** Symbols in this formula, used during counting 
+  /** Symbols in this formula, used during counting
       Functions are positive, predicates stored in the negative part
   **/
   DHSet<int> _symbolsInFormula;

--- a/UnitTests/tEqualityResolution.cpp
+++ b/UnitTests/tEqualityResolution.cpp
@@ -55,7 +55,7 @@ TEST_GENERATION(test_02,
 TEST_GENERATION(test_03,
     Generation::AsymmetricTest()
       .input(     clause({  selected(x != f(a)), selected(p(x))  }))
-      .expected( exactly( clause({  p(f(a))                              })))
+      .expected( exactly())
     )
 
 TEST_GENERATION(test_04,
@@ -74,4 +74,10 @@ TEST_GENERATION(test_06,
     Generation::AsymmetricTest()
       .input(     clause({  selected(f(g(x)) != f(x))  }))
       .expected( exactly())
+    )
+
+TEST_GENERATION(test_07,
+    Generation::AsymmetricTest()
+      .input(     clause({  selected(x != f(a)), selected(x != a)  }))
+      .expected( exactly( clause({  f(a) != a  })))
     )

--- a/checks/sanity
+++ b/checks/sanity
@@ -95,18 +95,18 @@ check_szs_status Theorem -t 1d -sas z3 -nwc 5.0 -br off Problems/DAT/DAT005_1.p
 check_szs_status Theorem -t 1d -alasca on -alascai on -thf on Problems/DAT/DAT023_1.p
 check_szs_status Theorem -t 1d -tha off Problems/DAT/DAT042_1.p
 check_szs_status Theorem -t 1d -s 1010 -thsq on -thsqr 8,1 -thsqc 64 -thsqd 64 -canc force Problems/DAT/DAT043_1.p
-check_szs_status Theorem -t 5d -sa discount -s 2 -awr 1:32 -to lpo -s2a on -s2agt 20 Problems/HWV/HWV087_2.p
-check_szs_status Theorem -t 1d -sa discount -awr 1:32 -to lpo -sp const_frequency -sos all -sac on Problems/ITP/ITP319_1.p
+check_szs_status Theorem -t 5d -sa discount -s 2 -awr 1:32 -to lpo -s2a on -s2agt 20 -bd all Problems/HWV/HWV087_2.p
+check_szs_status Theorem -t 1d -sa discount -awr 1:32 -to lpo -sp const_frequency -sos all -sac on -lma off Problems/ITP/ITP319_1.p
 check_szs_status Theorem -t 1d -sa discount -tha off -nwc 5.0 -gtg exists_sym -gtgl 5 Problems/ITP/ITP320_1.p
-check_szs_status Theorem -t 1d -to lpo -spb goal_then_units Problems/ITP/ITP412_1.p
+check_szs_status Theorem -t 1d -to lpo -spb goal_then_units -sp arity Problems/ITP/ITP412_1.p
 check_szs_status Theorem -t 1d -gve force -uwa one_side_interpreted -ep R Problems/NUM/NUM919_1.p
-check_szs_status ContradictoryAxioms -t 1d -s 1011 -thi all -uwa ground -br off Problems/PLA/PLA046_1.p
+check_szs_status ContradictoryAxioms -t 1d -s 1011 -thi all -uwa ground -br off -nwc 1.0 Problems/PLA/PLA046_1.p
 check_szs_status Theorem -t 1d -s 1002 -to kbo -kws inv_frequency -sas z3 -nwc 5.0 -gtg exists_all Problems/PLA/PLA050_1.p
-check_szs_status Theorem -t 1d -sa discount -s 1002 -to lpo -tha off -canc force -fsr off -fdi 10 Problems/SEV/SEV425_1.p
-check_szs_status Theorem -t 1d -isp bottom -to lpo -sas z3 -fd preordered -ev force Problems/SWC/SWC478_1.p
-check_szs_status Theorem --decode ott+11_1:1_to=lpo:thi=all:sas=z3:fdtod=on:sp=const_max:foolp=on:gtgl=5:asg=cautious:gtg=all:rawr=on_1 Problems/SWC/SWC482_1.p
+check_szs_status Theorem -t 1d -sa discount -s 1002 -to lpo -tha off -canc force -fsr off -fdi 10 -nwc 1.0 Problems/SEV/SEV425_1.p
+check_szs_status Theorem -t 1d -isp bottom -to lpo -sas z3 -fd preordered -ev force -bd all -nwc 1.0 -sp arity Problems/SWC/SWC478_1.p
+check_szs_status Theorem --decode ott+11_1:1_to=lpo:thi=all:sas=z3:bd=all:fdtod=on:sp=const_max:foolp=on:gtgl=5:asg=cautious:gtg=all:rawr=on_1 -lma off -uhcvi off -aer on -add on -nwc 1.0  Problems/SWC/SWC482_1.p
 check_szs_status Theorem -t 1d -s 1011 -to lpo -sp unary_frequency -tha off -newcnf on -s2a on -doe on Problems/SWW/SWW587_2.p
-check_szs_status Theorem -t 3d -s 1011 -tgt full -fde none -nm 0 Problems/SWW/SWW605_2.p
+check_szs_status Theorem -t 3d -s 1011 -tgt full -fde none -nm 0 -bd all -sp arity -lma off -aer on -add on -nwc 1.0 Problems/SWW/SWW605_2.p
 check_szs_status Theorem --decode ott+10_1:1024_to=kbo:norm_ineq=on:fde=unused:sas=z3:sos=on:tha=off:nm=16_1 Problems/SWW/SWW617_2.p
 check_szs_status Theorem -t 1d -t 1d -sas z3 -fs off -slsq off -s2a on -ep RSTC -fsr off -alasca on Problems/SWW/SWW620_2.p
 check_szs_status Theorem -t 1d -to lpo -sos all -doe on Problems/SWW/SWW629_2.p

--- a/checks/sanity
+++ b/checks/sanity
@@ -112,5 +112,5 @@ check_szs_status Theorem -t 1d -t 1d -sas z3 -fs off -slsq off -s2a on -ep RSTC 
 check_szs_status Theorem -t 1d -to lpo -sos all -doe on Problems/SWW/SWW629_2.p
 
 # Forward ground joinability
-check_szs_status Satisfiable -fgj on Problems/SWV/SWV021-1.p
-check_szs_status Unsatisfiable -fgj on Problems/SWW/SWW436-1.p
+check_szs_status Satisfiable -t 5d -fgj on Problems/SWV/SWV021-1.p
+check_szs_status Unsatisfiable -t 5d -fgj on -bd all Problems/SWW/SWW436-1.p

--- a/samplers/samplerFNT.smp
+++ b/samplers/samplerFNT.smp
@@ -134,7 +134,7 @@ sa!=fmb > etr ~cat off:500,on:30
 sa!=fmb ins=0 > er ~cat off:500,known:25,filter:26
 
 # extensionality_allow_pos_eq
-sa!=fmb er=filter > erape ~cat off:3,on:1
+sa!=fmb er=filter > eape ~cat off:3,on:1
 
 # extensionality_max_length
 sa!=fmb er!=off > erml ~cat 0:3,2:1,3:1

--- a/samplers/samplerFOL.smp
+++ b/samplers/samplerFOL.smp
@@ -188,7 +188,7 @@ sa!=fmb > etr ~cat off:500,on:30
 sa!=fmb ins=0 > er ~cat off:500,known:25,filter:26
 
 # extensionality_allow_pos_eq
-sa!=fmb er=filter > erape ~cat off:3,on:1
+sa!=fmb er=filter > eape ~cat off:3,on:1
 
 # extensionality_max_length
 sa!=fmb er!=off > erml ~cat 0:3,2:1,3:1

--- a/samplers/samplerIND.smp
+++ b/samplers/samplerIND.smp
@@ -193,7 +193,7 @@ bsd=on > bsdmm ~cat 0:10,1:3,2:2,3:1
 ins=0 > er ~cat off:500,known:25,filter:26
 
 # extensionality_allow_pos_eq
-er=filter > erape ~cat off:3,on:1
+er=filter > eape ~cat off:3,on:1
 
 # extensionality_max_length
 er!=off > erml ~cat 0:3,2:1,3:1

--- a/samplers/samplerSMT.smp
+++ b/samplers/samplerSMT.smp
@@ -196,7 +196,7 @@ bsd=on > bsdmm ~cat 0:10,1:3,2:2,3:1
 ins=0 > er ~cat off:500,known:25,filter:26
 
 # extensionality_allow_pos_eq
-er=filter > erape ~cat off:3,on:1
+er=filter > eape ~cat off:3,on:1
 
 # extensionality_max_length
 er!=off > erml ~cat 0:3,2:1,3:1

--- a/samplers/samplerUEQ.smp
+++ b/samplers/samplerUEQ.smp
@@ -157,7 +157,7 @@ bsd=on > bsdmm ~cat 0:10,1:3,2:2,3:1
 ins=0 > er ~cat off:500,known:25,filter:26
 
 # extensionality_allow_pos_eq
-er=filter > erape ~cat off:3,on:1
+er=filter > eape ~cat off:3,on:1
 
 # extensionality_max_length
 er!=off > erml ~cat 0:3,2:1,3:1

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -125,7 +125,8 @@ Problem *doProving(Problem* problem)
 {
   // a new strategy randomization mechanism
   if (!env.options->strategySamplerFilename().empty()) {
-    env.options->sampleStrategy(env.options->strategySamplerFilename());
+    env.options->sampleStrategy(env.options->strategySamplerFilename(),
+      problem->getProperty());
   }
 
   env.options->setForcedOptionValues();
@@ -447,7 +448,8 @@ void clausifyMode(Problem* problem, bool theory)
   simplifier.addFront(new DuplicateLiteralRemovalISE());
 
   if (!env.options->strategySamplerFilename().empty()) {
-    env.options->sampleStrategy(env.options->strategySamplerFilename());
+    env.options->sampleStrategy(env.options->strategySamplerFilename(),
+      problem->getProperty());
   }
 
   ScopedPtr<Problem> prb(preprocessProblem(problem));

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -123,10 +123,14 @@ void explainException(Exception& exception)
 [[nodiscard]]
 Problem *doProving(Problem* problem)
 {
+  if (env.options->showPropDict()) {
+    cout << "% Prop: " << problem->getProperty()->toDict() << endl;
+  }
+
   // a new strategy randomization mechanism
   if (!env.options->strategySamplerFilename().empty()) {
     env.options->sampleStrategy(env.options->strategySamplerFilename(),
-      problem->getProperty());
+      problem->getProperty()->toDict());
   }
 
   env.options->setForcedOptionValues();
@@ -449,7 +453,7 @@ void clausifyMode(Problem* problem, bool theory)
 
   if (!env.options->strategySamplerFilename().empty()) {
     env.options->sampleStrategy(env.options->strategySamplerFilename(),
-      problem->getProperty());
+      problem->getProperty()->toDict());
   }
 
   ScopedPtr<Problem> prb(preprocessProblem(problem));


### PR DESCRIPTION
- based on extensive experiments, these lead to a more robust default on TPTP

obviously, this will affect any existing schedules and also sanity runs; let's not rush merging until we are sure we are happy with this

On TPTP v9.0.0, CNF+FOF, the performance of `-i 5000 -sa discount -awr 10` goes from `7777` up to `7829`. Goes further up to `8059` with `nwc=10`.