### PR TITLE
switch existing code to use Substitution

### DIFF
--- a/FMB/FiniteModel.cpp
+++ b/FMB/FiniteModel.cpp
@@ -518,7 +518,7 @@ bool FiniteModel::evaluate(Formula* formula,unsigned depth)
 
      for(unsigned c=1;c<=_size;c++){
        Substitution s;
-       ALWAYS(s.bind(var,getDomainConstant(c)));
+       s.bindUnbound(var,getDomainConstant(c));
        Formula* next_sub = SubstHelper::apply(next,s);
        next_sub = SimplifyFalseTrue::simplify(next_sub);
        next_sub = Flattening::flatten(next_sub); 

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -904,7 +904,7 @@ bool FiniteModelMultiSorted::evaluate(Formula* formula,unsigned depth)
      unsigned srtU = srt.term()->functor();
      for(unsigned c=1;c<=_sizes[srtU];c++){
        Substitution s;
-       ALWAYS(s.bind(var,getDomainConstant(c,srtU)));
+       s.bindUnbound(var,getDomainConstant(c,srtU));
        Formula* next_sub = SubstHelper::apply(next,s);
        next_sub = SimplifyFalseTrue::simplify(next_sub);
        next_sub = Flattening::flatten(next_sub);

--- a/Inferences/ArgCong.cpp
+++ b/Inferences/ArgCong.cpp
@@ -78,7 +78,7 @@ struct ArgCong::ResultFn
       subst.reset();
       alpha1 = TermList(_freshVar+1, false);
       alpha2 = TermList(_freshVar+2, false);
-      ALWAYS(subst.bind(eqSort.var(), AtomicSort::arrowSort(alpha1, alpha2)));
+      subst.bindUnbound(eqSort.var(), AtomicSort::arrowSort(alpha1, alpha2));
     } else {
       alpha1 = *eqSort.term()->nthArgument(0);
       alpha2 = *eqSort.term()->nthArgument(1);

--- a/Inferences/FastCondensation.cpp
+++ b/Inferences/FastCondensation.cpp
@@ -16,10 +16,11 @@
 #include "Lib/Int.hpp"
 #include "Debug/TimeProfiling.hpp"
 
-#include "Kernel/Term.hpp"
 #include "Kernel/Clause.hpp"
 #include "Kernel/Inference.hpp"
 #include "Kernel/Matcher.hpp"
+#include "Kernel/Term.hpp"
+#include "Kernel/TermIterators.hpp"
 
 #include "Lib/Environment.hpp"
 #include "Shell/Statistics.hpp"

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -146,7 +146,7 @@ Formula* InductionContext::getFormula(const std::vector<TermList>& r, bool oppos
     replacementMap.insert(make_pair(ph,r[i]));
     if (subst) {
       ASS(r[i].isVar());
-      ALWAYS(subst->bind(r[i].var(), ph));
+      subst->bindUnbound(r[i].var(), ph);
     }
   }
   TermReplacement tr(replacementMap);
@@ -157,7 +157,7 @@ Formula* InductionContext::getFormulaWithFreeVar(const std::vector<TermList>& r,
 {
   Formula* replaced = getFormula(r, opposite, subst);
   Substitution s;
-  ALWAYS(s.bind(freeVar, freeVarSub));
+  s.bindUnbound(freeVar, freeVarSub);
   return SubstHelper::apply(replaced, s);
 }
 
@@ -174,7 +174,7 @@ Formula* InductionContext::getFormulaWithSquashedSkolems(const std::vector<TermL
     replacementMap.insert(make_pair(ph,r[i]));
     if (subst) {
       ASS(r[i].isVar());
-      ALWAYS(subst->bind(r[i].var(), ph));
+      subst->bindUnbound(r[i].var(), ph);
     }
   }
   SkolemSquashingTermReplacement tr(replacementMap, var);
@@ -186,7 +186,7 @@ Formula* InductionContext::getFormulaWithSquashedSkolems(const std::vector<TermL
       unsigned v;
       Term* t;
       it.next(t, v);
-      ALWAYS(subst->bind(v,t));
+      subst->bindUnbound(v,t);
     }
   }
   if (varList) {
@@ -1588,7 +1588,7 @@ void InductionClauseIterator::performRecursionInduction(const InductionContext& 
   for (unsigned i = 0; i < header->numTypeArguments(); i++) {
     auto arg = *header->nthArgument(i);
     ASS(arg.isVar());
-    ALWAYS(typeSubst.bind(arg.var(),typeArgs[i]));
+    typeSubst.bindUnbound(arg.var(),typeArgs[i]);
   }
 
   for (const auto& b : templ->branches()) {
@@ -1705,7 +1705,7 @@ void InductionClauseIterator::performStructInductionFreeVar(const InductionConte
   Term* xSkolem = bindings.get(xvar, nullptr);
   ASS(xSkolem != nullptr);
   ASS(freeVarSubst != nullptr);
-  ALWAYS(freeVarSubst->bind(int(freeVar), SubstHelper::apply<Substitution>(xSkolem, subst)));
+  freeVarSubst->bindUnbound(int(freeVar), SubstHelper::apply<Substitution>(xSkolem, subst));
 
   e->add(std::move(hyp_clauses), std::move(subst));
   return;

--- a/Inferences/Instantiation.cpp
+++ b/Inferences/Instantiation.cpp
@@ -162,13 +162,13 @@ void Instantiation::tryMakeLiteralFalse(Literal* lit, Stack<Substitution>& subs)
 
         // we are okay
         Substitution s1;
-        ALWAYS(s1.bind(var,t));
+        s1.bindUnbound(var,t);
         subs.push(s1);
         if(lit->polarity()){
          t = tryGetDifferentValue(t);
          if(t){
            Substitution s2;
-           ALWAYS(s2.bind(var,t));
+           s2.bindUnbound(var,t);
            subs.push(s2);
          }
         }
@@ -244,7 +244,7 @@ public:
       DArray<Term*>* cans;
       if(candidates.find(v,cans) && cans->size()!=0){
         unsigned at = current.get(v);
-        ALWAYS(sub.bind(v,(* cans)[at]));
+        sub.bindUnbound(v,(* cans)[at]);
       }
     }
     //cout << "sub is " << sub.toString() << endl;

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -622,7 +622,7 @@ template<class IterLits> TheoryInstAndSimp::SkolemizedLiterals TheoryInstAndSimp
       if(!subst.findBinding(var,fc)){
         Term* fc = _instantiationConstants.freshConstant(sort);
         ASS_EQ(SortHelper::getResultSort(fc), sort);
-        subst.bind(var,fc);
+        subst.bindUnbound(var,fc);
         vars.push(var);
       }
     }

--- a/Kernel/MLVariant.cpp
+++ b/Kernel/MLVariant.cpp
@@ -30,6 +30,7 @@
 #include "Term.hpp"
 #include "Matcher.hpp"
 #include "MLVariant.hpp"
+#include "TermIterators.hpp"
 
 #if VDEBUG
 #include <iostream>

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -13,11 +13,9 @@
  */
 
 #include "Lib/DHMap.hpp"
-#include "Lib/DHSet.hpp"
-
-#include "SubstHelper.hpp"
 
 #include "Matcher.hpp"
+#include "SubstHelper.hpp"
 
 namespace Kernel
 {
@@ -33,21 +31,21 @@ using namespace std;
 TermList MatchingUtils::getInstanceFromMatch(TermList matchedBase,
     TermList matchedInstance, TermList resultBase)
 {
-  static MapBinderAndApplicator bap;
-  bap.reset();
+  static Substitution subst;
+  subst.reset();
 
-  ALWAYS( matchTerms(matchedBase, matchedInstance, bap) );
-  return SubstHelper::apply(resultBase, bap);
+  ALWAYS( matchTerms(matchedBase, matchedInstance, subst) );
+  return SubstHelper::apply(resultBase, subst);
 }
 
 Formula* MatchingUtils::getInstanceFromMatch(Literal* matchedBase,
       Literal* matchedInstance, Formula* resultBase)
 {
-  static MapBinderAndApplicator bap;
-  bap.reset();
+  static Substitution subst;
+  subst.reset();
 
-  ALWAYS( match(matchedBase, matchedInstance, false, bap) );
-  return SubstHelper::apply(resultBase, bap);
+  ALWAYS( match(matchedBase, matchedInstance, false, subst) );
+  return SubstHelper::apply(resultBase, subst);
 }
 
 bool MatchingUtils::isVariant(Literal* l1, Literal* l2, bool complementary)
@@ -170,18 +168,18 @@ bool MatchingUtils::matchReversedArgs(Literal* base, Literal* instance)
   ASS_EQ(base->arity(), 2);
   ASS_EQ(instance->arity(), 2);
 
-  static MapBinder binder;
-  binder.reset();
+  static Substitution subst;
+  subst.reset();
 
-  return matchReversedArgs(base, instance, binder);
+  return matchReversedArgs(base, instance, subst);
 }
 
 bool MatchingUtils::matchArgs(Term* base, Term* instance)
 {
-  static MapBinder binder;
-  binder.reset();
+  static Substitution subst;
+  subst.reset();
 
-  return matchArgs(base, instance, binder);
+  return matchArgs(base, instance, subst);
 }
 
 bool MatchingUtils::matchTerms(TermList base, TermList instance)

--- a/Kernel/Matcher.hpp
+++ b/Kernel/Matcher.hpp
@@ -17,15 +17,9 @@
 #define __Matcher__
 
 #include "Forwards.hpp"
-
-#include "Lib/Backtrackable.hpp"
-#include "Lib/DHMap.hpp"
-#include "Lib/Hash.hpp"
 #include "Lib/Stack.hpp"
-#include "Lib/VirtualIterator.hpp"
 
 #include "Term.hpp"
-#include "TermIterators.hpp"
 #include "SortHelper.hpp"
 
 namespace Kernel {
@@ -47,8 +41,8 @@ public:
 
   static bool match(Literal* base, Literal* instance, bool complementary)
   {
-    static MapBinder binder;
-    return match(base, instance, complementary, binder);
+    static Substitution subst;
+    return match(base, instance, complementary, subst);
   }
 
   /**
@@ -126,31 +120,7 @@ public:
   template<class Binder>
   static bool matchReversedArgs(Literal* base, Literal* instance, Binder& binder);
 
-  typedef DHMap<unsigned,TermList,IdentityHash,DefaultHash> BindingMap;
-  struct MapBinder
-  {
-    bool bind(unsigned var, TermList term)
-    {
-      TermList* aux;
-      return _map.getValuePtr(var,aux,term) || *aux==term;
-    }
-    void specVar(unsigned var, TermList term)
-    { ASSERTION_VIOLATION; }
-    void reset() { _map.reset(); }
-
-    BindingMap _map;
-  };
-
-  struct MapBinderAndApplicator : MapBinder
-  {
-    TermList apply(unsigned var) {
-      TermList res;
-      if(!_map.find(var, res)) {
-        res = TermList::var(var);
-      }
-      return res;
-    }
-  };
+  //typedef DHMap<unsigned,TermList,IdentityHash,DefaultHash> BindingMap;
 };
 
 /**

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -65,7 +65,7 @@ void SortHelper::getTypeSub(const Term* t, Substitution& subst)
   for(unsigned i = 0; i < typeArgsArity; i++){
     TermList var = ot->quantifiedVar(i);
     ASS_REP(var.isVar(), t->toString());
-    ALWAYS(subst.bind(var.var(), *typeArg));
+    subst.bindUnbound(var.var(), *typeArg);
     typeArg = typeArg->next();
   }  
 } // getTypeSub
@@ -428,7 +428,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
               auto var = vit.next();
               TermList sort = AtomicSort::superSort();
               if (i < type->numTypeArguments()) {
-                ALWAYS(subst.bind(type->quantifiedVar(i).var(), TermList(var, false)));
+                subst.bindUnbound(type->quantifiedVar(i).var(), TermList(var, false));
               } else {
                 sort = SubstHelper::apply(type->arg(i),subst);
               }
@@ -465,7 +465,7 @@ void SortHelper::collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermL
               auto var = vit.next();
               TermList sort = AtomicSort::superSort();
               if (i < type->numTypeArguments()) {
-                ALWAYS(subst.bind(type->quantifiedVar(i).var(), TermList(var, false)));
+                subst.bindUnbound(type->quantifiedVar(i).var(), TermList(var, false));
               } else {
                 sort = SubstHelper::apply(type->arg(i),subst);
               }
@@ -705,7 +705,7 @@ void SortHelper::normaliseArgSorts(VList* qVars, TermStack& argSorts)
   unsigned i = 0;
   while(qVars){
     unsigned var = qVars->head();
-    ALWAYS(subst.bind(var, TermList(i++, false)));
+    subst.bindUnbound(var, TermList(i++, false));
     qVars = qVars->tail();
   }
 
@@ -720,7 +720,7 @@ void SortHelper::normaliseSort(VList* qVars, TermList& sort)
   unsigned i = 0;
   while(qVars){
     unsigned var = qVars->head();
-    ALWAYS(subst.bind(var, TermList(i++, false)));
+    subst.bindUnbound(var, TermList(i++, false));
     qVars = qVars->tail();
   }
 
@@ -731,7 +731,7 @@ void SortHelper::normaliseArgSorts(const TermStack& qVars, TermStack& argSorts)
 {
   Substitution subst;
   for(unsigned i = 0; i < qVars.size(); i++){
-    ALWAYS(subst.bind(qVars[i].var(), TermList(i, false)));
+    subst.bindUnbound(qVars[i].var(), TermList(i, false));
   }
 
   for(unsigned i = 0; i < argSorts.size(); i++){
@@ -743,7 +743,7 @@ void SortHelper::normaliseSort(TermStack qVars, TermList& sort)
 {
   Substitution subst;
   for(unsigned i = 0; i < qVars.size(); i++){
-    ALWAYS(subst.bind(qVars[i].var(), TermList(i, false)));
+    subst.bindUnbound(qVars[i].var(), TermList(i, false));
   }
 
   sort = SubstHelper::apply(sort, subst);

--- a/Kernel/SubstHelper.hpp
+++ b/Kernel/SubstHelper.hpp
@@ -666,35 +666,4 @@ inline TermList AppliedTerm::apply() const {
                   : term;
 }
 
-// a variable-term map that complies with the requirements for MatchingUtils and SubstHelper
-struct SimpleSubstitution
-{
-  std::unordered_map<unsigned, TermList> bindings;
-
-  TermList apply(unsigned var) {
-    if(auto bound = bindings.find(var); bound != bindings.end())
-      return bound->second;
-    return TermList(var, false);
-  }
-
-  void reset() { bindings.clear(); }
-
-  bool bind(unsigned var, TermList term)
-  {
-    auto [it, inserted] = bindings.insert({var, term});
-    return inserted || it->second == term;
-  }
-
-  void specVar(unsigned var, TermList term) { ASSERTION_VIOLATION; }
-};
-
-inline std::ostream &operator<<(std::ostream &out, const SimpleSubstitution &subst) {
-  out << "[";
-  for(auto [left, right] : subst.bindings) {
-    out << " " << left << " -> " << right;
-  }
-  out << "]";
-  return out;
-}
-
 #endif /* __SubstHelper__ */

--- a/Kernel/Substitution.hpp
+++ b/Kernel/Substitution.hpp
@@ -40,10 +40,17 @@ public:
 
   /**
    * Bind `v` to `t`.
-   * If v was already present, do nothing and return false.
+   * Succeeds and returns true if `v` is either not bound or already bound to `t`.
+   * Returns false otherwise, leaving the substitution untouched.
    */
-  bool bind(unsigned v, TermList t) { return _map.insert(v, t); }
-  bool bind(unsigned int v, Term *t) { return bind(v, TermList(t)); }
+  bool bind(unsigned v, TermList t) { return _map.findOrInsert(v, t) == t; }
+  bool bind(unsigned v, Term *t) { return bind(v, TermList(t)); }
+
+  /**
+   * Bind `v` to `t`: `v` must not be bound to anything.
+   */
+  void bindUnbound(unsigned v, TermList t) { ALWAYS(_map.insert(v, t)); }
+  void bindUnbound(unsigned int v, Term *t) { bindUnbound(v, TermList(t)); }
 
   /**
    * Bind `v` to `t`, regardless of what was there before (if anything).
@@ -56,6 +63,9 @@ public:
    * Otherwise return false and do nothing.
    */
   bool findBinding(unsigned v, TermList &out) const { return _map.find(v, out); }
+
+  // variable/term pairs
+  auto items() { return _map.items(); }
 
   /**
    * Return result of application of the substitution to variable @c var

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1474,7 +1474,7 @@ void SMTLIB2::parseLetEnd(LExpr* exp)
     VList::FIFO vars;
     Substitution subst;
     for (unsigned i = 0; i < exprT->arity(); i++) {
-      ALWAYS(subst.bind(exprT->nthArgument(i)->var(),TermList::var(_nextVar)));
+      subst.bindUnbound(exprT->nthArgument(i)->var(),TermList::var(_nextVar));
       vars.pushBack(_nextVar++);
     }
 
@@ -1584,7 +1584,7 @@ void SMTLIB2::parseMatchCase(LExpr *exp)
   for (unsigned i = 0; i < type->arity(); i++) {
     if (i < type->numTypeArguments()) {
       auto typeArg = *matchedTermSort.term()->nthArgument(i);
-      ALWAYS(subst.bind(type->quantifiedVar(i).var(),typeArg));
+      subst.bindUnbound(type->quantifiedVar(i).var(),typeArg);
       patternArgs.push(typeArg);
       continue;
     }
@@ -1682,7 +1682,7 @@ void SMTLIB2::parseMatchEnd(LExpr *exp)
       LOG2("CASE missing ", pattern);
       ASS(varPattern.isVar());
       Substitution subst;
-      ALWAYS(subst.bind(varPattern.var(), pattern));
+      subst.bindUnbound(varPattern.var(), pattern);
       matchArgs.push(pattern);
       matchArgs.push(SubstHelper::apply(varBody, subst));
     }
@@ -1796,7 +1796,7 @@ bool SMTLIB2::parseAsSortDefinition(const std::string& id, LExpr* exp)
     }
     TermList arg;
     ALWAYS(_results.pop().asTerm(arg) == AtomicSort::superSort());
-    ALWAYS(subst.bind(i, arg));
+    subst.bindUnbound(i, arg);
   }
   _results.push(ParseResult(AtomicSort::superSort(), SubstHelper::apply(def->second, subst)));
   return true;
@@ -1863,7 +1863,7 @@ bool SMTLIB2::parseAsUserDefinedSymbol(const std::string& id,LExpr* exp,bool isS
   unsigned arity = symbol->arity();
 
   TermStack termArgs;
-  MatchingUtils::MapBinderAndApplicator subst;
+  Substitution subst;
   for (unsigned i = numTypeArgs; i < arity; i++) {
     if (_results.isEmpty() || _results.top().isSeparator()) {
       complainAboutArgShortageOrWrongSorts("user defined symbol",exp);
@@ -1913,7 +1913,7 @@ bool SMTLIB2::parseAsUserDefinedSymbol(const std::string& id,LExpr* exp,bool isS
     // means the result sort contains some free variable, and the user
     // must enclose it in an (as <term> <sort>) block.
     // Note that the 'as' is handled just above.
-    if (!subst._map.find(typeVar, typeVarS)) {
+    if (!subst.findBinding(typeVar, typeVarS)) {
       USER_ERROR_EXPR("User defined term "+exp->toString()+" has ambiguous sort, use (as "+exp->toString()+" <sort>) block to disambiguate");
     }
     args.push(typeVarS);

--- a/SATSubsumption/SATSubsumptionAndResolution.cpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.cpp
@@ -69,7 +69,6 @@
    */
 
 #include "Kernel/Matcher.hpp"
-#include "Kernel/SubstHelper.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Int.hpp"
 #include "Shell/Statistics.hpp"
@@ -971,9 +970,9 @@ bool SATSubsumption::SATSubsumptionAndResolution::checkSubsumptionResolutionWith
   return (_solver.solve() == subsat::Result::Sat);
 }
 
-SimpleSubstitution SATSubsumption::SATSubsumptionAndResolution::getBindingsForSubsumptionResolutionWithLiteral()
+Substitution SATSubsumption::SATSubsumptionAndResolution::getBindingsForSubsumptionResolutionWithLiteral()
 {
-  SimpleSubstitution subst;
+  Substitution subst;
   _solver.get_model(_model);
   for(auto lit : _model) {
     if(lit.is_negative())
@@ -987,6 +986,9 @@ SimpleSubstitution SATSubsumption::SATSubsumptionAndResolution::getBindingsForSu
     Match match = _matchSet.getMatchForVar(var);
     Literal *l = (*_sidePremise)[match.i];
     Literal *k = (*_mainPremise)[match.j];
+    // matchArgs doesn't like nullary for some reason
+    if(!l->arity())
+      continue;
 
     // problem: with equality literals, they can be match straight or reversed
     bool reverseArgs = false;

--- a/SATSubsumption/SATSubsumptionAndResolution.hpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.hpp
@@ -515,7 +515,7 @@ public:
    * @brief Return the substitution required for the last subsumption resolution.
    * @note precondition: the last subsumption resolution succeeded
    */
-  SimpleSubstitution getBindingsForSubsumptionResolutionWithLiteral();
+  Substitution getBindingsForSubsumptionResolutionWithLiteral();
 
   /**
    * Creates a clause that is the subsumption resolution of @b mainPremise and @b sidePremise on @b m_j.

--- a/Shell/AnswerLiteralManager.cpp
+++ b/Shell/AnswerLiteralManager.cpp
@@ -176,7 +176,7 @@ Unit* AnswerLiteralManager::tryAddingAnswerLiteral(Unit* unit)
       OperatorType* ot = OperatorType::getConstantsType(sort);
       skSym->setType(ot);
       Term* skTerm = Term::create(skFun, /*arity=*/0, /*args=*/nullptr);
-      ALWAYS(subst.bind(var, skTerm));
+      subst.bindUnbound(var, skTerm);
       recordSkolemBinding(skTerm, var, questionVars ? questionVars->get(var) : TermList(var,false).toString() );
     }
     out = SubstHelper::apply(out, subst);
@@ -719,7 +719,7 @@ TermList SynthesisALManager::ConjectureSkolemReplacement::transformTermList(Term
         if (done.count(v) == 0) {
           done.insert(v);
           if (vsort == AtomicSort::intSort()) {
-            ALWAYS(s.bind(v, zero));
+            s.bindUnbound(v, zero);
           } else {
             std::string name = "cz_" + vsort.toString();
             unsigned czfn;
@@ -728,7 +728,7 @@ TermList SynthesisALManager::ConjectureSkolemReplacement::transformTermList(Term
               env.signature->getFunction(czfn)->setType(OperatorType::getConstantsType(sort));
             }
             TermList res(Term::createConstant(czfn));
-            ALWAYS(s.bind(v, res));
+            s.bindUnbound(v, res);
           }
         }
       }

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -171,7 +171,7 @@ void EqualityProxy::getArgumentEqualityLiterals(unsigned cnt, LiteralStack& lits
       vars2.push(v2);
     } else {
       TermList var = symbolType->quantifiedVar(i);
-      ALWAYS(localSubst.bind(var.var(), v1));
+      localSubst.bindUnbound(var.var(), v1);
       vars1.push(v1);
       vars2.push(v1);
     }

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -178,10 +178,10 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
     GenLit negativeCondition = GenLit(condition, NEGATIVE);
 
     Substitution thenSubst;
-    ALWAYS(thenSubst.bind(variable, thenBranch));
+    thenSubst.bindUnbound(variable, thenBranch);
 
     Substitution elseSubst;
-    ALWAYS(elseSubst.bind(variable, elseBranch));
+    elseSubst.bindUnbound(variable, elseBranch);
 
     List<LPair>* processedLiterals(0);
 
@@ -270,7 +270,7 @@ void NewCNF::process(Literal* literal, Occurrences &occurrences) {
         GenLit negCondition = GenLit(condition, NEGATIVE);
 
         Substitution subst;
-        ALWAYS(subst.bind(matchVar, branch));
+        subst.bindUnbound(matchVar, branch);
 
         Literal *branchLiteral = SubstHelper::apply(literal, subst);
 
@@ -498,7 +498,7 @@ void NewCNF::BindingStore::pushAndRememberWhileApplying(Binding b, BindingList* 
 {
   // turn b into a singleton substitution
   static Substitution subst;
-  ALWAYS(subst.bind(b.first,b.second));
+  subst.bindUnbound(b.first,b.second);
 
   // to go through the bindings from the end, put them on a stack...
   static Stack<BindingList*> st(5);
@@ -1329,10 +1329,10 @@ void NewCNF::toClauses(SPGenClause gc, Stack<Clause*>& output)
     Formula* skolem   = skolems.pop();
 
     Substitution thenSubst;
-    ALWAYS(thenSubst.bind(variable, Term::foolTrue()));
+    thenSubst.bindUnbound(variable, Term::foolTrue());
 
     Substitution elseSubst;
-    ALWAYS(elseSubst.bind(variable, Term::foolFalse()));
+    elseSubst.bindUnbound(variable, Term::foolFalse());
 
     List<List<GenLit>*>* processedGenClauses(0);
 
@@ -1376,7 +1376,7 @@ void NewCNF::toClauses(SPGenClause gc, Stack<Clause*>& output)
       Formula* naming = new AtomicFormula(createNamingLiteral(skolem, vars));
 
       Substitution skolemSubst;
-      ALWAYS(skolemSubst.bind(variable, Term::createFormula(skolem)));
+      skolemSubst.bindUnbound(variable, Term::createFormula(skolem));
 
       bool addedDefinition = false;
       while (List<List<GenLit>*>::isNonEmpty(genClauses)) {
@@ -1486,7 +1486,7 @@ Clause* NewCNF::toClause(SPGenClause gc)
     BindingList::Iterator bit(gc->bindings);
     while (bit.hasNext()) {
       Binding b = bit.next();
-      ALWAYS(subst->bind(b.first, b.second));
+      subst->bindUnbound(b.first, b.second);
     }
     _substitutionsByBindings.insert(gc->bindings, subst);
   }

--- a/Shell/SMTCheck.cpp
+++ b/Shell/SMTCheck.cpp
@@ -531,9 +531,9 @@ struct Identity {
   Literal *operator()(Literal *l) { return l; }
 };
 
-struct DoSimpleSubst {
-  SimpleSubstitution &subst;
-  DoSimpleSubst(SimpleSubstitution &subst) : subst(subst) {}
+struct DoSubst {
+  Substitution &subst;
+  DoSubst(Substitution &subst) : subst(subst) {}
   Literal *operator()(Literal *l) { return SubstHelper::apply(l, subst); }
 };
 
@@ -624,7 +624,7 @@ static void subsumptionResolution(std::ostream &out, SortMap &conclSorts, Clause
   auto subst = satSR.getBindingsForSubsumptionResolutionWithLiteral();
 
   outputPremise(out, conclSorts, left->asClause());
-  outputPremise(out, conclSorts, right->asClause(), DoSimpleSubst(subst));
+  outputPremise(out, conclSorts, right->asClause(), DoSubst(subst));
   outputConclusion(out, conclSorts, concl->asClause());
 }
 
@@ -707,7 +707,7 @@ static bool isL2RDemodulatorFor(Literal *demodulator, Clause *rewritten, TermLis
 
   // TODO this is waaay overkill, but it's very hard to work out which way a demodulator was used
   // consult MH about how best to do this
-  SimpleSubstitution subst;
+  Substitution subst;
   if (!MatchingUtils::matchTerms(demodulator->termArg(0), target, subst))
     return false;
   TermList rhsSubst = SubstHelper::apply(demodulator->termArg(1), subst);
@@ -724,7 +724,7 @@ static void demodulation(std::ostream &out, SortMap &conclSorts, Clause *concl)
   auto [left, right] = getParents<2>(concl);
   auto rw = env.proofExtra.get<Inferences::RewriteInferenceExtra>(concl);
 
-  SimpleSubstitution subst;
+  Substitution subst;
   Literal *rightLit = (*right)[0];
   TermList target = rw.rewritten;
   TermList from = rightLit->termArg(!isL2RDemodulatorFor(rightLit, left, target, concl));
@@ -734,7 +734,7 @@ static void demodulation(std::ostream &out, SortMap &conclSorts, Clause *concl)
   ALWAYS(MatchingUtils::matchTerms(from, target, subst))
 
   outputPremise(out, conclSorts, left->asClause());
-  outputPremise(out, conclSorts, right->asClause(), DoSimpleSubst(subst));
+  outputPremise(out, conclSorts, right->asClause(), DoSubst(subst));
   outputConclusion(out, conclSorts, concl->asClause());
 }
 

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -454,7 +454,7 @@ Formula* Skolem::skolemise (Formula* f)
 
         env.statistics->skolemFunctions++;
 
-        ALWAYS(_subst.bind(v,skolemTerm));
+        _subst.bindUnbound(v,skolemTerm);
 
         if (env.options->showSkolemisations()) {
           std::cout << "Skolemising: "<<skolemTerm->toString()<<" for X"<< v

--- a/Shell/SymbolDefinitionInlining.cpp
+++ b/Shell/SymbolDefinitionInlining.cpp
@@ -26,7 +26,7 @@ TermList SymbolDefinitionInlining::substitute(Term::Iterator tit) {
     unsigned var = vit.next();
     ASS(tit.hasNext());
     TermList arg = tit.next();
-    ALWAYS(substitution.bind(var, arg));
+    substitution.bindUnbound(var, arg);
   }
   ASS(!tit.hasNext());
 
@@ -51,7 +51,7 @@ TermList SymbolDefinitionInlining::substitute(Term::Iterator tit) {
     while (bit.hasNext()) {
       unsigned boundVar = bit.next();
       unsigned freshVar = ++_freshVarOffset;
-      ALWAYS(substitution.bind(boundVar, TermList(freshVar, false)));
+      substitution.bindUnbound(boundVar, TermList(freshVar, false));
       List<pair<unsigned, unsigned>>::push(make_pair(boundVar, freshVar), _varRenames);
     }
   }

--- a/Shell/SymbolOccurrenceReplacement.cpp
+++ b/Shell/SymbolOccurrenceReplacement.cpp
@@ -73,7 +73,7 @@ Term* SymbolOccurrenceReplacement::process(Term* term) {
     VList::Iterator fvit(_argVars);
     while (fvit.hasNext()) {
       unsigned var = fvit.next();
-      ALWAYS(substitution.bind(var, process(*arg)));
+      substitution.bindUnbound(var, process(*arg));
       arg = arg->next();
     }
   } else {
@@ -117,7 +117,7 @@ Formula* SymbolOccurrenceReplacement::process(Formula* formula) {
         VList::Iterator fvit(_argVars);
         while (fvit.hasNext()) {
           unsigned var = fvit.next();
-          ALWAYS(substitution.bind(var, process(*arg)));
+          substitution.bindUnbound(var, process(*arg));
           arg = arg->next();
         }
       } else {

--- a/Shell/TermAlgebra.cpp
+++ b/Shell/TermAlgebra.cpp
@@ -231,7 +231,7 @@ void TermAlgebra::getTypeSub(Term* sort, Substitution& subst)
   ASS_EQ(sort->functor(), t->functor());
   for (unsigned i = 0; i < sort->arity(); i++) {
     ASS(t->nthArgument(i)->isVar());
-    ALWAYS(subst.bind(t->nthArgument(i)->var(), *sort->nthArgument(i)));
+    subst.bindUnbound(t->nthArgument(i)->var(), *sort->nthArgument(i));
   }
 }
 
@@ -248,11 +248,11 @@ void TermAlgebra::excludeTermFromAvailables(TermStack& availables, TermList e, u
   TermStack temp;
   while (availables.isNonEmpty()) {
     auto p = availables.pop();
-    MatchingUtils::MapBinderAndApplicator subst;
+    Substitution subst;
     // if e is an instance of p, the remaining
     // instances of p are added
     if (MatchingUtils::matchTerms(p, e, subst)) {
-      auto items = subst._map.items();
+      auto items = subst.items();
       Substitution s;
       while (items.hasNext()) {
         auto kv = items.next();


### PR DESCRIPTION
Take 2 from #701. Now introduce `bindUnbound` for the old cases where we want to crash if there is already a binding, and use `bind` for the `MatchingUtils` interface. Replaces `MapBinderAndApplicator` and `SimpleSubstitution`.