### PR TITLE
Add assert-synth keyword for synthesis

### DIFF
--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -2824,31 +2824,24 @@ void SMTLIB2::readAssertSynth(LExpr* forall, LExpr* exist, LExpr* body)
     std::cout << "% WARNING: Found an assert-synth command but synthesis is not enabled. Consider running with '-qa synthesis'." << endl;
   }
 
-  auto fvars = VList::empty();
-  auto fsorts = SList::empty();
-  auto fRdr = READER(forall);
-  while (fRdr.hasNext()) {
-    auto pRdr = READER(fRdr.readList());
-    auto name = pRdr.readAtom();
-    auto var = TermList::var(_nextVar++);
-    auto sort = parseSort(pRdr.readExpr());
-    tryInsertIntoCurrentLookup(name, var, sort);
-    VList::push(var.var(), fvars);
-    SList::push(sort, fsorts);
-  }
+  auto parseVarList = [this](LExpr* lexp) {
+    auto vars = VList::empty();
+    auto sorts = SList::empty();
+    auto rdr = READER(lexp);
+    while (rdr.hasNext()) {
+      auto pRdr = READER(rdr.readList());
+      auto name = pRdr.readAtom();
+      auto var = TermList::var(_nextVar++);
+      auto sort = parseSort(pRdr.readExpr());
+      tryInsertIntoCurrentLookup(name, var, sort);
+      VList::push(var.var(), vars);
+      SList::push(sort, sorts);
+    }
+    return make_pair(vars, sorts);
+  };
 
-  auto evars = VList::empty();
-  auto esorts = SList::empty();
-  auto eRdr = READER(exist);
-  while (eRdr.hasNext()) {
-    auto pRdr = READER(eRdr.readList());
-    auto name = pRdr.readAtom();
-    auto var = TermList::var(_nextVar++);
-    auto sort = parseSort(pRdr.readExpr());
-    tryInsertIntoCurrentLookup(name, var, sort);
-    VList::push(var.var(), evars);
-    SList::push(sort, esorts);
-  }
+  auto [fvars, fsorts] = parseVarList(forall);
+  auto [evars, esorts] = parseVarList(exist);
   ParseResult res = parseTermOrFormula(body,false/*isSort*/);
 
   Formula* fla;

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -479,6 +479,13 @@ private:
   /**
    * Unofficial command
    *
+   * Used for synthesis based on forall-exist formulas.
+   */
+  void readAssertSynth(LExpr* forall, LExpr* exist, LExpr* body);
+
+  /**
+   * Unofficial command
+   *
    * Behaves like assert, but marks body clause as external theory axiom.
    * Assumes that body is already fully simplified (as this is usual the case for theory axioms).
    */

--- a/checks/parse/assert-synth-max5.smt2
+++ b/checks/parse/assert-synth-max5.smt2
@@ -1,0 +1,23 @@
+(set-logic LIA)
+
+(assert-synth (
+    (x1 Int)
+    (x2 Int)
+    (x3 Int)
+    (x4 Int)
+    (x5 Int))
+    ((y Int))
+        (and
+            (>= y x1)
+            (>= y x2)
+            (>= y x3)
+            (>= y x4)
+            (>= y x5)
+            (or
+                (= y x1)
+                (= y x2)
+                (= y x3)
+                (= y x4)
+                (= y x5)
+            )
+))

--- a/checks/sanity
+++ b/checks/sanity
@@ -79,6 +79,7 @@ check_szs_status Unsatisfiable -newcnf on parse/types-funs.smt2
 check_szs_status Unsatisfiable -t 2 parse/smtlib2-parametric-datatypes.smt2
 check_szs_status Unsatisfiable parse/smtlib2-mutual-recursion.smt2
 check_szs_status Unsatisfiable -newcnf on parse/let-bind-variable.smt2
+check_szs_status Unsatisfiable -qa synthesis parse/assert-synth-max5.smt2
 
 # Arithmetic
 check_szs_status Theorem -t 1d -s 32 -tgt ground -sas z3 -tha some -nm 6 Problems/ANA/ANA135_1.p


### PR DESCRIPTION
Adding special support for synthesis with forall-exists conjectures, via a new SMTLIB2 command `assert-synth`. This assumes a forall and an exist quantifier block in the beginning implicitly, and makes it easier to recognize such "synthesis tasks" in the future.