### PR TITLE
SAT: only one assumption mechanism, remove some unused oddities

### DIFF
--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -563,7 +563,7 @@ Option<Substitution> TheoryInstAndSimp::instantiateGeneralised(
       });
     }
 
-    DEBUG_CODE(auto res =) _solver->solveUnderAssumptions(theoryLits, 0);
+    DEBUG_CODE(auto res =) _solver->solveUnderAssumptionsLimited(theoryLits, 0);
     ASS_EQ(res, SATSolver::Status::UNSATISFIABLE)
 
     Set<TermList> usedDefs;
@@ -647,7 +647,7 @@ VirtualIterator<Solution> TheoryInstAndSimp::getSolutions(Stack<Literal*> const&
   DEBUG("skolemized: ", iterTraits(skolemized.lits.iterFifo()).map([&](SATLiteral l){ return _naming.toFO(l)->toString(); }).collect<Stack>())
 
   // now we can call the solver
-  SATSolver::Status status = _solver->solveUnderAssumptions(skolemized.lits, 0);
+  SATSolver::Status status = _solver->solveUnderAssumptionsLimited(skolemized.lits, 0);
 
   if(status == SATSolver::Status::UNSATISFIABLE) {
     DEBUG("unsat")
@@ -717,7 +717,7 @@ struct InstanceFn
         redundant = true;
       } else {
         auto skolem = parent->skolemize(iterTraits(invertedLits.iterFifo() /* without guards !! */));
-        auto status = parent->_solver->solveUnderAssumptions(skolem.lits, 0);
+        auto status = parent->_solver->solveUnderAssumptionsLimited(skolem.lits, 0);
         // we have an unsat solution without guards
         redundant = status == SATSolver::Status::UNSATISFIABLE;
       }

--- a/SAT/BufferedSolver.cpp
+++ b/SAT/BufferedSolver.cpp
@@ -114,7 +114,7 @@ void BufferedSolver::flushUnadded()
  *
  * @author Martin
  */
-SATSolver::Status BufferedSolver::solve(unsigned conflictCountLimit)
+SATSolver::Status BufferedSolver::solveLimited(unsigned conflictCountLimit)
 {
   // BufferedSolver does not support "UNKNOWN" status as
   // it needs _inner to have either a model or to be provably unsat
@@ -133,7 +133,7 @@ SATSolver::Status BufferedSolver::solve(unsigned conflictCountLimit)
     if(!checkAndRecordImplied(cl)){
       RSTAT_CTR_INC("solver_buffer_miss");
       flushUnadded();
-      return (_lastStatus = _inner->solve(conflictCountLimit));
+      return (_lastStatus = _inner->solveLimited(conflictCountLimit));
     }
   }
 

--- a/SAT/BufferedSolver.hpp
+++ b/SAT/BufferedSolver.hpp
@@ -51,7 +51,7 @@ public:
   }
 
   virtual void addClause(SATClause* cl) override;
-  virtual Status solve(unsigned conflictCountLimit) override;
+  virtual Status solveLimited(unsigned conflictCountLimit) override;
   virtual VarAssignment getAssignment(unsigned var) override;
 
   virtual bool isZeroImplied(unsigned var) override {

--- a/SAT/CadicalInterfacing.hpp
+++ b/SAT/CadicalInterfacing.hpp
@@ -43,7 +43,7 @@ public:
     _solver.simplify();
   }
 
-  virtual Status solve(unsigned conflictCountLimit) override;
+  virtual Status solveLimited(unsigned conflictCountLimit) override;
 
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
@@ -81,21 +81,8 @@ public:
     _solver.phase(vampire2Cadical(pol, var));
   }
 
-  /**
-   * Add an assumption into the solver.
-   */
-  virtual void addAssumption(SATLiteral lit) override;
-
-  virtual void retractAllAssumptions() override {
-    _assumptions.clear();
-    _status = Status::UNKNOWN;
-  };
-
-  virtual bool hasAssumptions() const override {
-    return _assumptions.size() > 0;
-  };
-
-  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  SATLiteralStack failedAssumptions() override;
 
   /**
    * Use minisat and solving under assumptions to minimize the given set of premises (= unsat core extraction).

--- a/SAT/FallbackSolverWrapper.cpp
+++ b/SAT/FallbackSolverWrapper.cpp
@@ -44,14 +44,14 @@ void FallbackSolverWrapper::addClause(SATClause* cl)
  *
  * @author Giles 
  */
-SATSolver::Status FallbackSolverWrapper::solve(unsigned conflictCountLimit)
+SATSolver::Status FallbackSolverWrapper::solveLimited(unsigned conflictCountLimit)
 {
   // Currently always run the _inner solver to see if we can use it
-  Status status = _inner->solve(conflictCountLimit);
+  Status status = _inner->solveLimited(conflictCountLimit);
 
   // Check if we need to use _fallback
   if(status == Status::UNKNOWN){
-    status = _fallback->solve(conflictCountLimit);
+    status = _fallback->solveLimited(conflictCountLimit);
     _usingFallback = true;
     ASS(status != Status::UNKNOWN);
     env.statistics->smtFallbacks++;

--- a/SAT/FallbackSolverWrapper.hpp
+++ b/SAT/FallbackSolverWrapper.hpp
@@ -57,7 +57,7 @@ public:
   }
 
   virtual void addClause(SATClause* cl) override;
-  virtual Status solve(unsigned conflictCountLimit) override;
+  virtual Status solveLimited(unsigned conflictCountLimit) override;
   virtual VarAssignment getAssignment(unsigned var) override;
 
   virtual bool isZeroImplied(unsigned var) override {

--- a/SAT/MinimizingSolver.cpp
+++ b/SAT/MinimizingSolver.cpp
@@ -62,10 +62,10 @@ void MinimizingSolver::addClauseIgnoredInPartialModel(SATClause* cl)
   _assignmentValid = false;
 }
 
-SATSolver::Status MinimizingSolver::solve(unsigned conflictCountLimit) 
+SATSolver::Status MinimizingSolver::solveLimited(unsigned conflictCountLimit)
 {
   _assignmentValid = false;
-  return _inner->solve(conflictCountLimit);
+  return _inner->solveLimited(conflictCountLimit);
 }
 
 SATSolver::VarAssignment MinimizingSolver::getAssignment(unsigned var)

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -48,7 +48,7 @@ public:
 
   virtual void addClause(SATClause* cl) override;
   virtual void addClauseIgnoredInPartialModel(SATClause* cl) override;
-  virtual Status solve(unsigned conflictCountLimit) override;
+  virtual Status solveLimited(unsigned conflictCountLimit) override;
   
   virtual VarAssignment getAssignment(unsigned var) override;
   virtual bool isZeroImplied(unsigned var) override;

--- a/SAT/MinisatInterfacing.cpp
+++ b/SAT/MinisatInterfacing.cpp
@@ -40,30 +40,26 @@ unsigned MinisatInterfacing::newVar()
   return minisatVar2Vampire(_solver.newVar());
 }
 
-SATSolver::Status MinisatInterfacing::solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit)
+SATSolver::Status MinisatInterfacing::solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit)
 {
-  ASS(!hasAssumptions());
-
   // load assumptions:
+  _assumptions.clear();
   SATLiteralStack::ConstIterator it(assumps);
   while (it.hasNext()) {
     _assumptions.push(vampireLit2Minisat(it.next()));
   }
 
   solveModuloAssumptionsAndSetStatus(conflictCountLimit);
-
-  if (_status == Status::UNSATISFIABLE) {
-    // unload minisat's internal conflict clause to _failedAssumptionBuffer
-    _failedAssumptionBuffer.reset();
-    Minisat::LSet& conflict = _solver.conflict;
-    for (int i = 0; i < conflict.size(); i++) {
-      _failedAssumptionBuffer.push(minisatLit2Vampire(conflict[i]).opposite());
-    }
-  }
-
-  _assumptions.clear();
-
   return _status;
+}
+
+SATLiteralStack MinisatInterfacing::failedAssumptions() {
+  ASS_EQ(_status, Status::UNSATISFIABLE)
+
+  SATLiteralStack result;
+  for (int i = 0; i < _solver.conflict.size(); i++)
+    result.push(minisatLit2Vampire(_solver.conflict[i]).opposite());
+  return result;
 }
 
 /**
@@ -94,14 +90,11 @@ void MinisatInterfacing::addClause(SATClause* cl)
 {
   // store to later generate the refutation
   PrimitiveProofRecordingSATSolver::addClause(cl);
-  
+
   // TODO: consider measuring time
-  
-  ASS_EQ(_assumptions.size(),0);
-                
   static vec<Lit> mcl;
   mcl.clear();
-    
+
   unsigned clen=cl->length();
   for(unsigned i=0;i<clen;i++) {
     SATLiteral l = (*cl)[i];
@@ -114,15 +107,11 @@ void MinisatInterfacing::addClause(SATClause* cl)
 /**
  * Perform solving and return status.
  */
-SATSolver::Status MinisatInterfacing::solve(unsigned conflictCountLimit)
+SATSolver::Status MinisatInterfacing::solveLimited(unsigned conflictCountLimit)
 {
+  _assumptions.clear();
   solveModuloAssumptionsAndSetStatus(conflictCountLimit);
   return _status;
-}
-
-void MinisatInterfacing::addAssumption(SATLiteral lit)
-{
-  _assumptions.push(vampireLit2Minisat(lit));
 }
 
 SATSolver::VarAssignment MinisatInterfacing::getAssignment(unsigned var)

--- a/SAT/MinisatInterfacing.hpp
+++ b/SAT/MinisatInterfacing.hpp
@@ -41,8 +41,8 @@ public:
     _solver.simplify();
   }
 
-  virtual Status solve(unsigned conflictCountLimit) override;
-  
+  virtual Status solveLimited(unsigned conflictCountLimit) override;
+
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
@@ -79,22 +79,9 @@ public:
     bool mpol = pol ? false : true; 
     _solver.suggestPolarity(vampireVar2Minisat(var),mpol);
   }
-  
-  /**
-   * Add an assumption into the solver.
-   */
-  virtual void addAssumption(SATLiteral lit) override;
-  
-  virtual void retractAllAssumptions() override {
-    _assumptions.clear();
-    _status = Status::UNKNOWN;
-  };
-  
-  virtual bool hasAssumptions() const override {
-    return (_assumptions.size() > 0);
-  };
 
-  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  SATLiteralStack failedAssumptions() override;
 
   /**
    * Use minisat and solving under assumptions to minimize the given set of premises (= unsat core extraction).

--- a/SAT/MinisatInterfacingNewSimp.hpp
+++ b/SAT/MinisatInterfacingNewSimp.hpp
@@ -43,7 +43,7 @@ public:
     _solver.simplify();
   }
 
-  virtual Status solve(unsigned conflictCountLimit) override;
+  virtual Status solveLimited(unsigned conflictCountLimit) override;
   
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
@@ -81,22 +81,9 @@ public:
     bool mpol = pol ? false : true; 
     _solver.suggestPolarity(vampireVar2Minisat(var),mpol);
   }
-  
-  /**
-   * Add an assumption into the solver.
-   */
-  virtual void addAssumption(SATLiteral lit) override;
-  
-  virtual void retractAllAssumptions() override {
-    _assumptions.clear();
-    _status = Status::UNKNOWN;
-  };
-  
-  virtual bool hasAssumptions() const override {
-    return (_assumptions.size() > 0);
-  };
 
-  Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  SATLiteralStack failedAssumptions() override;
 
   virtual SATClause* getRefutation() override { ASSERTION_VIOLATION; }
 

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -30,6 +30,7 @@ public:
     DONT_CARE,  // to represent partial models
     NOT_KNOWN
   };
+
   enum class Status {
     SATISFIABLE,
     UNSATISFIABLE,
@@ -84,9 +85,11 @@ public:
    * the number of conflicts, and in case it is reached, stop with
    * solving and assign the status to UNKNOWN.
    */
-  virtual Status solve(unsigned conflictCountLimit) = 0;
+  virtual Status solveLimited(unsigned conflictCountLimit) = 0;
 
-  Status solve(bool onlyPropagate=false) { return solve(onlyPropagate ? 0u : UINT_MAX); }
+  Status solve(bool onlyPropagate = false) {
+    return solveLimited(onlyPropagate ? 0 : std::numeric_limits<unsigned>::max());
+  }
 
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
@@ -206,108 +209,47 @@ inline std::ostream& operator<<(std::ostream& out, SATSolver::VarAssignment cons
   }
 }
 
-class SATSolverWithAssumptions:
-      public SATSolver {
+
+class SATSolverWithAssumptions: public SATSolver {
 public:
-
-  // The first three functions represent the original TWLSolver-style of interface ...
-
-  /**
-   * Add assumption to the solver. Perhaps process partially,
-   * but mainly ensure the assumption is considered during the next calls to solve()
-   */
-  virtual void addAssumption(SATLiteral lit) = 0;
-
-  /**
-   * Retract all the assumptions added so far.
-   * The solver becomes assumption-free.
-   *
-   * Note: this may destroy the model computed during a previous call to solve
-   * (as it currently does in TWL).
-   */
-  virtual void retractAllAssumptions() = 0;
-
-  /**
-   * Test whether any assumptions are currently registered by the solver.
-   */
-  virtual bool hasAssumptions() const = 0;
-
-  // ... a better alternative could be the interface below.
-
-  // It is currently implemented in terms of the one above
-  // (but may be overridden in SATSolver implementations).
-  // Note the the below interface allows the solver
-  // to identify a subset of the given assumptions that were only needed for
-  // previous contradiction to be derived.
-
-  // Note also, however, that solveUnderAssumptions cannot guarantee
-  // access to the model after it returns SATISFIABLE, as it uses retractAllAssumptions
-  // to clean in the end.
-
-  virtual Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit) {
-    ASS(!hasAssumptions());
-    _failedAssumptionBuffer.reset();
-
-    Status res = solve(conflictCountLimit);
-    if (res == Status::UNSATISFIABLE) {
-      return res;
-    }
-
-    SATLiteralStack::ConstIterator it(assumps);
-    while (it.hasNext()) {
-      SATLiteral lit = it.next();
-      addAssumption(lit);
-      _failedAssumptionBuffer.push(lit);
-
-      res = solve(conflictCountLimit);
-      if (res == Status::UNSATISFIABLE) {
-        break;
-      }
-    }
-
-    retractAllAssumptions();
-    return res;
-  }
-
   /**
    * Solve under the given set of assumptions @b assumps.
+   *
    * If UNSATISFIABLE is returned, a subsequent call to
    * failedAssumptions() returns a subset of these
    * that are already sufficient for the unsatisfiability.
-   *
-   * @b onlyPropagate suggests that a limited (and potentially incomplete)
-   * solving strategy should be employed which only performs unit propagation.
    */
+  virtual Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) = 0;
+
   Status solveUnderAssumptions(const SATLiteralStack& assumps, bool onlyPropagate=false) {
-    return solveUnderAssumptions(assumps,onlyPropagate ? 0u : UINT_MAX);
+    return solveUnderAssumptionsLimited(assumps,onlyPropagate ? 0u : UINT_MAX);
   }
 
   /**
-   * When solveUnderAssumptions(assumps) returns UNSATISFIABLE,
-   * failedAssumptions contain a subset of assumps that is sufficient
-   * for this UNSATISFIABLE status.
+   * Return a list of failed assumptions from the last solverUnderAssumptions call.
+   * Assumes the last call returned UNSAT
+   *
+   * Usually corresponds to the solver's internal unsat core.
    */
-  virtual const SATLiteralStack& failedAssumptions() {
-    return _failedAssumptionBuffer;
-  }
+  virtual SATLiteralStack failedAssumptions() = 0;
 
   /**
    * Apply fixpoint minimization to already obtained failed assumption set
    * and return the result (as failedAssumptions).
    */
-  const SATLiteralStack& explicitlyMinimizedFailedAssumptions(bool onlyPropagate=false, bool randomize = false) {
+  SATLiteralStack explicitlyMinimizedFailedAssumptions(bool onlyPropagate=false, bool randomize = false) {
     return explicitlyMinimizedFailedAssumptions(onlyPropagate ? 0u : UINT_MAX, randomize);
   }
 
-  virtual const SATLiteralStack& explicitlyMinimizedFailedAssumptions(unsigned conflictCountLimit, bool randomize) {
-    // assumes solveUnderAssumptions(...,conflictCountLimit,...) just returned UNSAT and initialized _failedAssumptionBuffer
+  // TODO this could be done much more efficiently
+  SATLiteralStack explicitlyMinimizedFailedAssumptions(unsigned conflictCountLimit, bool randomize) {
+    // assumes solveUnderAssumptions(...,conflictCountLimit,...) just returned UNSAT
 
-    ASS(!hasAssumptions());
-
-    unsigned sz = _failedAssumptionBuffer.size();
+    SATLiteralStack failed = failedAssumptions();
+    unsigned sz = failed.size();
 
     if (!sz) { // a special case. Because of the bloody unsigned (see below)!
-      return _failedAssumptionBuffer;
+      return failed;
     }
 
     if (randomize) {
@@ -315,36 +257,33 @@ public:
       // not to bias minimization from one side or another
       for(unsigned i=sz-1; i>0; i--) {
         unsigned tgtPos=Random::getInteger(i+1);
-        std::swap(_failedAssumptionBuffer[i], _failedAssumptionBuffer[tgtPos]);
+        std::swap(failed[i], failed[tgtPos]);
       }
     }
 
+    SATLiteralStack assumptions;
     unsigned i = 0;
     while (i < sz) {
+      assumptions.reset();
       // load all but i-th
       for (unsigned j = 0; j < sz; j++) {
         if (j != i) {
-          addAssumption(_failedAssumptionBuffer[j]);
+          assumptions.push(failed[i]);
         }
       }
 
-      if (solve(conflictCountLimit) == Status::UNSATISFIABLE) {
+      if (solveUnderAssumptionsLimited(assumptions, conflictCountLimit) == Status::UNSATISFIABLE) {
         // leave out forever by overwriting by the last one (buffer shrinks implicitly)
-        _failedAssumptionBuffer[i] = _failedAssumptionBuffer[--sz];
+        failed[i] = failed[--sz];
       } else {
         // move on
         i++;
       }
-
-      retractAllAssumptions();
     }
 
-    _failedAssumptionBuffer.truncate(sz);
-    return _failedAssumptionBuffer;
+    failed.truncate(sz);
+    return failed;
   }
-
-protected:
-  SATLiteralStack _failedAssumptionBuffer;
 };
 
 /**

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -185,7 +185,7 @@ public:
   void addClause(SATClause* cl) override;
 
   Status solve();
-  virtual Status solve(unsigned conflictCountLimit) override { return solve(); };
+  virtual Status solveLimited(unsigned conflictCountLimit) override { return solve(); };
   /**
    * If status is @c SATISFIABLE, return assignment of variable @c var
    */
@@ -225,11 +225,8 @@ public:
   // Currently not implemented for Z3
   virtual void suggestPolarity(unsigned var, unsigned pol) override {}
 
-  virtual void addAssumption(SATLiteral lit) override;
-  virtual void retractAllAssumptions() override;
-  virtual bool hasAssumptions() const override { return !_assumptions.isEmpty(); }
-
-  virtual Status solveUnderAssumptions(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  virtual Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
+  SATLiteralStack failedAssumptions() override;
 
   /**
    * The set of inserted clauses may not be propositionally UNSAT
@@ -309,6 +306,8 @@ public:
   };
 
 private:
+  void addAssumption(SATLiteral lit);
+  void solveModuloAssumptionsAndSetStatus();
 
   Map<SortId, z3::sort> _sorts;
   struct Z3Hash {

--- a/SAT/Z3MainLoop.cpp
+++ b/SAT/Z3MainLoop.cpp
@@ -63,7 +63,7 @@ MainLoopResult Z3MainLoop::runImpl()
    solver.addClause(sc);
  }
 
- SATSolver::Status status = solver.solve(UINT_MAX);
+ SATSolver::Status status = solver.solveLimited(UINT_MAX);
 
  TerminationReason reason = TerminationReason::UNKNOWN;
 

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -18,7 +18,6 @@
 
 #include "Forwards.hpp"
 
-#include "Lib/DHMap.hpp"
 #include "Lib/Event.hpp"
 #include "Lib/List.hpp"
 #include "Lib/ScopedPtr.hpp"
@@ -31,7 +30,6 @@
 
 #include "Inferences/InferenceEngine.hpp"
 #include "Inferences/Instantiation.hpp"
-#include "Inferences/TheoryInstAndSimp.hpp"
 
 #include "Saturation/ExtensionalityClauseContainer.hpp"
 

--- a/UnitTests/tSATSolver.cpp
+++ b/UnitTests/tSATSolver.cpp
@@ -192,28 +192,19 @@ void testInterface(SATSolverWithAssumptions &s) {
   }
   cout << endl;
 
-  s.addAssumption(getLit('d'));
-  s.addAssumption(getLit('a'));
-  ASS(s.hasAssumptions());
-  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
-  s.retractAllAssumptions();
-  ASS(!s.hasAssumptions());
-  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
+  SATLiteralStack assumptions;
+  assumptions.push(getLit('d'));
+  assumptions.push(getLit('a'));
+  ASS_EQ(s.solveUnderAssumptions(assumptions),SATSolver::Status::SATISFIABLE);
+  assumptions.reset();
 
-  ASS(!s.hasAssumptions());
-  s.addAssumption(getLit('A'));
-  ASS(s.hasAssumptions());
-  ASS_EQ(s.solve(),SATSolver::Status::UNSATISFIABLE);
-  s.retractAllAssumptions();
-  ASS(!s.hasAssumptions());
-  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
+  assumptions.push(getLit('A'));
+  ASS_EQ(s.solveUnderAssumptions(assumptions),SATSolver::Status::UNSATISFIABLE);
+  assumptions.reset();
 
-  s.addAssumption(getLit('a'));
-  ASS(s.hasAssumptions());
-  ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
-  s.retractAllAssumptions();
-  ASS(!s.hasAssumptions());
-  // ASS(s.getStatus() == SATSolver::UNKNOWN || s.getStatus() == SATSolver::SATISFIABLE);
+  assumptions.push(getLit('a'));
+  ASS_EQ(s.solveUnderAssumptions(assumptions),SATSolver::Status::SATISFIABLE);
+  assumptions.reset();
 
   ASS_EQ(s.solve(),SATSolver::Status::SATISFIABLE);
 }

--- a/UnitTests/tZ3Interfacing.cpp
+++ b/UnitTests/tZ3Interfacing.cpp
@@ -43,13 +43,14 @@ using FuncId = unsigned;
 /** runs z3 on a bunch of vampire literals as assumptions, and checks the status afterwards */
 void checkStatus(SAT::Z3Interfacing& z3, SAT2FO& s2f, SATSolver::Status expected, Stack<Literal*> assumptions) 
 {
+  SATLiteralStack assms;
   for (auto a : assumptions) {
     // Stack<SATLiteral> clause{s2f.toSAT(a)};
     // z3.addClause(SATClause::fromStack(clause));
-    z3.addAssumption(s2f.toSAT(a));
+    assms.push(s2f.toSAT(a));
   }
 
-  auto status = z3.solve();
+  auto status = z3.solveUnderAssumptions(assms);
   if(status != expected) {
     cout << "[ input    ] " << endl;
     for (auto a : assumptions) {
@@ -63,7 +64,6 @@ void checkStatus(SAT::Z3Interfacing& z3, SAT2FO& s2f, SATSolver::Status expected
     }
     exit(-1);
   }
-  z3.retractAllAssumptions();
 }
 
 void checkStatus(SATSolver::Status expected, Stack<Literal*> assumptions)
@@ -217,11 +217,12 @@ TEST_FUN(solve__dty__03_03) {
 
 void checkInstantiation(SAT::Z3Interfacing& z3, SAT2FO& s2f, Stack<Literal*> assumptions, TermList toInstantiate, TermList expected)
 {
+  SATLiteralStack assms;
   for (auto a : assumptions) {
-    z3.addAssumption(s2f.toSAT(a));
+    assms.push(s2f.toSAT(a));
   }
 
-  auto status = z3.solve();
+  auto status = z3.solveUnderAssumptions(assms);
   ASS_EQ(status, SATSolver::Status::SATISFIABLE);
   auto result = z3.evaluateInModel(toInstantiate.term());
   if (result != expected.term()) {
@@ -235,7 +236,6 @@ void checkInstantiation(SAT::Z3Interfacing& z3, SAT2FO& s2f, Stack<Literal*> ass
     cout << "[ model         ] " <<  z3.getModel() << endl;
     exit(-1);
   }
-  z3.retractAllAssumptions();
 }
 
 


### PR DESCRIPTION
First in a series of patches to clear up the `SATSolver` interface before I start hacking it about to do e.g. proofs.

@quickbeam123 left a nice comment here from ...2015?, reproduced below
```
 // The first three functions represent the original TWLSolver-style of interface ...

  /**
   * Add assumption to the solver. Perhaps process partially,
   * but mainly ensure the assumption is considered during the next calls to solve()
   */
  virtual void addAssumption(SATLiteral lit) = 0;

  /**
   * Retract all the assumptions added so far.
   * The solver becomes assumption-free.
   *
   * Note: this may destroy the model computed during a previous call to solve
   * (as it currently does in TWL).
   */
  virtual void retractAllAssumptions() = 0;

  /**
   * Test whether any assumptions are currently registered by the solver.
   */
  virtual bool hasAssumptions() const = 0;

  // ... a better alternative could be the interface below.

  // It is currently implemented in terms of the one above
  // (but may be overridden in SATSolver implementations).
  // Note the the below interface allows the solver
  // to identify a subset of the given assumptions that were only needed for
  // previous contradiction to be derived.

  // Note also, however, that solveUnderAssumptions cannot guarantee
  // access to the model after it returns SATISFIABLE, as it uses retractAllAssumptions
  // to clean in the end.
```

The "better alternative" is indeed better! And it conforms more easily with the API of the SAT solvers we use, so let's just have one.

Also:
- remove/rename a couple of confusing overloads, the way C++ resolves virtual calls is bonkers
- don't probe for failed literals during `solveUnderAssumptions`, we might not need it - do it all in `failedLiterals`