### PR TITLE
minimum viable fixes for LaTeX output (or maybe remove LaTeX altogether)

### DIFF
--- a/Shell/LaTeX.cpp
+++ b/Shell/LaTeX.cpp
@@ -331,7 +331,7 @@ std::string LaTeX::toString (Literal* l) const
 
   //Check if this symbol has an interpreted LaTeX name
   // this should be true for all known interpreted symbols and any recorded symbols
-  std::string template_str = theory->tryGetInterpretedLaTeXName(l->functor(),true,l->isNegative());
+  std::string template_str = theory->tryGetInterpretedLaTeXName(l->functor(),true,l->isPositive());
 
   if(template_str.empty()){
     std::string res;
@@ -495,9 +495,13 @@ std::string LaTeX::toString (TermList* terms,bool single) const
      //Check if this symbol has an interpreted LaTeX name
      // this should be true for all known interpreted symbols and any recorded symbols
       std::string template_str = theory->tryGetInterpretedLaTeXName(trm->functor(),false);
-   
+
       if(template_str.empty()){
-        result += symbolToString(trm->functor(), false) + toString(trm->args());
+        if(trm->isSpecial())
+          // not ideal, but what can you do
+          result += trm->toString();
+        else
+          result += symbolToString(trm->functor(), false) + toString(trm->args());
       }
       else{
         // replace arguments in the template, arg0 replaces a0 etc.


### PR DESCRIPTION
Closes #721, #722. Thanks for the report, @mbalfakeih! However, do not get too excited, this not what you might call a proper fix:
- In quite a few cases the LaTeX output flipped polarity, and somehow nobody noticed. Don't do that.
- Special terms (like `$ite`) are not handled properly: this used to crash, now it prints out the TPTP format instead when encountering a special term.

---

More generally, I think the LaTeX mode needs to die. It's clearly unloved (nobody noticed these quite glaring deficiencies until now), and people who do actually want this also tend to want to customise the output a bit. What they should do instead is read a TSTP proof, and write some Prolog to format it how they please. Maybe we can put an example on the wiki or something.

If there are not screams of outrage, I will upgrade this PR to remove LaTeX altogether. Let's focus on what we're actually good at.