### PR TITLE
Disentangled ImmediateSimplificationEngine::{simplify,simplifyMany}

### DIFF
--- a/Inferences/CasesSimp.cpp
+++ b/Inferences/CasesSimp.cpp
@@ -100,7 +100,7 @@ struct CasesSimp::RewriteableSubtermsFn
 };
 
 
-ClauseIterator CasesSimp::simplifyMany(Clause* premise)
+Option<ClauseIterator> CasesSimp::simplifyMany(Clause* premise)
 {
   auto it1 = premise->getLiteralIterator();
   auto it2 = getFilteredIterator(it1, isEqualityLit()); 
@@ -110,7 +110,11 @@ ClauseIterator CasesSimp::simplifyMany(Clause* premise)
   //Perform  Narrow
   auto it4 = getMapAndFlattenIterator(it3,ResultFn(premise, *this));
 
-  return pvi( it4 );
+  if (it4.hasNext()) {
+    return some(pvi(it4));
+  } else {
+    return {};
+  }
 }
 
 }

--- a/Inferences/CasesSimp.hpp
+++ b/Inferences/CasesSimp.hpp
@@ -21,10 +21,9 @@
 
 namespace Inferences {
 
-class CasesSimp : public ImmediateSimplificationEngine {
+class CasesSimp : public ImmediateSimplificationEngineMany {
   public:
-    ClauseIterator simplifyMany(Clause* premise);
-    Clause* simplify(Clause* premise){ NOT_IMPLEMENTED; }
+    Option<ClauseIterator> simplifyMany(Clause* premise);
 
     ClauseIterator performSimplification(Clause* cl, Literal* lit, TermList t);
     ClauseIterator generateClauses(Clause* premise);

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -72,24 +72,6 @@ void CompositeISE::addFront(ImmediateSimplificationEngine* ise)
   ASS_EQ(_salg,0);
   ISList::push(ise,_inners);
 }
-void CompositeISE::addFrontMany(ImmediateSimplificationEngine* ise)
-{
-  ASS_EQ(_salg,0);
-  ISList::push(ise,_innersMany);
-}
-ClauseIterator CompositeISE::simplifyMany(Clause* cl)
-{
-  ISList* curr=_innersMany;
-  while(curr && cl) {
-    ClauseIterator cIt=curr->head()->simplifyMany(cl);
-    if(cIt.hasNext()){
-      return cIt;
-    } else {
-      curr=curr->tail();      
-    }
-  }
-  return ClauseIterator::getEmpty();
-}
 Clause* CompositeISE::simplify(Clause* cl)
 {
   ISList* curr=_inners;

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -79,6 +79,7 @@ public:
 
   void setGeneratingInferenceEngine(SimplifyingGeneratingInference* generator);
   void setImmediateSimplificationEngine(ImmediateSimplificationEngine* immediateSimplifier);
+  void setImmediateSimplificationEngineMany(CompositeISEMany ise) { _immediateSimplifierMany = std::move(ise); }
 
   void setLabelFinder(LabelFinder* finder){ _labelFinder = finder; }
 
@@ -201,6 +202,7 @@ protected:
 
   ScopedPtr<SimplifyingGeneratingInference> _generator;
   ScopedPtr<ImmediateSimplificationEngine> _immediateSimplifier;
+  CompositeISEMany _immediateSimplifierMany;
 
   typedef List<ForwardSimplificationEngine*> FwSimplList;
   FwSimplList* _fwSimplifiers;
@@ -250,7 +252,7 @@ protected:
   unsigned _generatedClauseCount;
   unsigned _activationLimit;
 private:
-  static CompositeISE* createISE(Problem& prb, const Options& opt, Ordering& ordering,
+  static std::pair<CompositeISE*, CompositeISEMany> createISE(Problem& prb, const Options& opt, Ordering& ordering,
      bool alascaTakesOver);
 
   // a "soft" time limit in deciseconds, checked manually: 0 is no limit


### PR DESCRIPTION
This PR removes the function `simplifyMany` from `ImmediateSimplificationEngine` and moves it to its own class.
There was no reason for both methods to be present in the same class in the first place as subclasses would always only implement exactly `simplify` or `simplifyMany` and fail `NOT_IMPLEMENTED` in the other method.
By moving the method into a new class `ImmediateSimplificationEngineMany` we fix the broken class hierarchy.

Further the PR changes them interface to return an `Option` instead of an interator. This allows for implementors of the method to return `some(VirtualIterator::getEmpty)` in order to signal that the clause that is being simplified should be deleted, which was not possible in the old interface.