### PR TITLE
TPTP: Fix OR term order in proof

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -3389,7 +3389,7 @@ void TPTP::endFormula()
     case AND:
     case OR:
       f = _formulas.pop();
-      f = makeJunction((Connective)con,_formulas.pop(),f);
+      f = makeJunction((Connective)con,f,_formulas.pop());
       if (conReverse) {
 	f = new NegatedFormula(f);
       }

--- a/checks/sanity
+++ b/checks/sanity
@@ -106,7 +106,7 @@ check_szs_status Theorem -t 1d -sas z3 -nwc 5.0 -br off Problems/DAT/DAT005_1.p
 check_szs_status Theorem -t 1d -alasca on -alascai on -thf on Problems/DAT/DAT023_1.p
 check_szs_status Theorem -t 1d -tha off Problems/DAT/DAT042_1.p
 check_szs_status Theorem -t 1d -s 1010 -thsq on -thsqr 8,1 -thsqc 64 -thsqd 64 -canc force Problems/DAT/DAT043_1.p
-check_szs_status Theorem -t 5d -sa discount -s 2 -awr 1:32 -to lpo -s2a on -s2agt 20 -bd all Problems/HWV/HWV087_2.p
+check_szs_status Theorem -t 10d -sa discount -s 2 -awr 1:32 -to lpo -s2a on -s2agt 20 -bd all Problems/HWV/HWV087_2.p
 check_szs_status Theorem -t 1d -sa discount -awr 1:32 -to lpo -sp const_frequency -sos all -sac on -lma off Problems/ITP/ITP319_1.p
 check_szs_status Theorem -t 1d -sa discount -tha off -nwc 5.0 -gtg exists_sym -gtgl 5 Problems/ITP/ITP320_1.p
 check_szs_status Theorem -t 1d -to lpo -spb goal_then_units -sp arity Problems/ITP/ITP412_1.p


### PR DESCRIPTION
After running Vampire 6d35e0bef on the following problem:
```tptp
% Law of excluded middle (Pel86 problem 6; tff variant of SYN387+1.p)

tff(p, type, p: $o).
%---p ∨ ¬p
tff(excluded_middle, conjecture, p | ~p).
```
the first line of the proof is:

```
1. ~p | p [input(conjecture)]
```

Somewhat disconcertingly, the two terms have switched places. This PR fixes the `OR` term concat order so that the first line of the proof becomes:

```
1. p | ~p [input(conjecture)]
```