### PR TITLE
Fix code tree crash with gcc

### DIFF
--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -290,7 +290,6 @@ CodeTree::MatchInfo*& CodeTree::ILStruct::getMatch(unsigned matchIndex)
 CodeTree::CodeOp CodeTree::CodeOp::getLitEnd(ILStruct* ils)
 {
   CodeOp res;
-  res.setAlternative(0);
   res._setData(ils);
   res._setInstruction(LIT_END);
   ASS(res.isLitEnd());
@@ -302,7 +301,6 @@ CodeTree::CodeOp CodeTree::CodeOp::getTermOp(Instruction i, unsigned num)
   ASS(i==CHECK_FUN || i==CHECK_VAR || i==ASSIGN_VAR);
 
   CodeOp res;
-  res.setAlternative(0);
   res._setInstruction(i);
   res._setArg(num);
   return res;
@@ -313,7 +311,6 @@ CodeTree::CodeOp CodeTree::CodeOp::getGroundTermCheck(const Term* trm)
   ASS(trm->ground());
 
   CodeOp res;
-  res.setAlternative(0);
   res._setData(trm);
   ASS(res.isCheckGroundTerm());
   return res;
@@ -420,7 +417,6 @@ std::ostream& operator<<(std::ostream& out, const CodeTree::CodeOp& op)
 CodeTree::SearchStruct::SearchStruct(Kind kind, size_t length)
 : kind(kind)
 {
-  landingOp.setAlternative(0);
   landingOp._setInstruction(SEARCH_STRUCT);
   ASS(length);
 

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -172,7 +172,6 @@ public:
     {
       ASS(ptr); //data has to be a non-zero pointer
       CodeOp res;
-      res.setAlternative(0);
       res._setData(ptr);
       res._setInstruction(SUCCESS_OR_FAIL);
       ASS(res.isSuccess());
@@ -242,7 +241,7 @@ public:
      * If nonzero, either points to the first operation of
      * a @b CodeBlock or to a @b landingOp of a @b SearchStruct.
      */
-    CodeOp* _alternative;
+    CodeOp* _alternative = 0;
   };
 
   /**


### PR DESCRIPTION
Debug sample tested on TPTP and inductive benchmarks.

Credit goes to Michael for finding this.

As a remark, maybe we should `-fsanitize` on a more regular basis.