### PR TITLE
align Coproduct bytes

### DIFF
--- a/Lib/Coproduct.hpp
+++ b/Lib/Coproduct.hpp
@@ -266,6 +266,16 @@ namespace CoproductImpl {
   struct MaxSize<T, Ts...>
   { static constexpr unsigned value = std::max<unsigned>(sizeof(T), MaxSize<Ts...>::value); };
 
+  template<class... Ts>
+  struct MaxAlign;
+
+  template<>
+  struct MaxAlign<>
+  { static constexpr unsigned value = 0; };
+
+  template<class T, class... Ts>
+  struct MaxAlign<T, Ts...>
+  { static constexpr unsigned value = std::max<unsigned>(alignof(T), MaxAlign<Ts...>::value); };
 
   template<class... As>
   class RawCoproduct {
@@ -293,7 +303,7 @@ namespace CoproductImpl {
 
     using Bytes = char [MaxSize<As...>::value];
     unsigned _tag: neededBits(nTags);
-    Bytes _content;
+    alignas(MaxAlign<As...>::value) Bytes _content;
 
 
     TrivialOperations::DisableIfNeeded<TrivialOperations::CopyCons, Ts> _copyCons;


### PR DESCRIPTION
UBSan runs were complaining about unaligned memory accesses from `Coproduct`. I think this is the appropriate fix: the performance impact may be non-zero, but correctness trumps speed.

There again, performance could be better if we're not constantly doing misaligned loads. Hard to say.