### PR TITLE
isolate post-hoc unsat minimisation

### DIFF
--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -59,10 +59,10 @@ UnitInputType Kernel::getInputType(UnitList* units)
 /**
  * To be kept around in _ptr2 of INFERENCE_FROM_SAT_REFUTATION
  **/
-struct FromSatRefutationInfo {
-  USE_ALLOCATOR(FromSatRefutationInfo);
+struct NeedsMinimizationInfo {
+  USE_ALLOCATOR(NeedsMinimizationInfo);
 
-  FromSatRefutationInfo(const FromSatRefutation& fsr) : _satPremises(fsr._satPremises), _usedAssumptions(fsr._usedAssumptions)
+  NeedsMinimizationInfo(const NeedsMinimization& fsr) : _satPremises(fsr._satPremises), _usedAssumptions(fsr._usedAssumptions)
   { ASS(_satPremises); }
 
   SAT::SATClauseList* _satPremises;
@@ -73,8 +73,8 @@ struct FromSatRefutationInfo {
 void Inference::destroyDirectlyOwned()
 {
   switch(_kind) {
-    case Kind::INFERENCE_FROM_SAT_REFUTATION:
-      delete static_cast<FromSatRefutationInfo*>(_ptr2);
+    case Kind::SAT_NEEDS_MINIMIZATION:
+      delete static_cast<NeedsMinimizationInfo*>(_ptr2);
       // intentionally fall further
     case Kind::INFERENCE_MANY:
       UnitList::destroy(static_cast<UnitList*>(_ptr1));
@@ -90,8 +90,8 @@ void Inference::destroy()
       if (_ptr1) static_cast<Unit*>(_ptr1)->decRefCnt();
       if (_ptr2) static_cast<Unit*>(_ptr2)->decRefCnt();
       break;
-    case Kind::INFERENCE_FROM_SAT_REFUTATION:
-      delete static_cast<FromSatRefutationInfo*>(_ptr2);
+    case Kind::SAT_NEEDS_MINIMIZATION:
+      delete static_cast<NeedsMinimizationInfo*>(_ptr2);
       // intentionally fall further
     case Kind::INFERENCE_MANY:
       UnitList* it=static_cast<UnitList*>(_ptr1);
@@ -105,7 +105,7 @@ void Inference::destroy()
   }
 }
 
-Inference::Inference(const FromSatRefutation& fsr) {
+Inference::Inference(const NeedsMinimization& fsr) {
   initMany(fsr._rule,fsr._premises);
 
   ASS_REP(isSatRefutationRule(fsr._rule),ruleName(fsr._rule));
@@ -114,8 +114,8 @@ Inference::Inference(const FromSatRefutation& fsr) {
     return; // SAT solver did not support minimization anyway
   }
 
-  _kind = Kind::INFERENCE_FROM_SAT_REFUTATION;
-  _ptr2 = new FromSatRefutationInfo(fsr);
+  _kind = Kind::SAT_NEEDS_MINIMIZATION;
+  _ptr2 = new NeedsMinimizationInfo(fsr);
 }
 
 /**
@@ -130,7 +130,7 @@ Inference::Iterator Inference::iterator() const
       it.integer=0;
       break;
     case Kind::INFERENCE_MANY:
-    case Kind::INFERENCE_FROM_SAT_REFUTATION:
+    case Kind::SAT_NEEDS_MINIMIZATION:
       it.pointer = _ptr1;
       break;
   }
@@ -159,7 +159,7 @@ bool Inference::hasNext(Iterator& it) const
       }
       break;
     case Kind::INFERENCE_MANY:
-    case Kind::INFERENCE_FROM_SAT_REFUTATION:
+    case Kind::SAT_NEEDS_MINIMIZATION:
       return (it.pointer != nullptr);
     default:
       ASSERTION_VIOLATION;
@@ -187,7 +187,7 @@ Unit* Inference::next(Iterator& it) const
       }
       break;
     case Kind::INFERENCE_MANY:
-    case Kind::INFERENCE_FROM_SAT_REFUTATION: {
+    case Kind::SAT_NEEDS_MINIMIZATION: {
       UnitList* lst = static_cast<UnitList*>(it.pointer);
       it.pointer = lst->tail();
       return lst->head();
@@ -225,7 +225,7 @@ void Inference::updateStatistics()
 
       break;
     case Kind::INFERENCE_MANY:
-    case Kind::INFERENCE_FROM_SAT_REFUTATION:
+    case Kind::SAT_NEEDS_MINIMIZATION:
       _inductionDepth = 0;
       _XXNarrows = 0;
       _reductions = 0;
@@ -249,8 +249,8 @@ std::ostream& Kernel::operator<<(std::ostream& out, Inference const& self)
     case Inference::Kind::INFERENCE_MANY:
       out << "INFERENCE_MANY, (";
       break;
-    case Inference::Kind::INFERENCE_FROM_SAT_REFUTATION:
-      out << "INFERENCE_FROM_SAT_REFUTATION, (";
+    case Inference::Kind::SAT_NEEDS_MINIMIZATION:
+      out << "SAT_NEEDS_MINIMIZATION, (";
       break;
   }
   // TODO get rid of intermediate string generation by ruleName
@@ -484,14 +484,15 @@ std::string Inference::name() const {
 
 void Inference::minimizePremises()
 {
-  if (_kind != Kind::INFERENCE_FROM_SAT_REFUTATION)
+  if (_kind != Kind::SAT_NEEDS_MINIMIZATION)
     return;
-  if (_ptr2 == nullptr)
-    return; // already minimized
+  if(!env.options->minimizeSatProofs())
+    return;
 
   TIME_TRACE("sat proof minimization");
 
-  FromSatRefutationInfo* info = static_cast<FromSatRefutationInfo*>(_ptr2);
+  NeedsMinimizationInfo* info = static_cast<NeedsMinimizationInfo*>(_ptr2);
+  ASS(info)
 
   SATClauseList* minimized = MinisatInterfacing<>::minimizePremiseList(info->_satPremises,info->_usedAssumptions);
 

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -736,7 +736,7 @@ struct NonspecificInferenceMany {
   UnitList* premises;
 };
 
-struct FromSatRefutation; // defined in SATInference.hpp
+struct NeedsMinimization; // defined in SATInference.hpp
 
 class Inference;
 std::ostream& operator<<(std::ostream& out, Inference const& self);
@@ -752,7 +752,7 @@ private:
   enum class Kind : unsigned char {
     INFERENCE_012,
     INFERENCE_MANY,
-    INFERENCE_FROM_SAT_REFUTATION
+    SAT_NEEDS_MINIMIZATION
   };
 
   void initDefault(UnitInputType inputType, InferenceRule r) {
@@ -805,7 +805,7 @@ public:
   Inference(const NonspecificInference2& gi);
   Inference(const NonspecificInferenceMany& gi);
 
-  Inference(const FromSatRefutation& fsr);
+  Inference(const NeedsMinimization& fsr);
 
   Inference(const Inference&) = default;
 

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -778,16 +778,6 @@ VirtualIterator<ELEMENT_TYPE(Inner)> getUniquePersistentIteratorFromPtr(Inner* i
 }
 
 /**
- * Remove duplicate elements from the container @c cont
- */
-template<class Container>
-void makeUnique(Container& cont)
-{
-  VirtualIterator<ELEMENT_TYPE(Container)> uniqueIt = pvi(
-      getUniquePersistentIterator(ITERATOR_TYPE(Container)(cont)) );
-}
-
-/**
  * Return number of elements in iterator @c it
  */
 template<class It>

--- a/SAT/CadicalInterfacing.hpp
+++ b/SAT/CadicalInterfacing.hpp
@@ -17,6 +17,7 @@
 #include "SATSolver.hpp"
 #include "SATLiteral.hpp"
 #include "SATClause.hpp"
+#include "MinisatInterfacing.hpp"
 
 #include "cadical/src/cadical.hpp"
 
@@ -56,6 +57,13 @@ public:
 
   Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
   SATLiteralStack failedAssumptions() override;
+
+  SATClauseList *minimizePremises(SATClauseList *premises) override {
+    SATLiteralStack assumps;
+    for(int l : _assumptions)
+      assumps.push(cadical2Vampire(l));
+    return MinisatInterfacing<>::minimizePremiseList(premises, assumps);
+  }
 
 protected:
   void solveModuloAssumptionsAndSetStatus(unsigned conflictCountLimit = UINT_MAX);

--- a/SAT/FallbackSolverWrapper.hpp
+++ b/SAT/FallbackSolverWrapper.hpp
@@ -89,6 +89,11 @@ public:
     return _inner->failedAssumptions();
   }
 
+  SATClauseList *minimizePremises(SATClauseList *premises) override {
+    if(_usingFallback)
+      return _fallback->minimizePremises(premises);
+    return _inner->minimizePremises(premises);
+  }
 private:
 
   ScopedPtr<SATSolver> _inner;

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -65,6 +65,10 @@ public:
 
   SATLiteralStack failedAssumptions() override { return _inner->failedAssumptions(); }
 
+  SATClauseList *minimizePremises(SATClauseList *premises) override {
+    return _inner->minimizePremises(premises);
+  }
+
 private:
   bool admitsDontcare(unsigned var) { 
     ASS_G(var,0); ASS_LE(var,_varCnt);

--- a/SAT/MinisatInterfacing.hpp
+++ b/SAT/MinisatInterfacing.hpp
@@ -76,6 +76,13 @@ public:
    */
   static void interpolateViaAssumptions(unsigned maxVar, const SATClauseStack& first, const SATClauseStack& second, SATClauseStack& result);
 
+  SATClauseList *minimizePremises(SATClauseList *premises) override {
+    SATLiteralStack assumps;
+    for(unsigned i = 0; i < _assumptions.size(); i++)
+      assumps.push(minisatLit2Vampire(_assumptions[i]));
+    return minimizePremiseList(premises, assumps);
+  }
+
 protected:    
   void solveModuloAssumptionsAndSetStatus(unsigned conflictCountLimit = UINT_MAX);
   

--- a/SAT/ProofProducingSATSolver.hpp
+++ b/SAT/ProofProducingSATSolver.hpp
@@ -67,6 +67,7 @@ public:
     return _inner->failedAssumptions();
   }
 
+  // only to conform with SATSolver, would be a bit weird to call this
   SATClauseList *minimizePremises(SATClauseList *premises) override {
     return _inner->minimizePremises(premises);
   }
@@ -75,9 +76,9 @@ public:
   SATClauseList *premiseList() const { return _addedClauses; }
 
   /*
-   * only those premises required to get unsat from the last solve() call
-   * may be a superset of those actually necessary depending on
-   * how well the minimisation process goes
+   * Returns only those premises required to get unsat from the last solve() call.
+   * This may be a superset of those actually necessary depending on
+   * how well the minimisation process goes.
    */
   SATClauseList *minimizedPremises() { return _inner->minimizePremises(_addedClauses); }
 

--- a/SAT/SATInference.cpp
+++ b/SAT/SATInference.cpp
@@ -24,15 +24,6 @@ namespace SAT
 // SATInference
 //
 
-/**
- * Collect first-order premises of @c cl into @c res. Make sure that elements in @c res are unique.
- */
-void SATInference::collectFOPremises(SATClause* cl, Stack<Unit*>& acc)
-{
-  collectFilteredFOPremises(cl,acc, [](SATClause*) {return true; } );
-}
-
-
 UnitList* SATInference::getFOPremises(SATClause* cl)
 {
   ASS(cl);
@@ -41,7 +32,7 @@ UnitList* SATInference::getFOPremises(SATClause* cl)
   static Stack<Unit*> prems;
   prems.reset();
 
-  collectFOPremises(cl, prems);
+  collectFilteredFOPremises(cl, prems, [](SATClause *) {return true;});
 
   UnitList* res = 0;
   while (prems.isNonEmpty()) {
@@ -50,38 +41,6 @@ UnitList* SATInference::getFOPremises(SATClause* cl)
   }
 
   return res;
-}
-
-void SATInference::collectPropAxioms(SATClause* cl, SATClauseStack& res)
-{
-  static Stack<SATClause*> toDo;
-  static DHSet<SATClause*> seen;
-  toDo.reset();
-  seen.reset();
-
-  toDo.push(cl);
-  while (toDo.isNonEmpty()) {
-    SATClause* cur = toDo.pop();
-    if (!seen.insert(cur)) {
-      continue;
-    }
-    SATInference* sinf = cur->inference();
-    ASS(sinf);
-    switch(sinf->getType()) {
-    case SATInference::FO_CONVERSION:
-      res.push(cur);
-      break;
-    case SATInference::PROP_INF:
-    {
-      PropInference* pinf = static_cast<PropInference*>(sinf);
-      toDo.loadFromIterator(SATClauseList::Iterator(pinf->getPremises()));
-      break;
-    }
-    default:
-      ASSERTION_VIOLATION;
-    }
-  }
-  makeUnique(res);
 }
 
 ///////////////////////

--- a/SAT/SATInference.cpp
+++ b/SAT/SATInference.cpp
@@ -32,7 +32,7 @@ UnitList* SATInference::getFOPremises(SATClause* cl)
   static Stack<Unit*> prems;
   prems.reset();
 
-  collectFilteredFOPremises(cl, prems, [](SATClause *) {return true;});
+  collectFOPremises(cl, prems);
 
   UnitList* res = 0;
   while (prems.isNonEmpty()) {

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -77,8 +77,16 @@ public:
   virtual ~SATInference() {}
   virtual InfType getType() const = 0;
 
+  /**
+   * Collect first-order premises of @c cl into @c res if they satisfy a filter.
+   */
   template <typename Filter>
   static void collectFilteredFOPremises(SATClause* cl, Stack<Unit*>& acc, Filter f);
+  /**
+   * Collect all first-order premises of @c cl into @c res.
+   */
+  static void collectFOPremises(SATClause* cl, Stack<Unit*>& acc)
+  { collectFilteredFOPremises(cl, acc, [](SATClause*) {return true;});}
   static UnitList* getFOPremises(SATClause* cl);
 };
 

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -24,11 +24,17 @@ namespace Kernel {
 using namespace SAT;
 
 /**
- * To initialize a first order inference coming from a SAT refutation.
- * Possibly the SAT refutation was unnecessarily too large
- * and may be minimized before the final proof outputting.
+ * During search (currently only GlobalSubsumption),
+ * we may make an inference on the first-order level via SAT solving.
+ *
+ * We don't want to minimize the set of premises during search,
+ * as we don't know whether they will be used in the proof or not.
+ *
+ * Therefore: use this object with a (large) superset of first-order
+ * and SAT premises. Then, in Inference::minimizePremises,
+ * minimize the SAT premises and use their parents to work out the true first-order parents.
  */
-struct FromSatRefutation {
+struct NeedsMinimization {
   /**
    * The inherited first order part (@b premises) must be already given,
    * but it is expected that it is much larger than necessary.
@@ -37,19 +43,22 @@ struct FromSatRefutation {
    * (no memory responsibility overtaken; the list must survive till the minimization call),
    * a stack of @b usedAssumptions is copied.
    */
-  FromSatRefutation(InferenceRule rule, UnitList* premises, SATClauseList* satPremises, const SATLiteralStack& usedAssumptions) :
+  NeedsMinimization(InferenceRule rule, UnitList* premises, SATClauseList* satPremises, const SATLiteralStack& usedAssumptions) :
     _rule(rule), _premises(premises), _satPremises(satPremises), _usedAssumptions(usedAssumptions) {}
 
   /**
    * Constructor versions with no assumptions.
    */
-  FromSatRefutation(InferenceRule rule, UnitList* premises, SATClauseList* satPremises) :
+  NeedsMinimization(InferenceRule rule, UnitList* premises, SATClauseList* satPremises) :
       _rule(rule), _premises(premises), _satPremises(satPremises) {}
 
   InferenceRule _rule;
+  // the first-order premises to be minimised
   UnitList* _premises;
-  SATClauseList* _satPremises; // may be a nullptr, in which case no minimization will be possible
-  SATLiteralStack _usedAssumptions; // possibly an empty stack
+  // the SAT premises that will be used to minimise them
+  SATClauseList* _satPremises;
+  // the SAT assumptions used, possibly empty
+  SATLiteralStack _usedAssumptions;
 };
 
 }
@@ -70,8 +79,6 @@ public:
 
   template <typename Filter>
   static void collectFilteredFOPremises(SATClause* cl, Stack<Unit*>& acc, Filter f);
-  static void collectFOPremises(SATClause* cl, Stack<Unit*>& acc);
-  static void collectPropAxioms(SATClause* cl, SATClauseStack& res);
   static UnitList* getFOPremises(SATClause* cl);
 };
 
@@ -119,7 +126,7 @@ private:
 };
 
 /**
- * Collect first-order premises of @c cl into @c res. Make sure that elements in @c res are unique.
+ * Collect first-order premises of @c cl into @c res.
  * Only consider those SATClauses and their parents which pass the given Filter f.
  */
 template <typename Filter>
@@ -157,7 +164,6 @@ void SATInference::collectFilteredFOPremises(SATClause* cl, Stack<Unit*>& acc, F
       ASSERTION_VIOLATION;
     }
   }
-  makeUnique(acc);
 }
 
 

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -182,6 +182,9 @@ public:
    * Assuming that the last solving call was unsatisfiable,
    * try to produce a minimal set of premises that it still unsatisfiable
    * (with respect to assumptions)
+   *
+   * `premises` should be all the clauses asserted so far:
+   * usually you would get this from ProofProducingSATSolver.
    */
   virtual SATClauseList *minimizePremises(SATClauseList *premises) = 0;
 };

--- a/SAT/SATSolver.hpp
+++ b/SAT/SATSolver.hpp
@@ -177,6 +177,13 @@ public:
   }
 
   SATLiteralStack explicitlyMinimizedFailedAssumptions(unsigned conflictCountLimit, bool randomize);
+
+  /**
+   * Assuming that the last solving call was unsatisfiable,
+   * try to produce a minimal set of premises that it still unsatisfiable
+   * (with respect to assumptions)
+   */
+  virtual SATClauseList *minimizePremises(SATClauseList *premises) = 0;
 };
 }
 

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -207,6 +207,9 @@ public:
   virtual Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
   SATLiteralStack failedAssumptions() override;
 
+  // TODO do something more useful here: should now be possible
+  SATClauseList *minimizePremises(SATClauseList *premises) override { return premises; }
+
   template<class F>
   auto scoped(F f)  -> decltype(f())
   {

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -184,7 +184,7 @@ void SplittingBranchSelector::handleSatRefutation()
   if (!env.colorUsed) { // color oblivious, simple approach
     UnitStack premStack;
     for(SATClause *satPrem : iterTraits(satPremises->iter()))
-      SATInference::collectFilteredFOPremises(satPrem, premStack, [](SATClause *) { return true; });
+      SATInference::collectFOPremises(satPrem, premStack);
     UnitList* prems = UnitList::fromIterator(premStack.iter());
 
     Clause* foRef = Clause::empty(NonspecificInferenceMany(

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -85,7 +85,6 @@ void SplittingBranchSelector::init()
 #if VZ3
     case Options::SatSolver::Z3:
       {
-        _solverIsSMT = true;
         inner = new Z3Interfacing(_parent.getOptions(),_parent.satNaming(), /* unsat core */ false, _parent.getOptions().exportAvatarProblem(), _parent.getOptions().problemExportSyntax());
         if(_parent.getOptions().satFallbackForSMT()){
           // TODO make fallback minimizing?
@@ -112,12 +111,7 @@ void SplittingBranchSelector::init()
   }
 
   auto satSolver = _parent.getOptions().satSolver();
-  ::new(&_solver) ProofProducingSATSolver(
-    inner,
-    /* can minimize if */
-    satSolver == Options::SatSolver::MINISAT ||
-    satSolver == Options::SatSolver::CADICAL
-  );
+  ::new(&_solver) ProofProducingSATSolver(inner);
 }
 
 void SplittingBranchSelector::updateVarCnt()
@@ -182,34 +176,34 @@ static Color colorFromPossiblyDeepFOConversion(SATClause* scl,Unit*& u)
 
 void SplittingBranchSelector::handleSatRefutation()
 {
-  SATClause* satRefutation = _solver.getRefutation();
-  SATClauseList* satPremises = env.options->minimizeSatProofs() ?
-      _solver.getRefutationPremiseList() : nullptr; // getRefutationPremiseList may be nullptr already, if our solver does not support minimization
+  SATClauseList* satPremises = env.options->minimizeSatProofs()
+    ? _solver.minimizedPremises()
+    : _solver.premiseList();
+  ASS(satPremises);
 
   if (!env.colorUsed) { // color oblivious, simple approach
-    UnitList* prems = SATInference::getFOPremises(satRefutation);
+    UnitStack premStack;
+    for(SATClause *satPrem : iterTraits(satPremises->iter()))
+      SATInference::collectFilteredFOPremises(satPrem, premStack, [](SATClause *) { return true; });
+    UnitList* prems = UnitList::fromIterator(premStack.iter());
 
-    Clause* foRef = Clause::fromIterator(LiteralIterator::getEmpty(),
-        FromSatRefutation(_solverIsSMT ? InferenceRule::AVATAR_REFUTATION_SMT : InferenceRule::AVATAR_REFUTATION, prems, satPremises));
+    Clause* foRef = Clause::empty(NonspecificInferenceMany(
+#if VZ3
+      _parent.hasSMTSolver
+      ? InferenceRule::AVATAR_REFUTATION_SMT
+      : InferenceRule::AVATAR_REFUTATION,
+#else
+      InferenceRule::AVATAR_REFUTATION,
+#endif
+      prems
+    ));
+
     // TODO: in principle, the user might be interested in this final clause's age (currently left 0)
     throw MainLoop::RefutationFoundException(foRef);
   } else { // we must produce a well colored proof
-
-    // collect actually used SAT premises
-    SATClauseStack actualSatPremises;
-
-    if (satPremises) { // does our SAT solver support postponed minimization?
-      SATLiteralStack dummy;
-      SATClauseList* minimizedSatPremises = MinisatInterfacing<>::minimizePremiseList(satPremises,dummy);
-
-      actualSatPremises.loadFromIterator(SATClauseList::DestructiveIterator(minimizedSatPremises));
-    } else {
-      SATInference::collectPropAxioms(satRefutation,actualSatPremises);
-    }
-
     // decide which side is "bigger" and should go "first"
     int colorCnts[3] = {0,0,0};
-    SATClauseStack::Iterator it1(actualSatPremises);
+    SATClauseList::Iterator it1(satPremises);
     while (it1.hasNext()) {
       SATClause* scl = it1.next();
       // cout << "SAT: " << scl->toString() << endl;
@@ -233,7 +227,7 @@ void SplittingBranchSelector::handleSatRefutation()
     SATClauseStack second;
     UnitList* second_prems = UnitList::empty();
 
-    SATClauseStack::Iterator it2(actualSatPremises);
+    SATClauseList::Iterator it2(satPremises);
     while (it2.hasNext()) {
       SATClause* scl = it2.next();
       Unit* u;

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -71,7 +71,7 @@ class Splitter;
  */
 class SplittingBranchSelector {
 public:
-  SplittingBranchSelector(Splitter& parent) : _parent(parent), _solverIsSMT(false) {}
+  SplittingBranchSelector(Splitter& parent) : _parent(parent) {}
   /** To be called from Splitter::init() */
   void init();
 
@@ -98,7 +98,6 @@ private:
 
   Splitter& _parent;
 
-  bool _solverIsSMT;
   ProofProducingSATSolver _solver;
   ScopedPtr<DecisionProcedure> _dp;
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -337,7 +337,7 @@ void Options::init()
     _proof.addHardConstraint(If(equal(Proof::SMTCHECK)).then(_proofExtra.is(equal(ProofExtra::FULL))));
 
     _minimizeSatProofs = BoolOptionValue("minimize_sat_proofs","msp",true);
-    _minimizeSatProofs.description="Perform unsat core minimization when a sat solver finds a clause set UNSAT\n"
+    _minimizeSatProofs.description="Perform premise minimization when a sat solver finds a clause set UNSAT\n"
         "(such as with AVATAR proofs or with global subsumption).";
     _lookup.insert(&_minimizeSatProofs);
     _minimizeSatProofs.tag(OptionTag::OUTPUT);

--- a/UnitTests/tSATSolver.cpp
+++ b/UnitTests/tSATSolver.cpp
@@ -111,13 +111,15 @@ void testProofWithAssumptions()
 
 TEST_FUN(testProofWithAssums)
 {
-  ProofProducingSATSolver s(new MinisatInterfacing, true);
+  ProofProducingSATSolver s(new MinisatInterfacing);
   s.ensureVarCount(2);
   s.addClause(getClause("a"));
   s.addClause(getClause("A"));
 
   ASS_EQ(s.solve(),Status::UNSATISFIABLE);
 
+  // TODO check proof?
+  /*
   SATClause* refutation = s.getRefutation();
   PropInference* inf = static_cast<PropInference*>(refutation->inference());
 
@@ -131,8 +133,7 @@ TEST_FUN(testProofWithAssums)
     // cout << prems->head()->toString() << endl;
     prems = prems->tail();
   }
-
-
+  */
 }
 
 void testInterface(SATSolver &s) {


### PR DESCRIPTION
There are currently two SAT inferences which may need minimisation: global subsumption and AVATAR. AVATAR we can minimise _in situ_ as we know it will lead to a proof directly. Global subsumption we need to do lazily, as we're not sure what will end up in the final proof.

However, the two are somewhat entangled. Separate them out:
- Rename `FromSatRefutation` to `NeedsMinimization`.
- Use `NonSpecificInferenceMany` with pre-minimised premises for AVATAR.
- `NeedsMinimization` inferences *definitely require* minimisation, and it *will be* possible since it's only used by global subsumption, and global subsumption only produces SAT inferences that can be minimised by Minisat post-hoc.
- Oddity: `Metaiterator.hpp`'s `makeUnique` never did anything, so just remove it and calls to it.
- To support the AVATAR use-case, add a `minimizePremises` method to `SATSolver` that tries to minimise supplied unsatisfiable premises on a best-effort basis.
  + `CadicalInterfacing` forwards to `MinisatInterfacing`, which does something homebrew. In the near future I will extract DRAT proofs from CaDiCaL and use those instead, which should be much more efficient.
  + `Z3Interfacing` does nothing with this (as usual), but now it should be possible to minimise these as we have access to the meaning of theory literals.
- Temporarily remove `getRefutation` from `ProofProducingSATSolver`, as nothing uses this. In the near future this will be replaced with something that produces a (first-order) inference, either the usual "by sat" or a detailed proof via DRAT.