### PR TITLE
TPTP fof/tff formula should not contain an unquantified variable

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -3577,7 +3577,7 @@ void TPTP::endFof()
   if (isFof) { // fof() or tff()
     env.statistics->inputFormulas++;
     if (freeVariables(f)) {
-      USER_ERROR("unquantified variable detected for an fof formula");
+      USER_ERROR("unquantified variable detected for a formula named '",nm,"'");
     }
     original = unit = new FormulaUnit(f,FromInput(_lastInputType));
     unit->setInheritedColor(_currentColor);


### PR DESCRIPTION
Some users asked for this feature: to complain when we encounter an unquantified variable in fof, such as:
```
fof(a,axiom,![Entity] : human(Entity) -> mortal(Entyty) ).
```
as a good sanity check against typos. (Our current behavior is to silently treat the "free variables" as top-level universally quantified.)

There is a mild performance overhead connected with this. Will run the TPTP numbers soon.