### PR TITLE
remove unused methods from SortHelper; hide some implementation details

### DIFF
--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -67,6 +67,8 @@ typedef List<Literal*> LiteralList;
 typedef Stack<Literal*> LiteralStack;
 typedef VirtualIterator<Literal*> LiteralIterator;
 
+class AtomicSort;
+
 class Inference;
 
 class Unit;

--- a/Kernel/Rebalancing.hpp
+++ b/Kernel/Rebalancing.hpp
@@ -11,7 +11,9 @@
 #define __REBALANCING_H__
 
 #include <iostream>
+
 #include "Forwards.hpp"
+#include "Term.hpp"
 #include "SortHelper.hpp"
 
 

--- a/Kernel/SortHelper.hpp
+++ b/Kernel/SortHelper.hpp
@@ -17,34 +17,9 @@
 
 #include "Forwards.hpp"
 
-#include "Kernel/Term.hpp"
-
 namespace Kernel {
 
 class SortHelper {
-private:
-  enum CollectWhat {
-    COLLECT_TERM,
-    COLLECT_TERMLIST,
-    COLLECT_SPECIALTERM,
-    COLLECT_FORMULA,
-    BIND,
-    UNBIND,
-  };
-
-  struct CollectTask {
-    CollectTask(CollectWhat what) : fncTag(what) {}
-    CollectWhat fncTag;
-    union {
-      TermList ts;
-      Term* t; // shared by TERM and SPECIALTERM
-      Formula* f;
-      VList* vars; // to bind/unbind by BIND/UNBIND
-    };
-    TermList contextSort; // only used by TERMLIST and SPECIALTERM
-  };
-
-  static void collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermList>& map, bool ignoreBound = false);
 public:
   static TermList getResultSort(const Term* t);
   static TermList getResultSortMono(const Term* t);
@@ -62,8 +37,6 @@ public:
   // DEPRECATED: this function scans the whole formula to figure out a variable's sort and is very inefficient - moreover, such information is normally carried around (see QuantifiedFormula's sorts())
   static bool tryGetVariableSort(unsigned var, Formula* f, TermList& res);
   static TermList getVariableSort(TermList var, Term* t);
-  [[deprecated("This function is usually only used if we loose the information about the sort of a variable somewhere while over subterms. Recovering the information using this method iterating the literal/term again, is very inefficient and should be avoided. Make sure to use TermIterators that return TypedTermList instead, or raise a discussion on slack/github if you have a use case where this function is *really* needed.")]]
-  static TermList getTermSort(TermList trm, Literal* lit);
 
   static void collectVariableSorts(Unit* u, DHMap<unsigned,TermList>& map);
   static void collectVariableSorts(Term* t, DHMap<unsigned,TermList>& map);
@@ -80,8 +53,6 @@ public:
   static void normaliseSort(VList* qVars, TermList& sort);
   static void normaliseArgSorts(const TermStack& qVars, TermStack& argSorts);
   static void normaliseSort(TermStack qVars, TermList& sort);
-
-  static OperatorType* getType(Term const* t);
 
   /**
    * This function achieves the following. Let t = f<a1, a2>(t1, t2)

--- a/Kernel/TypedTermList.hpp
+++ b/Kernel/TypedTermList.hpp
@@ -11,8 +11,10 @@
 #ifndef __Kernel_TypedTermList__
 #define __Kernel_TypedTermList__
 
-#include "Kernel/SortHelper.hpp"
 #include <tuple>
+
+#include "Term.hpp"
+#include "SortHelper.hpp"
 #include "Lib/Reflection.hpp"
 
 namespace Kernel {


### PR DESCRIPTION
See #157. There were also some implementation details leaking from the header that didn't need to, replaced by static linkage.