### PR TITLE
do not need to compute iterators for LookaheadLiteralSelector

### DIFF
--- a/Kernel/LookaheadLiteralSelector.hpp
+++ b/Kernel/LookaheadLiteralSelector.hpp
@@ -46,9 +46,6 @@ protected:
 private:
   Literal* pickTheBest(Literal** lits, unsigned cnt);
   void removeVariants(LiteralStack& lits);
-  VirtualIterator<std::tuple<>> getGeneraingInferenceIterator(Literal* lit);
-
-  struct GenIteratorIterator;
 
   bool _completeSelection;
   LiteralSelector* _startupSelector;

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -1767,10 +1767,6 @@ auto iterPointer(P p) { return iterTraits(IterPointer<P>(std::move(p))); }
 
 ///@}
 
-template<class Iterator>
-auto dropElementType(Iterator iter) 
-{ return iterTraits(std::move(iter)).map([](auto _) { return std::make_tuple(); }); }
-
 template<class Array, class Size>
 auto arrayIter(Array const& a, Size s) { return range(0, s).map([&](auto i) -> decltype(auto) { return a[i]; }); }
 

--- a/Lib/Option.hpp
+++ b/Lib/Option.hpp
@@ -82,7 +82,7 @@ struct MaybeUninit {
   { return MV(_elem.init); }                                                              \
                                                                                           \
   void init(T REF content)                                                                \
-  { ::new(&_elem)T(MV(content)); }                                                        \
+  { ::new(&_elem.init)T(MV(content)); }                                                        \
                                                                                           \
   MaybeUninit& operator=(T REF content)                                                   \
   {                                                                                       \


### PR DESCRIPTION
`LookaheadLiteralSelector` does an odd thing where it computes largish iterator that only yields unit tuples, then works out which iterators are the shortest. This is I assume for historical reasons.

Don't do that, instead compute a `size_t` estimate of the number of inferences (in the same way as before, but no iterators) and then find the minimal candidate literals.

Also, there was a bug in `Option<T>` that I fixed in #319 but somehow got broken again. Throw this in here as it's too dodgy to leave alone and I found it by running `clang-tidy` on `LookaheadLiteralSelector`.

Testing: shuffle at `i=1000` with `-s 11`, and a few debug runs where the old and new ways of estimating the number of inferences agree.