### PR TITLE
enable UBSan and fix all the immediate flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,9 +47,6 @@ if(CCACHE_PROGRAM)
   message(STATUS "CCACHE_PROGRAM: " ${CCACHE_PROGRAM})
 endif()
 
-# wrap up common object files so not built multiple times for each target
-add_library(common OBJECT ${SOURCES})
-
 ################################################################
 # compiler configuration
 ################################################################
@@ -104,6 +101,11 @@ if(GCC_OR_CLANG)
   add_compile_options(-fno-threadsafe-statics)
   # ...or RTTI
   add_compile_options(-fno-rtti)
+
+  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+    add_compile_options(-fsanitize=undefined)
+    add_link_options(-fsanitize=undefined)
+  endif()
 endif()
 
 # switch on coverage options per-compiler if desired
@@ -204,6 +206,15 @@ else ()
 endif()
 
 ################################################################
+# Vampire
+################################################################
+# wrap up common object files so not built multiple times for each target
+add_library(common OBJECT ${SOURCES})
+
+# the actual Vampire executable
+add_executable(vampire vampire.cpp $<TARGET_OBJECTS:common>)
+
+################################################################
 # UNIT TESTING
 ################################################################
 
@@ -267,8 +278,3 @@ add_executable(subsat
     SATSubsumption/subsat/subsat_main.cpp
     $<TARGET_OBJECTS:common>
 )
-
-################################################################
-# Vampire
-################################################################
-add_executable(vampire vampire.cpp $<TARGET_OBJECTS:common>)

--- a/Indexing/CodeTree.cpp
+++ b/Indexing/CodeTree.cpp
@@ -230,6 +230,13 @@ bool CodeTree::ILStruct::equalsForOpMatching(const ILStruct& o) const
   if(varCnt!=o.varCnt) {
     return false;
   }
+  // avoids passing nullptr to memcmp below,
+  // which is technically UB
+  if(!varCnt)
+    return true;
+
+  ASS(globalVarNumbers)
+  ASS(o.globalVarNumbers)
   return std::memcmp(globalVarNumbers, o.globalVarNumbers, varCnt * sizeof(unsigned)) == 0;
 }
 

--- a/Inferences/BinaryResolution.cpp
+++ b/Inferences/BinaryResolution.cpp
@@ -17,7 +17,6 @@
 #include "Indexing/ResultSubstitution.hpp"
 #include "Kernel/UnificationWithAbstraction.hpp"
 #include "Lib/Environment.hpp"
-#include "Lib/Int.hpp"
 #include "Lib/Metaiterators.hpp"
 #include "Lib/VirtualIterator.hpp"
 
@@ -98,7 +97,7 @@ Clause* BinaryResolution::generateClause(Clause* queryCl, Literal* queryLit, Cla
   // since we have not built the clause yet we compute lower bounds on the weight of the clause after each step and recheck whether the weight-limit can still be fulfilled.
   unsigned wlb=0;//weight lower bound
   unsigned numPositiveLiteralsLowerBound = // lower bound on number of positive literals, don't know at this point whether duplicate positive literals will occur
-      Int::max(queryLit->isPositive() ?  queryCl->numPositiveLiterals()-1 :  queryCl->numPositiveLiterals(),
+      std::max(queryLit->isPositive() ?  queryCl->numPositiveLiterals()-1 :  queryCl->numPositiveLiterals(),
               resultLit->isPositive() ? resultCl->numPositiveLiterals()-1 : resultCl->numPositiveLiterals());
 
   auto constraints = computeConstraints();

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -321,7 +321,7 @@ Clause* Superposition::performSuperposition(
   // we already know the age here so we can immediately conclude whether the clause fulfils the age limit
   // since we have not built the clause yet we compute lower bounds on the weight of the clause after each step and recheck whether the weight-limit can still be fulfilled.
 
-  unsigned numPositiveLiteralsLowerBound = Int::max(eqClause->numPositiveLiterals()-1, rwClause->numPositiveLiterals()); // lower bound on number of positive literals, don't know at this point whether duplicate positive literals will occur
+  unsigned numPositiveLiteralsLowerBound = std::max(eqClause->numPositiveLiterals()-1, rwClause->numPositiveLiterals()); // lower bound on number of positive literals, don't know at this point whether duplicate positive literals will occur
   //TODO update inference rule name AYB
   Inference inf(GeneratingInference2(unifier->usesUwa() ? InferenceRule::CONSTRAINED_SUPERPOSITION : InferenceRule::SUPERPOSITION, rwClause, eqClause));
   Inference::Destroyer inf_destroyer(inf);

--- a/Lib/Int.cpp
+++ b/Lib/Int.cpp
@@ -103,17 +103,6 @@ std::string Int::toString(unsigned long i)
   return result;
 } // Int::toString
 
-std::string Int::toHexString(size_t i)
-{
-  constexpr auto BUFSIZE = 256;
-  char tmp [BUFSIZE];
-  snprintf(tmp,BUFSIZE,"0x%zx",i);
-  std::string result(tmp);
-
-  return result;
-} // Int::toString
-
-
 /**
  * Convert a string to a long value.
  * @since 30/08/2004 Torrevieja
@@ -271,31 +260,3 @@ bool Int::stringToUnsigned64 (const std::string& str,long long unsigned& result)
 {
   return stringToUnsigned64(str.c_str(),result);
 } // Int::stringToUnsigned64
-
-/**
- * True if @b str is a string representing an (arbitrary precision) integer.
- * @since 30/07/2010 Linz
- */
-bool Int::isInteger(const char* str)
-{
-	if (*str == '-') {
-		str++;
-	}
-
-	// str must represent a non-negative integer
-	if (! *str) {
-		return false;
-	}
-
-	// str is non-empty and must represent a non-negative integer
-	do {
-		if (*str < '0' || *str > '9') {
-			return false;
-		}
-		str++;
-	}
-	while (*str);
-
-	return true;
-} // Int::isInteger
-

--- a/Lib/Int.hpp
+++ b/Lib/Int.hpp
@@ -20,16 +20,9 @@
 
 #include "Comparison.hpp"
 
-#include <iostream>
-#include <limits>
-
-#ifdef _MSC_VER // VC++
-#  undef max
-#  undef min
-#endif
+#include <string>
 
 namespace Lib {
-
 
 /**
  * Various functions on integers that should probably
@@ -45,12 +38,6 @@ class Int
   /** Return the std::string representation of a float */
   static std::string toString(float f) { return toString((double)f); }
   static std::string toString(double d);
-
-  static std::string toHexString(size_t i);
-
-	static bool isInteger(const char* str);
-	/** True if @b str is a string representing an (arbitrary precision) integer */
-	static inline bool isInteger(const std::string& str) { return isInteger(str.c_str()); }
 
   /** Compare two integers. */
   inline static Comparison compare (int i1, int i2)
@@ -87,220 +74,7 @@ class Int
   static bool stringToFloat(const char*,float& result);
   static bool stringToUnsigned64(const std::string& str,long long unsigned& result);
   static bool stringToUnsigned64(const char* str,long long unsigned& result);
-  static int sign(int i);
-  static int sign(long i);
-  static int sign(double);
-  static int max(int i,int j);
-  static int min(int i,int j);
-
-  /** Return the greatest common divisor of @b i and @b j */
-  template<typename INT>
-  static unsigned gcd(INT i,INT j)
-  {
-    unsigned a=safeAbs(i);
-    unsigned b=safeAbs(j);
-
-    if(!a && !b) {
-      return 1; // gcd of (0,0) set arbitrarily to 1
-    }
-
-    while (b!=0) {
-      a %= b;
-      if(a==0) {
-        return b;
-      }
-      b %= a;
-    }
-    return a;
-  }
-
-  /**
-   * If -num does not overflow, return true and save -num to res.
-   * Otherwise, return false.
-   */
-  template<typename INT>
-  static bool safeUnaryMinus(const INT num, INT& res)
-  {
-    if(num == std::numeric_limits<INT>::min()) {
-      return false;
-    }
-    res=-num;
-    return true;
-  }
-
-  static unsigned safeAbs(const int num)
-  {
-    if(num == std::numeric_limits<int>::min()) { // = -2147483648
-      return (unsigned)num; // = 2147483648
-    }
-    // abs works for all other values
-    return std::abs(num);
-  }
-
-  /**
-   * If arg1+arg2 does not overflow, return true and save the sum to res.
-   * Otherwise, return false.
-   */
-  template<typename INT>
-  static bool safePlus(INT arg1, INT arg2, INT& res)
-  {
-    if(arg2<0) {
-      if(std::numeric_limits<INT>::min() - arg2 > arg1) { return false; }
-    }
-    else {
-      if(std::numeric_limits<INT>::max() - arg2 < arg1) { return false; }
-    }
-    res=arg1+arg2;
-    return true;
-  }
-
-  /**
-   * If arg1-arg2 does not overflow, return true and save the result to res.
-   * Otherwise, return false.
-   */
-  template<typename INT>
-  static bool safeMinus(INT num, INT sub, INT& res)
-  {
-    if(sub<0) {
-      if(std::numeric_limits<INT>::max() + sub < num) { return false; }
-    }
-    else {
-      if(std::numeric_limits<INT>::min() + sub > num) { return false; }
-    }
-    res=num-sub;
-    return true;
-  }
-
-  template <typename T>
-  static int sgn(T val) {
-    return (T(0) < val) - (val < T(0));
-  }
-
-  /**
-   * If arg1*arg2 does not overflow, return true and save the result to res.
-   * Otherwise, return false.
-   */
-  template<typename INT>
-  static bool safeMultiply(INT arg1, INT arg2, INT& res)
-  {
-    if (arg1 == 0 || arg1 == 1 || arg2 == 0 || arg2 == 1) {
-      res=arg1*arg2;
-      return true;
-    }
-
-    if (arg1 == std::numeric_limits<INT>::min() || arg2 == std::numeric_limits<INT>::min()) {
-      // cannot take abs of min() and all safe operations with min have been ruled out above
-      return false;
-    }
-
-    // we can safely apply uminus on negative ones
-    INT arg1abs = arg1 < 0 ? -arg1 : arg1;
-    INT arg2abs = arg2 < 0 ? -arg2 : arg2;
-
-    if (arg1abs > std::numeric_limits<INT>::max() / arg2abs) {
-      return false;
-    }
-
-    INT mres = arg1*arg2;
-
-    // this is perhaps obsolete and could be removed
-    if ((mres == std::numeric_limits<INT>::min() && arg1 == -1) || // before, there was a SIGFPE for "-2147483648 / -1" TODO: are there other evil cases?
-        (sgn(arg1)*sgn(arg2) != sgn(mres)) || // 1073741824 * 2 = -2147483648 is evil, and passes the test below
-        (arg1 != 0 && mres / arg1 != arg2)) {
-      return false;
-    }
-    res=mres;
-    return true;
-  }
-
-  inline static bool safeDivide(int arg1, int arg2, int& res)
-  {
-    if (arg2 == 0) return false;
-
-    // check for 2 complement representation
-    if (std::numeric_limits<int>::min() != -std::numeric_limits<int>::max())  {
-      if (arg1 == std::numeric_limits<int>::min() && arg2 == -1)  {
-        return false;
-      }
-    }
-    res = arg1 / arg2;
-    return true;
-  }
 };
-
-
-
-/**
- * Return
- * <ol>
- *  <li>-1 if i&lt;0;</li>
- *  <li>0 if i=0;</li>
- *  <li>1 if i&gt;0.</li>
- * </ol>
- *
- * @since 22/04/2005 Manchester
- */
-inline
-int Int::sign(int i)
-{
-  return i < 0 ? -1 :
-         i == 0 ? 0 :
-         1;
-}
-
-
-/**
- * Return
- * <ol>
- *  <li>-1 if l&lt;0;</li>
- *  <li>0 if l=0;</li>
- *  <li>1 if l&gt;0.</li>
- * </ol>
- *
- * @since 22/04/2005 Manchester
- */
-inline
-int Int::sign(long l)
-{
-  return l < 0 ? -1 :
-         l == 0 ? 0 :
-         1;
-}
-
-
-/**
- * Return
- * <ol>
- *  <li>-1 if d&lt;0;</li>
- *  <li>0 if d=0;</li>
- *  <li>1 if d&gt;0.</li>
- * </ol>
- *
- * @since 22/04/2005 Manchester
- */
-inline
-int Int::sign(double d)
-{
-  return d < 0 ? -1 :
-         d == 0 ? 0 :
-         1;
-}
-
-/** Return the maximum of two integers */
-inline
-int Int::max (int i,int j)
-{
-  return i >= j ? i : j;
-}
-
-/** Return the minimum of two integers */
-inline
-int Int::min (int i,int j)
-{
-  return i <= j ? i : j;
-}
-
-
 
 template <typename T>
 using disable_deduction = typename std::enable_if_t<true, T>;  // C++20: can use std::type_identity_t instead of this
@@ -320,8 +94,6 @@ inline bool isAdditionOverflow(disable_deduction<T> a, disable_deduction<T> b)
   static_assert(std::is_unsigned<T>::value, "overflow check is only defined for unsigned types");
   return static_cast<T>(a + b) < a;
 }
-
-
 
 }
 

--- a/Lib/SharedSet.hpp
+++ b/Lib/SharedSet.hpp
@@ -525,7 +525,7 @@ public:
   }
 
   auto iter() const
-  { return arrayIter(_items, size()); }
+  { return arrayIter(static_cast<const T *>(_items), size()); }
 
 };
 

--- a/Saturation/PredicateSplitPassiveClauseContainers.cpp
+++ b/Saturation/PredicateSplitPassiveClauseContainers.cpp
@@ -27,10 +27,6 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
-int computeLCM(int a, int b) {
-  return (a*b)/Int::gcd(a, b);
-}
-
 PredicateSplitPassiveClauseContainer::PredicateSplitPassiveClauseContainer(bool isOutermost, const Shell::Options& opt, std::string name,
     std::vector<std::unique_ptr<PassiveClauseContainer>> queues,
     std::vector<float> cutoffs, std::vector<int> ratios, bool layeredArrangement)
@@ -61,7 +57,7 @@ PredicateSplitPassiveClauseContainer::PredicateSplitPassiveClauseContainer(bool 
   auto lcm = 1;
   for (unsigned i = 0; i < ratios.size(); i++)
   {
-    lcm = computeLCM(lcm, ratios[i]);
+    lcm = std::lcm(lcm, ratios[i]);
   }
   // initialize
   for (unsigned i = 0; i < ratios.size(); i++)

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -17,7 +17,6 @@
 #include "Debug/RuntimeStatistics.hpp"
 
 #include "Lib/DHMap.hpp"
-#include "Lib/Int.hpp"
 #include "Lib/Environment.hpp"
 #include "Debug/TimeProfiling.hpp"
 
@@ -263,7 +262,7 @@ Formula* Naming::apply_iter(Formula* top_f) {
         FormulaList* currArg = f->args();
         for (unsigned i = 0; i < length; i++) {
           int c = sand.cls[i];
-          sum = Int::min(_threshold, sum + c);
+          sum = std::min(_threshold, sum + c);
           bool canBeDefEvaluated = false;
           bool canBeDef = false;
           if (c > maxPos) {
@@ -276,7 +275,7 @@ Formula* Naming::apply_iter(Formula* top_f) {
           }
           if (tas.where == UNDER_IFF) {
             int d = sand.negCls[i];
-            product = Int::min(_threshold, product * d);
+            product = std::min(_threshold, product * d);
             if (d > maxNeg) {
               if (!canBeDefEvaluated) {
                 canBeDef = canBeInDefinition(currArg->head(), tas.where);
@@ -382,7 +381,7 @@ Formula* Naming::apply_iter(Formula* top_f) {
         FormulaList* currArg = f->args();
         for (unsigned i = 0; i < length; i++) {
           int c = sor.cls[i];
-          product = Int::min(_threshold, product * c);
+          product = std::min(_threshold, product * c);
           bool canBeDefEvaluated = false;
           bool canBeDef = false;
           if (c > maxPos) {
@@ -395,7 +394,7 @@ Formula* Naming::apply_iter(Formula* top_f) {
           }
           if (tas.where == UNDER_IFF) {
             int d = sor.negCls[i];
-            sum = Int::min(_threshold, sum + d);
+            sum = std::min(_threshold, sum + d);
             if (d > maxNeg) {
               if (!canBeDefEvaluated) {
                 canBeDef = canBeInDefinition(currArg->head(), tas.where);
@@ -524,12 +523,12 @@ Formula* Naming::apply_iter(Formula* top_f) {
           f = new BinaryFormula(con, l, r);
         }
 
-        // pos = Int::min(_threshold, Int::max(posl, posr));
+        // pos = std::min(_threshold, std::max(posl, posr));
         // return f;
 
         {
           Result r;
-          r.resSub.pos = Int::min(_threshold, Int::max(posl, posr));
+          r.resSub.pos = std::min(_threshold, std::max(posl, posr));
           r.resSub.res = f;
           result_stack.push(r);
         }
@@ -537,8 +536,8 @@ Formula* Naming::apply_iter(Formula* top_f) {
         todo_stack.pop();  // finished
         break; // case APPLY_SUB_IFFXOR
       }
-      int pos = Int::min(negl * posr + negr * posl, _threshold);
-      int neg = Int::min(posl * posr + negl * negr, _threshold);
+      int pos = std::min(negl * posr + negr * posl, _threshold);
+      int neg = std::min(posl * posr + negl * negr, _threshold);
       bool left; // name left
       if (pos < _threshold) {
         if (tas.where != UNDER_IFF || neg < _threshold) {
@@ -586,12 +585,12 @@ Formula* Naming::apply_iter(Formula* top_f) {
       if (left) {
         Formula* newl = introduceDefinition(l, true);
         f = new BinaryFormula(con, newl, r);
-        // neg = Int::min(posr + negr, _threshold);
+        // neg = std::min(posr + negr, _threshold);
         // pos = neg;
         // return f;
         {
           Result r;
-          r.resSub.neg = Int::min(posr + negr, _threshold);
+          r.resSub.neg = std::min(posr + negr, _threshold);
           r.resSub.pos = neg;
           r.resSub.res = f;
           result_stack.push(r);
@@ -603,12 +602,12 @@ Formula* Naming::apply_iter(Formula* top_f) {
 
       Formula* newr = introduceDefinition(r, true);
       f = new BinaryFormula(con, l, newr);
-      // neg = Int::min(posl + negl, _threshold);
+      // neg = std::min(posl + negl, _threshold);
       // pos = neg;
       // return f;
       {
         Result r;
-        r.resSub.neg = Int::min(posl + negl, _threshold);
+        r.resSub.neg = std::min(posl + negl, _threshold);
         r.resSub.pos = neg;
         r.resSub.res = f;
         result_stack.push(r);
@@ -763,7 +762,7 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
       FormulaList* currArg = f->args();
       for (unsigned i = 0; i < length; i++) {
         int c = cls[i];
-        sum = Int::min(_threshold, sum + c);
+        sum = std::min(_threshold, sum + c);
         bool canBeDefEvaluated = false;
         bool canBeDef;
         if (c > maxPos) {
@@ -776,7 +775,7 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
         }
         if (where == UNDER_IFF) {
           int d = negCls[i];
-          product = Int::min(_threshold, product * d);
+          product = std::min(_threshold, product * d);
           if (d > maxNeg) {
             if (!canBeDefEvaluated) {
               canBeDef = canBeInDefinition(currArg->head(), where);
@@ -871,7 +870,7 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
       FormulaList* currArg = f->args();
       for (unsigned i = 0; i < length; i++) {
         int c = cls[i];
-        product = Int::min(_threshold, product * c);
+        product = std::min(_threshold, product * c);
         bool canBeDefEvaluated = false;
         bool canBeDef;
         if (c > maxPos) {
@@ -884,7 +883,7 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
         }
         if (where == UNDER_IFF) {
           int d = negCls[i];
-          sum = Int::min(_threshold, sum + d);
+          sum = std::min(_threshold, sum + d);
           if (d > maxNeg) {
             if (!canBeDefEvaluated) {
               canBeDef = canBeInDefinition(currArg->head(), where);
@@ -977,11 +976,11 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
       if (l != f->left() || r != f->right()) {
         f = new BinaryFormula(con, l, r);
       }
-      pos = Int::min(_threshold, Int::max(posl, posr));
+      pos = std::min(_threshold, std::max(posl, posr));
       return f;
     }
-    pos = Int::min(negl * posr + negr * posl, _threshold);
-    neg = Int::min(posl * posr + negl * negr, _threshold);
+    pos = std::min(negl * posr + negr * posl, _threshold);
+    neg = std::min(posl * posr + negl * negr, _threshold);
     bool left; // name left
     if (pos < _threshold) {
       if (where != UNDER_IFF || neg < _threshold) {
@@ -1011,14 +1010,14 @@ Formula* Naming::apply_sub(Formula* f, Where where, int& pos, int& neg) {
     if (left) {
       Formula* newl = introduceDefinition(l, true);
       f = new BinaryFormula(con, newl, r);
-      neg = Int::min(posr + negr, _threshold);
+      neg = std::min(posr + negr, _threshold);
       pos = neg;
       return f;
     }
 
     Formula* newr = introduceDefinition(r, true);
     f = new BinaryFormula(con, l, newr);
-    neg = Int::min(posl + negl, _threshold);
+    neg = std::min(posl + negl, _threshold);
     pos = neg;
     return f;
   }

--- a/UnitTests/tIntegerConstantType.cpp
+++ b/UnitTests/tIntegerConstantType.cpp
@@ -21,6 +21,15 @@ using namespace std;
 using namespace Lib;
 using namespace Kernel;
 
+static unsigned safeAbs(const int num)
+{
+  if(num == std::numeric_limits<int>::min()) { // = -2147483648
+    return (unsigned)num; // = 2147483648
+  }
+  // abs works for all other values
+  return std::abs(num);
+}
+
 TEST_FUN(list_1)
 {
   IntList* lst = 0;
@@ -43,7 +52,7 @@ inline auto rct(int i, int j) -> RationalConstantType { return RationalConstantT
 TEST_FUN(test01) {
 
   for (int i = -512; i <= 512; i++) {
-    auto exp = ict(BitUtils::log2(Int::safeAbs(i)));
+    auto exp = ict(BitUtils::log2(safeAbs(i)));
     auto is = ict(i).abs().log2();
     if (is != exp ) {
       std::cout << "[ fail ] ict(" << i << ").abs().log2()" << std::endl;


### PR DESCRIPTION
Enable [UndefinedBehaviourSanitiser](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html) for Debug builds with Clang and GCC. Then fix the warnings it gives us until I don't see any more, explanations inline.

Also found some unused gubbins in `Int`, remove that.

@quickbeam123 - if you want in on this, please patch the Makefile (probably just append `-fsanitize=undefined` to `CXXFLAGS` and `LDFLAGS`) as you see fit.