### PR TITLE
minimise SMT proofs by unsat core

### DIFF
--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -204,8 +204,7 @@ public:
   Status solveUnderAssumptionsLimited(const SATLiteralStack& assumps, unsigned conflictCountLimit) override;
   SATLiteralStack failedAssumptions() override;
 
-  // TODO do something more useful here: should now be possible
-  SATClauseList *minimizePremises(SATClauseList *premises) override { return premises; }
+  SATClauseList *minimizePremises(SATClauseList *premises) override;
 
   template<class F>
   auto scoped(F f)  -> decltype(f())
@@ -319,7 +318,7 @@ public:
   };
 
 
-  Representation getRepresentation(Term* trm);
+  z3::expr getRepresentation(Term* trm);
   Representation getRepresentation(SATLiteral lit);
   Representation getRepresentation(SATClause* cl);
 

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -176,7 +176,7 @@ void SplittingBranchSelector::handleSatRefutation()
   SATClauseList *satPremises = nullptr;
 #if VZ3
   if(_parent.hasSMTSolver) {
-    satPremises = _solver.premiseList();
+    satPremises = _solver.minimizedPremises();
     // SATClause::removeDuplicateLiterals can insert a single PROP_INF between here and the FO_CONVERSION
     // replace these cases with the "true" duplicate-literal premise
     for(SATClause *&cl : iterTraits(satPremises->iter())) {


### PR DESCRIPTION
Following on from #754, we can now do minimised AVATAR SMT refutations.

The implementation works by conjuring another instance of Z3 to compute an unsat core of the now known-unsat set of SMT clauses. I don't say this is the best implementation, but it's the first and easiest thing that came to mind.

Testing: I've done about 20 minutes' worth of random TPTP problems with `-sas z3` and nothing horrible cropped up. I expect this *will* be slower than the existing implementation since it does more work, but it's The Right Thing so I'm not too bothered. I imagine @quickbeam123 will disagree with me on this, so let the discussion begin!