### PR TITLE
do not use reference counting for VirtualIterator

### DIFF
--- a/DP/ShortConflictMetaDP.hpp
+++ b/DP/ShortConflictMetaDP.hpp
@@ -41,7 +41,7 @@ public:
   : _inner(inner), _sat2fo(sat2fo), _solver(solver) {}
 
   void addLiterals(LiteralIterator lits, bool onlyEqualites) override {
-    _inner->addLiterals(lits, onlyEqualites);
+    _inner->addLiterals(std::move(lits), onlyEqualites);
   }
 
   void reset() override {

--- a/FMB/DefinitionIntroduction.hpp
+++ b/FMB/DefinitionIntroduction.hpp
@@ -31,7 +31,7 @@ namespace FMB {
   //TODO mark as an actual iterator?
   class DefinitionIntroduction{
   public:
-    DefinitionIntroduction(ClauseIterator cit) : _cit(cit) {
+    DefinitionIntroduction(ClauseIterator cit) : _cit(std::move(cit)) {
       //_ng = env.options->fmbNonGroundDefs();
     }
 

--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -53,9 +53,9 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
 
   ClauseList* checkingClauses = getCheckingClauses();
 
-  ClauseIterator cit = pvi(concatIters(clauses,ClauseList::Iterator(checkingClauses)));
+  ClauseIterator cit = pvi(concatIters(std::move(clauses),ClauseList::Iterator(checkingClauses)));
 
-  Problem prb(cit,false);
+  Problem prb(std::move(cit),false);
   Options opt; // default saturation algorithm options
 
   Problem* inputProblem = env.getMainProblem();

--- a/Indexing/ClauseVariantIndex.cpp
+++ b/Indexing/ClauseVariantIndex.cpp
@@ -14,7 +14,6 @@
 
 #include "Lib/List.hpp"
 #include "Lib/Metaiterators.hpp"
-#include "Lib/SmartPtr.hpp"
 #include "Debug/TimeProfiling.hpp"
 
 #include "Kernel/Clause.hpp"
@@ -39,10 +38,6 @@ public:
   : _lits(lits), _length(length), _queryIndex(new LiteralMiniIndex(lits, length))
   {
   }
-  ~ResultClauseToVariantClauseFn()
-  {
-  }
-
 
   Clause* operator()(Clause* mcl)
   {
@@ -98,7 +93,7 @@ public:
 private:
   Literal* const * _lits;
   unsigned _length;
-  SmartPtr<LiteralMiniIndex> _queryIndex;
+  std::unique_ptr<LiteralMiniIndex> _queryIndex;
 };
 
 //-------------------//-------------------//-------------------//-------------------

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -215,7 +215,7 @@ void BackwardDemodulation::perform(Clause* cl,
   //replacementIterator right at this point, so we can measure the time just
   //simply (which cannot be generally done when iterators are involved)
 
-  simplifications=getPersistentIterator(replacementIterator);
+  simplifications=getPersistentIterator(std::move(replacementIterator));
 }
 
 }

--- a/Inferences/Cases.cpp
+++ b/Inferences/Cases.cpp
@@ -95,11 +95,11 @@ ClauseIterator Cases::generateClauses(Clause* premise)
 
   auto it2 = getMapAndFlattenIterator(it1,RewriteableSubtermsFn(_salg->getOrdering()));
 
-  auto it3 = getMappingIterator(it2,ResultFn(premise, *this));
+  auto it3 = getMappingIterator(std::move(it2),ResultFn(premise, *this));
 
-  auto it4 = getFilteredIterator(it3,NonzeroFn());
+  auto it4 = getFilteredIterator(std::move(it3),NonzeroFn());
 
-  return pvi( it4 );
+  return pvi( std::move(it4) );
 }
 
 }

--- a/Inferences/CasesSimp.cpp
+++ b/Inferences/CasesSimp.cpp
@@ -102,10 +102,10 @@ Option<ClauseIterator> CasesSimp::simplifyMany(Clause* premise)
   auto it3 = getMapAndFlattenIterator(it2,RewriteableSubtermsFn());
 
   //Perform  Narrow
-  auto it4 = getMapAndFlattenIterator(it3,ResultFn(premise, *this));
+  auto it4 = getMapAndFlattenIterator(std::move(it3),ResultFn(premise, *this));
 
   if (it4.hasNext()) {
-    return some(pvi(it4));
+    return some(pvi(std::move(it4)));
   } else {
     return {};
   }

--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -190,13 +190,13 @@ ClauseIterator Choice::generateClauses(Clause* premise)
   auto it2 = getMapAndFlattenIterator(it1, SubtermsFn());
 
   //pair of literals and possible rewrites that can be applied to literals
-  auto it3 = getFilteredIterator(it2, IsChoiceTerm());
+  auto it3 = getFilteredIterator(std::move(it2), IsChoiceTerm());
 
   //apply rewrite rules to literals
-  auto it4 = getMapAndFlattenIterator(it3, ResultFn());
+  auto it4 = getMapAndFlattenIterator(std::move(it3), ResultFn());
 
 
-  return pvi( it4 );
+  return pvi( std::move(it4) );
 
 }
 

--- a/Inferences/EqualityFactoring.cpp
+++ b/Inferences/EqualityFactoring.cpp
@@ -72,9 +72,9 @@ struct EqualityFactoring::FactorablePairsFn
 
     auto it3 = getMapAndFlattenIterator(it2,EqHelper::EqualityArgumentIteratorFn());
 
-    auto it4 = pushPairIntoRightIterator(arg,it3);
+    auto it4 = pushPairIntoRightIterator(arg,std::move(it3));
 
-    return pvi( it4 );
+    return pvi( std::move(it4) );
   }
 private:
   Clause* _cl;
@@ -182,15 +182,15 @@ ClauseIterator EqualityFactoring::generateClauses(Clause* premise)
 
   auto it3 = getMapAndFlattenIterator(it2,EqHelper::LHSIteratorFn(_salg->getOrdering()));
 
-  auto it4 = getMapAndFlattenIterator(it3,FactorablePairsFn(premise));
+  auto it4 = getMapAndFlattenIterator(std::move(it3),FactorablePairsFn(premise));
 
-  auto it5 = getMappingIterator(it4,ResultFn(*this, premise,
+  auto it5 = getMappingIterator(std::move(it4),ResultFn(*this, premise,
       getOptions().literalMaximalityAftercheck() && _salg->getLiteralSelector().isBGComplete(),
       _salg->getOrdering(), _uwaFixedPointIteration));
 
-  auto it6 = getFilteredIterator(it5,NonzeroFn());
+  auto it6 = getFilteredIterator(std::move(it5),NonzeroFn());
 
-  return pvi( it6 );
+  return pvi( std::move(it6) );
 }
 
 }

--- a/Inferences/ExtensionalityResolution.cpp
+++ b/Inferences/ExtensionalityResolution.cpp
@@ -81,7 +81,7 @@ struct ExtensionalityResolution::ForwardUnificationsFn
     if (!unifs.hasNext()) {
       return VirtualIterator<pair<pair<Literal*, ExtensionalityClause>, RobSubstitution*> >::getEmpty();
     }
-    return pvi(pushPairIntoRightIterator(arg, unifs));
+    return pvi(pushPairIntoRightIterator(arg, std::move(unifs)));
   }
 private:
   RobSubstitutionSP _subst;
@@ -159,7 +159,7 @@ struct ExtensionalityResolution::BackwardUnificationsFn
     if (!unifs.hasNext()) {
       return VirtualIterator<pair<pair<Clause*, Literal*>, RobSubstitution*> >::getEmpty();
     }
-    return pvi(pushPairIntoRightIterator(arg, unifs));
+    return pvi(pushPairIntoRightIterator(arg, std::move(unifs)));
   }
 private:
   Literal* _extLit;
@@ -254,15 +254,15 @@ ClauseIterator ExtensionalityResolution::generateClauses(Clause* premise)
     // For each <clause,literal> pair, we get 2 substitutions (by unifying
     // X=Y from given extensionality clause and literal.
     // Elements: <<clause,literal>,subst>
-    auto it2 = getMapAndFlattenIterator(it1,BackwardUnificationsFn(extLit));
+    auto it2 = getMapAndFlattenIterator(std::move(it1),BackwardUnificationsFn(extLit));
 
     // Construct result clause by applying substitution.
-    auto it3 = getMappingIterator(it2,BackwardResultFn(premise, extLit, *this));
+    auto it3 = getMappingIterator(std::move(it2),BackwardResultFn(premise, extLit, *this));
 
     // filter out only non-zero results
-    auto it4 = getFilteredIterator(it3, NonzeroFn());
+    auto it4 = getFilteredIterator(std::move(it3), NonzeroFn());
 
-    backwardIterator = pvi(it4);
+    backwardIterator = pvi(std::move(it4));
   } else {
     backwardIterator = ClauseIterator::getEmpty();
   }
@@ -276,17 +276,17 @@ ClauseIterator ExtensionalityResolution::generateClauses(Clause* premise)
   // unifying literal and extClause.literal, i.e. the variable equality in
   // extensionality clause).
   // Elements: <<literal,extClause>,subst>
-  auto it2 = getMapAndFlattenIterator(it1,ForwardUnificationsFn());
+  auto it2 = getMapAndFlattenIterator(std::move(it1),ForwardUnificationsFn());
 
   // Construct result clause by applying substitution.
-  auto it3 = getMappingIterator(it2,ForwardResultFn(premise, *this));
+  auto it3 = getMappingIterator(std::move(it2),ForwardResultFn(premise, *this));
 
   // filter out only non-zero results
-  auto it4 = getFilteredIterator(it3, NonzeroFn());
+  auto it4 = getFilteredIterator(std::move(it3), NonzeroFn());
 
   // Concatenate results from forward extensionality and (above constructed)
   // backward extensionality.
-  auto it5 = concatIters(it4,backwardIterator);
+  auto it5 = concatIters(std::move(it4),std::move(backwardIterator));
 
-  return pvi(it5);
+  return pvi(std::move(it5));
 }

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -216,7 +216,7 @@ CompositeSGI::ClauseGenerationResult CompositeSGI::generateSimplify(Kernel::Clau
   /* apply generations as until a redundancy is discovered */
   for (auto simpl : _simplifiers) {
     auto res = simpl->generateSimplify(cl);
-    clauses.push(res.clauses);
+    clauses.push(std::move(res.clauses));
     if (res.premiseRedundant) {
       redundant = true;
       break;

--- a/Inferences/Superposition.cpp
+++ b/Inferences/Superposition.cpp
@@ -121,34 +121,34 @@ ClauseIterator Superposition::generateClauses(Clause* premise)
 
   // Get clauses with a literal whose complement unifies with the rewritable subterm,
   // returns a pair with the original pair and the unification result (includes substitution)
-  auto itf3 = getMapAndFlattenIterator(itf2,
+  auto itf3 = getMapAndFlattenIterator(std::move(itf2),
       [this](pair<Literal*, TypedTermList> arg)
       { return pushPairIntoRightIterator(arg, _lhsIndex->getUwa(arg.second, env.options->unificationWithAbstraction(), env.options->unificationWithAbstractionFixedPointIteration())); });
 
   //Perform forward superposition
-  auto itf4 = getMappingIterator(itf3,ForwardResultFn(premise, *this));
+  auto itf4 = getMappingIterator(std::move(itf3),ForwardResultFn(premise, *this));
 
   auto itb1 = premise->getSelectedLiteralIterator();
   auto itb2 = getMapAndFlattenIterator(itb1,EqHelper::SuperpositionLHSIteratorFn(_salg->getOrdering(), _salg->getOptions()));
-  auto itb3 = getMapAndFlattenIterator(itb2,
+  auto itb3 = getMapAndFlattenIterator(std::move(itb2),
       [this] (pair<Literal*, TermList> arg)
       { return pushPairIntoRightIterator(
               arg,
               _subtermIndex->getUwa(TypedTermList(arg.second, SortHelper::getEqualityArgumentSort(arg.first)), env.options->unificationWithAbstraction(), env.options->unificationWithAbstractionFixedPointIteration())); });
 
   //Perform backward superposition
-  auto itb4 = getMappingIterator(itb3,BackwardResultFn(premise, *this));
+  auto itb4 = getMappingIterator(std::move(itb3),BackwardResultFn(premise, *this));
 
   // Add the results of forward and backward together
-  auto it5 = concatIters(itf4,itb4);
+  auto it5 = concatIters(std::move(itf4),std::move(itb4));
 
   // Remove null elements - these can come from performSuperposition
-  auto it6 = getFilteredIterator(it5,NonzeroFn());
+  auto it6 = getFilteredIterator(std::move(it5),NonzeroFn());
 
   // The outer iterator ensures we update the time counter for superposition
-  auto it7 = TIME_TRACE_ITER("superposition", it6);
+  auto it7 = TIME_TRACE_ITER("superposition", std::move(it6));
 
-  return pvi( it7 );
+  return pvi( std::move(it7) );
 }
 
 /**

--- a/Inferences/TermAlgebraReasoning.cpp
+++ b/Inferences/TermAlgebraReasoning.cpp
@@ -188,7 +188,7 @@ namespace Inferences {
     auto it1 = c->getSelectedLiteralIterator();
     auto it2 = getMappingIterator(it1, SubtermEqualityFn(c));
     auto it3 = getFlattenedIterator(it2);
-    return pvi(it3);
+    return pvi(std::move(it3));
   }
 
   Clause* InjectivityISE::simplify(Clause *c)
@@ -294,7 +294,7 @@ namespace Inferences {
     AcyclicityGenIterator(Clause *premise, Indexing::CycleQueryResultsIterator results)
       :
       _premise(premise),
-      _queryResults(results)
+      _queryResults(std::move(results))
     {}
 
     DECL_ELEMENT_TYPE(Clause *);
@@ -370,7 +370,7 @@ namespace Inferences {
     auto it1 = c->getSelectedLiteralIterator();
     auto it2 = getMappingIterator(it1, AcyclicityGenFn(_acyclIndex, c));
     auto it3 = getFlattenedIterator(it2);
-    return pvi(it3);
+    return pvi(std::move(it3));
   }
 
   void pushSubterms(TermList *tl, Stack<TermList*> &stack)
@@ -501,7 +501,7 @@ namespace Inferences {
     LiteralIterator it1(c);
     auto it2 = getMappingIterator(it1, SubtermDisequalityFn(c));
     auto it3 = getFlattenedIterator(it2);
-    return pvi(it3);
+    return pvi(std::move(it3));
   }
  
 }

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -930,10 +930,10 @@ SimplifyingGeneratingInference::ClauseGenerationResult TheoryInstAndSimp::genera
     })
     .filter([](Clause* cl) { return cl != nullptr; });
 
-  auto it2 = TIME_TRACE_ITER(THEORY_INST_SIMP, it1);
+  auto it2 = TIME_TRACE_ITER(THEORY_INST_SIMP, std::move(it1));
 
   // we need to strictily evaluate the iterator to
-  auto clauses =  getPersistentIterator(it2);
+  auto clauses =  getPersistentIterator(std::move(it2));
 
   if (premiseRedundant && _thiTautologyDeletion) {
     return ClauseGenerationResult {
@@ -942,7 +942,7 @@ SimplifyingGeneratingInference::ClauseGenerationResult TheoryInstAndSimp::genera
     };
   } else {
     return ClauseGenerationResult {
-      .clauses          = clauses,
+      .clauses          = std::move(clauses),
       .premiseRedundant = false,
     };
   }

--- a/Inferences/URResolution.cpp
+++ b/Inferences/URResolution.cpp
@@ -201,10 +201,10 @@ struct URResolution::Item
       if (!_ansLit || _ansLit->ground()) {
         single = Renaming::normalize(single);
       }
-      res = Clause::fromIterator(concatIters(getSingletonIterator(single), it), inf);
+      res = Clause::fromIterator(concatIters(getSingletonIterator(single), std::move(it)), inf);
     }
     else {
-      res = Clause::fromIterator(it, inf);
+      res = Clause::fromIterator(std::move(it), inf);
     }
     return res;
   }

--- a/Kernel/LookaheadLiteralSelector.cpp
+++ b/Kernel/LookaheadLiteralSelector.cpp
@@ -139,7 +139,7 @@ struct LookaheadLiteralSelector::GenIteratorIterator
     ASS(prepared);
     prepared=false;
     stage++;
-    return nextIt;
+    return std::move(nextIt);
   }
 private:
 
@@ -225,7 +225,7 @@ Literal* LookaheadLiteralSelector::pickTheBest(Literal** lits, unsigned cnt)
   }
 
   for(unsigned i=0;i<cnt;i++) {
-    runifs[i].drop(); //release the iterators
+    runifs[i].~VirtualIterator(); //release the iterators
   }
   return res;
 }

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -104,8 +104,8 @@ bool MatchingUtils::haveReversedVariantArgs(Term* l1, Term* l2)
       vi( new DisagreementSetIterator(*l1->nthArgument(1),*l2->nthArgument(0)) ));
 
   VirtualIterator<pair<TermList, TermList> > dsit =
-  sortUsed ? pvi(concatIters(vi(new DisagreementSetIterator(s1,s2)), it1)) :
-             pvi(it1);
+  sortUsed ? pvi(concatIters(vi(new DisagreementSetIterator(s1,s2)), std::move(it1))) :
+             pvi(std::move(it1));
 
   while(dsit.hasNext()) {
     pair<TermList,TermList> dp=dsit.next(); //disagreement pair

--- a/Lib/Metaiterators.hpp
+++ b/Lib/Metaiterators.hpp
@@ -1417,7 +1417,7 @@ static auto __ifElseIter(Args... args)
         }
       }
   });
-  return coproductIter(out ? *out : Out::template variant<total/2>(tupleGetApplied(Constant<total - 1>{})));
+  return coproductIter(out ? std::move(*out) : Out::template variant<total/2>(tupleGetApplied(Constant<total - 1>{})));
 }
 
 template<class... Args>
@@ -1778,7 +1778,7 @@ template<class Array, class Size>
 auto arrayIter(Array      & a, Size s) { return range(0, s).map([&](auto i) -> decltype(auto) { return a[i]; }); }
 
 template<class Array, class Size>
-auto arrayIter(Array     && a, Size s) { return range(0, s).map([a = std::move(a)](auto i) { return std::move(a[i]); }); }
+auto arrayIter(Array     && a, Size s) { return range(0, s).map([a = std::move(a)](auto i) mutable { return std::move(a[i]); }); }
 
 template<class Array> auto arrayIter(Array const& a) { return arrayIter(          a , a.size()); }
 template<class Array> auto arrayIter(Array     && a) { return arrayIter(std::move(a), a.size()); }
@@ -1838,7 +1838,7 @@ STLIterator<Iterator> getSTLIterator(Iterator begin, Iterator end)
  */
 template<class Inner>
 auto getPersistentIterator(Inner it)
-{ return pvi(arrayIter(iterTraits(it).template collect<Stack>())); }
+{ return pvi(arrayIter(iterTraits(std::move(it)).template collect<Stack>())); }
 
 /* wrapper around an iterator that implements ==, <, > and hash functions.
  * <,> are implemented as lexicographic comparison of the iterator elements */

--- a/Lib/PairUtils.hpp
+++ b/Lib/PairUtils.hpp
@@ -71,7 +71,7 @@ template<typename C, typename DIt>
 MappingIterator<DIt,PairRightPushingFn<C,ELEMENT_TYPE(DIt)> >
   pushPairIntoRightIterator(C c, DIt dit)
 {
-  return getMappingIterator(dit, PairRightPushingFn<C,ELEMENT_TYPE(DIt)>(c));
+  return getMappingIterator(std::move(dit), PairRightPushingFn<C,ELEMENT_TYPE(DIt)>(c));
 }
 
 template<typename C, typename D>

--- a/Lib/VirtualIterator.hpp
+++ b/Lib/VirtualIterator.hpp
@@ -24,6 +24,8 @@
 #include "Exception.hpp"
 #include "Reflection.hpp"
 
+#include <memory>
+
 namespace Lib {
 
 ///@addtogroup Iterators
@@ -41,11 +43,6 @@ template<typename T>
  * @b IteratorCore objects can be used as ordinary stack allocated
  * or static iterators as well, but in that case they must not be
  * passed to a @b VirtualIterator object as an inside.
- *
- * If used as an inside of a @b VirtualIterator object, updating
- * the reference counter @b _refCnt is done by the @b VirtualIterator
- * object, as well as calling the destructor when the counter reaches
- * zero.
  */
 template<typename T>
 class IteratorCore {
@@ -56,10 +53,9 @@ public:
   IteratorCore& operator=(IteratorCore&&) = default;
 
   DECL_ELEMENT_TYPE(T);
-  /** Create new IteratorCore object */
-  IteratorCore() : _refCnt(0) {}
-  /** Destroy IteratorCore object */
-  virtual ~IteratorCore() { ASS(_refCnt==0); }
+  IteratorCore() = default;
+  virtual ~IteratorCore() = default;
+
   /** Return true if there is a next element */
   virtual bool hasNext() = 0;
   /**
@@ -81,14 +77,6 @@ public:
    * returns true.
    */
   virtual size_t size() const { INVALID_OPERATION("This iterator cannot retrieve its size."); }
-
-private:
-  /**
-   * Reference counter field used by the @b VirtualIterator object
-   */
-  mutable int _refCnt;
-
-  friend class VirtualIterator<T>;
 };
 
 /**
@@ -122,104 +110,29 @@ public:
  * @see IteratorCore
  */
 template<typename T>
-class VirtualIterator {
+class VirtualIterator final {
 public:
   USE_ALLOCATOR(VirtualIterator);
 
   DECL_ELEMENT_TYPE(T);
 
-  /** Return an empty iterator */
-  static VirtualIterator getEmpty()
-  {
-    static VirtualIterator inst(new EmptyIterator<T>());
-    return inst;
-  }
-
-  /** Return an invalid iterator */
-  static VirtualIterator getInvalid()
-  {
-    return VirtualIterator();
-  }
-
-  /**
-   * Create an uninitialized object
-   *
-   * When created with this constructor, the object must be assigned
-   * an initialized VirtualIterator object through the @b operator=(),
-   * before any of the @b hasNext(), @b next(), @b knowsSize() or @b size()
-   * functions can be called.
-   */
-  inline
-  VirtualIterator() : _core(0) {}
-
+  VirtualIterator() = default;
   /**
    * Create an object with @b core as its core.
    */
   inline
-  explicit VirtualIterator(IteratorCore<T>* core) : _core(core) { _core->_refCnt++; }
+  explicit VirtualIterator(IteratorCore<T>* core) : _core(core) {}
 
-  IGNORE_MAYBE_UNINITIALIZED(
+  VirtualIterator(const VirtualIterator &) = delete;
+  VirtualIterator &operator=(const VirtualIterator &) = delete;
 
-  inline
-  VirtualIterator(const VirtualIterator& obj) : _core(obj._core)
-  {
-    if(_core) {
-      _core->_refCnt++;
-    }
-  }
+  VirtualIterator(VirtualIterator &&) noexcept = default;
+  VirtualIterator &operator=(VirtualIterator &&other) noexcept = default;
 
-  inline
-  ~VirtualIterator()
+  /** Return an empty iterator */
+  static VirtualIterator getEmpty()
   {
-    if(_core) {
-	_core->_refCnt--;
-	if(!_core->_refCnt) {
-	  delete _core;
-	}
-    }
-  }
-  )
-  VirtualIterator& operator=(const VirtualIterator& obj)
-  {
-    IteratorCore<T>* oldCore=_core;
-    _core=obj._core;
-    if(_core) {
-      _core->_refCnt++;
-    }
-    if(oldCore) {
-      oldCore->_refCnt--;
-      if(!oldCore->_refCnt) {
-	delete oldCore;
-      }
-    }
-    return *this;
-  }
-
-  /**
-   * Remove reference to the iterator core.
-   * Return true iff the the iterator core does not exist
-   * any more after return from this function.
-   *
-   * The returned value can be useful for asserting
-   * that the iterator core (and all resources it
-   * used) was indeed released.
-   */
-  inline
-  bool drop()
-  {
-    if(_core) {
-      _core->_refCnt--;
-      if(_core->_refCnt) {
-	_core=0;
-	return false;
-      }
-      else {
-	delete _core;
-	_core=0;
-      }
-    }
-    _core=0;
-    return true;
+    return VirtualIterator(new EmptyIterator<T>());
   }
 
   /** Return true if there is a next element */
@@ -275,7 +188,7 @@ public:
   bool isInvalid() { return !_core; }
 private:
   /** The polymorphous core of this @b VirtualIterator object */
-  IteratorCore<T>* _core;
+  std::unique_ptr<IteratorCore<T>> _core;
 };
 
 /**
@@ -301,7 +214,7 @@ public:
   USE_ALLOCATOR(ProxyIterator);
   DEFAULT_CONSTRUCTORS(ProxyIterator)
   ~ProxyIterator() override {}
-  
+
   explicit ProxyIterator(Inner inn) : _inn(std::move(inn)) {}
   bool hasNext() override { return _inn.hasNext(); };
   T next() override { return _inn.next(); };
@@ -326,10 +239,7 @@ VirtualIterator<ELEMENT_TYPE(Inner)> pvi(Inner it)
   return VirtualIterator<ELEMENT_TYPE(Inner)>(new ProxyIterator<ELEMENT_TYPE(Inner),Inner>(std::move(it)));
 }
 
-
-
-
-///@}�
+///@}
 
 }
 

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -1312,7 +1312,7 @@ void Splitter::onClauseReduction(Clause* cl, ClauseIterator premises, Clause* re
   SplitSet* unionAll;
   if(replacement) {
     unionAll = replacement->splits();
-    ASS(forAll(premises, 
+    ASS(forAll(std::move(premises),
             [replacement] (Clause* premise) { 
               //SplitSet* difference = premise->splits()->subtract(replacement->splits());
               //if(difference->isEmpty()) return true; // isSubsetOf true

--- a/Shell/SMTCheck.cpp
+++ b/Shell/SMTCheck.cpp
@@ -754,7 +754,7 @@ static void splitClause(std::ostream &out, SortMap &conclSorts, Unit *concl)
   ALWAYS(parents.hasNext())
   Clause *split = parents.next()->asClause();
   outputPremise(out, conclSorts, split);
-  for (Unit *u : iterTraits(parents)) {
+  for (Unit *u : iterTraits(std::move(parents))) {
     Clause *component = env.proofExtra.get<Indexing::SplitDefinitionExtra>(u).component;
     SortMap otherSorts;
     SortHelper::collectVariableSorts(component, otherSorts);

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -543,7 +543,7 @@ void SineTheorySelector::updateDefRelation(Unit* u)
 
   static Stack<SymId> symIds;
   symIds.reset();
-  symIds.loadFromIterator(sit0);
+  symIds.loadFromIterator(std::move(sit0));
 
   Stack<SymId>::Iterator sit(symIds);
 

--- a/Test/FwdBwdSimplificationTester.hpp
+++ b/Test/FwdBwdSimplificationTester.hpp
@@ -147,7 +147,7 @@ public:
         if (replacement) {
           results.push(replacement);
         }
-        justifications.loadFromIterator(premises);
+        justifications.loadFromIterator(std::move(premises));
       }
     }
     justifications.sort();
@@ -199,7 +199,7 @@ public:
       } catch (Lib::Exception& e) { 
         testFail("bwd", e); 
       }
-      for (auto simpl : iterTraits(simpls)) {
+      for (auto simpl : iterTraits(std::move(simpls))) {
         results.push(simpl.replacement);
       }
     }

--- a/Test/GenerationTester.hpp
+++ b/Test/GenerationTester.hpp
@@ -333,7 +333,7 @@ public:
 
     // run checks
     auto sExp = this->_expected.unwrap();
-    auto sRes = Stack<Kernel::Clause*>::fromIterator(res.clauses);
+    auto sRes = Stack<Kernel::Clause*>::fromIterator(std::move(res.clauses));
 
     if (!sExp.matches(sRes, simpl)) {
       testFail(sRes, sExp);

--- a/Test/SimplificationTester.hpp
+++ b/Test/SimplificationTester.hpp
@@ -149,7 +149,7 @@ public:
   void run(SimplificationManyTester<Rule>& simpl) {
     auto resOp = simpl.simplifyMany(_input);
     if (resOp.isSome()) {
-      auto res = Stack<Kernel::Clause*>::fromIterator(*resOp);
+      auto res = Stack<Kernel::Clause*>::fromIterator(std::move(*resOp));
       std::cout  << std::endl;
       std::cout << "[     case ]: " << pretty(*_input) << std::endl;
       std::cout << "[       is ]: " << pretty(res) << std::endl;
@@ -190,7 +190,7 @@ public:
       std::cout << "[ expected ]: " << pretty(exp) << std::endl;
       exit(-1);
     } else {
-      auto res = Stack<Kernel::Clause*>::fromIterator(*resOp);
+      auto res = Stack<Kernel::Clause*>::fromIterator(std::move(*resOp));
       if (!exp.matches(res, simpl)) {
         std::cout  << std::endl;
         std::cout << "[     case ]: " << pretty(*_input) << std::endl;


### PR DESCRIPTION
`VirtualIterator` manages its internal "core" by reference counting. This is weird, as you never want two copies of the same iterator pointing to the same core.

Instead, insist on unique ownership by making `VirtualIterator` non-copyable. This required a few more `std::move`s, which the compiler enforced.