### PR TITLE
Update macos 13 builder

### DIFF
--- a/.github/workflows/multiplatform-build.yml
+++ b/.github/workflows/multiplatform-build.yml
@@ -37,7 +37,7 @@ jobs:
       run: >-
         mkdir build &&
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DZ3_BUILD_EXECUTABLE=OFF -DZ3_BUILD_TEST_EXECUTABLES=OFF -DZ3_BUILD_LIBZ3_SHARED=OFF &&
-        make -j8 -C build
+        make -j4 -C build
     - name: Configure and Build Vampire
       working-directory: ${{ runner.workspace }}/vampire
       shell: bash
@@ -47,7 +47,7 @@ jobs:
       run: >-
         mkdir build &&
         cmake -B build -DCMAKE_BUILD_TYPE=Release -DCCACHE_PROGRAM=OFF &&
-        make -j8 -C build vampire
+        make -j4 -C build vampire
     - name: Obtain Cygwin DLL
       working-directory: ${{ runner.workspace }}/vampire
       run: mv ${{ steps.cygwin.outputs.root }}/bin/cygwin1.dll build/cygwin1.dll


### PR DESCRIPTION
The builder image `macos-13` is no longer available, so we had to change to `macos-15-intel`. I also lowered the number of cores used because [we only get 4 cores](https://docs.github.com/en/actions/reference/runners/github-hosted-runners) and otherwise a too high number can cause issues.