### PR TITLE
Bump version number to 5.0.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required (VERSION 3.14.0)
 project(Vampire)
 
 # version
-set(VAMPIRE_VERSION_NUMBER 5.0.0)
+set(VAMPIRE_VERSION_NUMBER 5.0.1)
 
 include(CheckSymbolExists)
 include(CTest)

--- a/Makefile
+++ b/Makefile
@@ -492,7 +492,7 @@ all: #default make disabled
 ################################################################
 # automated generation of Vampire revision information
 
-VERSION_NUMBER = 5.0.0
+VERSION_NUMBER = 5.0.1
 
 # We extract the revision number from svn every time the svn meta-data are modified
 # (that's why there is the dependency on .svn/entries) 


### PR DESCRIPTION
This PR bumps the version number to 5.0.1 in the build files and fixes #801. I see the `Makefile` is deprecated but I suppose there's no harm in bumping the version number there.