### PR TITLE
Fix linker error on Mac OSX Tahoe 26.3

### DIFF
--- a/Minisat/core/Solver.h
+++ b/Minisat/core/Solver.h
@@ -26,6 +26,8 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 #ifndef Minisat_Solver_h
 #define Minisat_Solver_h
 
+#include <utility>
+
 #include "Minisat/mtl/Vec.h"
 #include "Minisat/mtl/Heap.h"
 #include "Minisat/mtl/Alg.h"


### PR DESCRIPTION
The issue seems to be a variant of [this LLVM issue](https://github.com/llvm/llvm-project/issues/56206).

The compiler sees a certain `std::swap` definition but the symbol is apparently never compiled, leading to an undefined symbol error.

Maybe there is still something wrong with my setup, but the solution seems so innocuous that I would go with it now.