### PR TITLE
Subsumption equality resolution

### DIFF
--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -46,16 +46,15 @@ bool DemodulationHelper::redundancyCheckNeededForPremise(Clause* rwCl, Literal* 
 }
 
 /**
- * Test whether the @param applicator is a renaming on the variables of @param t.
+ * Test whether the @param applicator is a renaming on the variables of @param object.
  */
-bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, TermList t)
+template<typename Object>
+bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, Object obj)
 {
   DHSet<TermList> renamingDomain;
   DHSet<TermList> renamingRange;
 
-  VariableIterator it(t);
-  while(it.hasNext()) {
-    TermList v = it.next();
+  for (const auto& v : iterTraits(VariableIterator(obj))) {
     ASS(v.isVar());
     if (!renamingDomain.insert(v)) {
       continue;
@@ -71,6 +70,9 @@ bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, TermLis
   }
   return true;
 }
+
+template bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, TermList);
+template bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, Literal*);
 
 bool DemodulationHelper::isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm,
   TermList tgtTerm, TermList eqLHS, const SubstApplicator* eqApplicator) const

--- a/Inferences/DemodulationHelper.cpp
+++ b/Inferences/DemodulationHelper.cpp
@@ -13,8 +13,6 @@
 #include "Kernel/SubstHelper.hpp"
 #include "Kernel/Term.hpp"
 #include "Kernel/Ordering.hpp"
-#include "Kernel/TermIterators.hpp"
-#include "Kernel/Ordering.hpp"
 
 #include "Shell/Options.hpp"
 
@@ -44,35 +42,6 @@ bool DemodulationHelper::redundancyCheckNeededForPremise(Clause* rwCl, Literal* 
   // check is needed if encompassment demodulation is off or we demodulate a positive unit
   return !_encompassing || (rwLit->isPositive() && (rwCl->length() == 1));
 }
-
-/**
- * Test whether the @param applicator is a renaming on the variables of @param object.
- */
-template<typename Object>
-bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, Object obj)
-{
-  DHSet<TermList> renamingDomain;
-  DHSet<TermList> renamingRange;
-
-  for (const auto& v : iterTraits(VariableIterator(obj))) {
-    ASS(v.isVar());
-    if (!renamingDomain.insert(v)) {
-      continue;
-    }
-
-    TermList vSubst = (*applicator)(v.var());
-    if (!vSubst.isVar()) {
-      return false;
-    }
-    if (!renamingRange.insert(vSubst)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-template bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, TermList);
-template bool DemodulationHelper::isRenamingOn(const SubstApplicator* applicator, Literal*);
 
 bool DemodulationHelper::isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm,
   TermList tgtTerm, TermList eqLHS, const SubstApplicator* eqApplicator) const

--- a/Inferences/DemodulationHelper.hpp
+++ b/Inferences/DemodulationHelper.hpp
@@ -24,7 +24,8 @@ public:
   DemodulationHelper() = default;
   DemodulationHelper(const Options& opts, const Ordering* ord);
 
-  static bool isRenamingOn(const SubstApplicator* applicator, TermList t);
+  template<typename Object>
+  static bool isRenamingOn(const SubstApplicator* applicator, Object obj);
 
   bool redundancyCheckNeededForPremise(Clause* rwCl, Literal* rwLit, TermList rwTerm) const;
   bool isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm,

--- a/Inferences/DemodulationHelper.hpp
+++ b/Inferences/DemodulationHelper.hpp
@@ -12,6 +12,10 @@
 #define __DemodulationHelper__
 
 #include "Forwards.hpp"
+#include "Lib/DHSet.hpp"
+#include "Kernel/SubstHelper.hpp"
+#include "Kernel/Term.hpp"
+#include "Kernel/TermIterators.hpp"
 
 namespace Inferences {
 
@@ -25,7 +29,27 @@ public:
   DemodulationHelper(const Options& opts, const Ordering* ord);
 
   template<typename Object>
-  static bool isRenamingOn(const SubstApplicator* applicator, Object obj);
+  static bool isRenamingOn(const SubstApplicator* applicator, Object obj) {
+    DHSet<unsigned> domain;
+    DHSet<unsigned> range;
+    return isRenamingOn(applicator, obj, domain, range);
+  }
+  template<typename Object>
+  static bool isRenamingOn(const SubstApplicator* applicator, Object obj, DHSet<unsigned>& domain, DHSet<unsigned>& range)
+  {
+    for (const auto& v : iterTraits(VariableIterator(obj))) {
+      ASS(v.isVar());
+      if (!domain.insert(v.var())) {
+        continue;
+      }
+
+      TermList vSubst = (*applicator)(v.var());
+      if (!vSubst.isVar() || !range.insert(vSubst.var())) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   bool redundancyCheckNeededForPremise(Clause* rwCl, Literal* rwLit, TermList rwTerm) const;
   bool isPremiseRedundant(Clause* rwCl, Literal* rwLit, TermList rwTerm, TermList tgtTerm,

--- a/Inferences/SubsumptionEqualityResolution.cpp
+++ b/Inferences/SubsumptionEqualityResolution.cpp
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file SubsumptionEqualityResolution.cpp
+ * Implements class SubsumptionEqualityResolution.
+ */
+
+#include "Inferences/DemodulationHelper.hpp"
+#include "Lib/Stack.hpp"
+
+#include "Kernel/Clause.hpp"
+#include "Kernel/Inference.hpp"
+#include "Kernel/RobSubstitution.hpp"
+#include "Kernel/SubstHelper.hpp"
+
+#include "SubsumptionEqualityResolution.hpp"
+
+namespace Inferences
+{
+
+Clause* SubsumptionEqualityResolution::simplify(Clause* cl)
+{
+  for (const auto& lit : *cl) {
+    if (!lit->isEquality() || lit->isPositive()) {
+      continue;
+    }
+
+    auto [lhs, rhs] = lit->eqArgs();
+
+    struct Unifier : SubstApplicator {
+      bool unify(TermList lhs, TermList rhs) {
+        return subst.unify(lhs, 0, rhs, 0);
+      }
+      TermList operator()(unsigned v) const override {
+        return subst.apply(TermList::var(v), 0);
+      }
+      RobSubstitution subst;
+    } unifier;
+
+    if (!unifier.unify(lhs, rhs)) {
+      continue;
+    }
+
+    RStack<Literal*> resLits;
+    for (const auto& curr : *cl) {
+      if (lit == curr) {
+        continue;
+      }
+      if (!DemodulationHelper::isRenamingOn(&unifier, curr)) {
+        goto fail;
+      }
+      resLits->push(curr);
+    }
+    return Clause::fromStack(*resLits, SimplifyingInference1(InferenceRule::SUBSUMPTION_EQUALITY_RESOLUTION, cl));
+fail:
+    continue;
+  }
+  return cl;
+}
+
+}

--- a/Inferences/SubsumptionEqualityResolution.cpp
+++ b/Inferences/SubsumptionEqualityResolution.cpp
@@ -49,11 +49,13 @@ Clause* SubsumptionEqualityResolution::simplify(Clause* cl)
     }
 
     RStack<Literal*> resLits;
+    DHSet<unsigned> renamingDomain;
+    DHSet<unsigned> renamingRange;
     for (const auto& curr : *cl) {
       if (lit == curr) {
         continue;
       }
-      if (!DemodulationHelper::isRenamingOn(&unifier, curr)) {
+      if (!DemodulationHelper::isRenamingOn(&unifier, curr, renamingDomain, renamingRange)) {
         goto fail;
       }
       resLits->push(curr);

--- a/Inferences/SubsumptionEqualityResolution.hpp
+++ b/Inferences/SubsumptionEqualityResolution.hpp
@@ -19,22 +19,21 @@
 #include "Forwards.hpp"
 
 #include "InferenceEngine.hpp"
-#include "Inferences/ProofExtra.hpp"
 
 namespace Inferences {
 
-using namespace Kernel;
-using namespace Indexing;
-using namespace Saturation;
-
+/**
+ * This inference tries to perform an equality resolution that only
+ * succeeds if the resulting clause subsumes the premise. It is also
+ * similar to subsumption resolution, but performs it with the equation
+ * x = x that is only implicitly present in the search space.
+ */
 class SubsumptionEqualityResolution
 : public ImmediateSimplificationEngine
 {
 public:
   Clause* simplify(Clause* cl) override;
 };
-
-using SubsumptionEqualityResolutionExtra = LiteralInferenceExtra;
 
 };
 

--- a/Inferences/SubsumptionEqualityResolution.hpp
+++ b/Inferences/SubsumptionEqualityResolution.hpp
@@ -1,0 +1,41 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file SubsumptionEqualityResolution.hpp
+ * Defines class SubsumptionEqualityResolution.
+ */
+
+
+#ifndef __SubsumptionEqualityResolution__
+#define __SubsumptionEqualityResolution__
+
+#include "Forwards.hpp"
+
+#include "InferenceEngine.hpp"
+#include "Inferences/ProofExtra.hpp"
+
+namespace Inferences {
+
+using namespace Kernel;
+using namespace Indexing;
+using namespace Saturation;
+
+class SubsumptionEqualityResolution
+: public ImmediateSimplificationEngine
+{
+public:
+  Clause* simplify(Clause* cl) override;
+};
+
+using SubsumptionEqualityResolutionExtra = LiteralInferenceExtra;
+
+};
+
+#endif /* __SubsumptionEqualityResolution__ */

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -628,6 +628,8 @@ std::string Kernel::ruleName(InferenceRule rule)
     return "forward subsumption resolution";
   case InferenceRule::BACKWARD_SUBSUMPTION_RESOLUTION:
     return "backward subsumption resolution";
+  case InferenceRule::SUBSUMPTION_EQUALITY_RESOLUTION:
+    return "subsumption equality resolution";
   case InferenceRule::SUPERPOSITION:
     return "superposition";
   case InferenceRule::FUNCTION_DEFINITION_REWRITING:

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -224,6 +224,7 @@ enum class InferenceRule : unsigned char {
   FORWARD_SUBSUMPTION_RESOLUTION,
   /** backward subsumption resolution simplification rule */
   BACKWARD_SUBSUMPTION_RESOLUTION,
+  SUBSUMPTION_EQUALITY_RESOLUTION,
   /** forward demodulation inference */
   FORWARD_DEMODULATION,
   /** backward demodulation inference */

--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,7 @@ VINF_OBJ=Inferences/BackwardDemodulation.o\
          Inferences/ForwardLiteralRewriting.o\
          Inferences/ForwardSubsumptionAndResolution.o\
          Inferences/SubsumptionDemodulationHelper.o\
+         Inferences/SubsumptionEqualityResolution.o\
          Inferences/ForwardSubsumptionDemodulation.o\
          Inferences/GlobalSubsumption.o\
          Inferences/InnerRewriting.o\

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -96,6 +96,7 @@
 #include "Inferences/CNFOnTheFly.hpp"
 #include "Inferences/DefinitionIntroduction.hpp"
 #include "Inferences/LfpRule.hpp"
+#include "Inferences/SubsumptionEqualityResolution.hpp"
 
 #include "Saturation/ExtensionalityClauseContainer.hpp"
 
@@ -1701,6 +1702,10 @@ std::pair<CompositeISE*, CompositeISEMany> SaturationAlgorithm::createISE(Proble
   bool mayHaveEquality = couldEqualityArise(prb,opt);
   bool alascaTakesOver = doesAlascaTakeOver(prb, opt);
   auto& ordering = salg.getOrdering();
+
+  if (mayHaveEquality) {
+    res->addFront(new SubsumptionEqualityResolution());
+  }
 
   // InnerRewriting is relatively expensive, so let's insert it first,
   // so that it gets applied as the last ImmediateSimplification

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1703,14 +1703,14 @@ std::pair<CompositeISE*, CompositeISEMany> SaturationAlgorithm::createISE(Proble
   bool alascaTakesOver = doesAlascaTakeOver(prb, opt);
   auto& ordering = salg.getOrdering();
 
-  if (mayHaveEquality && opt.subsumptionEqualityResolution()) {
-    res->addFront(new SubsumptionEqualityResolution());
-  }
-
   // InnerRewriting is relatively expensive, so let's insert it first,
   // so that it gets applied as the last ImmediateSimplification
   if (mayHaveEquality && opt.innerRewriting()) {
     res->addFront(new InnerRewriting(salg));
+  }
+
+  if (mayHaveEquality && opt.subsumptionEqualityResolution()) {
+    res->addFront(new SubsumptionEqualityResolution());
   }
 
   if (mayHaveEquality && opt.equationalTautologyRemoval()) {

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1703,7 +1703,7 @@ std::pair<CompositeISE*, CompositeISEMany> SaturationAlgorithm::createISE(Proble
   bool alascaTakesOver = doesAlascaTakeOver(prb, opt);
   auto& ordering = salg.getOrdering();
 
-  if (mayHaveEquality) {
+  if (mayHaveEquality && opt.subsumptionEqualityResolution()) {
     res->addFront(new SubsumptionEqualityResolution());
   }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1878,6 +1878,12 @@ void Options::init()
     _equationalTautologyRemoval.onlyUsefulWith(ProperSaturationAlgorithm());
     _equationalTautologyRemoval.tag(OptionTag::INFERENCES);
 
+    _subsumptionEqualityResolution = BoolOptionValue("subsumption_equality_resolution","ser",false);
+    _subsumptionEqualityResolution.description="Similar to subsumption resolution but uses the implicit x = x clause to resolve a literal.";
+    _lookup.insert(&_subsumptionEqualityResolution);
+    _subsumptionEqualityResolution.onlyUsefulWith(ProperSaturationAlgorithm());
+    _subsumptionEqualityResolution.tag(OptionTag::INFERENCES);
+
     _partialRedundancyCheck = BoolOptionValue("partial_redundancy_check","prc",false);
     _partialRedundancyCheck.description=
       "Skip generating inferences on clause instances on which we already performed a simplifying inference.";

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2084,6 +2084,7 @@ public:
   bool simulatenousSuperposition() const { return _simultaneousSuperposition.actualValue; }
   bool innerRewriting() const { return _innerRewriting.actualValue; }
   bool equationalTautologyRemoval() const { return _equationalTautologyRemoval.actualValue; }
+  bool subsumptionEqualityResolution() const { return _subsumptionEqualityResolution.actualValue; }
   bool partialRedundancyCheck() const { return _partialRedundancyCheck.actualValue; }
   bool partialRedundancyOrderingConstraints() const { return _partialRedundancyOrderingConstraints.actualValue; }
   bool partialRedundancyAvatarConstraints() const { return _partialRedundancyAvatarConstraints.actualValue; }
@@ -2483,6 +2484,7 @@ private:
   BoolOptionValue _simultaneousSuperposition;
   BoolOptionValue _innerRewriting;
   BoolOptionValue _equationalTautologyRemoval;
+  BoolOptionValue _subsumptionEqualityResolution;
   BoolOptionValue _partialRedundancyCheck;
   BoolOptionValue _partialRedundancyOrderingConstraints;
   BoolOptionValue _partialRedundancyAvatarConstraints;

--- a/UnitTests/tInferences_SubsumptionEqualityResolution.cpp
+++ b/UnitTests/tInferences_SubsumptionEqualityResolution.cpp
@@ -1,0 +1,75 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+
+#include "Test/SyntaxSugar.hpp"
+#include "Inferences/SubsumptionEqualityResolution.hpp"
+
+#include "Test/SimplificationTester.hpp"
+
+using namespace std;
+using namespace Kernel;
+using namespace Inferences;
+using namespace Test;
+
+namespace {
+
+#define MY_SIMPL_RULE   SubsumptionEqualityResolution
+#define MY_SIMPL_TESTER Simplification::SimplificationTester
+
+#define MY_SYNTAX_SUGAR                                                                                       \
+  DECL_DEFAULT_VARS                                                                                           \
+  DECL_VAR(u, 3)                                                                                              \
+  DECL_SORT(s)                                                                                                \
+  DECL_FUNC(f, {s, s}, s)                                                                                     \
+  DECL_FUNC(g, {s}, s)                                                                                        \
+  DECL_CONST(a, s)                                                                                            \
+  DECL_PRED (p, {s})                                                                                          \
+  DECL_PRED (q, {s})
+
+// not applicable to positive literals or non-equalities
+TEST_SIMPLIFY(fail01,
+  Simplification::NotApplicable()
+    .input(clause({ p(g(x)), y.sort(s) == z, ~q(u) }))
+  )
+
+// not applicable if not renaming on the rest of literals
+TEST_SIMPLIFY(fail02,
+  Simplification::NotApplicable()
+    .input(clause({ f(x,y) != f(a,g(z)), p(x), ~p(y) }))
+  )
+
+// not applicable if not renaming on the rest of literals
+TEST_SIMPLIFY(fail03,
+  Simplification::NotApplicable()
+    .input(clause({ x.sort(s) != y, p(x), ~p(y) }))
+  )
+
+// applicable to some negative equations
+TEST_SIMPLIFY(success01,
+  Simplification::Success()
+    .input(clause({ f(a,y) != f(x,g(z)) }))
+    .expected(clause({ }))
+)
+
+// applicable despite variable being bound
+TEST_SIMPLIFY(success02,
+  Simplification::Success()
+    .input(clause({ ~p(y), f(x,y) != f(x,x) }))
+    .expected(clause({ ~p(y) }))
+  )
+
+// applicable to some negative equations and other literals
+TEST_SIMPLIFY(success03,
+  Simplification::Success()
+    .input(clause({ p(z), f(f(z,u),y) != f(x,g(z)), q(f(u,z)) }))
+    .expected(clause({ p(z), q(f(u,z)) }))
+)
+
+}

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -76,8 +76,9 @@ set(UNIT_TESTS
     UnitTests/tInferences_InferenceEngine.cpp
     UnitTests/tInferences_InnerRewriting.cpp
     UnitTests/tInferences_PushUnaryMinus.cpp
-    UnitTests/tInferences_SubsumptionDemodulation.cpp
     UnitTests/tInferences_SubsumptionAndResolution.cpp
+    UnitTests/tInferences_SubsumptionDemodulation.cpp
+    UnitTests/tInferences_SubsumptionEqualityResolution.cpp
     UnitTests/tInferences_Superposition.cpp
     UnitTests/tInferences_TautologyDeletionISE.cpp
     UnitTests/tInferences_URResolution.cpp

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -335,6 +335,8 @@ set(SOURCES
     Inferences/PushUnaryMinus.hpp
     Inferences/SubsumptionDemodulationHelper.cpp
     Inferences/SubsumptionDemodulationHelper.hpp
+    Inferences/SubsumptionEqualityResolution.cpp
+    Inferences/SubsumptionEqualityResolution.hpp
     Inferences/Superposition.cpp
     Inferences/Superposition.hpp
     Inferences/TautologyDeletionISE.cpp

--- a/samplers/samplerFNT.smp
+++ b/samplers/samplerFNT.smp
@@ -166,6 +166,9 @@ sa!=fmb > fdi ~cat 0:100,2:1,4:1,8:1,16:1,32:1,64:1,128:1,256:1,512:1,1024:1
 # inner_rewriting
 sa!=fmb > irw ~cat off:165,on:6
 
+# subsumption_equality_resolution
+sa!=fmb > ser ~cat off:9,on:1
+
 # binary_resolution
 sa!=fmb urr=on > br ~cat on:10,off:1
 

--- a/samplers/samplerFOL.smp
+++ b/samplers/samplerFOL.smp
@@ -224,6 +224,9 @@ sa!=fmb > fdi ~cat 0:100,2:1,4:1,8:1,16:1,32:1,64:1,128:1,256:1,512:1,1024:1
 # inner_rewriting
 sa!=fmb > irw ~cat off:165,on:6
 
+# subsumption_equality_resolution
+sa!=fmb > ser ~cat off:9,on:1
+
 # SINE LEVELS and shit
 
 # sine_to_age

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -225,6 +225,9 @@ intent=unsat sa!=fmb > flr ~cat off:8,on:1
 # inner_rewriting
 sa!=fmb > irw ~cat off:165,on:6
 
+# subsumption_equality_resolution
+sa!=fmb > ser ~cat off:9,on:1
+
 # SINE LEVELS and shit
 
 # sine_to_age

--- a/samplers/samplerIND.smp
+++ b/samplers/samplerIND.smp
@@ -228,6 +228,9 @@ sa!=fmb > fgj ~cat on:1,off:1
 # inner_rewriting
 > irw ~cat off:165,on:6
 
+# subsumption_equality_resolution
+sa!=fmb > ser ~cat off:9,on:1
+
 # SINE LEVELS and shit
 
 # sine_to_age

--- a/samplers/samplerSMT.smp
+++ b/samplers/samplerSMT.smp
@@ -231,6 +231,9 @@ sa!=fmb > fgj ~cat on:1,off:1
 # inner_rewriting
 > irw ~cat off:165,on:6
 
+# subsumption_equality_resolution
+sa!=fmb > ser ~cat off:9,on:1
+
 # SINE LEVELS and shit
 
 # sine_to_age


### PR DESCRIPTION
Adds the new inference subsumption equality resolution that is similar in spirit to subsumption resolution and is based on equality resolution rather than resolution. The inference is behind a (default false) flag so it shouldn't cause much trouble now.

Some figures over FOL benchmarks when it's enabled:

Discount:
run 0 unsat: 9208 (5) sat: 1042 (0) cputime: 56575.07 s instructions: 222740733 Mi memory: 1461763.85 MB
run 1 unsat: 9215 (12) sat: 1042 (0) cputime: 57393.50 s instructions: 222608978 Mi memory: 1459148.81 MB

Otter:
run 0 unsat: 9322 (7) sat: 1025 (0) cputime: 61514.09 s instructions: 222752334 Mi memory: 1694391.73 MB
run 1 unsat: 9327 (12) sat: 1025 (0) cputime: 62363.23 s instructions: 222637658 Mi memory: 1691635.40 MB