### PR TITLE
bump action versions to silence GitHub warning

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Tree
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Check Copyright Headers
@@ -22,7 +22,7 @@ jobs:
         echo "z3_hash=$(git rev-parse HEAD:z3)" >> $GITHUB_OUTPUT
     - name: Restore Z3 build cache
       id: cache-z3
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: z3/build
         key: z3-build-${{ steps.z3hash.outputs.z3_hash }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
         sudo apt-get install -y gcovr
 
     - name: Checkout Tree
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
 
@@ -38,7 +38,7 @@ jobs:
         make -j4 vtest vcoverage
 
     - name: Upload coverage files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: vcoverage-${{ github.sha }}
         path: |

--- a/.github/workflows/multiplatform-build.yml
+++ b/.github/workflows/multiplatform-build.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Tree
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Install Cygwin
@@ -53,7 +53,7 @@ jobs:
       run: mv ${{ steps.cygwin.outputs.root }}/bin/cygwin1.dll build/cygwin1.dll
       if: runner.os == 'Windows'
     - name: Upload Vampire
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: vampire-${{ runner.os }}-${{ runner.arch }}
         path: |

--- a/.github/workflows/source.yml
+++ b/.github/workflows/source.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Tree
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: true
     - name: Strip Git Information
@@ -16,7 +16,7 @@ jobs:
       working-directory: ${{ runner.workspace }}
       run: tar czf vampire-z3.tar.gz vampire
     - name: Upload Tarball
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: vampire-z3.tar.gz
         path: ${{ runner.workspace }}/vampire-z3.tar.gz
@@ -29,7 +29,7 @@ jobs:
       working-directory: ${{ runner.workspace }}
       run: tar czf vampire.tar.gz vampire
     - name: Upload Vampire (no Z3)
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: vampire.tar.gz
         path: ${{ runner.workspace }}/vampire.tar.gz


### PR DESCRIPTION
[blah blah NodeJS](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

Hopefully the latest version of each action is OK.