### PR TITLE
HOL improvements (continued)

### DIFF
--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -57,8 +57,8 @@ Clause* Choice::createChoiceAxiom(TermList op, TermList set)
   t2 =          HC::app(setSort, set, t2);
 
   return Clause::fromLiterals(
-      { Literal::createEquality(true, t1, TermList(Term::foolFalse()), AtomicSort::boolSort()),
-        Literal::createEquality(true, t2, TermList(Term::foolTrue()), AtomicSort::boolSort())},
+      { Literal::createEquality(true, t1, HOL::create::bottom(), AtomicSort::boolSort()),
+        Literal::createEquality(true, t2, HOL::create::top(), AtomicSort::boolSort())},
        NonspecificInference0(UnitInputType::AXIOM, InferenceRule::HILBERTS_CHOICE_INSTANCE)
   );
 }

--- a/Inferences/HOL/CNFOnTheFly.cpp
+++ b/Inferences/HOL/CNFOnTheFly.cpp
@@ -199,7 +199,6 @@ ClauseIterator produceClauses(Clause* c, bool generating, SkolemisingFormulaInde
               auto tS = subst.apply(t, 0);
               auto argS = subst.apply(args[0],1); 
 
-              // can't use replaceLits, as we need to apply the type unifier
               RStack<Literal*> resLits;
               for (const auto& curr : *c) {
                 resLits->push(curr == lit

--- a/Inferences/HOL/CNFOnTheFly.cpp
+++ b/Inferences/HOL/CNFOnTheFly.cpp
@@ -64,10 +64,6 @@ ClauseIterator produceClauses(Clause* c, bool generating, SkolemisingFormulaInde
   if(generating && (eager || simp)){ return ClauseIterator::getEmpty(); }
   if(!generating && gen){ return ClauseIterator::getEmpty(); }
 
-  if (instantiations) {
-    INVALID_OPERATION("Options::CNFOnTheFly::CONJ_EAGER not yet supported");
-  }
-
   static TermStack args;
 
   for (const auto& lit : *c) {
@@ -180,13 +176,39 @@ ClauseIterator produceClauses(Clause* c, bool generating, SkolemisingFormulaInde
       case Proxy::PI:
       case Proxy::SIGMA: {
         ASS_EQ(args.size(), 1);
+        ClauseStack instCls;
         TermList srt = *SortHelper::getResultSort(head.term()).term()->nthArgument(0);
         TermList newTerm;
         Proxy proxy;
-        if((prox == Proxy::PI && positive) ||
-          (prox == Proxy::SIGMA && !positive)){
+        if ((prox == Proxy::PI && positive) || (prox == Proxy::SIGMA && !positive)) {
           proxy = Proxy::PI;
           newTerm = piRemoval(args[0], c, srt);
+          if (instantiations && !args[0].isVar()) {
+            auto insts = env.signature->getInstantiations();
+            for (const auto& t : iterTraits(insts->iter())) {
+              ASS(t.isTerm());
+              static RobSubstitution subst;
+              subst.reset();
+
+              auto tSort = SortHelper::getResultSort(t.term());
+              auto aSort = srt.domain();
+
+              if (!subst.unify(tSort,0,aSort,1)) {
+                continue;
+              }
+              auto tS = subst.apply(t, 0);
+              auto argS = subst.apply(args[0],1); 
+
+              // can't use replaceLits, as we need to apply the type unifier
+              RStack<Literal*> resLits;
+              for (const auto& curr : *c) {
+                resLits->push(curr == lit
+                  ? boolEq(HOL::create::app(argS, tS), rhs)
+                  : subst.apply(curr, 1));
+              }
+              instCls.push(Clause::fromStack(*resLits, GeneratingInference1(InferenceRule::HEURISTIC_INSTANTIATION, c)));
+            }
+          }
         } else {
           ASS(term.isTerm());
           bool newTermCreated = false;
@@ -209,8 +231,8 @@ ClauseIterator produceClauses(Clause* c, bool generating, SkolemisingFormulaInde
           }
           proxy = Proxy::SIGMA;
         }
-        return pvi(iterItems(replaceLits(c, lit, proxy, false,
-          positive ? eqTroo(newTerm) : eqFols(newTerm))));
+        return pvi(concatIters(iterItems(replaceLits(c, lit, proxy, false,
+          positive ? eqTroo(newTerm) : eqFols(newTerm))), getPersistentIterator(ClauseStack::Iterator(instCls))));
       }
     }
   }

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -289,8 +289,7 @@ Clause* TautologyDeletionISE2::simplify(Clause* c)
 
   for(unsigned i = 0; i < c->length(); i++){
     Literal* lit = (*c)[i];
-    TermList lhs = *lit->nthArgument(0);
-    TermList rhs = *lit->nthArgument(1);
+    auto [lhs, rhs] = lit->eqArgs();
     if(!lit->polarity() && HOL::isBool(lhs) && HOL::isBool(rhs) &&
       (HOL::isTrue(lhs) != HOL::isTrue(rhs))){
       //false != true

--- a/Kernel/HOL/Convert.cpp
+++ b/Kernel/HOL/Convert.cpp
@@ -161,9 +161,9 @@ static TermList formulaToNameless(Formula *formula, const VarToIndexMap& map) {
     case Connective::BOOL_TERM:
       return termToNameless(formula->getBooleanTerm(), map);
     case Connective::TRUE:
-      return TermList(Term::foolTrue());
+      return HOL::create::top();
     case Connective::FALSE:
-      return TermList(Term::foolFalse());
+      return HOL::create::bottom();
     default:
       ASSERTION_VIOLATION;
   }
@@ -171,4 +171,8 @@ static TermList formulaToNameless(Formula *formula, const VarToIndexMap& map) {
 
 TermList HOL::convert::toNameless(TermList term) {
   return termToNameless(term, {});
+}
+
+TermList HOL::convert::toNameless(Formula* formula) {
+  return formulaToNameless(formula, {});
 }

--- a/Kernel/HOL/Convert.cpp
+++ b/Kernel/HOL/Convert.cpp
@@ -173,6 +173,18 @@ TermList HOL::convert::toNameless(TermList term) {
   return termToNameless(term, {});
 }
 
-TermList HOL::convert::toNameless(Formula* formula) {
+TermList HOL::convert::toNameless(Formula* formula)
+{
+  // remove leading universal type quantifiers
+  if (formula->connective() == FORALL) {
+    auto vars = formula->vars();
+    while (vars && vars->head().second == AtomicSort::superSort()) {
+      vars = vars->tail();
+    }
+    if (vars != formula->vars()) {
+      auto f = formula->qarg();
+      formula = vars ? new QuantifiedFormula(FORALL, vars, f) : f;
+    }
+  }
   return formulaToNameless(formula, {});
 }

--- a/Kernel/HOL/HOL.cpp
+++ b/Kernel/HOL/HOL.cpp
@@ -11,8 +11,9 @@
  * @file HOL.cpp
  */
 
-#include "Kernel/HOL/HOL.hpp"
+#include "HOL.hpp"
 
+#include "SubtermReplacer.hpp"
 #include "ToPlaceholders.hpp"
 #include "Kernel/Formula.hpp"
 
@@ -481,4 +482,44 @@ TermList HOL::createGeneralBinding(TermList head, const TermStack& sorts, unsign
 
   auto res = create::app(head, args);
   return surround ? create::surroundWithLambdas(res, sorts) : res;
+}
+
+TermStack HOL::getAbstractionTerms(Literal* lit)
+{
+  auto [lhs, rhs] = lit->eqArgs();
+  TermList eqSort = SortHelper::getEqualityArgumentSort(lit);
+
+  TermStack res;
+  auto dealWithArg = [&](TermList arg, TermList argSort){
+    if (arg.containsLooseDBIndex()) {
+      return;
+    }
+    using namespace create;
+    SubtermReplacer st(arg, getDeBruijnIndex(0,argSort), true);
+    TermList lhsReplaced = st.replace(lhs);
+    TermList rhsReplaced = st.replace(rhs);
+
+    TermList eq = app2(equality(eqSort), lhsReplaced, rhsReplaced);
+    eq = lit->polarity() ? app(neg(),eq) : eq; // reverse the polarity of the literal
+    res.push(namelessLambda(argSort,eq));
+  };
+
+  TermList lhsHead, rhsHead;
+  TermList lhsMatrix, rhsMatrix;
+  static TermStack lhsArgs;
+  static TermStack lhsArgSorts;
+  static TermStack rhsArgs;
+  static TermStack rhsArgSorts;
+
+  getHeadArgsAndArgSorts(lhs, lhsHead, lhsArgs, lhsArgSorts);
+  getHeadArgsAndArgSorts(rhs, rhsHead, rhsArgs, rhsArgSorts);
+  if (lhsHead.isTerm() && lhsHead.deBruijnIndex().isNone() && lhsHead == rhsHead) {
+    for(unsigned i = 0; i < lhsArgs.size(); i++){
+      dealWithArg(lhsArgs[i], lhsArgSorts[i]);
+    }
+    for(unsigned i = 0; i < rhsArgs.size(); i++){
+      dealWithArg(rhsArgs[i], rhsArgSorts[i]);
+    }
+  }
+  return res;
 }

--- a/Kernel/HOL/HOL.hpp
+++ b/Kernel/HOL/HOL.hpp
@@ -79,6 +79,12 @@ Stack<std::pair<TermList, UnificationInference>> getProjAndImitBindings(TermList
 
 TermList createGeneralBinding(TermList head, const TermStack& sorts, unsigned& freshVar, bool surround = true);
 
+// Creates abstractions of lit as described below to be used for heuristically
+// instantiating Π terms (proxified universal quantification, see CNFOnTheFly).
+//
+// If lit is of the form s ⋈ t, where ⋈ ∈ {=,≠}, s is λ x1,...,xn. f s1,...,sk,
+// and t is λ y1,...,ym. f t1,...,tl, then w.l.o.g. we create an abstracted
+// disequality λ x. s' ≠ t for each 1 ≤ i ≤ k where s' is s with si replaced with x.
 TermStack getAbstractionTerms(Literal* lit);
 
 } // namespace HOL

--- a/Kernel/HOL/HOL.hpp
+++ b/Kernel/HOL/HOL.hpp
@@ -79,6 +79,8 @@ Stack<std::pair<TermList, UnificationInference>> getProjAndImitBindings(TermList
 
 TermList createGeneralBinding(TermList head, const TermStack& sorts, unsigned& freshVar, bool surround = true);
 
+TermStack getAbstractionTerms(Literal* lit);
+
 } // namespace HOL
 
 namespace HOL::create {
@@ -130,6 +132,7 @@ namespace HOL::create {
 namespace HOL::convert {
 
 TermList toNameless(TermList term);
+TermList toNameless(Formula* formula);
 
 inline TermList toNameless(Term* term) {
   return toNameless(TermList(term));

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -927,6 +927,8 @@ std::string Kernel::ruleName(InferenceRule rule)
     return "beta-eta normalization";
   case InferenceRule::EQ_TO_DISEQ:
     return "bool equality to disequality";
+  case InferenceRule::HEURISTIC_INSTANTIATION:
+    return "heuristic instantiation";
   case InferenceRule::PRIMITIVE_INSTANTIATION:
     return "primitive instantiation";
   case InferenceRule::IMITATION:

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -347,6 +347,7 @@ enum class InferenceRule : unsigned char {
   NEGATIVE_EXTENSIONALITY,
   POSITIVE_EXTENSIONALITY,
   EQ_TO_DISEQ,
+  HEURISTIC_INSTANTIATION,
   /** The next five rules can be either simplifying or generating */
   NOT_PROXY_CLAUSIFICATION,
   AND_PROXY_CLAUSIFICATION,

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -661,6 +661,14 @@ class Signature
     return &_choiceSymbols;
   }
 
+  void addInstantiation(TermList inst) {
+    _instantiations.insert(inst);
+  }
+
+  DHSet<TermList>* getInstantiations() {
+    return &_instantiations;
+  }
+
   /** return the number of functions */
   unsigned functions() const { return _funs.length(); }
   /** return the number of predicates */
@@ -993,7 +1001,9 @@ private:
   /** Stack of type constructor symbols */  
   Stack<Symbol*> _typeCons;
 
+  // TODO(HOL): these two don't belong in the signature
   DHSet<unsigned> _choiceSymbols;
+  DHSet<TermList> _instantiations;
 
   SymbolMap _funNames;
   SymbolMap _predNames;

--- a/Saturation/PredicateSplitPassiveClauseContainers.cpp
+++ b/Saturation/PredicateSplitPassiveClauseContainers.cpp
@@ -497,9 +497,6 @@ unsigned numOfAppVarsAndLambdas(TermList t, unsigned lambdaWeight, unsigned appl
 
   // it's OK that the entry in cache has already been created, will only possibly ask for proper subterms
 
-  // TODO(mhajdu): I think this is not okay because the DHMap may reallocate during the recursive call,
-  //               so either remove the cache or put the value into the shared terms. Also remove recursion.
-
   unsigned res = 0;
 
   if (tt->isLambdaTerm()) {
@@ -516,6 +513,8 @@ unsigned numOfAppVarsAndLambdas(TermList t, unsigned lambdaWeight, unsigned appl
     }
   }
 
+  // reallocation may occur in-between, so ask for the pointer again
+  ALWAYS(cached = cache.findPtr(tt));
   *cached = res;
   return res;
 }

--- a/Saturation/PredicateSplitPassiveClauseContainers.cpp
+++ b/Saturation/PredicateSplitPassiveClauseContainers.cpp
@@ -17,6 +17,7 @@
 
 #include "Shell/Options.hpp"
 #include "Kernel/Clause.hpp"
+#include "Kernel/HOL/HOL.hpp"
 #include "Kernel/Inference.hpp"
 #include "Lib/SharedSet.hpp"
 #include "Lib/Int.hpp"
@@ -479,6 +480,66 @@ float TheoryMultiSplitPassiveClauseContainer::evaluateFeatureEstimate(unsigned, 
   // No Clause* available during construction; return most-favorable value
   // so LRS never discards based on theory-split features alone.
   return -std::numeric_limits<float>::max();
+}
+
+unsigned numOfAppVarsAndLambdas(TermList t, unsigned lambdaWeight, unsigned appliedVarWeight)
+{
+  if (t.isVar()) {
+    return 0;
+  }
+  const Term* tt = t.term();
+
+  static DHMap<const Term*,unsigned> cache;
+  unsigned* cached;
+  if (!cache.getValuePtr(tt,cached)) {
+    return *cached;
+  }
+
+  // it's OK that the entry in cache has already been created, will only possibly ask for proper subterms
+
+  // TODO(mhajdu): I think this is not okay because the DHMap may reallocate during the recursive call,
+  //               so either remove the cache or put the value into the shared terms. Also remove recursion.
+
+  unsigned res = 0;
+
+  if (tt->isLambdaTerm()) {
+    res = lambdaWeight + numOfAppVarsAndLambdas(tt->lambdaBody(), lambdaWeight, appliedVarWeight);
+  } else if (tt->isApplication()) {
+    TermStack args;
+    auto head = HOL::getHeadAndArgs(t, args);
+    ASS(!head.isLambdaTerm()); // should be beta-reduced
+    if (head.isVar()) {
+      res += appliedVarWeight;
+    }
+    while(!args.isEmpty()){
+      res += numOfAppVarsAndLambdas(args.pop(), lambdaWeight, appliedVarWeight);
+    }
+  }
+
+  *cached = res;
+  return res;
+}
+
+HoFeaturesMultiSplitPassiveClauseContainer::HoFeaturesMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, std::string name, std::vector<std::unique_ptr<PassiveClauseContainer>> queues) :
+PredicateSplitPassiveClauseContainer(isOutermost, opt, name, std::move(queues), opt.hoSplitQueueCutoffs(), opt.hoSplitQueueRatios(), opt.hoSplitQueueLayeredArrangement()),
+_lambdaWeight(opt.hoSplitQueueLambdaWeight()), _appliedVarWeight(opt.hoSplitQueueAppVarWeight()) {}
+
+float HoFeaturesMultiSplitPassiveClauseContainer::evaluateFeature(Clause* cl) const
+{
+  // calculate the number of higher-order features (applied variable and lambdas) in the clause
+  unsigned res = 0;
+  for (const auto& lit : *cl){
+    auto [lhs, rhs] = lit->eqArgs();
+    res = res + numOfAppVarsAndLambdas(lhs, _lambdaWeight, _appliedVarWeight)
+              + numOfAppVarsAndLambdas(rhs, _lambdaWeight, _appliedVarWeight);
+  }
+  return res;
+}
+
+float HoFeaturesMultiSplitPassiveClauseContainer::evaluateFeatureEstimate(unsigned, const Inference& inf) const
+{
+  // from the information provided we cannot estimate the feature sadly...
+  return 0;
 }
 
 AvatarMultiSplitPassiveClauseContainer::AvatarMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, std::string name, std::vector<std::unique_ptr<PassiveClauseContainer>> queues) :

--- a/Saturation/PredicateSplitPassiveClauseContainers.hpp
+++ b/Saturation/PredicateSplitPassiveClauseContainers.hpp
@@ -106,6 +106,19 @@ private:
   mutable DHMap<unsigned, std::pair<float,float>> _teoryFeatureCache;
 };
 
+class HoFeaturesMultiSplitPassiveClauseContainer : public PredicateSplitPassiveClauseContainer
+{
+public:
+  HoFeaturesMultiSplitPassiveClauseContainer(bool isOutermost, const Shell::Options &opt, std::string name, std::vector<std::unique_ptr<PassiveClauseContainer>> queues);
+
+private:
+  float evaluateFeature(Clause* cl) const override;
+  float evaluateFeatureEstimate(unsigned numPositiveLiterals, const Inference& inf) const override;
+
+  const unsigned _lambdaWeight;
+  const unsigned _appliedVarWeight;
+};
+
 class AvatarMultiSplitPassiveClauseContainer : public PredicateSplitPassiveClauseContainer
 {
 public:

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -75,6 +75,7 @@
 #include "Inferences/ForwardSubsumptionDemodulation.hpp"
 #include "Inferences/GlobalSubsumption.hpp"
 
+#include "Inferences/HOL/ArgCong.hpp"
 #include "Inferences/HOL/BetaEtaSimplify.hpp"
 #include "Inferences/HOL/BoolEqToDiseq.hpp"
 #include "Inferences/HOL/BoolSimp.hpp"
@@ -1450,6 +1451,7 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if (prb.isHigherOrder()){
+    gie->addFront(new ArgCong(*res));
     gie->addFront(new NegativeExtensionality(*res));
     if (opt.positiveExtensionality()) {
       gie->addFront(new PositiveExtensionality(*res));
@@ -1458,13 +1460,12 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
       gie->addFront(new BoolEqToDiseq(*res));
     }
     if(true/* !opt.higherOrderUnifDepth() && !opt.applicativeUnify() */){
-      // only add when we are not carrying out higher-order unification
+      // TODO(HOL): only add when we are not carrying out higher-order unification
       gie->addFront(new ImitateProject(*res));
     }
-  }
-
-  if (opt.choiceReasoning()) {
-    gie->addFront(new Choice());
+    if (opt.choiceReasoning()) {
+      gie->addFront(new Choice());
+    }
   }
 
   gie->addFront(new Factoring(*res));
@@ -1747,7 +1748,7 @@ std::pair<CompositeISE*, CompositeISEMany> SaturationAlgorithm::createISE(Proble
       break;
   }
 
-  if (opt.choiceReasoning()) {
+  if (prb.isHigherOrder() && opt.choiceReasoning()) {
     res->addFront(new ChoiceDefinitionISE());
   }
 
@@ -1819,7 +1820,7 @@ std::pair<CompositeISE*, CompositeISEMany> SaturationAlgorithm::createISE(Proble
     res->addFront(new TrivialInequalitiesRemovalISE());
   }
   res->addFront(new TautologyDeletionISE());
-  if (opt.newTautologyDel()) {
+  if (prb.isHigherOrder() && opt.newTautologyDel()) {
     res->addFront(new TautologyDeletionISE2());
   }
   res->addFront(new DuplicateLiteralRemovalISE());

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -150,8 +150,17 @@ std::unique_ptr<PassiveClauseContainer> makeLevel0(bool isOutermost, const Optio
   return std::make_unique<AWPassiveClauseContainer>(isOutermost, opt, name + "AWQ");
 }
 
-std::unique_ptr<PassiveClauseContainer> makeLevel1(bool isOutermost, const Options& opt, std::string name)
+std::unique_ptr<PassiveClauseContainer> makeLevel1(bool isOutermost, bool forHO, const Options& opt, std::string name)
 {
+  if (opt.hoSplitQueues() && forHO) {
+    vector<std::unique_ptr<PassiveClauseContainer>> queues;
+    auto cutoffs = opt.hoSplitQueueCutoffs();
+    for (const auto& co : cutoffs) {
+      auto queueName = name + "HoSQ" + Int::toString(co) + ":";
+      queues.push_back(makeLevel0(false, opt, queueName));
+    }
+    return std::make_unique<HoFeaturesMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "HoFSQ", std::move(queues));
+  }
   if (opt.useTheorySplitQueues()) {
     std::vector<std::unique_ptr<PassiveClauseContainer>> queues;
     auto cutoffs = opt.theorySplitQueueCutoffs();
@@ -166,51 +175,51 @@ std::unique_ptr<PassiveClauseContainer> makeLevel1(bool isOutermost, const Optio
   }
 }
 
-std::unique_ptr<PassiveClauseContainer> makeLevel2(bool isOutermost, const Options& opt, std::string name)
+std::unique_ptr<PassiveClauseContainer> makeLevel2(bool isOutermost, bool forHO, const Options& opt, std::string name)
 {
   if (opt.useAvatarSplitQueues()) {
     std::vector<std::unique_ptr<PassiveClauseContainer>> queues;
     auto cutoffs = opt.avatarSplitQueueCutoffs();
     for (unsigned i = 0; i < cutoffs.size(); i++) {
       auto queueName = name + "AvSQ" + Int::toString(cutoffs[i]) + ":";
-      queues.push_back(makeLevel1(false, opt, queueName));
+      queues.push_back(makeLevel1(false, forHO, opt, queueName));
     }
     return std::make_unique<AvatarMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "AvSQ", std::move(queues));
   }
   else {
-    return makeLevel1(isOutermost, opt, name);
+    return makeLevel1(isOutermost, forHO, opt, name);
   }
 }
 
-std::unique_ptr<PassiveClauseContainer> makeLevel3(bool isOutermost, const Options& opt, std::string name)
+std::unique_ptr<PassiveClauseContainer> makeLevel3(bool isOutermost, bool forHO, const Options& opt, std::string name)
 {
   if (opt.useSineLevelSplitQueues()) {
     std::vector<std::unique_ptr<PassiveClauseContainer>> queues;
     auto cutoffs = opt.sineLevelSplitQueueCutoffs();
     for (unsigned i = 0; i < cutoffs.size(); i++) {
       auto queueName = name + "SLSQ" + Int::toString(cutoffs[i]) + ":";
-      queues.push_back(makeLevel2(false, opt, queueName));
+      queues.push_back(makeLevel2(false, forHO, opt, queueName));
     }
     return std::make_unique<SineLevelMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "SLSQ", std::move(queues));
   }
   else {
-    return makeLevel2(isOutermost, opt, name);
+    return makeLevel2(isOutermost, forHO, opt, name);
   }
 }
 
-std::unique_ptr<PassiveClauseContainer> makeLevel4(bool isOutermost, const Options& opt, std::string name)
+std::unique_ptr<PassiveClauseContainer> makeLevel4(bool isOutermost, bool forHO, const Options& opt, std::string name)
 {
   if (opt.usePositiveLiteralSplitQueues()) {
     std::vector<std::unique_ptr<PassiveClauseContainer>> queues;
     std::vector<float> cutoffs = opt.positiveLiteralSplitQueueCutoffs();
     for (unsigned i = 0; i < cutoffs.size(); i++) {
       auto queueName = name + "PLSQ" + Int::toString(cutoffs[i]) + ":";
-      queues.push_back(makeLevel3(false, opt, queueName));
+      queues.push_back(makeLevel3(false, forHO, opt, queueName));
     }
     return std::make_unique<PositiveLiteralMultiSplitPassiveClauseContainer>(isOutermost, opt, name + "PLSQ", std::move(queues));
   }
   else {
-    return makeLevel3(isOutermost, opt, name);
+    return makeLevel3(isOutermost, forHO, opt, name);
   }
 }
 
@@ -247,7 +256,7 @@ SaturationAlgorithm::SaturationAlgorithm(Problem& prb, const Options& opt)
     _passive = std::make_unique<ManCSPassiveClauseContainer>(true, opt);
   }
   else {
-    _passive = makeLevel4(true, opt, "");
+    _passive = makeLevel4(true, prb.isHigherOrder(), opt, "");
   }
   _active = new ActiveClauseContainer();
 

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -213,16 +213,6 @@ Formula* FOOLElimination::convertToProxified(Formula* formula) {
 }
 
 Formula* FOOLElimination::process(Formula* formula) {
-  if (env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
-      !_polymorphic) {
-    Formula* processedFormula = toEquality(TermList(Term::createFormula(formula)));
-
-    if (env.options->showPreprocessing()) {
-      reportProcessed(formula->toString(), processedFormula->toString());
-    }
-
-    return processedFormula;
-  }
   switch (formula->connective()) {
     case LITERAL: {
       Literal* literal = formula->literal();

--- a/Shell/FOOLElimination.cpp
+++ b/Shell/FOOLElimination.cpp
@@ -49,7 +49,23 @@ const char* FOOLElimination::MATCH_PREFIX  = "mG";
 
 FOOLElimination::FOOLElimination() : _defs(0), _currentDefs(0), _higherOrder(0), _polymorphic(0) {}
 
-bool FOOLElimination::needsElimination(FormulaUnit* unit) {
+bool FOOLElimination::needsElimination(FormulaUnit* unit)
+{
+  if (env.higherOrder()) {
+    switch(env.options->cnfOnTheFly()){
+      case Options::CNFOnTheFly::EAGER:
+        break;
+      case Options::CNFOnTheFly::CONJ_EAGER:
+        if (unit->inputType() != UnitInputType::NEGATED_CONJECTURE &&
+            unit->inputType() != UnitInputType::CONJECTURE) {
+          return true;
+        }
+        break;
+      default:
+        return true;
+    }
+  }
+
   /**
    * Be careful with the difference between FOOLElimination::needsElimination
    * and Property::_hasFOOL!
@@ -142,7 +158,19 @@ FormulaUnit* FOOLElimination::apply(FormulaUnit* unit) {
 
   SortHelper::collectVariableSorts(formula, _varSorts);
 
-  Formula* processedFormula = process(formula);
+  bool isConjecture =
+    unit->inputType() == UnitInputType::NEGATED_CONJECTURE ||
+    unit->inputType() == UnitInputType::CONJECTURE;
+
+  // The old implementation (combinator implementation) had a check !_polymorphic
+  // I've removed it here, but if we start seeing issues on polymorphic problems, that
+  // is one place to check immediately
+  bool proxify = env.higherOrder() &&
+    env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER &&
+    env.options->cnfOnTheFly() != Options::CNFOnTheFly::OFF   &&
+   (env.options->cnfOnTheFly() != Options::CNFOnTheFly::CONJ_EAGER || !isConjecture);
+
+  Formula* processedFormula = proxify ? convertToProxified(formula) : process(formula);
   if (formula == processedFormula) {
     return rectifiedUnit;
   }
@@ -159,6 +187,29 @@ FormulaUnit* FOOLElimination::apply(FormulaUnit* unit) {
   }
 
   return processedUnit;
+}
+
+Formula* FOOLElimination::convertToProxified(Formula* formula) {
+  Formula* processedFormula;
+  if (formula->connective() == LITERAL) {
+    // don't proxify the equality itself, as this blocks
+    // definition rewriting which really harms performance
+    auto literal = formula->literal();
+    auto [lhs, rhs] = literal->eqArgs();
+    lhs = HOL::convert::toNameless(lhs);
+    rhs = HOL::convert::toNameless(rhs);
+    processedFormula = new AtomicFormula(
+      Literal::createEquality(literal->polarity(), lhs, rhs, SortHelper::getEqualityArgumentSort(literal)));
+  } else {
+    TermList proxifiedFormula = HOL::convert::toNameless(formula);
+    processedFormula = toEquality(proxifiedFormula);
+  }
+
+  if (env.options->showPreprocessing()) {
+    reportProcessed(formula->toString(), processedFormula->toString());
+  }
+
+  return processedFormula;
 }
 
 Formula* FOOLElimination::process(Formula* formula) {
@@ -750,12 +801,12 @@ void FOOLElimination::process(Term* term, Context context, TermList& termResult,
         Connective connective = sd->getFormula()->connective();
 
         if (connective == TRUE) {
-          termResult = TermList(Term::foolTrue());
+          termResult = HOL::create::top();
           break;
         }
 
         if (connective == FALSE) {
-          termResult = TermList(Term::foolFalse());
+          termResult = HOL::create::bottom();
           break;
         }
 

--- a/Shell/FOOLElimination.hpp
+++ b/Shell/FOOLElimination.hpp
@@ -61,6 +61,7 @@ private:
   /** Process a given part of the unit */
   FormulaList* process(FormulaList* fs);
   Formula* process(Formula* f);
+  Formula* convertToProxified(Formula* f);
 
   // A context in one of two possible values, so we model it with bool constants
   typedef bool Context;

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -223,7 +223,7 @@ Literal* InequalitySplitting::makeNameLiteral(unsigned predNum, TermList arg, bo
     vars.push(arg);
     return Literal::create(predNum, vars.size(), polarity, vars.begin());
   } else {
-    TermList boolT = polarity ? TermList(Term::foolTrue()) : TermList(Term::foolFalse());
+    TermList boolT = polarity ? HOL::create::top() : HOL::create::bottom();
     TermList head = TermList(Term::create(predNum, vars.size(), vars.begin()));
     TermList t = HOL::create::app(head, arg);
     return Literal::createEquality(true, t, boolT, AtomicSort::boolSort());

--- a/Shell/InequalitySplitting.cpp
+++ b/Shell/InequalitySplitting.cpp
@@ -47,7 +47,7 @@ InequalitySplitting::InequalitySplitting(const Options& opt)
 
 void InequalitySplitting::perform(Problem& prb)
 {
-  _appify = prb.hasApp();
+  _appify = prb.isHigherOrder();
   if(perform(prb.units())) {
     prb.invalidateByRemoval();
   }

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1137,7 +1137,7 @@ Literal* Naming::getDefinitionLiteral(Formula* f, VList* freeVars) {
     sym->setType(OperatorType::getConstantsType(sort, typeArgArity)); 
     TermList head = TermList(Term::create(fun, typeVars.size(), typeVars.begin()));
     TermList t = HOL::create::app(head, termVars);
-    return  Literal::createEquality(true, TermList(t), TermList(Term::foolTrue()), AtomicSort::boolSort());  
+    return  Literal::createEquality(true, TermList(t), HOL::create::top(), AtomicSort::boolSort());  
   }
 }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1086,6 +1086,45 @@ void Options::init()
     _positiveLiteralSplitQueueLayeredArrangement.onlyUsefulWith(_usePositiveLiteralSplitQueues.is(equal(true)));
     _positiveLiteralSplitQueueLayeredArrangement.tag(OptionTag::SATURATION);
 
+    _hoSplitQueues = BoolOptionValue("ho_split_queue","hsq",false);
+    _hoSplitQueues.description = "Turn on clause selection using multiple queues containing different clauses (split by amount of higher-order featues)";
+    _hoSplitQueues.onlyUsefulWith(ProperSaturationAlgorithm()); // could be "IncludingInstgen"? (not with theories...)
+    _hoSplitQueues.addProblemConstraint(hasHigherOrder());
+    _lookup.insert(&_hoSplitQueues);
+    _hoSplitQueues.tag(OptionTag::SATURATION);
+
+    _hoSplitQueueLambdaWeight = UnsignedOptionValue("ho_split_queue_lambda_weight","hsqlw",1);
+    _hoSplitQueueLambdaWeight.description = "How much should lambda occurrences count in the HO features";
+    _hoSplitQueueLambdaWeight.onlyUsefulWith(_hoSplitQueues.is(equal(true)));
+    _hoSplitQueueLambdaWeight.addProblemConstraint(hasHigherOrder());
+    _lookup.insert(&_hoSplitQueueLambdaWeight);
+    _hoSplitQueueLambdaWeight.tag(OptionTag::SATURATION);
+
+    _hoSplitQueueAppVarWeight = UnsignedOptionValue("ho_split_queue_appvar_weight","hsqaw",1);
+    _hoSplitQueueAppVarWeight.description = "How much should app-var occurrences count in the HO features";
+    _hoSplitQueueAppVarWeight.onlyUsefulWith(_hoSplitQueues.is(equal(true)));
+    _hoSplitQueueAppVarWeight.addProblemConstraint(hasHigherOrder());
+    _lookup.insert(&_hoSplitQueueAppVarWeight);
+    _hoSplitQueueAppVarWeight.tag(OptionTag::SATURATION);
+
+    _hoSplitQueueCutoffs = StringOptionValue("ho_split_queue_cutoffs", "hsqc", "0");
+    _hoSplitQueueCutoffs.description = "The cutoff-values for the split-queues (the cutoff value for the last queue has to be omitted, as it is always infinity). Any split-queue contains all clauses which are assigned a feature-value less or equal to the cutoff-value of the queue. If no custom value for this option is set, the implementation will use cutoffs 0,4*d,10*d,infinity (where d denotes the theory split queue expected ratio denominator).";
+    _lookup.insert(&_hoSplitQueueCutoffs);
+    _hoSplitQueueCutoffs.onlyUsefulWith(_hoSplitQueues.is(equal(true)));
+    _hoSplitQueueCutoffs.tag(OptionTag::SATURATION);
+
+    _hoSplitQueueRatios = StringOptionValue("ho_split_queue_ratios", "hsqr", "1,1");
+    _hoSplitQueueRatios.description = "The ratios for picking clauses from the split-queues using weighted round robin. If a queue is empty, the clause will be picked from the next non-empty queue to the right. Note that this option implicitly also sets the number of queues.";
+    _lookup.insert(&_hoSplitQueueRatios);
+    _hoSplitQueueRatios.onlyUsefulWith(_hoSplitQueues.is(equal(true)));
+    _hoSplitQueueRatios.tag(OptionTag::AVATAR);
+
+    _hoSplitQueueLayeredArrangement = BoolOptionValue("ho_split_queue_layered_arrangement","hsql",true);
+    _hoSplitQueueLayeredArrangement.description = "If turned on, use a layered arrangement to split clauses into queues. Otherwise use a tammet-style-arrangement.";
+    _lookup.insert(&_hoSplitQueueLayeredArrangement);
+    _hoSplitQueueLayeredArrangement.onlyUsefulWith(_hoSplitQueues.is(equal(true)));
+    _hoSplitQueueLayeredArrangement.tag(OptionTag::SATURATION);
+
     _literalMaximalityAftercheck = BoolOptionValue("literal_maximality_aftercheck","lma",true);
     _literalMaximalityAftercheck.description =
                                    "Allows to disable a secondary (literal maximality) ordering check (in the superposition calculus) after a substitution is applied."
@@ -3876,6 +3915,39 @@ std::vector<float> Options::positiveLiteralSplitQueueCutoffs() const
     }
   }
 
+  return cutoffs;
+}
+
+vector<int> Options::hoSplitQueueRatios() const
+{
+  auto inputRatios = parseCommaSeparatedList<int>(_hoSplitQueueRatios.actualValue);
+
+  // sanity checks
+  if (inputRatios.size() < 2) {
+    USER_ERROR("Wrong usage of option '-hfsqr'. Needs to have at least two values (e.g. '10,1')");
+  }
+  for (const auto& r : inputRatios) {
+    if (r <= 0) {
+      USER_ERROR("Each ratio (supplied by option '-hfsqr') needs to be a positive integer");
+    }
+  }
+
+  return inputRatios;
+}
+
+vector<float> Options::hoSplitQueueCutoffs() const
+{
+  // initialize cutoffs and add float-max as last value
+  auto cutoffs = parseCommaSeparatedList<float>(_hoSplitQueueCutoffs.actualValue);
+  cutoffs.push_back(std::numeric_limits<float>::max());
+
+  // sanity checks
+  for (unsigned i = 0; i < cutoffs.size(); i++) {
+    auto cutoff = cutoffs[i];
+    if (i > 0 && cutoff <= cutoffs[i-1]) {
+      USER_ERROR("The cutoff values (supplied by option '-hfsqc') must be strictly increasing");
+    }
+  }
   return cutoffs;
 }
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2034,6 +2034,15 @@ void Options::init()
     // potentially could be useful for FOOL, so am not adding the HOL constraint    
     _booleanEqTrick.tag(OptionTag::HIGHER_ORDER);
 
+    _heuristicInstantiation = BoolOptionValue("heur_inst","hi",false);
+    _heuristicInstantiation.onlyUsefulWith(ProperSaturationAlgorithm());
+    _heuristicInstantiation.addProblemConstraint(hasHigherOrder());   
+    _heuristicInstantiation.addHardConstraint(If(notEqual(false)).then(_clausificationOnTheFly.is(equal(CNFOnTheFly::CONJ_EAGER)))); 
+    _heuristicInstantiation.description =
+      "Heuristically instantiates universally quantified variables with abstractions of literals from negated conjecture";
+    _lookup.insert(&_heuristicInstantiation);
+    _heuristicInstantiation.tag(OptionTag::HIGHER_ORDER);
+
     _casesSimp = BoolOptionValue("cases_simp","cs",false);
     _casesSimp.description=
     "FOOL Paramodulation with two conclusion as a simplification";

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2159,6 +2159,12 @@ public:
   std::vector<int> positiveLiteralSplitQueueRatios() const;
   std::vector<float> positiveLiteralSplitQueueCutoffs() const;
   bool positiveLiteralSplitQueueLayeredArrangement() const { return _positiveLiteralSplitQueueLayeredArrangement.actualValue; }
+  bool hoSplitQueues() const { return _hoSplitQueues.actualValue; }
+  unsigned hoSplitQueueLambdaWeight() const { return _hoSplitQueueLambdaWeight.actualValue; }
+  unsigned hoSplitQueueAppVarWeight() const { return _hoSplitQueueAppVarWeight.actualValue; }
+  std::vector<int> hoSplitQueueRatios() const;
+  std::vector<float> hoSplitQueueCutoffs() const;
+  bool hoSplitQueueLayeredArrangement() const { return _hoSplitQueueLayeredArrangement.actualValue; }
   void setWeightRatio(int v){ _ageWeightRatio.otherValue = v; }
   bool literalMaximalityAftercheck() const { return _literalMaximalityAftercheck.actualValue; }
   bool superpositionFromVariables() const { return _superpositionFromVariables.actualValue; }
@@ -2418,6 +2424,12 @@ private:
   StringOptionValue _positiveLiteralSplitQueueRatios;
   StringOptionValue _positiveLiteralSplitQueueCutoffs;
   BoolOptionValue _positiveLiteralSplitQueueLayeredArrangement;
+  BoolOptionValue _hoSplitQueues;
+  UnsignedOptionValue _hoSplitQueueLambdaWeight;
+  UnsignedOptionValue _hoSplitQueueAppVarWeight;
+  StringOptionValue _hoSplitQueueRatios;
+  StringOptionValue _hoSplitQueueCutoffs;
+  BoolOptionValue _hoSplitQueueLayeredArrangement;
 	BoolOptionValue _randomAWR;
   BoolOptionValue _literalMaximalityAftercheck;
   BoolOptionValue _arityCheck;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2304,6 +2304,7 @@ public:
   bool equalityToEquivalence () const { return _equalityToEquivalence.actualValue; }
   bool complexBooleanReasoning () const { return _complexBooleanReasoning.actualValue; }
   bool booleanEqTrick() const { return _booleanEqTrick.actualValue; }
+  bool heuristicInstantiation() const { return _heuristicInstantiation.actualValue; }
   bool casesSimp() const { return _casesSimp.actualValue; }
   bool cases() const { return _cases.actualValue; }
   bool newTautologyDel() const { return _newTautologyDel.actualValue; }
@@ -2430,6 +2431,7 @@ private:
   BoolOptionValue _backwardSubsumptionDemodulation;
   UnsignedOptionValue _backwardSubsumptionDemodulationMaxMatches;
   BoolOptionValue _binaryResolution;
+  BoolOptionValue _superposition;
 
   BoolOptionValue _colorUnblocking;
   ChoiceOptionValue<Condensation> _condensation;
@@ -2734,7 +2736,7 @@ private:
   BoolOptionValue _equalityToEquivalence;
   BoolOptionValue _complexBooleanReasoning;
   BoolOptionValue _booleanEqTrick;
-  BoolOptionValue _superposition;
+  BoolOptionValue _heuristicInstantiation;
   BoolOptionValue _casesSimp;
   BoolOptionValue _cases;
   BoolOptionValue _newTautologyDel;

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -17,9 +17,10 @@
 
 #include "Lib/ScopedLet.hpp"
 
-#include "Kernel/Unit.hpp"
 #include "Kernel/Clause.hpp"
+#include "Kernel/HOL/HOL.hpp"
 #include "Kernel/Problem.hpp"
+#include "Kernel/Unit.hpp"
 
 #include "GoalGuessing.hpp"
 #include "AnswerLiteralManager.hpp"
@@ -417,6 +418,10 @@ void Preprocess::preprocess(Problem& prb)
      twee.apply(prb,(env.options->tweeGoalTransformation() == Options::TweeGoalTransformation::GROUND));
    }
 
+   if (prb.isHigherOrder() && _options.heuristicInstantiation()) {
+     findAbstractions(prb.units());
+   }
+
    if (!prb.isHigherOrder() && _options.equalityProxy()!=Options::EqualityProxy::OFF && prb.mayHaveEquality()) {
      env.statistics->phase=ExecutionPhase::EQUALITY_PROXY;
      if (env.options->showPreprocessing())
@@ -783,4 +788,22 @@ void Preprocess::clausify(Problem& prb)
     prb.invalidateProperty();
   }
   prb.reportFormulasEliminated();
+}
+
+void Preprocess::findAbstractions(UnitList*& units)
+{
+  for (const auto& u : iterTraits(UnitList::RefIterator(units))) {
+    if (!u->derivedFromGoal()) {
+      continue;
+    }
+
+    ASS(u->isClause());
+    auto c = u->asClause();
+
+    for (const auto& lit : *c) {
+      for (const auto& t : HOL::getAbstractionTerms(lit)) {
+        env.signature->addInstantiation(t);
+      }
+    }
+  }
 }

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -798,9 +798,7 @@ void Preprocess::findAbstractions(UnitList*& units)
     }
 
     ASS(u->isClause());
-    auto c = u->asClause();
-
-    for (const auto& lit : *c) {
+    for (const auto& lit : *u->asClause()) {
       for (const auto& t : HOL::getAbstractionTerms(lit)) {
         env.signature->addInstantiation(t);
       }

--- a/Shell/Preprocess.hpp
+++ b/Shell/Preprocess.hpp
@@ -52,6 +52,8 @@ private:
   void preprocess3(Problem& prb);
   void clausify(Problem& prb);
 
+  void findAbstractions(UnitList*& units);
+
   void newCnf(Problem& prb);
 
   /** Options used in the normalisation */

--- a/Shell/Skolem.cpp
+++ b/Shell/Skolem.cpp
@@ -419,6 +419,10 @@ Formula* Skolem::skolemise (Formula* f)
         TermList rangeSort=_varSorts.get(v, AtomicSort::defaultSort());
 
         bool skolemisingTypeVar = rangeSort == AtomicSort::superSort();
+        if (skolemisingTypeVar && termVars.size()) {
+          // TODO maybe do this while parsing TPTP?
+          USER_ERROR("TH1 does not allow an existential type quantifier beneath a universal term quantifier");
+        }
 
         if(rangeSort.isVar() || !rangeSort.term()->shared() || !rangeSort.term()->ground()) {
           //the range sort may include existential type variables that have been skolemised above

--- a/Shell/TweeGoalTransformation.cpp
+++ b/Shell/TweeGoalTransformation.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "Kernel/Clause.hpp"
+#include "Kernel/HOL/HOL.hpp"
 #include "Kernel/Problem.hpp"
 #include "Kernel/TermIterators.hpp"
 #include "Kernel/TermTransformer.hpp"
@@ -69,6 +70,8 @@ class Definizator : public BottomUpTermTransformer {
     bool _groundOnly;
 
     unsigned _typeArity;
+    TermStack _typeVars;
+    TermStack _termVars;
     TermStack _allVars; // including typeVars, which will come first, then termVars
     TermStack _termVarSorts;
 
@@ -78,6 +81,8 @@ class Definizator : public BottomUpTermTransformer {
       static DHSet<unsigned> varSeen;
       varSeen.reset();
       _typeArity = 0;
+      _typeVars.reset();
+      _termVars.reset();
       _allVars.reset();
       static TermStack termVars;
       termVars.reset();
@@ -86,17 +91,14 @@ class Definizator : public BottomUpTermTransformer {
       // fake scanVars cheaply
       if (t->ground()) return;
 
-      VariableWithSortIterator it(t);
-      while (it.hasNext()) {
-        auto varAndSort = it.next();
-        unsigned v = varAndSort.first.var();
-        TermList s = varAndSort.second;
-        if (varSeen.insert(v)) {
+      for (const auto& [v,s] : iterTraits(VariableWithSortIterator(t))) {
+        if (varSeen.insert(v.var())) {
           if(s == AtomicSort::superSort()) {
-            _allVars.push(TermList(v,false));
+            _allVars.push(v);
+            _typeVars.push(v);
           } else {
-            termVars.push(TermList(v,false));
-            _termVarSorts.push(varAndSort.second);
+            _termVars.push(v);
+            _termVarSorts.push(s);
           }
         }
       }
@@ -105,6 +107,7 @@ class Definizator : public BottomUpTermTransformer {
         _allVars.push(termVars[i]);
       }
 
+      SortHelper::normaliseArgSorts(_typeVars, _termVarSorts);
       ASS_EQ(_typeArity+_termVarSorts.size(), _allVars.size())
     }
 
@@ -137,21 +140,32 @@ class Definizator : public BottomUpTermTransformer {
         Clause* newDef;
         scanVars(t);
 
+        SortHelper::normaliseSort(_typeVars, outSort);
+
         // will the definition folding decrease term weight?
         // (whether we will also demodulate in this direction may depend on the ordering, but with a constant-weight KBO we will)
         if (t->weight() > _allVars.size()+1) {
           // this is always true in the ground case (where t->weight()>=2 and _allVars.size() == 0)
 
-          newSym = env.signature->addFreshFunction(_allVars.size(), "sF");
-          OperatorType* type = OperatorType::getFunctionType(_termVarSorts.size(),_termVarSorts.begin(),outSort,_typeArity);
-          env.signature->getFunction(newSym)->setType(type);
+          if (env.higherOrder()) {
+            newSym = env.signature->addFreshFunction(_typeVars.size(), "sF");
+            auto sort = AtomicSort::arrowSort(_termVarSorts, outSort);
+            env.signature->getFunction(newSym)->setType(OperatorType::getConstantsType(sort, _typeVars.size()));
 
-          // res is used both to replace here, but also in the new definition
-          res = TermList(Term::create(newSym,_allVars.size(),_allVars.begin()));
+            TermList head(Term::create(newSym, _typeVars.size(), _typeVars.begin()));
+            res = HOL::create::app(head, _termVars);
+          } else {
+            newSym = env.signature->addFreshFunction(_allVars.size(), "sF");
+            auto type = OperatorType::getFunctionType(_termVarSorts.size(),_termVarSorts.begin(),outSort,_typeArity);
+            env.signature->getFunction(newSym)->setType(type);
+
+            // res is used both to replace here, but also in the new definition
+            res = TermList(Term::create(newSym,_allVars.size(),_allVars.begin()));
+          }
 
           // (we don't care the definition is not rectified, as long as it's correct)
           // it is correct, because the lhs below is t and not key
-          Literal* equation = Literal::createEquality(true, TermList(t), res, outSort);
+          auto equation = Literal::createEquality(true, TermList(t), res, SortHelper::getResultSort(res.term()));
           Inference inference(NonspecificInference0(UnitInputType::AXIOM,InferenceRule::FUNCTION_DEFINITION));
           newDef = Clause::fromLiterals({ equation }, inference);
 
@@ -179,7 +193,12 @@ class Definizator : public BottomUpTermTransformer {
         }
 
         scanVars(t);
-        res = TermList(Term::create(symAndDef.first,_allVars.size(),_allVars.begin()));
+        if (env.higherOrder()) {
+          TermList head = TermList(Term::create(symAndDef.first, _typeVars.size(), _typeVars.begin()));
+          res = HOL::create::app(head, _termVars);
+        } else {
+          res = TermList(Term::create(symAndDef.first,_allVars.size(),_allVars.begin()));
+        }
       }
       // record as a new premise
       UnitList::push(symAndDef.second,premises);

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -474,11 +474,10 @@ func_ext!=axiom > pe ~cat off:20,on:1
 > inj ~cat off:4,on:1
 
 # higher order split queue
-# TODO(HOL)
-#> hfsq ~cat off:10,on:1
-#hfsq=on > hfsql ~cat off:1,on:4
-#hfsq=on > hfsqc ~cat 0:80,1:30,2:20,3:20,4:10,5:5
-#hfsq=on > hfsqr ~u2r -5;3;,
+> hsq ~cat off:10,on:1
+hsq=on > hsql ~cat off:1,on:4
+hsq=on > hsqc ~cat 0:80,1:30,2:20,3:20,4:10,5:5
+hsq=on > hsqr ~u2r -5;3;,
 
-#hfsq=on > hflw ~cat 0:1,1:5,2:3,3:2,4:2,5:1
-#hfsq=on > hfaw ~cat 0:1,1:5,2:3,3:2,4:2,5:1
+hsq=on > hlw ~cat 0:1,1:5,2:3,3:2,4:2,5:1
+hsq=on > haw ~cat 0:1,1:5,2:3,3:2,4:2,5:1

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -479,5 +479,5 @@ hsq=on > hsql ~cat off:1,on:4
 hsq=on > hsqc ~cat 0:80,1:30,2:20,3:20,4:10,5:5
 hsq=on > hsqr ~u2r -5;3;,
 
-hsq=on > hlw ~cat 0:1,1:5,2:3,3:2,4:2,5:1
-hsq=on > haw ~cat 0:1,1:5,2:3,3:2,4:2,5:1
+hsq=on > hsqlw ~cat 0:1,1:5,2:3,3:2,4:2,5:1
+hsq=on > hsqaw ~cat 0:1,1:5,2:3,3:2,4:2,5:1

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -429,8 +429,7 @@ apa=on  > cnfonf ~cat off:1
 apa=off > cnfonf ~cat eager:111,off:43,lazy_gen:29,conj_eager:19,lazy_not_gen_be_off:15,lazy_pi_sigma_gen:26,lazy_not_be_gen:12,lazy_simp:19,lazy_not_gen:12
 
 # heur_inst
-# TODO(HOL)
-#cnfonf=conj_eager > hi ~cat off:100,on:5
+cnfonf=conj_eager > hi ~cat off:100,on:5
 
 # bool_inst (disable for now)
 # cnfonf!=off > bi ~cat off:1,abs:1,abs_sub:1

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -474,7 +474,7 @@ func_ext!=axiom > pe ~cat off:20,on:1
 > inj ~cat off:4,on:1
 
 # higher order split queue
-> hsq ~cat off:10,on:1
+sa!=fmb > hsq ~cat off:10,on:1
 hsq=on > hsql ~cat off:1,on:4
 hsq=on > hsqc ~cat 0:80,1:30,2:20,3:20,4:10,5:5
 hsq=on > hsqr ~u2r -5;3;,


### PR DESCRIPTION
Yet another HOL PR, this time going over many small things, mostly preprocessing-related:
- FOOLElimination
- InequalitySplitting
- The heuristics instantiations and its inference counterpart in CNFOnTheFly
- TweeGoalTransformation
- Higher-order split queues
- Some adjustments in how HO inferences are added: some are now hidden behind the `prb.isHigherOrder()` flag, and `ArgCong` was added (it was accidentally left out previously)
- Updated the HOL sampler

After running some iterations of debug sampling with `samplerHOL.smp`, there were only a few dozen errors left, mostly related to substitutions using loose DB indices, which needs further work on indices/unification/matching.

Here are some results:

FOL TPTP:

Discount
run 0 unsat: 9208 (0) sat: 1042 (0) cputime: 56725.35 s instructions: 222732776 Mi memory: 1462299.73 MB
run 1 unsat: 9208 (0) sat: 1042 (0) cputime: 56951.17 s instructions: 222734542 Mi memory: 1462058.74 MB

Otter
run 0 unsat: 9321 (1) sat: 1025 (0) cputime: 61791.53 s instructions: 222705868 Mi memory: 1694925.40 MB
run 1 unsat: 9320 (0) sat: 1025 (0) cputime: 62014.35 s instructions: 222707271 Mi memory: 1694757.50 MB

(one problem lost due to noise)

HOL TPTP:

Discount
run 0 unsat: 2147 (7) sat: 1 (0) cputime: 8842.38 s instructions: 44028487 Mi memory: 113310.06 MB
run 1 unsat: 2232 (92) sat: 1 (0) cputime: 8992.22 s instructions: 44261476 Mi memory: 114153.27 MB

Otter
run 0 unsat: 2107 (5) sat: 1 (0) cputime: 9257.15 s instructions: 44915239 Mi memory: 135458.60 MB
run 1 unsat: 2201 (99) sat: 1 (0) cputime: 9419.50 s instructions: 44903685 Mi memory: 136672.79 MB

Note that here the big increase in solved problems can be mostly attributed to `ArgCong` kicking in.