### PR TITLE
Choice inference

### DIFF
--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -159,8 +159,7 @@ ClauseIterator Choice::generateClauses(Clause* premise)
 {
   return pvi(premise->getSelectedLiteralIterator()
     .flatMap([](Literal* lit) {
-      NonVariableNonTypeIterator nvi(lit);
-      return pvi(getUniquePersistentIteratorFromPtr(&nvi));
+      return getUniquePersistentIterator(NonVariableNonTypeIterator(lit));
     })
     .filter(IsChoiceTerm())
     .flatMap(ResultFn()));

--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -65,13 +65,13 @@ Clause* Choice::createChoiceAxiom(TermList op, TermList set)
 
 struct Choice::AxiomsIterator
 {
-  AxiomsIterator(Term* term)
+  AxiomsIterator(TermList term)
   {
-    _set = *term->nthArgument(3);
-    _headSort = AtomicSort::arrowSort(*term->nthArgument(0),*term->nthArgument(1));
-    _resultSort = HOL::getResultAppliedToNArgs(_headSort, 1);
+    ASS(term.isApplication());
 
-    //cout << "the result sort is " + _resultSort.toString() << endl;
+    _set = term.rhs();
+    _headSort = HOL::lhsSort(term);
+    _resultSort = SortHelper::getResultSort(term.term());
 
     DHSet<unsigned>* ops = env.signature->getChoiceOperators();
     DHSet<unsigned>::Iterator opsIt(*ops);
@@ -132,14 +132,13 @@ private:
 
 struct Choice::ResultFn
 {
-  ResultFn(){}
-
-  VirtualIterator<Clause*> operator() (Term* term){
-    TermList op = *term->nthArgument(2);
+  VirtualIterator<Clause*> operator() (Term* t){
+    TermList term(t);
+    TermList op = term.lhs();
     if(op.isVar()){
       return pvi(AxiomsIterator(term));
     } else {
-      Clause* axiom = createChoiceAxiom(op, *term->nthArgument(3));
+      Clause* axiom = createChoiceAxiom(op, term.rhs());
       return pvi(getSingletonIterator(axiom));
     }
   }
@@ -149,55 +148,35 @@ struct Choice::IsChoiceTerm
 {
   bool operator()(Term* t)
   {
+    if (t->isLambdaTerm()) {
+      return false;
+    }
     auto [head, args] = HOL::getHeadAndArgs(TermList(t));
-    if(args.size() != 1){ return false; }
+    if (args.size() != 1 || args[0].isVar() || args[0].containsLooseDBIndex()) {
+      return false;
+    }
+    TermList headSort = HOL::lhsSort(TermList(t));
 
-    TermList headSort = AtomicSort::arrowSort(*t->nthArgument(0), *t->nthArgument(1));
-
-    TermList tv = TermList(0, false);
+    TermList tv = TermList::var(0); // put on QUERY_BANK to separate in from variables in headSort
     TermList o  = AtomicSort::boolSort();
     TermList sort = AtomicSort::arrowSort(AtomicSort::arrowSort(tv, o), tv);
 
     static RobSubstitution subst;
     subst.reset();
-
-    subst.reset();
     return ((head.isVar() || env.signature->isChoiceOperator(head.term()->functor())) &&
            subst.match(sort,0,headSort,1));
-
-  }
-};
-
-
-struct Choice::SubtermsFn
-{
-  SubtermsFn() {}
-
-  VirtualIterator<Term*> operator()(Literal* lit)
-  {
-    NonVariableNonTypeIterator nvi(lit);
-    return pvi(getUniquePersistentIteratorFromPtr(&nvi));
   }
 };
 
 ClauseIterator Choice::generateClauses(Clause* premise)
 {
-  //cout << "Choice with " << premise->toString() << endl;
-
-  //is this correct?
-  auto it1 = premise->getSelectedLiteralIterator();
-  //filter out literals that are not suitable for narrowing
-  auto it2 = getMapAndFlattenIterator(it1, SubtermsFn());
-
-  //pair of literals and possible rewrites that can be applied to literals
-  auto it3 = getFilteredIterator(std::move(it2), IsChoiceTerm());
-
-  //apply rewrite rules to literals
-  auto it4 = getMapAndFlattenIterator(std::move(it3), ResultFn());
-
-
-  return pvi( std::move(it4) );
-
+  return pvi(premise->getSelectedLiteralIterator()
+    .flatMap([](Literal* lit) {
+      NonVariableNonTypeIterator nvi(lit);
+      return pvi(getUniquePersistentIteratorFromPtr(&nvi));
+    })
+    .filter(IsChoiceTerm())
+    .flatMap(ResultFn()));
 }
 
 }

--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -145,9 +145,8 @@ struct Choice::IsChoiceTerm
     }
     TermList headSort = HOL::lhsSort(TermList(t));
 
-    TermList tv = TermList::var(0); // put on QUERY_BANK to separate in from variables in headSort
-    TermList o  = AtomicSort::boolSort();
-    TermList sort = AtomicSort::arrowSort(AtomicSort::arrowSort(tv, o), tv);
+    TermList tv = TermList::var(0);
+    TermList sort = AtomicSort::arrowSort(AtomicSort::arrowSort(tv, AtomicSort::boolSort()), tv);
 
     static RobSubstitution subst;
     subst.reset();

--- a/Inferences/Choice.cpp
+++ b/Inferences/Choice.cpp
@@ -43,24 +43,21 @@ Clause* Choice::createChoiceAxiom(TermList op, TermList set)
   TermList setSort = SortHelper::getResultSort(op.term()).domain();
 
   unsigned max = 0;
-  FormulaVarIterator fvi(set);
-  while (fvi.hasNext()) {
-    unsigned var = fvi.next();
+  for (const auto& var : iterTraits(FormulaVarIterator(set))) {
     if (var > max) {
       max = var;
     }
   }
-  TermList freshVar = TermList(max+1, false);
+  auto freshVar = TermList::var(max+1);
 
   TermList t1 = HC::app(setSort, set, freshVar);
   TermList t2 = HC::app(op, set);
   t2 =          HC::app(setSort, set, t2);
 
-  return Clause::fromLiterals(
-      { Literal::createEquality(true, t1, TermList(Term::foolFalse()), AtomicSort::boolSort()),
-        Literal::createEquality(true, t2, TermList(Term::foolTrue()), AtomicSort::boolSort())},
-       NonspecificInference0(UnitInputType::AXIOM, InferenceRule::HILBERTS_CHOICE_INSTANCE)
-  );
+  return Clause::fromLiterals({
+    Literal::createEquality(true, t1, TermList(Term::foolFalse()), AtomicSort::boolSort()),
+    Literal::createEquality(true, t2, TermList(Term::foolTrue()), AtomicSort::boolSort())
+  }, NonspecificInference0(UnitInputType::AXIOM, InferenceRule::HILBERTS_CHOICE_INSTANCE));
 }
 
 struct Choice::AxiomsIterator
@@ -71,40 +68,35 @@ struct Choice::AxiomsIterator
 
     _set = term.rhs();
     _headSort = HOL::lhsSort(term);
-    _resultSort = SortHelper::getResultSort(term.term());
-
-    DHSet<unsigned>* ops = env.signature->getChoiceOperators();
-    DHSet<unsigned>::Iterator opsIt(*ops);
-    _choiceOps.loadFromIterator(opsIt);
-    _inBetweenNextandHasNext = false;
+    _choiceOps.loadFromIterator(env.signature->getChoiceOperators()->iter());
   }
 
   DECL_ELEMENT_TYPE(Clause*);
 
   bool hasNext() {
-    if(_inBetweenNextandHasNext){ return true; }
+    if (_curr) {
+      return true;
+    }
 
-    while(!_choiceOps.isEmpty()){
-      unsigned op = _choiceOps.getOneKey();
-      _choiceOps.remove(op);
-      OperatorType* type = env.signature->getFunction(op)->fnType();
+    while (_choiceOps.isNonEmpty()) {
+      auto op = _choiceOps.pop();
+      auto type = env.signature->getFunction(op)->fnType();
 
-      static RobSubstitution subst;
       static TermStack typeArgs;
       typeArgs.reset();
+      for (int i = type->numTypeArguments() -1; i >= 0; i--) {
+        typeArgs.push(TermList::var((unsigned)i));
+      }
+
+      auto choiceOp = Term::create(op, typeArgs.size(), typeArgs.begin());
+      static RobSubstitution subst;
       subst.reset();
 
-      for(int i = type->numTypeArguments() -1; i >= 0; i--){
-        TermList typeArg = TermList((unsigned)i, false);
-        typeArgs.push(typeArg);
-      }
-      Term* choiceOp = Term::create(op, typeArgs.size(), typeArgs.begin());
-      TermList choiceOpSort = SortHelper::getResultSort(choiceOp);
-      if(subst.unify(choiceOpSort, 0, _headSort, 1)){
-        _nextChoiceOperator = TermList(choiceOp);
-        _opApplied = subst.apply(_nextChoiceOperator, 0);
-        _setApplied = subst.apply(_set, 1);
-        _inBetweenNextandHasNext = true;
+      if (subst.unify(SortHelper::getResultSort(choiceOp), 0, _headSort, 1)) {
+        _curr = createChoiceAxiom(
+          subst.apply(TermList(choiceOp), 0),
+          subst.apply(_set, 1)
+        );
         return true;
       }
     }
@@ -114,20 +106,16 @@ struct Choice::AxiomsIterator
 
   OWN_ELEMENT_TYPE next()
   {
-    _inBetweenNextandHasNext = false;
-    Clause* c = createChoiceAxiom(_opApplied, _setApplied);
-    return c;
+    Clause* res = nullptr;
+    std::swap(res, _curr);
+    return res;
   }
 
 private:
-  DHSet<unsigned> _choiceOps;
-  TermList _opApplied;
-  TermList _setApplied;
-  TermList _nextChoiceOperator;
-  TermList _resultSort;
+  Stack<unsigned> _choiceOps;
+  Clause* _curr = nullptr;
   TermList _headSort;
   TermList _set;
-  bool _inBetweenNextandHasNext;
 };
 
 struct Choice::ResultFn

--- a/Inferences/Choice.hpp
+++ b/Inferences/Choice.hpp
@@ -8,8 +8,8 @@
  * and in the source directory
  */
 /**
- * @file BoolSimp.hpp
- * Defines class BoolSimp.
+ * @file Choice.hpp
+ * Defines class Choice.
  */
 
 #ifndef __CHOICE__
@@ -24,10 +24,10 @@ namespace Inferences {
 class Choice : public GeneratingInferenceEngine
 {
   public:
+    Choice(SaturationAlgorithm&) {}
     ClauseIterator generateClauses(Clause* premise) override;
 
   private:
-    struct SubtermsFn;
     struct IsChoiceTerm;
     struct ResultFn;
     struct AxiomsIterator;

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -131,7 +131,7 @@ CompositeSGI::~CompositeSGI() {
 
 Clause* ChoiceDefinitionISE::simplify(Clause* c)
 {
-  if (c->length() != 2) {
+  if (c->length() != 2 || !c->noSplits()) {
     return c;
   }
 
@@ -154,9 +154,9 @@ Clause* ChoiceDefinitionISE::simplify(Clause* c)
   return c;
 }
 
-bool ChoiceDefinitionISE::isPositive(Literal* lit) {
-  TermList lhs = *lit->nthArgument(0);
-  TermList rhs = *lit->nthArgument(1);
+bool ChoiceDefinitionISE::isPositive(Literal* lit)
+{
+  auto [lhs, rhs] = lit->eqArgs();
   if(!HOL::isBool(lhs) && !HOL::isBool(rhs)){ return false; }
   if(HOL::isBool(lhs) && HOL::isBool(rhs)){ return false; }
   if(HOL::isBool(lhs)){ 
@@ -166,10 +166,27 @@ bool ChoiceDefinitionISE::isPositive(Literal* lit) {
     return lit->polarity() == HOL::isTrue(rhs);
   }
   return false;
-};
+}
+
+bool ChoiceDefinitionISE::isNegative(Literal* lit)
+{
+  auto [lhs, rhs] = lit->eqArgs();
+  if(!HOL::isBool(lhs) && !HOL::isBool(rhs)){ return false; }
+  if(HOL::isBool(lhs) && HOL::isBool(rhs)){ return false; }
+  
+  if(HOL::isBool(lhs)){ 
+    return lit->polarity() != HOL::isTrue(lhs);
+  }
+  if(HOL::isBool(rhs)){ 
+    return lit->polarity() != HOL::isTrue(rhs);
+  }
+  return false;
+}
 
 bool ChoiceDefinitionISE::is_of_form_xy(Literal* lit, TermList& x){
   TermList term = HOL::isBool(*lit->nthArgument(0)) ? *lit->nthArgument(1) : *lit->nthArgument(0);
+
+  if(term.isLambdaTerm()){ return false; }
   
   TermStack args;
   x = HOL::getHeadAndArgs(term, args);
@@ -178,6 +195,8 @@ bool ChoiceDefinitionISE::is_of_form_xy(Literal* lit, TermList& x){
 
 bool ChoiceDefinitionISE::is_of_form_xfx(Literal* lit, TermList x, TermList& f){
   TermList term = HOL::isBool(*lit->nthArgument(0)) ? *lit->nthArgument(1) : *lit->nthArgument(0);
+
+  if(term.isLambdaTerm()){ return false; }
   
   TermStack args;
   auto head = HOL::getHeadAndArgs(term, args);

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -323,6 +323,7 @@ public:
   Clause* simplify(Clause* cl) override;
 
   bool isPositive(Literal* lit);
+  bool isNegative(Literal* lit);
  
   bool is_of_form_xy(Literal* lit,  TermList& x);
   bool is_of_form_xfx(Literal* lit, TermList x, TermList& f);

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1456,7 +1456,7 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if (opt.choiceReasoning()) {
-    gie->addFront(new Choice());
+    gie->addFront(new Choice(*res));
   }
 
   gie->addFront(new Factoring(*res));

--- a/UnitTests/tInferences_HOL_Choice.cpp
+++ b/UnitTests/tInferences_HOL_Choice.cpp
@@ -25,26 +25,78 @@ using namespace Test;
   FOLS                                             \
   DECL_PRED(p, { srt })                            \
   DECL_CONST(f, arrow(arrow(srt, Bool), srt))      \
-  DECL_POLY_CONST(g2, 1, x)                        \
-  DECL_POLY_CONST(g3, 1, x)                        \
-  DECL_DE_BRUIJN_INDEX(db0, 0, srt)                \
-  DECL_CONST(a, srt)                               \
-  DECL_CONST(b, srt)
+  DECL_CONST(g, arrow(arrow(srt, Bool), srt))      \
+  DECL_CONST(h, arrow({srt, srt}, srt))            \
+  DECL_CONST(a, arrow(srt, Bool))                  \
+  DECL_CONST(b, arrow(srt, Bool))                  \
+  DECL_CONST(c, srt)
 
 #define MY_GEN_RULE   Choice
 #define MY_GEN_TESTER Generation::GenerationTester
 
-// TEST_GENERATION(rule_fail_1,
-//     Generation::AsymmetricTest()
-//       .input( clause({ selected(x == y), g == lam(srt, ap(f, {db0, db0})) }))
-//       .expected(none())
-//     )
+// not done for non-selected literals
+TEST_GENERATION(rule_fail_1,
+    env.signature->addChoiceOperator(f.functor());
+    env.signature->addChoiceOperator(g.functor());
+    Generation::AsymmetricTest()
+      .input( clause({ ap(f, a) == c }))
+      .expected(none())
+    )
 
-// TEST_GENERATION(rule_success_1,
-//     Generation::AsymmetricTest()
-//       .input( clause({ selected(g == lam(srt, ap(f, {x, x}))) }))
-//       .expected(exactly(clause({ ap(g, y) == ap(lam(srt, ap(f, {x, x})), y) })))
-//     )
+// not done for non-choice operators
+TEST_GENERATION(rule_fail_2,
+    env.signature->addChoiceOperator(g.functor());
+    Generation::AsymmetricTest()
+      .input( clause({ selected(ap(f, a) == c) }))
+      .expected(none())
+    )
+
+// not done for variable arguments
+TEST_GENERATION(rule_fail_3,
+    env.signature->addChoiceOperator(f.functor());
+    env.signature->addChoiceOperator(g.functor());
+    Generation::AsymmetricTest()
+      .input( clause({ selected(ap(f, x) == c) }))
+      .expected(none())
+    )
+
+// not done for variable heads with no choice operators
+TEST_GENERATION(rule_fail_4,
+    Generation::AsymmetricTest()
+    .input( clause({ selected(ap(x.sort(arrow(arrow(srt, Bool), srt)), a) == c) }))
+    .expected(none())
+    )
+
+TEST_GENERATION(rule_success_1,
+    env.signature->addChoiceOperator(f.functor());
+    env.signature->addChoiceOperator(g.functor());
+    Generation::AsymmetricTest()
+      .input( clause({ selected(ap(f, a) == c) }))
+      .expected(exactly(clause({ ap(a, y) == fols, ap(a, ap(f, a)) == troo })))
+    )
+
+TEST_GENERATION(rule_success_2,
+    env.signature->addChoiceOperator(f.functor());
+    env.signature->addChoiceOperator(g.functor());
+    Generation::AsymmetricTest()
+      .input( clause({ selected(ap(x.sort(arrow(arrow(srt, Bool), srt)), a) == c) }))
+      .expected(exactly(
+        clause({ ap(a, y) == fols, ap(a, ap(f, a)) == troo }),
+        clause({ ap(a, y) == fols, ap(a, ap(g, a)) == troo })
+      ))
+    )
+
+TEST_GENERATION(rule_success_3,
+    env.signature->addChoiceOperator(f.functor());
+    env.signature->addChoiceOperator(g.functor());
+    Generation::AsymmetricTest()
+      .input( clause({ selected(ap(h, {x, ap(f, a)}) != ap(h, {c, ap(y.sort(arrow(arrow(srt, Bool), srt)), b)})) }))
+      .expected(exactly(
+        clause({ ap(a, y) == fols, ap(a, ap(f, a)) == troo }),
+        clause({ ap(b, y) == fols, ap(b, ap(f, b)) == troo }),
+        clause({ ap(b, y) == fols, ap(b, ap(g, b)) == troo })
+      ))
+    )
 
 #define MY_SIMPL_RULE   ChoiceDefinitionISE
 #define MY_SIMPL_TESTER Simplification::SimplificationTester

--- a/UnitTests/tInferences_HOL_Choice.cpp
+++ b/UnitTests/tInferences_HOL_Choice.cpp
@@ -34,13 +34,13 @@ using namespace Test;
 #define MY_GEN_RULE   Choice
 #define MY_GEN_TESTER Generation::GenerationTester
 
-// TEST_GENERATION(fail_1,
+// TEST_GENERATION(rule_fail_1,
 //     Generation::AsymmetricTest()
 //       .input( clause({ selected(x == y), g == lam(srt, ap(f, {db0, db0})) }))
 //       .expected(none())
 //     )
 
-// TEST_GENERATION(success_1,
+// TEST_GENERATION(rule_success_1,
 //     Generation::AsymmetricTest()
 //       .input( clause({ selected(g == lam(srt, ap(f, {x, x}))) }))
 //       .expected(exactly(clause({ ap(g, y) == ap(lam(srt, ap(f, {x, x})), y) })))

--- a/UnitTests/tInferences_HOL_Choice.cpp
+++ b/UnitTests/tInferences_HOL_Choice.cpp
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+#include "Test/SyntaxSugar.hpp"
+#include "Inferences/Choice.hpp"
+#include "Inferences/InferenceEngine.hpp"
+
+#include "Test/GenerationTester.hpp"
+#include "Test/SimplificationTester.hpp"
+
+using namespace Test;
+
+#define MY_SYNTAX_SUGAR                            \
+  DECL_SORT(srt)                                   \
+  DECL_SORT_BOOL                                   \
+  DECL_DEFAULT_VARS                                \
+  DECL_VAR_SORTED(xs, 0, arrow(srt, Bool))         \
+  TROO                                             \
+  FOLS                                             \
+  DECL_PRED(p, { srt })                            \
+  DECL_CONST(f, arrow(arrow(srt, Bool), srt))      \
+  DECL_POLY_CONST(g2, 1, x)                        \
+  DECL_POLY_CONST(g3, 1, x)                        \
+  DECL_DE_BRUIJN_INDEX(db0, 0, srt)                \
+  DECL_CONST(a, srt)                               \
+  DECL_CONST(b, srt)
+
+#define MY_GEN_RULE   Choice
+#define MY_GEN_TESTER Generation::GenerationTester
+
+// TEST_GENERATION(fail_1,
+//     Generation::AsymmetricTest()
+//       .input( clause({ selected(x == y), g == lam(srt, ap(f, {db0, db0})) }))
+//       .expected(none())
+//     )
+
+// TEST_GENERATION(success_1,
+//     Generation::AsymmetricTest()
+//       .input( clause({ selected(g == lam(srt, ap(f, {x, x}))) }))
+//       .expected(exactly(clause({ ap(g, y) == ap(lam(srt, ap(f, {x, x})), y) })))
+//     )
+
+#define MY_SIMPL_RULE   ChoiceDefinitionISE
+#define MY_SIMPL_TESTER Simplification::SimplificationTester
+
+// nothing happens with one literal
+TEST_SIMPLIFY(fail_1,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, y) == fols }))
+    )
+
+TEST_SIMPLIFY(fail_2,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, y) == troo }))
+    )
+
+TEST_SIMPLIFY(fail_3,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, y) != fols }))
+    )
+
+TEST_SIMPLIFY(fail_4,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, y) != troo }))
+    )
+
+TEST_SIMPLIFY(fail_5,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, ap(f, xs)) == troo }))
+    )
+
+TEST_SIMPLIFY(fail_6,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, ap(f, xs)) != troo }))
+    )
+
+TEST_SIMPLIFY(fail_7,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, ap(f, xs)) == fols }))
+    )
+
+TEST_SIMPLIFY(fail_8,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, ap(f, xs)) != fols }))
+    )
+
+// wrong polarities
+TEST_SIMPLIFY(fail_9,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, y) == troo, ap(xs, ap(f, xs)) == troo, }))
+    )
+
+TEST_SIMPLIFY(fail_10,
+    Simplification::NotApplicable()
+      .input(clause({ ap(xs, y) == fols, ap(xs, ap(f, xs)) == fols, }))
+    )
+
+TEST_SIMPLIFY(success_1,
+    Simplification::Success()
+      .input(clause({ ap(xs, y) == fols, ap(xs, ap(f, xs)) == troo, }))
+      .expected(Simplification::Redundant{})
+    )
+
+TEST_SIMPLIFY(success_2,
+    Simplification::Success()
+      .input(clause({ ap(xs, ap(f, xs)) == troo, ap(xs, z) != troo, }))
+      .expected(Simplification::Redundant{})
+    )

--- a/cmake/sources.cmake
+++ b/cmake/sources.cmake
@@ -66,11 +66,12 @@ set(UNIT_TESTS
     UnitTests/tInferences_FunctionDefinitionRewriting.cpp
     UnitTests/tInferences_GaussianVariableElimination.cpp
     UnitTests/tInferences_HOL_ArgCong.cpp
+    UnitTests/tInferences_HOL_BetaEtaSimplify.cpp
     UnitTests/tInferences_HOL_BoolEqToDiseq.cpp
     UnitTests/tInferences_HOL_BoolSimp.cpp
     UnitTests/tInferences_HOL_Cases.cpp
     UnitTests/tInferences_HOL_CasesSimp.cpp
-    UnitTests/tInferences_HOL_BetaEtaSimplify.cpp
+    UnitTests/tInferences_HOL_Choice.cpp
     UnitTests/tInferences_HOL_CNFOnTheFly.cpp
     UnitTests/tInferences_HOL_FlexFlexSimplify.cpp
     UnitTests/tInferences_HOL_ImitateProject.cpp


### PR DESCRIPTION
Cleaning up the choice inferences, merging the relevant changes from the HOL branch, and adding some unit tests.

HOL regression (with choice reasoning enabled, `-chr on`), shows a bit of improvement, mostly because loose DB indices are not bound and hence some errors are avoided:

Discount
run 0 unsat: 2240 (0) sat: 1 (0) cputime: 8449.42 s instructions: 41927093 Mi memory: 112563.93 MB
run 1 unsat: 2252 (12) sat: 1 (0) cputime: 8696.54 s instructions: 44143448 Mi memory: 117507.94 MB

Otter
run 0 unsat: 2212 (1) sat: 1 (0) cputime: 8943.08 s instructions: 42962767 Mi memory: 138522.92 MB
run 1 unsat: 2220 (9) sat: 1 (0) cputime: 9103.20 s instructions: 44816098 Mi memory: 141062.58 MB

Once review is done, I would like to move the `Choice` and `ChoiceDefinitionISE` to `Inferences/HOL`.