### PR TITLE
Fix divisibility evaluation

### DIFF
--- a/Kernel/PolynomialNormalizer/PredicateEvaluator.hpp
+++ b/Kernel/PolynomialNormalizer/PredicateEvaluator.hpp
@@ -33,11 +33,13 @@ using LitSimplResult = Inferences::SimplifyingGeneratingLiteralSimplification::R
 template<class ConstantType, class EvalGround>
 Option<LitSimplResult> tryEvalConstant2(Literal* orig, PolyNf* evaluatedArgs, EvalGround fun) 
 {
+  ASS(orig->numTermArguments() == 2);
   using Number = NumTraits<ConstantType>;
-  auto& lhs = *evaluatedArgs[0].downcast<Number>().unwrap();
-  auto& rhs = *evaluatedArgs[1].downcast<Number>().unwrap();
-  if (lhs.isNumber() && rhs.isNumber()) {
-    return Option<LitSimplResult>(LitSimplResult::constant(fun(lhs.unwrapNumber(), rhs.unwrapNumber())));
+  auto lhs = evaluatedArgs[0].template wrapPoly<NumTraits<ConstantType>>();
+  auto rhs = evaluatedArgs[1].template wrapPoly<NumTraits<ConstantType>>();
+  auto polarity = orig->polarity();
+  if (lhs->isNumber() && rhs->isNumber()) {
+    return Option<LitSimplResult>(LitSimplResult::constant(polarity == fun(lhs->unwrapNumber(), rhs->unwrapNumber())));
   } else {
     return Option<LitSimplResult>();
   }
@@ -87,7 +89,6 @@ IMPL_EVALUATE_PRED(Interpretation::EQUAL,
 
 template<class ConstantType, class EvalIneq> Option<LitSimplResult> evaluateInequality(Literal* orig, PolyNf* evaluatedArgs, bool strict, EvalIneq evalIneq) {
   ASS(orig->numTermArguments() == 2);
-
 
   auto lhs = evaluatedArgs[0].template wrapPoly<NumTraits<ConstantType>>();
   auto rhs = evaluatedArgs[1].template wrapPoly<NumTraits<ConstantType>>();

--- a/Test/SyntaxSugar.hpp
+++ b/Test/SyntaxSugar.hpp
@@ -237,6 +237,7 @@ public:
     remainderF = IntTraits::remainderF;
     quotientE = IntTraits::quotientE;
     remainderE = IntTraits::remainderE;
+    divisible = IntTraits::divides;
   }
 
   void setNumTraits(RatTraits)
@@ -252,6 +253,7 @@ public:
   std::function<TermList(TermList, TermList)> add;
   std::function<TermList(TermList, TermList)> mul;
   std::function<TermList(TermList, TermList)> div;
+  std::function<Literal*(bool, TermList, TermList)> divisible;
 
   std::function<TermList(TermList, TermList)> quotientT;
   std::function<TermList(TermList, TermList)> remainderT;
@@ -443,6 +445,7 @@ inline TermSugar lam(SortSugar varSort, TermSugar body)
 inline TermSugar db(unsigned i, SortSugar srt)
 { return HOL::getDeBruijnIndex(i, srt); }
 
+inline Lit divisible(TermSugar lhs, TermSugar rhs)  { return syntaxSugarGlobals().divisible(true, lhs, rhs); }
 inline TermSugar operator+(TermSugar lhs, TermSugar rhs)  { return syntaxSugarGlobals().add(lhs, rhs); }
 inline TermSugar operator-(TermSugar lhs, TermSugar rhs)  { return lhs + -rhs; }
 inline TermSugar operator*(TermSugar lhs, TermSugar rhs)  {

--- a/UnitTests/tInterpretedFunctions.cpp
+++ b/UnitTests/tInterpretedFunctions.cpp
@@ -582,6 +582,11 @@ INT_TEST(divisible_01,
     true
     )
 
+INT_TEST(divisible_01b,
+    ~divisible(num(2), num(6)),
+    false
+    )
+
 INT_TEST(divisible_02,
     divisible(num(2), num(-6)),
     true
@@ -595,6 +600,16 @@ INT_TEST(divisible_03,
 INT_TEST(divisible_04,
     divisible(num(2), a),
     evaluationFail
+    )
+
+INT_TEST(divisible_05,
+    divisible(num(5), num(-6)),
+    false
+    )
+
+INT_TEST(divisible_05b,
+    ~divisible(num(5), num(-6)),
+    true
     )
 
 

--- a/UnitTests/tInterpretedFunctions.cpp
+++ b/UnitTests/tInterpretedFunctions.cpp
@@ -577,6 +577,26 @@ INT_TEST(div_zero_2,
     r(remainderE(num(7), 0),     11     )
     )
 
+INT_TEST(divisible_01,
+    divisible(num(2), num(6)),
+    true
+    )
+
+INT_TEST(divisible_02,
+    divisible(num(2), num(-6)),
+    true
+    )
+
+INT_TEST(divisible_03,
+    divisible(a, num(-6)),
+    evaluationFail
+    )
+
+INT_TEST(divisible_04,
+    divisible(num(2), a),
+    evaluationFail
+    )
+
 
 ALL_NUMBERS_TEST(NUM_IS_NUM_01,
      ~isInt(num(3)),


### PR DESCRIPTION
Fixes the evaluation of the divisibility predicate which crashed whenever it was attempted to be evaluated on two non-numeral terms. 
Unit tests covering these cases have been added.