### PR TITLE
removed unstable alasca options from samplers

### DIFF
--- a/samplers/samplerIND.smp
+++ b/samplers/samplerIND.smp
@@ -252,7 +252,8 @@ slsq=on > slsqr ~u2r -5;2;,
 > alasca ~cat on:1,off:1
 
 # alasca_integer_conversion
-alasca=on > alascai ~cat on:1,off:1
+# alasca=on > alascai ~cat on:1,off:1
+# Joe: -alascai is not in a usable state yet
 
 # alasca_abstraction
 alasca=on > alascaa ~cat on:1,off:1

--- a/samplers/samplerSMT.smp
+++ b/samplers/samplerSMT.smp
@@ -255,7 +255,8 @@ slsq=on > slsqr ~u2r -5;2;,
 > alasca ~cat on:1,off:1
 
 # alasca_integer_conversion
-alasca=on > alascai ~cat on:1,off:1
+# alasca=on > alascai ~cat on:1,off:1
+# Joe: -alascai is not in a usable state yet
 
 # alasca_abstraction
 alasca=on > alascaa ~cat on:1,off:1


### PR DESCRIPTION
I realized that the arithmetic sampler files contained two options that were never meant to be there, as they are not well-enough tested yet, and also might be removed in the future. Thus i commented them out, so no portfolios rely on unstable code.