### PR TITLE
Fix divisibility

### DIFF
--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -444,7 +444,7 @@ void TheoryInstAndSimp::ConstantCache::reset()
 
 Term* TheoryInstAndSimp::ConstantCache::freshConstant(SortId sort) 
 { 
-  auto& cache = _inner.getOrInit(sort, [](){ 
+  auto& cache = _inner.getOrInit(sort, [&](){
       DEBUG("new constant cache for sort ", _inner.size());
       return SortedConstantCache(); 
     });
@@ -967,9 +967,9 @@ bool TheoryInstAndSimp::isTheoryLemma(Clause* cl, bool& couldNotCheck) {
   return !solutions.next().sat;
 }
 
-} // namespace Inferences
-
 std::ostream& operator<<(std::ostream& out, Inferences::Solution const& self)
 { return out << "Solution(" << (self.sat ? "sat" : "unsat") << ", " << self.subst << ")"; }
+
+} // namespace Inferences
 
 #endif

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -1159,7 +1159,6 @@ protected:
       case Theory::REAL_FLOOR:     out << "|$floor|";       return;
 
       case Theory::EQUAL: out << "="; return;
-
       case UNSUPPORTED_INTERPRETATIONS:
          throw UserErrorException("divides function ", itp, " does not exist in SMT2");
 
@@ -1353,7 +1352,12 @@ protected:
         if (t->isLiteral()) {
           outputPredicateName(out, t->functor());
         } else {
-          outputFunctionName(out, t->functor());
+          if (theory->isInterpretedFunction(t->functor(), Theory::INT_DIVIDES) 
+              && IntTraits::isNumeral(t->termArg(0) )) {
+            out << "( (_ divisible " << *IntTraits::tryNumeral(t->termArg(0)) << ") " << t->termArg(1) << " )";
+          } else {
+            outputFunctionName(out, t->functor());
+          }
         }
 
         for (unsigned i = 0; i < t->numTermArguments(); i++) {

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -1641,11 +1641,8 @@ z3::expr Z3Interfacing::getRepresentation(Term* trm)
             switch(interp){
             // Numerical operations
             case Theory::INT_DIVIDES:
-              {
-              auto k = getNamingConstantFor(toEval, _context->int_sort());
-              // a divides b <-> k * a ==  b
-              return k * args[0] == args[1];
-              }
+              // a divides b <-> b mod a == 0
+              return z3::mod(args[1], args[0]) == int_zero;
 
             case Theory::INT_UNARY_MINUS:
             case Theory::RAT_UNARY_MINUS:


### PR DESCRIPTION
As divisibility appears to never have been benchmarked really, i ran into some more bugs with it when trying out some benchmarks that use it. 
This PR fixes SMT-LIB format proof-checker output for divisibility, as well as an issue in theory instantiation that lead to an unsoundness in some cases.