### PR TITLE
fix the cnf-claim path

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -36,6 +36,7 @@
 #include "Shell/Options.hpp"
 #include "Shell/DistinctGroupExpansion.hpp"
 #include "Shell/UIHelper.hpp"
+#include "Shell/Rectify.hpp"
 
 #include "Parse/TPTP.hpp"
 
@@ -3767,9 +3768,17 @@ Unit* TPTP::processClaimFormula(Unit* unit, Formula * f, const std::string& nm)
   if (!added) {
     USER_ERROR("Names of claims must be unique: "+nm);
   }
+  if (unit->isClause()) {
+    VList* vars = freeVariables(f);
+    if (VList::isNonEmpty(vars)) {
+      std::tie(f,unit) = Rectify::closeOverGivenVars(vars,f,unit);
+    }
+  } else {
+    // only clauses can have free variables at this point!
+    ASS_EQ(freeVariables(f),VList::empty())
+  }
   env.signature->getPredicate(pred)->markLabel();
   Formula* claim = new AtomicFormula(Literal::create(pred, /* polarity */ true, {}));
-  ASS_EQ(freeVariables(f),VList::empty())
   f = new BinaryFormula(IFF,claim,f);
   return new FormulaUnit(f,
       FormulaClauseTransformation(InferenceRule::CLAIM_DEFINITION,unit));

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -55,6 +55,27 @@ Rectify::VarWithUsageInfo Rectify::Renaming::getBoundAndUsage(unsigned var) cons
 }
 
 /**
+ * Assuming vars are (a non-empty list) free variables (occuring in) formula f, staged as a unit u.
+ * Creates the clore formula and a corresponding new unit documenting the CLOSURE inference.
+ * It hunts for the sorts of vars using SortHelper::collectVariableSorts.
+ */
+std::pair<Formula*,FormulaUnit*> Rectify::closeOverGivenVars(VList* vars, Formula* f, Unit* u)
+{
+  ASS(VList::isNonEmpty(vars))
+
+  DHMap<unsigned, TermList> varSorts;
+  SortHelper::collectVariableSorts(f, varSorts);
+  VSList::FIFO vsfifo;
+  VList::Iterator vit(vars);
+  while (vit.hasNext()) {
+    unsigned v = vit.next();
+    vsfifo.pushBack({v, varSorts.get(v)});
+  }
+  f = new QuantifiedFormula(FORALL, vsfifo.list(), f);
+  return {f,new FormulaUnit(f,FormulaClauseTransformation(InferenceRule::CLOSURE,u))};
+}
+
+/**
  * Rectify the formula from this unit. If the input type of this unit
  * contains free variables, then ask Signature::sig to create an answer
  * atom.
@@ -81,15 +102,7 @@ FormulaUnit* Rectify::rectify (FormulaUnit* unit0, bool removeUnusedVars)
 
   // note that this only kicks in when rectifying formulas with free variables
   if (VList::isNonEmpty(vars)) {
-    DHMap<unsigned, TermList> varSorts;
-    SortHelper::collectVariableSorts(g, varSorts);
-    VSList::FIFO vsfifo;
-    VList::Iterator vit(vars);
-    while (vit.hasNext()) {
-      unsigned v = vit.next();
-      vsfifo.pushBack({v, varSorts.get(v)});
-    }
-    unit = new FormulaUnit(new QuantifiedFormula(FORALL, vsfifo.list(), g),FormulaClauseTransformation(InferenceRule::CLOSURE,unit));
+    std::tie(g,unit) = closeOverGivenVars(vars,g,unit);
   }
   return unit;
 } // Rectify::rectify (Unit& unit)

--- a/Shell/Rectify.hpp
+++ b/Shell/Rectify.hpp
@@ -46,6 +46,7 @@ public:
   Rectify() : _free(0), _removeUnusedVars(true) {}
   static FormulaUnit* rectify(FormulaUnit*, bool removeUnusedVars=true);
   static void rectify(UnitList*& units);
+  static std::pair<Formula*,FormulaUnit*> closeOverGivenVars(VList* vars, Formula* f, Unit* u);
 private:
   typedef std::pair<unsigned,bool> VarWithUsageInfo;
   typedef List<VarWithUsageInfo> VarUsageTrackingList;


### PR DESCRIPTION
The claims feature was silently unsound for inputs in cnf, e.g.:
```
cnf(cl1,claim,p(X)).
```
would become
```
![X]: (claim <=> p(X)
```
in Vampire, which is wrong.

This PR fixes the problem by requesting a formula closure before "claimifying".

(The needed functionality was factored our from a piece of, likely dead, code in `Recrify.cpp` to prevent code duplication.)

