### PR TITLE
add a space after printing TPTP negations

### DIFF
--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -177,6 +177,9 @@ std::string Formula::toString () const
         res += toString(c);
 
         const Formula* arg = f->uarg();
+        Connective subc = arg->connective();
+        if(subc == FORALL || subc == EXISTS || subc == NOT)
+          res += " ";
         stack.push({arg->parenthesesRequired(c),NOCONN,arg});
 
         continue;


### PR DESCRIPTION
Vampire will currently output e.g. `~?[X]: ...`. This is OK by the letter of the (Geoff) law, but Prolog won't parse it and my life would be considerably easier if it output `~ ?[X]: ....` instead.

I only need the space in some cases to prevent it getting tokenised as the `~?` operator.