### PR TITLE
Fix skolemizing index

### DIFF
--- a/Indexing/CodeTreeInterfaces.cpp
+++ b/Indexing/CodeTreeInterfaces.cpp
@@ -167,6 +167,7 @@ template class CodeTreeTIS<false, TermLiteralClause>;
 template class CodeTreeTIS<true,  TermLiteralClause>;
 template class CodeTreeTIS<false, DemodulatorData>;
 template class CodeTreeTIS<true,  DemodulatorData>;
+template class CodeTreeTIS<true,  TermWithValue<TermList>>;
 
 /////////////////   CodeTreeSubsumptionIndex   //////////////////////
 

--- a/Indexing/Index.hpp
+++ b/Indexing/Index.hpp
@@ -189,14 +189,12 @@ public:
 
   void attachContainer(ClauseContainer* cc);
 protected:
-  Index() {}
-
   void onAddedToContainer(Clause* c)
   { handleClause(c, true); }
   void onRemovedFromContainer(Clause* c)
   { handleClause(c, false); }
 
-  virtual void handleClause(Clause* c, bool adding) {}
+  virtual void handleClause(Clause* c, bool adding) = 0;
 
   //TODO: postponing index modifications during iteration (methods isBeingIterated() etc...)
 

--- a/Indexing/IndexManager.cpp
+++ b/Indexing/IndexManager.cpp
@@ -43,7 +43,6 @@ SIMP_INDEX_IMPL(RewriteRuleIndex)
 SIMP_INDEX_IMPL(UnitClauseLiteralIndex)
 SIMP_INDEX_IMPL(DemodulationSubtermIndex<false>)
 SIMP_INDEX_IMPL(DemodulationSubtermIndex<true>)
-SIMP_INDEX_IMPL(SkolemisingFormulaIndex)
 SIMP_INDEX_IMPL(FSDLiteralIndex)
 
 GEN_INDEX_IMPL(AlascaIndex<ALASCA::CoherenceConf<NumTraits<RealConstantType>>::Lhs>)

--- a/Indexing/TermCodeTree.cpp
+++ b/Indexing/TermCodeTree.cpp
@@ -168,5 +168,6 @@ template class TermCodeTree<false, TermLiteralClause>;
 template class TermCodeTree<true,  TermLiteralClause>;
 template class TermCodeTree<false, DemodulatorData>;
 template class TermCodeTree<true,  DemodulatorData>;
+template class TermCodeTree<true,  TermWithValue<TermList>>;
 
 };

--- a/Indexing/TermIndex.cpp
+++ b/Indexing/TermIndex.cpp
@@ -229,12 +229,4 @@ void StructInductionTermIndex::handleClause(Clause* c, bool adding)
   }
 }
 
-SkolemisingFormulaIndex::SkolemisingFormulaIndex(SaturationAlgorithm&)
-  : TermIndex(new TermSubstitutionTree<TermWithValue<TermList>>()) {}
-
-void SkolemisingFormulaIndex::insertFormula(TermList formula, TermList skolem)
-{
-  _is->insert(TermWithValue<TermList>(TypedTermList(formula.term()), skolem));
-}
-
 } // namespace Indexing

--- a/Indexing/TermIndex.hpp
+++ b/Indexing/TermIndex.hpp
@@ -152,13 +152,5 @@ private:
   const bool _inductionGroundOnly;
 };
 
-class SkolemisingFormulaIndex
-: public TermIndex<TermWithValue<TermList>>
-{
-public:
-  SkolemisingFormulaIndex(SaturationAlgorithm&);
-  void insertFormula(TermList formula, TermList skolem);
-};
-
 } // namespace Indexing
 #endif /* __TermIndex__ */

--- a/Inferences/HOL/CNFOnTheFly.cpp
+++ b/Inferences/HOL/CNFOnTheFly.cpp
@@ -23,8 +23,6 @@
 
 #include "Shell/Skolem.hpp"
 
-#include "Saturation/SaturationAlgorithm.hpp"
-
 #include "CNFOnTheFly.hpp"
 
 namespace Inferences {
@@ -212,7 +210,7 @@ ClauseIterator produceClauses(Clause* c, bool generating, SkolemisingFormulaInde
           ASS(term.isTerm());
           bool newTermCreated = false;
           if(index){
-            auto results = index->getGeneralizations(TypedTermList(term.term()), true);
+            auto results = index->getSkolem(term.term());
             if(results.hasNext()){
               auto tqr = results.next();
               TermList skolemTerm = tqr.data->value;
@@ -385,14 +383,6 @@ Clause* IFFXORRewriterISE::simplify(Clause* c){
   return c;
 }
 
-LazyClausificationGIE::LazyClausificationGIE(SaturationAlgorithm& salg)
-  : _formulaIndex(salg.getSimplifyingIndex<SkolemisingFormulaIndex>())
-{}
-
-LazyClausification::LazyClausification(SaturationAlgorithm& salg)
-  : _formulaIndex(salg.getSimplifyingIndex<SkolemisingFormulaIndex>())
-{}
-
 Option<ClauseIterator> EagerClausificationISE::simplifyMany(Clause* c)
 {
   auto it = produceClauses(c, false);
@@ -404,12 +394,12 @@ Option<ClauseIterator> EagerClausificationISE::simplifyMany(Clause* c)
 
 ClauseIterator LazyClausificationGIE::generateClauses(Clause* c)
 {
-  return produceClauses(c, true, _formulaIndex.get());
+  return produceClauses(c, true, &_formulaIndex);
 }
 
 ClauseIterator LazyClausification::perform(Clause* c)
 {
-  return produceClauses(c, false, _formulaIndex.get());
+  return produceClauses(c, false, &_formulaIndex);
 }
 
 

--- a/Inferences/HOL/CNFOnTheFly.hpp
+++ b/Inferences/HOL/CNFOnTheFly.hpp
@@ -18,10 +18,23 @@
 #include "Forwards.hpp"
 #include "Inferences/InferenceEngine.hpp"
 
-#include "Indexing/TermIndex.hpp"
+#include "Indexing/CodeTreeInterfaces.hpp"
+using namespace Indexing;
 
 namespace Inferences {
-using namespace Indexing;
+
+class SkolemisingFormulaIndex
+{
+public:
+  void insertFormula(TermList formula, TermList skolem) {
+    _ct.insert(TermWithValue<TermList>(TypedTermList(formula.term()), skolem));
+  }
+  auto getSkolem(Term* forTerm) {
+    return _ct.getGeneralizations(TypedTermList(forTerm), true);
+  }
+private:
+  CodeTreeTIS<true, TermWithValue<TermList>> _ct;
+};
 
 class IFFXORRewriterISE
   : public ImmediateSimplificationEngine
@@ -41,22 +54,20 @@ class LazyClausification
   : public SimplificationEngine
 {
 public:
-  LazyClausification(SaturationAlgorithm& salg);
-
+  LazyClausification(SaturationAlgorithm&) {}
   ClauseIterator perform(Clause* c) override;
 private:
-  std::shared_ptr<SkolemisingFormulaIndex> _formulaIndex;
+  SkolemisingFormulaIndex _formulaIndex;
 };
 
 class LazyClausificationGIE
   : public GeneratingInferenceEngine
 {
 public:
-  LazyClausificationGIE(SaturationAlgorithm& salg);
   ClauseIterator generateClauses(Clause* c) override;
 
 private:
-  std::shared_ptr<SkolemisingFormulaIndex> _formulaIndex;
+  SkolemisingFormulaIndex _formulaIndex;
 };
 
 }

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1504,7 +1504,7 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
   if((prb.hasLogicalProxy() || prb.hasBoolVar() || prb.hasFOOL()) && prb.isHigherOrder()){
     if(env.options->cnfOnTheFly() != Options::CNFOnTheFly::EAGER && 
        env.options->cnfOnTheFly() != Options::CNFOnTheFly::OFF){
-      gie->addFront(new LazyClausificationGIE(*res));
+      gie->addFront(new LazyClausificationGIE());
     }
   }
 


### PR DESCRIPTION
Skolemizing index could still bind to terms with loose DB indices, so let's switch to higher-order code trees to avoid this.
Also, this index was a `TermIndex` (and `Index`) for no reason. From now on require any descendant of `Index` to actually implement `handleClause`, which takes care of clauses popping up in saturation.