### PR TITLE
Fix subst tree generalizations for hol

### DIFF
--- a/Indexing/SubstitutionTree_FastGen.hpp
+++ b/Indexing/SubstitutionTree_FastGen.hpp
@@ -49,14 +49,11 @@ struct SubstitutionTree<LeafData_>::GenMatcher::Binder
    */
   bool bind(unsigned var, TermList term)
   {
-    if(var > _maxVar) {
+    if (var > _maxVar || term.containsLooseDBIndex()) {
       return false;
     }
     TermList* aux;
     if(_parent->_bindings.getValuePtr(var,aux,term)) {
-      if (term.containsLooseDBIndex()) {
-        return false;
-      }
       _parent->_boundVars.push(var);
       return true;
     } else {

--- a/Kernel/PolynomialNormalizer/PredicateEvaluator.hpp
+++ b/Kernel/PolynomialNormalizer/PredicateEvaluator.hpp
@@ -34,7 +34,6 @@ template<class ConstantType, class EvalGround>
 Option<LitSimplResult> tryEvalConstant2(Literal* orig, PolyNf* evaluatedArgs, EvalGround fun) 
 {
   ASS(orig->numTermArguments() == 2);
-  using Number = NumTraits<ConstantType>;
   auto lhs = evaluatedArgs[0].template wrapPoly<NumTraits<ConstantType>>();
   auto rhs = evaluatedArgs[1].template wrapPoly<NumTraits<ConstantType>>();
   auto polarity = orig->polarity();

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1661,15 +1661,14 @@ SaturationAlgorithm *SaturationAlgorithm::createFromOptions(Problem& prb, const 
   }
 
   if (opt.forwardSubsumption()) {
-    if (prb.isHigherOrder()) {
-      // Only use the code trees for HOL, as the other is not yet adapted
-      res->addForwardSimplifierToFront<CodeTreeForwardSubsumptionAndResolution<true>>();
-    } else {
-      if (opt.codeTreeSubsumption()) {
-        res->addForwardSimplifierToFront<CodeTreeForwardSubsumptionAndResolution<false>>();
+    if (opt.codeTreeSubsumption()) {
+      if (prb.isHigherOrder()) {
+        res->addForwardSimplifierToFront<CodeTreeForwardSubsumptionAndResolution<true>>();
       } else {
-        res->addForwardSimplifierToFront<ForwardSubsumptionAndResolution>();
+        res->addForwardSimplifierToFront<CodeTreeForwardSubsumptionAndResolution<false>>();
       }
+    } else {
+      res->addForwardSimplifierToFront<ForwardSubsumptionAndResolution>();
     }
   }
   else if (opt.forwardSubsumptionResolution()) {

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -288,7 +288,7 @@ $s2a=on > s2at ~cat -1.0:50,1.0:150,1.5:37,2.0:60,2.5:20,3.0:70,3.5:15,4.0:60,4.
 > av ~cat on:15,off:4
 
 # partial_redundancy_check
-> prc ~cat on:3,off:5
+uwa=off > prc ~cat on:3,off:5
 
 # partial_redundancy_ordering_constraints
 prc=on > proc ~cat on:1,off:1


### PR DESCRIPTION
Fixes bug in substitution tree fast generalizations binder:
- Bindings were erroneously inserted when bound term contains a loose DB index.
- This could result in incorrect results later, including unbound variables bound to random terms with loose DB indices.
- This also fixes SAT-subsumption+resolution for HOL.

Extra changes: one warning was silenced, one error in HOL sampler fixed.