### PR TITLE
also add space for the negated-conjecture case ~~p

### DIFF
--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -178,7 +178,7 @@ std::string Formula::toString () const
 
         const Formula* arg = f->uarg();
         Connective subc = arg->connective();
-        if(subc == FORALL || subc == EXISTS || subc == NOT)
+        if(subc == FORALL || subc == EXISTS || subc == NOT || subc == LITERAL)
           res += " ";
         stack.push({arg->parenthesesRequired(c),NOCONN,arg});
 


### PR DESCRIPTION
In #871 I forgot about the case where there is a *negated literal* under the negation, ugh. Not urgent, just annoying.