### PR TITLE
report correct file paths for axioms

### DIFF
--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -54,7 +54,8 @@ static void doCheck(UnitList* units)
       Unit* u = uit.next();
       if(u->inputType()!= UnitInputType::MODEL_DEFINITION) continue;
       std::string name;
-      ALWAYS(Parse::TPTP::findAxiomName(u,name));
+      std::filesystem::path path;
+      ALWAYS(Parse::TPTP::findAxiomName(u,name,path));
       if(StringUtils::starts_with(name,"finite_domain")){
         std::cout << "Finite domain axiom found:" << std::endl << u->toString() << std::endl;
         // Set model size and domainConstants
@@ -141,7 +142,8 @@ static void doCheck(UnitList* units)
       Unit* u = uit.next();
       if(u->inputType()!= UnitInputType::MODEL_DEFINITION) continue;
       std::string name;
-      ALWAYS(Parse::TPTP::findAxiomName(u,name));
+      std::filesystem::path path;
+      ALWAYS(Parse::TPTP::findAxiomName(u,name,path));
       if(StringUtils::starts_with(name,"finite_domain") || StringUtils::starts_with(name,"distinct_domain")) continue;
 
       // All model formulas should be conjunctions of definitions

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -274,8 +274,9 @@ protected:
       if (outputAxiomNames && rule==InferenceRule::INPUT) {
         ASS(!parents.hasNext()); //input clauses don't have parents
         std::string name;
-        if (Parse::TPTP::findAxiomName(cs, name)) {
-          out << " " << name;
+        std::filesystem::path path;
+        if (Parse::TPTP::findAxiomName(cs, name, path)) {
+          out << " " << name << " " << path;
         }
       }
 
@@ -651,23 +652,19 @@ std::string getSkolemizeMap(unsigned unitNumber, It symIt){
 
     std::string inferenceStr;
     if (rule==InferenceRule::INPUT) {
-      std::string fileName;
-      if (env.options->inputFile()=="") {
-	      fileName="unknown";
-      }
-      else {
-	      fileName="'"+env.options->inputFile()+"'";
-      }
       std::string axiomName;
-      if (!outputAxiomNames || !Parse::TPTP::findAxiomName(us, axiomName)) {
+      std::filesystem::path axiomPath;
+      if (!outputAxiomNames || !Parse::TPTP::findAxiomName(us, axiomName, axiomPath)) {
         // Giles' ucore extraction code parses labels from smtlib files, let's try printing these too
         if (!us->isClause() && us->getFormula()->hasLabel()) {
           axiomName = us->getFormula()->getLabel();
+          axiomPath = "unknown";
         } else {
 	        axiomName="unknown";
+          axiomPath = "unknown";
         }
       }
-      inferenceStr="file("+fileName+","+quoteAxiomName(axiomName)+")";
+      inferenceStr="file("+std::string(axiomPath)+","+quoteAxiomName(axiomName)+")";
     }
     else if (!parents.hasNext()) {
       std::string newSymbolInfo;

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -60,7 +60,7 @@ static VSList* zipVarsSorts(VList* vars, SList* sorts) {
 
 #define DEBUG_SHOW_UNITS 0
 #define DEBUG_SOURCE 0
-DHMap<unsigned, std::string> TPTP::_axiomNames;
+DHMap<unsigned, std::pair<std::string, std::filesystem::path>> TPTP::_axiomNames;
 DHMap<unsigned, Map<unsigned,std::string>> TPTP::_questionVariableNames;
 
 //Numbers chosen to avoid clashing with connectives.
@@ -3719,7 +3719,7 @@ void TPTP::endFof()
   }
 
   if (env.options->outputAxiomNames()) {
-    assignAxiomName(original,nm);
+    ALWAYS(_axiomNames.insert(unit->number(), {nm, currentFile.path}));
   }
 #if DEBUG_SHOW_UNITS
   cout << "Unit: " << unit->toString() << "\n";
@@ -4849,21 +4849,17 @@ unsigned TPTP::addUninterpretedConstant(const std::string& name, bool& added)
 } // TPTP::addUninterpretedConstant
 
 /**
- * Associate name @b name with unit @b unit
- * Each formula can have its name assigned at most once
- */
-void TPTP::assignAxiomName(const Unit* unit, std::string& name)
-{
-  ALWAYS(_axiomNames.insert(unit->number(), name));
-} // TPTP::assignAxiomName
-
-/**
  * If @b unit has a name associated, assign it into @b result,
  * and return true; otherwise return false
  */
-bool TPTP::findAxiomName(const Unit* unit, std::string& result)
+bool TPTP::findAxiomName(const Unit* unit, std::string& name, std::filesystem::path &path)
 {
-  return _axiomNames.find(unit->number(), result);
+  std::pair<std::string, std::filesystem::path> found;
+  if(!_axiomNames.find(unit->number(), found))
+    return false;
+  name = std::move(found.first);
+  path = std::move(found.second);
+  return true;
 } // TPTP::findAxiomName
 
 /**

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -341,9 +341,7 @@ public:
    * based on this value.
    */
   bool containsConjecture() const { return _containsConjecture; }
-  static bool findAxiomName(const Unit* unit, std::string& result);
-  //this function is used also by the API
-  static void assignAxiomName(const Unit* unit, std::string& name);
+  static bool findAxiomName(const Unit* unit, std::string& name, std::filesystem::path &path);
   unsigned lineNumber(){ return currentFile.lineNumber; }
   std::string currentPath(){ return currentFile.path; }
 
@@ -861,9 +859,9 @@ public:
 private:
   DHMap<unsigned,SourceRecord*>* _unitSources;
 
-  /** This field stores names of input units if the
+  /** This field stores names of input units (and their file names) if the
    * output_axiom_names option is enabled */
-  static DHMap<unsigned, std::string> _axiomNames;
+  static DHMap<unsigned, std::pair<std::string, std::filesystem::path>> _axiomNames;
 
   /**
    * During question parsing, we store the mapping from int variables

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -149,7 +149,8 @@ void TPTPPrinter::printTffWrapper(Unit* u, std::string bodyStr)
 {
   tgt() << "tff(";
   std::string unitName;
-  if(Parse::TPTP::findAxiomName(u, unitName)) {
+  std::filesystem::path unitPath;
+  if(Parse::TPTP::findAxiomName(u, unitName, unitPath)) {
     tgt() << unitName;
   }
   else {
@@ -535,7 +536,8 @@ std::string TPTPPrinter::toString (const Unit* unit)
   }
 
   std::string unitName;
-  if(!Parse::TPTP::findAxiomName(unit, unitName)) {
+  std::filesystem::path unitPath;
+  if(!Parse::TPTP::findAxiomName(unit, unitName, unitPath)) {
     unitName="u" + Int::toString(unit->number());
   }
 


### PR DESCRIPTION
With `--output_axiom_names on -p tptp` we currently just report the file passed on the command line, not necessarily where the axiom was found (!). This can be confusing when multiple axioms called the same thing in different files end up in Vampire's output.

The code is not beautiful, but the whole thing needs a re-work at some point anyway, strings-that-should-be-ostreams everywhere.