### PR TITLE
remove output_axiom_names option

### DIFF
--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -199,10 +199,7 @@ std::string getQuantifiedStr(Unit* u, List<unsigned>* nonQuantified=0)
 struct InferenceStore::ProofPrinter
 {
   ProofPrinter(std::ostream& out, InferenceStore* is)
-  : _is(is), out(out)
-  {
-    outputAxiomNames=env.options->outputAxiomNames();
-  }
+  : _is(is), out(out) {}
 
   // compute closure of `us`' ancestors for printing and insert into `proof`
   void scheduleForPrinting(Unit* us)
@@ -271,7 +268,7 @@ protected:
 
       out <<"["<<cs->inference().name();
 
-      if (outputAxiomNames && rule==InferenceRule::INPUT) {
+      if (rule==InferenceRule::INPUT) {
         ASS(!parents.hasNext()); //input clauses don't have parents
         std::string name;
         std::filesystem::path path;
@@ -306,7 +303,6 @@ protected:
 
   InferenceStore *_is = nullptr;
   ostream &out;
-  bool outputAxiomNames;
 
 private:
   struct CompareSATClauses {
@@ -657,7 +653,7 @@ std::string getSkolemizeMap(unsigned unitNumber, It symIt){
     if (rule==InferenceRule::INPUT) {
       std::string axiomName;
       std::filesystem::path axiomPath;
-      if (!outputAxiomNames || !Parse::TPTP::findAxiomName(us, axiomName, axiomPath)) {
+      if (!Parse::TPTP::findAxiomName(us, axiomName, axiomPath)) {
         // Giles' ucore extraction code parses labels from smtlib files, let's try printing these too
         if (!us->isClause() && us->getFormula()->hasLabel()) {
           axiomName = us->getFormula()->getLabel();

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -3718,9 +3718,7 @@ void TPTP::endFof()
     _unitSources->insert(original->number(),source);
   }
 
-  if (env.options->outputAxiomNames()) {
-    ALWAYS(_axiomNames.insert(original->number(), {nm, currentFile.path}));
-  }
+  ALWAYS(_axiomNames.insert(original->number(), {nm, currentFile.path}));
 #if DEBUG_SHOW_UNITS
   cout << "Unit: " << unit->toString() << "\n";
 #endif

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -650,12 +650,6 @@ void Options::init()
     _inlineLet.tag(OptionTag::PREPROCESSING);
 
 //*********************** Output  ***********************
-
-    _outputAxiomNames = BoolOptionValue("output_axiom_names","",false);
-    _outputAxiomNames.description="Preserve names of axioms from the problem file in the proof output";
-    _lookup.insert(&_outputAxiomNames);
-    _outputAxiomNames.tag(OptionTag::OUTPUT);
-
     _printClausifierPremises = BoolOptionValue("print_clausifier_premises","",false);
     _printClausifierPremises.description="Output how the clausified problem was derived.";
     _lookup.insert(&_printClausifierPremises);
@@ -3504,7 +3498,6 @@ std::string Options::generateEncodedOptions() const
     forbidden.insert(&_decode);
     forbidden.insert(&_sampleStrategy);
     forbidden.insert(&_normalize);
-    forbidden.insert(&_outputAxiomNames);
     forbidden.insert(&_randomizeSeedForPortfolioWorkers);
     forbidden.insert(&_schedule);
     forbidden.insert(&_scheduleFile);

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2197,8 +2197,6 @@ public:
   TweeGoalTransformation tweeGoalTransformation() const { return _tweeGoalTransformation.actualValue; }
   bool tweeSkipArrows() const { return _tweeSkipArrows.actualValue; }
   bool codeTreeSubsumption() const { return _codeTreeSubsumption.actualValue; }
-  bool outputAxiomNames() const { return _outputAxiomNames.actualValue; }
-  void setOutputAxiomNames(bool newVal) { _outputAxiomNames.actualValue = newVal; }
   QuestionAnsweringMode questionAnswering() const { return _questionAnswering.actualValue; }
   bool questionAnsweringGroundOnly() const { return _questionAnsweringGroundOnly.actualValue; }
   std::string questionAnsweringAvoidThese() const { return _questionAnsweringAvoidThese.actualValue; }
@@ -2578,8 +2576,6 @@ private:
   BoolOptionValue _normalize;
   BoolOptionValue _shuffleInput;
   BoolOptionValue _randomPolarities;
-
-  BoolOptionValue _outputAxiomNames;
 
   StringOptionValue _printProofToFile;
   BoolOptionValue _printClausifierPremises;

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -676,10 +676,6 @@ int main(int argc, char* argv[])
 
     Lib::setMemoryLimit(env.options->memoryLimit() * 1048576ul);
 
-    if (opts.mode() == Options::Mode::MODEL_CHECK) {
-      opts.setOutputAxiomNames(true);
-    }
-
     if (opts.interactive()) {
       interactiveMetamode();
     } else {


### PR DESCRIPTION
I claim that the overhead of `--output_axiom_names on` is negligible and it's a nice thing to have. Remove the option and fix the 'on' behaviour.

If you disagree about the overhead, then I can run some performance tests.