### PR TITLE
output proofs in the TPTP fragment of the input problem

### DIFF
--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -59,7 +59,7 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
   Options opt; // default saturation algorithm options
 
   Problem* inputProblem = env.getMainProblem();
-  env.setMainProblem(&prb);
+  env.setMainProblem(&prb, /* isInputProblem */ false);
   unsigned useTimeLimit = env.options->fmbDetectSortBoundsTimeLimit();
   opt.setSplitting(false);
   opt.resolveAwayAutoValues0();
@@ -76,7 +76,7 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
     // This is expected behaviour
   }
 
-  env.setMainProblem(inputProblem);
+  env.setMainProblem(inputProblem, /* isInputProblem */ false);
 
   Stack<unsigned> foundLabels = labelFinder->getFoundLabels();
 

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -198,11 +198,9 @@ std::string Formula::toString () const
           res += Term::variableToString(var);
           // a variable of a sort other than $i must always be annotated, and
           // preprocessing is not expected to introduce such a sort into an
-          // initially untyped problem; if that ever happens, debug builds fail
-          // here and release builds still print the sort rather than drop the
-          // annotation
+          // initially untyped problem
           ASS(sort == AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts());
-          if (sort != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts()) {
+          if (env.initiallyHasNonDefaultSorts()) {
             res += " : " + sort.toString();
           }
           first = false;

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -196,7 +196,10 @@ std::string Formula::toString () const
             res += ",";
           }
           res += Term::variableToString(var);
-          if (sort != AtomicSort::defaultSort() || env.getMainProblem()->hasNonDefaultSorts()) {
+          // a variable of a sort other than $i must always be annotated: the
+          // problem's own hasNonDefaultSorts() is recomputed from the current
+          // unit list and forgets sorts that preprocessing removed
+          if (sort != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts()) {
             res += " : " + sort.toString();
           }
           first = false;

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -196,9 +196,12 @@ std::string Formula::toString () const
             res += ",";
           }
           res += Term::variableToString(var);
-          // a variable of a sort other than $i must always be annotated: the
-          // problem's own hasNonDefaultSorts() is recomputed from the current
-          // unit list and forgets sorts that preprocessing removed
+          // a variable of a sort other than $i must always be annotated, and
+          // preprocessing is not expected to introduce such a sort into an
+          // initially untyped problem; if that ever happens, debug builds fail
+          // here and release builds still print the sort rather than drop the
+          // annotation
+          ASS(sort == AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts());
           if (sort != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts()) {
             res += " : " + sort.toString();
           }

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -149,18 +149,6 @@ std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<
 }
 
 /**
- * Return @b inner quentified over variables in @b vars
- *
- * It is caller's responsibility to ensure that variables in @b vars are unique.
- */
-template<typename VarContainer>
-std::string getQuantifiedStr(const VarContainer& vars, std::string inner, bool innerParentheses=true)
-{
-  static DHMap<unsigned,TermList> d;
-  return getQuantifiedStr(vars,inner,d,innerParentheses);
-}
-
-/**
  * Return std::string containing quantified unit @b u.
  */
 std::string getQuantifiedStr(Unit* u, List<unsigned>* nonQuantified=0)
@@ -442,9 +430,14 @@ struct InferenceStore::TPTPProofPrinter
 
   void print() override
   {
-    //outputSymbolDeclarations also deals with sorts for now
-    //UIHelper::outputSortDeclarations(out);
-    UIHelper::outputSymbolDeclarations(out);
+    //an fof proof needs no type declarations, and the signature can hold a
+    //typed symbol no unit ever used, whose declaration would put a tff line
+    //into an otherwise fof proof
+    if(env.initiallyHasNonDefaultSorts() || env.initiallyHigherOrder()){
+      //outputSymbolDeclarations also deals with sorts for now
+      //UIHelper::outputSortDeclarations(out);
+      UIHelper::outputSymbolDeclarations(out);
+    }
     ProofPrinter::print();
   }
 
@@ -780,6 +773,11 @@ std::string getSkolemizeMap(unsigned unitNumber, It symIt){
 
     Literal* nameLit=_is->_splittingNameLiterals.get(us->number()); //the name literal must always be stored
 
+    //sorts of the clause's variables, so the quantifiers of the definition
+    //below are annotated like every other formula in the proof
+    DHMap<unsigned,TermList> t_map;
+    SortHelper::collectVariableSorts(us, t_map);
+
     std::string defId=tptpDefId(us);
 
     out<<getFofString(tptpUnitId(us), getFormulaString(us),
@@ -821,11 +819,11 @@ std::string getSkolemizeMap(unsigned unitNumber, It symIt){
     }
     ASS(!first);
 
-    compStr=getQuantifiedStr(compOnlyVars, compStr, multiple);
+    compStr=getQuantifiedStr(compOnlyVars, compStr, t_map, multiple);
     List<unsigned>::destroy(compOnlyVars);
 
     std::string defStr=compStr+" <=> "+Literal::complementaryLiteral(nameLit)->toString();
-    defStr=getQuantifiedStr(nameVars, defStr);
+    defStr=getQuantifiedStr(nameVars, defStr, t_map);
     List<unsigned>::destroy(nameVars);
 
     SymbolId nameSymbol = SymbolId(SymbolType::PRED,nameLit->functor());
@@ -850,9 +848,12 @@ protected:
     InferenceRule rule = cs->inference().rule();
     UnitIterator parents= cs->getParents();
 
-    //outputSymbolDeclarations also deals with sorts for now
-    //UIHelper::outputSortDeclarations(out);
-    UIHelper::outputSymbolDeclarations(out);
+    //an fof proof needs no type declarations, see TPTPProofPrinter::print
+    if(env.initiallyHasNonDefaultSorts() || env.initiallyHigherOrder()){
+      //outputSymbolDeclarations also deals with sorts for now
+      //UIHelper::outputSortDeclarations(out);
+      UIHelper::outputSymbolDeclarations(out);
+    }
 
     // fragment of the unpreprocessed input, see the comment in getFofString
     std::string kind = "fof";

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -117,9 +117,11 @@ std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<
     std::string ty="";
     TermList t;
 
-    if(t_map.find(var,t) && env.getMainProblem()->hasNonDefaultSorts()){
-      //hasNonDefaultSorts is true if the problem contains a sort
-      //that is not $i and not a variable
+    if(t_map.find(var,t) &&
+       (t != AtomicSort::defaultSort() || env.getMainProblem()->hasNonDefaultSorts())){
+      //a variable of a sort other than $i must always be annotated: relying on
+      //hasNonDefaultSorts alone loses the annotation when preprocessing removes
+      //the last unit mentioning that sort. Same predicate as Formula::toString.
       ty=" : " + t.toString();
     }
     if(ty == " : $tType"){
@@ -530,9 +532,10 @@ protected:
 
   std::string getFofString(std::string id, std::string formula, std::string inference, InferenceRule rule, UnitInputType origin=UnitInputType::AXIOM)
   {
-    std::string kind = "fof";
-    if(env.getMainProblem()->hasNonDefaultSorts()){ kind="tff"; }
-    if(env.getMainProblem()->isHigherOrder()){ kind="thf"; }
+    // always TFF: it subsumes FOF, and choosing between them from
+    // hasNonDefaultSorts() is wrong, because that property is recomputed from
+    // the current unit list and so forgets sorts that preprocessing removed.
+    std::string kind = env.getMainProblem()->isHigherOrder() ? "thf" : "tff";
 
     return kind+"("+id+","+getRole(rule,origin)+",("+"\n"
 	+"  "+formula+"),\n"
@@ -858,9 +861,8 @@ protected:
     //UIHelper::outputSortDeclarations(out);
     UIHelper::outputSymbolDeclarations(out);
 
-    std::string kind = "fof";
-    if(env.getMainProblem()->hasNonDefaultSorts()){ kind="tff"; }
-    if(env.getMainProblem()->isHigherOrder()){ kind="thf"; }
+    // always TFF, see the comment in getFofString
+    std::string kind = env.getMainProblem()->isHigherOrder() ? "thf" : "tff";
 
     out << kind
         << "(r"<< cs->number()

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -120,11 +120,9 @@ std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<
     if(t_map.find(var,t)){
       //a variable of a sort other than $i must always be annotated, and
       //preprocessing is not expected to introduce such a sort into an
-      //initially untyped problem; if that ever happens, debug builds fail
-      //here and release builds still print the sort rather than drop the
-      //annotation. Same predicate as Formula::toString.
+      //initially untyped problem. Same predicate as Formula::toString.
       ASS(t == AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts());
-      if(t != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts()){
+      if(env.initiallyHasNonDefaultSorts()){
         ty=" : " + t.toString();
       }
     }

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -117,13 +117,16 @@ std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<
     std::string ty="";
     TermList t;
 
-    if(t_map.find(var,t) &&
-       (t != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts())){
-      //a variable of a sort other than $i must always be annotated: the
-      //problem's own hasNonDefaultSorts() loses the annotation when
-      //preprocessing removes the last unit mentioning that sort.
-      //Same predicate as Formula::toString.
-      ty=" : " + t.toString();
+    if(t_map.find(var,t)){
+      //a variable of a sort other than $i must always be annotated, and
+      //preprocessing is not expected to introduce such a sort into an
+      //initially untyped problem; if that ever happens, debug builds fail
+      //here and release builds still print the sort rather than drop the
+      //annotation. Same predicate as Formula::toString.
+      ASS(t == AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts());
+      if(t != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts()){
+        ty=" : " + t.toString();
+      }
     }
     if(ty == " : $tType"){
       if (!first) { varStr = "," + varStr; }

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -118,10 +118,11 @@ std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<
     TermList t;
 
     if(t_map.find(var,t) &&
-       (t != AtomicSort::defaultSort() || env.getMainProblem()->hasNonDefaultSorts())){
-      //a variable of a sort other than $i must always be annotated: relying on
-      //hasNonDefaultSorts alone loses the annotation when preprocessing removes
-      //the last unit mentioning that sort. Same predicate as Formula::toString.
+       (t != AtomicSort::defaultSort() || env.initiallyHasNonDefaultSorts())){
+      //a variable of a sort other than $i must always be annotated: the
+      //problem's own hasNonDefaultSorts() loses the annotation when
+      //preprocessing removes the last unit mentioning that sort.
+      //Same predicate as Formula::toString.
       ty=" : " + t.toString();
     }
     if(ty == " : $tType"){
@@ -520,10 +521,14 @@ protected:
 
   std::string getFofString(std::string id, std::string formula, std::string inference, InferenceRule rule, UnitInputType origin=UnitInputType::AXIOM)
   {
-    // always TFF: it subsumes FOF, and choosing between them from
-    // hasNonDefaultSorts() is wrong, because that property is recomputed from
-    // the current unit list and so forgets sorts that preprocessing removed.
-    std::string kind = env.getMainProblem()->isHigherOrder() ? "thf" : "tff";
+    // use the fragment of the unpreprocessed input: the problem's own
+    // hasNonDefaultSorts() and isHigherOrder() are recomputed from the current
+    // unit list, so they forget sorts that preprocessing removed, and TPTP
+    // conventions allow a proof in a weaker fragment than the input but not in
+    // a stronger one
+    std::string kind = "fof";
+    if(env.initiallyHasNonDefaultSorts()){ kind="tff"; }
+    if(env.initiallyHigherOrder()){ kind="thf"; }
 
     return kind+"("+id+","+getRole(rule,origin)+",("+"\n"
 	+"  "+formula+"),\n"
@@ -849,8 +854,10 @@ protected:
     //UIHelper::outputSortDeclarations(out);
     UIHelper::outputSymbolDeclarations(out);
 
-    // always TFF, see the comment in getFofString
-    std::string kind = env.getMainProblem()->isHigherOrder() ? "thf" : "tff";
+    // fragment of the unpreprocessed input, see the comment in getFofString
+    std::string kind = "fof";
+    if(env.initiallyHasNonDefaultSorts()){ kind="tff"; }
+    if(env.initiallyHigherOrder()){ kind="thf"; }
 
     out << kind
         << "(r"<< cs->number()

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -64,9 +64,21 @@ public:
    * be explicitly passed to all the functions interested in knowing...)
    */
   Kernel::Problem* getMainProblem() { return _problem; }
-  void setMainProblem(Kernel::Problem* p) {
+  /**
+   * Set the problem accessed through getMainProblem(). When @b isInputProblem
+   * is true, additionally record which TPTP fragment (fof/tff/thf) the problem
+   * starts out in, so that proof output can keep printing that fragment after
+   * preprocessing has changed the unit list. Pass false when temporarily
+   * swapping in an auxiliary problem (see FunctionRelationshipInference), so
+   * the recorded fragment of the input problem survives the swap.
+   */
+  void setMainProblem(Kernel::Problem* p, bool isInputProblem = true) {
     _problem = p;
     _higherOrder = _problem->isHigherOrder();
+    if (isInputProblem) {
+      _initiallyHigherOrder = _higherOrder;
+      _initiallyHasNonDefaultSorts = _problem->hasNonDefaultSorts();
+    }
   }
 
   bool higherOrder() const {
@@ -77,9 +89,22 @@ public:
     _higherOrder = value;
   }
 
+  bool initiallyHigherOrder() const {
+    return _initiallyHigherOrder;
+  }
+
+  bool initiallyHasNonDefaultSorts() const {
+    return _initiallyHasNonDefaultSorts;
+  }
+
 private:
   Kernel::Problem* _problem;
   bool _higherOrder;
+  // the fragment of the input problem before preprocessing: Problem's own
+  // hasNonDefaultSorts() and isHigherOrder() are recomputed from the current
+  // unit list, so they forget sorts whose last occurrence preprocessing removed
+  bool _initiallyHigherOrder = false;
+  bool _initiallyHasNonDefaultSorts = false;
 }; // class Environment
 
 extern Environment env;

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -685,7 +685,9 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool funct
 
   //don't output type of app. It is an internal Vampire thing
   if(!(function && env.signature->isAppFun(symNumber))){
-    out << (env.getMainProblem()->isHigherOrder() ? "thf(" : "tff(")
+    //match the fragment used for the proof steps (see
+    //InferenceStore's getFofString), so one proof does not mix languages
+    out << (env.initiallyHigherOrder() ? "thf(" : "tff(")
         << (function ? "func" : (typeCon ?  "type" : "pred"))
         << "_def_" << symNumber << ", type, "
         << symName << ": ";

--- a/checks/Problems/ARI/ARI496_1.p
+++ b/checks/Problems/ARI/ARI496_1.p
@@ -1,0 +1,34 @@
+%------------------------------------------------------------------------------
+% File     : ARI496_1 : TPTP v9.3.0. Released v5.0.0.
+% Domain   : Arithmetic
+% Problem  : Mixed: 6 is an integer
+% Version  : Especial.
+% English  :
+
+% Refs     :
+% Source   : [TPTP]
+% Names    :
+
+% Status   : Theorem
+% Rating   : 0.00 v6.2.0, 0.20 v6.1.0, 0.11 v6.0.0, 0.12 v5.4.0, 0.25 v5.3.0, 0.29 v5.2.0, 0.40 v5.1.0, 0.50 v5.0.0
+% Syntax   : Number of formulae    :    1 (   1 unt;   0 typ;   0 def)
+%            Number of atoms       :    1 (   0 equ)
+%            Maximal formula atoms :    1 (   1 avg)
+%            Number of connectives :    0 (   0   ~;   0   |;   0   &)
+%                                         (   0 <=>;   0  =>;   0  <=;   0 <~>)
+%            Maximal formula depth :    1 (   1 avg)
+%            Maximal term depth    :    1 (   1 avg)
+%            Number arithmetic     :    2 (   1 atm;   0 fun;   1 num;   0 var)
+%            Number of types       :    0 (   0 usr)
+%            Number of type conns  :    0 (   0   >;   0   *;   0   +;   0  <<)
+%            Number of predicates  :    1 (   0 usr;   0 prp; 1-1 aty)
+%            Number of functors    :    1 (   0 usr;   1 con; 0-0 aty)
+%            Number of variables   :    0 (   0   !;   0   ?;   0   :)
+% SPC      : TF0_THM_NEQ_ARI
+
+% Comments :
+%------------------------------------------------------------------------------
+tff(mixed_types_problem_1,conjecture,
+    $is_int(6) ).
+
+%------------------------------------------------------------------------------

--- a/checks/proof/gsp-typed.p
+++ b/checks/proof/gsp-typed.p
@@ -1,8 +1,5 @@
-% ax1 chains four literals through single shared variables, so -gsp on names
-% part of it, and the proof contains a general splitting definition whose
-% quantified variables must carry their $int sorts. Keep the predicates at
-% most binary: the sanity check greps the definition for a bare variable, and
-% an argument list with three or more variables would look like one.
+% expected: with -gsp on, the proof contains a general splitting definition
+% whose quantified variables carry their $int sorts.
 tff(pp_decl,type, pp: $int > $o ).
 tff(qq_decl,type, qq: ($int * $int) > $o ).
 tff(rr_decl,type, rr: ($int * $int) > $o ).

--- a/checks/proof/gsp-typed.p
+++ b/checks/proof/gsp-typed.p
@@ -1,0 +1,14 @@
+% ax1 chains four literals through single shared variables, so -gsp on names
+% part of it, and the proof contains a general splitting definition whose
+% quantified variables must carry their $int sorts. Keep the predicates at
+% most binary: the sanity check greps the definition for a bare variable, and
+% an argument list with three or more variables would look like one.
+tff(pp_decl,type, pp: $int > $o ).
+tff(qq_decl,type, qq: ($int * $int) > $o ).
+tff(rr_decl,type, rr: ($int * $int) > $o ).
+tff(ss_decl,type, ss: $int > $o ).
+tff(ax1,axiom, ![X:$int, Y:$int, Z:$int]: (pp(X) | qq(X,Y) | rr(Y,Z) | ss(Z)) ).
+tff(ax2,axiom, ![X:$int]: ~pp(X) ).
+tff(ax3,axiom, ![Z:$int]: ~ss(Z) ).
+tff(ax4,axiom, ![Y:$int, Z:$int]: ~rr(Y,Z) ).
+tff(c,conjecture, qq(1,2) ).

--- a/checks/proof/mixed-language.p
+++ b/checks/proof/mixed-language.p
@@ -1,0 +1,9 @@
+% p is the only symbol of a sort other than $i, and the only unit mentioning it
+% collapses to $true during preprocessing. The signature keeps p, so its type
+% declaration is still printed, while the surviving units are all $i. Choosing
+% the proof output language from a Problem property therefore used to emit a tff
+% type declaration followed by fof formulas in the same proof.
+tff(p_decl,type, p: $int > $o ).
+tff(erased,axiom, p(1) | $is_int(6) ).
+fof(a1,axiom, q(a) ).
+fof(c1,conjecture, q(a) ).

--- a/checks/proof/mixed-language.p
+++ b/checks/proof/mixed-language.p
@@ -1,8 +1,5 @@
-% p is the only symbol of a sort other than $i, and the only unit mentioning it
-% collapses to $true during preprocessing. The signature keeps p, so its type
-% declaration is still printed, while the surviving units are all $i. Choosing
-% the proof output language from a Problem property therefore used to emit a tff
-% type declaration followed by fof formulas in the same proof.
+% expected: the whole proof is tff, with no fof lines after p's type
+% declaration.
 tff(p_decl,type, p: $int > $o ).
 tff(erased,axiom, p(1) | $is_int(6) ).
 fof(a1,axiom, q(a) ).

--- a/checks/proof/unused-typed-symbol.p
+++ b/checks/proof/unused-typed-symbol.p
@@ -1,6 +1,4 @@
-% p is declared with a typed signature but never occurs in a formula, so the
-% problem parses as untyped and the proof is fof. The declaration is printed
-% from the signature, which used to put a tff line in front of the fof proof.
+% expected: the proof stays fof even though p has a typed declaration.
 tff(p_decl,type, p: $int > $o ).
 fof(a1,axiom, q(a) ).
 fof(c1,conjecture, q(a) ).

--- a/checks/proof/unused-typed-symbol.p
+++ b/checks/proof/unused-typed-symbol.p
@@ -1,0 +1,6 @@
+% p is declared with a typed signature but never occurs in a formula, so the
+% problem parses as untyped and the proof is fof. The declaration is printed
+% from the signature, which used to put a tff line in front of the fof proof.
+tff(p_decl,type, p: $int > $o ).
+fof(a1,axiom, q(a) ).
+fof(c1,conjecture, q(a) ).

--- a/checks/sanity
+++ b/checks/sanity
@@ -75,6 +75,26 @@ check_no_fof() {
 	fi
 }
 
+# check the proof of an untyped problem stays in fof: TPTP allows a proof in a
+# weaker fragment than the input, not in a stronger one
+check_fof_only() {
+	run_vampire $@
+	typed=`grep -E '^(tff|thf)\(' checks/vampire-stdout`
+	if test -n "$typed"
+	then
+		echo "proof output should be fof only: offending lines follow"
+		echo "$typed"
+		exit 1
+	fi
+	fof=`grep -E '^fof\(' checks/vampire-stdout`
+	if test -z "$fof"
+	then
+		echo "expected fof formulas in the proof output"
+		cat checks/vampire-stdout checks/vampire-stderr
+		exit 1
+	fi
+}
+
 # Some simple problems: fail early!
 check_szs_status Theorem Problems/PUZ/PUZ001+1.p
 
@@ -182,10 +202,10 @@ check_szs_status Unsatisfiable -qa synthesis synthesis/ex2-inverse_of_ixopiy.smt
 check_szs_status Theorem hol/hol1.p
 
 # Proof output language: the arithmetic goes away during preprocessing, so a
-# problem-level "does this need tff?" test gets this wrong
+# test on the current units gets this wrong
 check_no_fof -p tptp Problems/ARI/ARI496_1.p
 check_no_fof -p proofcheck Problems/ARI/ARI496_1.p
 # a tff type declaration used to be followed by fof formulas in one proof
 check_no_fof -p tptp proof/mixed-language.p
-# untyped problems are output as tff too
-check_no_fof -p tptp Problems/PUZ/PUZ001+1.p
+# untyped problems keep fof
+check_fof_only -p tptp Problems/PUZ/PUZ001+1.p

--- a/checks/sanity
+++ b/checks/sanity
@@ -75,6 +75,26 @@ check_no_fof() {
 	fi
 }
 
+# check the proof contains a general splitting definition and that its
+# variables carry sort annotations
+check_gsp_defs_typed() {
+	run_vampire $@
+	def=`grep -B1 'general_splitting_component_introduction' checks/vampire-stdout`
+	if test -z "$def"
+	then
+		echo "expected a general splitting definition in the proof"
+		cat checks/vampire-stdout checks/vampire-stderr
+		exit 1
+	fi
+	bare=`echo "$def" | grep -E '[[,]X[0-9]+[],]'`
+	if test -n "$bare"
+	then
+		echo "general splitting definition has unannotated variables:"
+		echo "$bare"
+		exit 1
+	fi
+}
+
 # check the proof of an untyped problem stays in fof: TPTP allows a proof in a
 # weaker fragment than the input, not in a stronger one
 check_fof_only() {
@@ -209,3 +229,7 @@ check_no_fof -p proofcheck Problems/ARI/ARI496_1.p
 check_no_fof -p tptp proof/mixed-language.p
 # untyped problems keep fof
 check_fof_only -p tptp Problems/PUZ/PUZ001+1.p
+# a typed declaration of a symbol that no unit uses must not force tff either
+check_fof_only -p tptp proof/unused-typed-symbol.p
+# general splitting definitions must annotate their variables
+check_gsp_defs_typed -gsp on -p tptp proof/gsp-typed.p

--- a/checks/sanity
+++ b/checks/sanity
@@ -62,6 +62,19 @@ check_smtcomp_status() {
 	fi
 }
 
+# check the proof output does not fall back to fof, which is wrong as soon as
+# anything typed survives into the proof
+check_no_fof() {
+	run_vampire $@
+	fof=`grep -E '^fof\(' checks/vampire-stdout`
+	if test -n "$fof"
+	then
+		echo "proof output should be tff, not fof: offending lines follow"
+		echo "$fof"
+		exit 1
+	fi
+}
+
 # Some simple problems: fail early!
 check_szs_status Theorem Problems/PUZ/PUZ001+1.p
 
@@ -157,3 +170,12 @@ check_szs_status Unsatisfiable -qa synthesis synthesis/ex2-inverse_of_ixopiy.smt
 
 # Higher-order logic
 check_szs_status Theorem hol/hol1.p
+
+# Proof output language: the arithmetic goes away during preprocessing, so a
+# problem-level "does this need tff?" test gets this wrong
+check_no_fof -p tptp Problems/ARI/ARI496_1.p
+check_no_fof -p proofcheck Problems/ARI/ARI496_1.p
+# a tff type declaration used to be followed by fof formulas in one proof
+check_no_fof -p tptp proof/mixed-language.p
+# untyped problems are output as tff too
+check_no_fof -p tptp Problems/PUZ/PUZ001+1.p

--- a/checks/sanity
+++ b/checks/sanity
@@ -62,59 +62,6 @@ check_smtcomp_status() {
 	fi
 }
 
-# check the proof output does not fall back to fof, which is wrong as soon as
-# anything typed survives into the proof
-check_no_fof() {
-	run_vampire $@
-	fof=`grep -E '^fof\(' checks/vampire-stdout`
-	if test -n "$fof"
-	then
-		echo "proof output should be tff, not fof: offending lines follow"
-		echo "$fof"
-		exit 1
-	fi
-}
-
-# check the proof contains a general splitting definition and that its
-# variables carry sort annotations
-check_gsp_defs_typed() {
-	run_vampire $@
-	def=`grep -B1 'general_splitting_component_introduction' checks/vampire-stdout`
-	if test -z "$def"
-	then
-		echo "expected a general splitting definition in the proof"
-		cat checks/vampire-stdout checks/vampire-stderr
-		exit 1
-	fi
-	bare=`echo "$def" | grep -E '[[,]X[0-9]+[],]'`
-	if test -n "$bare"
-	then
-		echo "general splitting definition has unannotated variables:"
-		echo "$bare"
-		exit 1
-	fi
-}
-
-# check the proof of an untyped problem stays in fof: TPTP allows a proof in a
-# weaker fragment than the input, not in a stronger one
-check_fof_only() {
-	run_vampire $@
-	typed=`grep -E '^(tff|thf)\(' checks/vampire-stdout`
-	if test -n "$typed"
-	then
-		echo "proof output should be fof only: offending lines follow"
-		echo "$typed"
-		exit 1
-	fi
-	fof=`grep -E '^fof\(' checks/vampire-stdout`
-	if test -z "$fof"
-	then
-		echo "expected fof formulas in the proof output"
-		cat checks/vampire-stdout checks/vampire-stderr
-		exit 1
-	fi
-}
-
 # Some simple problems: fail early!
 check_szs_status Theorem Problems/PUZ/PUZ001+1.p
 
@@ -220,16 +167,3 @@ check_szs_status Unsatisfiable -qa synthesis synthesis/ex2-inverse_of_ixopiy.smt
 
 # Higher-order logic
 check_szs_status Theorem hol/hol1.p
-
-# Proof output language: the arithmetic goes away during preprocessing, so a
-# test on the current units gets this wrong
-check_no_fof -p tptp Problems/ARI/ARI496_1.p
-check_no_fof -p proofcheck Problems/ARI/ARI496_1.p
-# a tff type declaration used to be followed by fof formulas in one proof
-check_no_fof -p tptp proof/mixed-language.p
-# untyped problems keep fof
-check_fof_only -p tptp Problems/PUZ/PUZ001+1.p
-# a typed declaration of a symbol that no unit uses must not force tff either
-check_fof_only -p tptp proof/unused-typed-symbol.p
-# general splitting definitions must annotate their variables
-check_gsp_defs_typed -gsp on -p tptp proof/gsp-typed.p


### PR DESCRIPTION
Fixes #730.

`InferenceStore` chose between `fof` and `tff` using `Problem::hasNonDefaultSorts()`. That property is recomputed from the current unit list (`refreshProperty` calls `Property::scan(_units)`), so it answers "do the units I am holding right now mention a non-`$i` sort" rather than "which fragment was the input problem in". Preprocessing can delete the last unit mentioning a sort, and the property then reports an untyped problem while the proof still contains typed formulas.

The eight problems listed in #730 hit this. The conjecture normalizes to `~$true`, the arithmetic disappears, and the proof comes out as:

```tptp
fof(f1,conjecture,(
  $is_int(6)),
  file('ARI496_1.p',mixed_types_problem_1)).
```

## What changed

The first version of this PR printed `tff` unconditionally, as @MichaelRawson suggested in #730. It is now the union of that and @mezpusz's counter-proposal on `fix-output-tptp-fragment`:

- `Problem` records `initiallyHasNonDefaultSorts` and `initiallyHigherOrder` when the input problem is set, and the proof printers pick `fof`, `tff` or `thf` from those flags. A pure FOF problem keeps its `fof` proof.
- Variable annotations use a per-formula test (`t != defaultSort() || initiallyHasNonDefaultSorts()`) in `getQuantifiedStr` and `Formula::toString`, so a `$int` variable surviving in a proof step never prints bare and reads back as `$i`.
- The `getQuantifiedStr` overload without a sort map is gone. It passed a static `DHMap` that nothing ever filled, and `printGeneralSplittingComponent` went through it: `ALWAYS(t_map.find(var,t))` on an empty map is undefined behaviour in release, and the general splitting definitions printed their variables without sorts either way. The definition printer now collects the sorts from the clause.
- `FunctionRelationshipInference` swaps the main problem twice during FMB sort bound detection, which runs after preprocessing, so the flags got recomputed from the preprocessed units and the bug came back for fmb strategies. Those two calls now skip the recording (`isInputProblem=false`).
- `outputSymbolTypeDeclarationIfNeeded` follows the saved flags, and the proof printers skip type declarations entirely when the recorded fragment is fof. The signature can hold a typed symbol that no unit ever used, and its declaration would put a `tff` line in front of an `fof` proof.

`-p on`, `-p smtcheck` and `-p smt2_proofcheck` are untouched, and SAT steps from AVATAR still print as `cnf`.

## Testing

- `checks/sanity` passes. The new checks test both directions: no `fof` in the proofs of ARI496_1 and `mixed-language.p`, only `fof` for PUZ001+1 and for a problem whose signature holds an unused typed symbol, and sort annotations on the gsp definitions (`checks/proof/gsp-typed.p` fails on master).
- 97/97 unit tests pass in debug, plus assertion-enabled runs including `-sa fmb -fmbdsb on`.
- `-p tptp` over the checks problems against master: ARI496_1, `let-bool.p` and `mixed-language.p` change `fof(` to `tff(`, `unused-typed-symbol.p` drops the unused declaration, every SZS status is unchanged, and the remaining outputs are identical up to the clause renumbering master already shows between runs.

I still have not checked the output against a strict TPTP parser like tptp4X; Vampire's own parser accepted the broken proofs, so round-tripping through Vampire does not catch the old behaviour.
