### PR TITLE
build $let definitions of Boolean symbols as formulas

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -2736,7 +2736,16 @@ void TPTP::endLet()
       }
       vars = varList;
     }
-    auto binding = Formula::createDefinition(Term::create(symbol, args), body, vars);
+    Term* lhs;
+    if (isPredicate) {
+      // symbol is a predicate number, so it cannot go through Term::create.
+      // Wrap it as a formula to preserve the term-formula boundary, the same
+      // way SMTLIB2::parseLet does.
+      lhs = Term::createFormula(new AtomicFormula(Literal::create(symbol, args.size(), true, args.begin())));
+    } else {
+      lhs = Term::create(symbol, args);
+    }
+    auto binding = Formula::createDefinition(lhs, body, vars);
     let = TermList(Term::createLet(binding, let, sort));
   }
   _termLists.push(let);

--- a/checks/sanity
+++ b/checks/sanity
@@ -85,6 +85,16 @@ check_szs_status Theorem -newcnf on theory/let-tuple-bool.p
 check_szs_status Theorem -newcnf on -ile off theory/let-function.p
 check_szs_status Theorem -newcnf on -ile off theory/let-tuple.p
 check_szs_status Theorem -newcnf on -ile off theory/let-tuple-bool.p
+check_szs_status Theorem theory/let-bool.p
+check_szs_status Theorem -newcnf on theory/let-bool.p
+check_szs_status Theorem -ile off theory/let-bool.p
+check_szs_status Theorem -newcnf on -ile off theory/let-bool.p
+check_szs_status Theorem theory/let-bool-pred.p
+check_szs_status Theorem -newcnf on theory/let-bool-pred.p
+check_szs_status Theorem -ile off theory/let-bool-pred.p
+check_szs_status Theorem -newcnf on -ile off theory/let-bool-pred.p
+check_szs_status Theorem theory/let-bool-simultaneous.p
+check_szs_status Theorem -newcnf on theory/let-bool-simultaneous.p
 
 # Arrays
 check_szs_status Unsatisfiable theory/arrays.smt2

--- a/checks/theory/let-bool-pred.p
+++ b/checks/theory/let-bool-pred.p
@@ -1,0 +1,9 @@
+% As let-bool.p, but the bound Boolean symbol takes an argument, so the
+% definition is quantified over it. Also shadows a global of the same name.
+tff(r,type,
+    r: $int > $o ).
+
+tff(let_bool_pred,conjecture,
+    $let(r: $int > $o,
+      r(X) := ( r(X) | ~ r(X) ),
+      r(1) ) ).

--- a/checks/theory/let-bool-simultaneous.p
+++ b/checks/theory/let-bool-simultaneous.p
@@ -1,0 +1,9 @@
+% Two Boolean symbols bound in one $let, so endLet builds a definition for each.
+% One of them is Boolean and one is not, which used to give a sort error rather
+% than a crash.
+tff(let_bool_simultaneous,conjecture,
+    $let(
+      [ b: $o, k: $int ],
+      [ b := $true, k := 1 ],
+      ( b
+      & $greater(k,0) ) ) ).

--- a/checks/theory/let-bool-simultaneous.p
+++ b/checks/theory/let-bool-simultaneous.p
@@ -1,6 +1,5 @@
-% Two Boolean symbols bound in one $let, so endLet builds a definition for each.
-% One of them is Boolean and one is not, which used to give a sort error rather
-% than a crash.
+% Two symbols bound in one $let, one Boolean and one not, so endLet builds a
+% definition for each. On master this shape is a sort error, not a crash.
 tff(let_bool_simultaneous,conjecture,
     $let(
       [ b: $o, k: $int ],

--- a/checks/theory/let-bool.p
+++ b/checks/theory/let-bool.p
@@ -1,0 +1,11 @@
+% A $let binding a nullary Boolean symbol, shadowing a global of the same name.
+% The definition used to be built by passing a predicate number to Term::create,
+% which then read past the end of the function signature. The definition is a
+% tautology, so the conjecture is a theorem.
+tff(q,type,
+    q: $o ).
+
+tff(let_bool,conjecture,
+    $let(q: $o,
+      q := ( q | ~ q ),
+      q ) ).


### PR DESCRIPTION
Fixes #863.

`TPTP::endLet` built the definition with `Term::create(symbol, args)`. When the `$let` binds a Boolean symbol, `symbol` is a predicate number, so `Term::create` looked it up in the function half of the signature: `Signature::functionArity` then indexed past the end of the function stack. In a debug build it trips the bounds assertion in `Lib::Stack::operator[]`, in a release build it segfaults.

`SMTLIB2::parseLet` already handles this, with a comment about preserving the term-formula boundary, so this makes the TPTP parser do the same thing.

## Shadowing is not the cause

The issue puts it down to shadowing, and `SWX006_1.p` does shadow `bad`, `max` and `i` repeatedly, but shadowing turns out to be irrelevant. This is enough on its own:

```tptp
tff(c,conjecture, $let(p: $o, p := $true, p ) ).
```

Any `$let` over a Boolean symbol crashes on master, shadowing or not, fresh name or not. `SWX006_1.p` is just the first problem anyone ran into that contains one.

With the fix, `SWX006_1.p` gives `SZS status Theorem`, which matches its TPTP header, and `--show_everything on` no longer dies while printing.

## A separate problem this uncovers

Once the crash is gone, `-newcnf on` gives a wrong answer for a conjecture holding two or more Boolean `$let`s. It reports `CounterSatisfiable` for this theorem:

```tptp
tff(q,type, q: $o ).
tff(c,conjecture,
    ( $let(b: $o, b := ( q | ~ q ), b )
    & $let(d: $o, d := ( q | ~ q ), d ) ) ).
```

That one predates this change and I have left it alone. NewCNF gets the same shape from the SMT-LIB parser, which has always built Boolean let definitions this way, so it reproduces on master with no parser change at all:

```smt2
(set-logic ALL)
(declare-fun q () Bool)
(assert (not (and (let ((b (or q (not q)))) b) (let ((d (or q (not q)))) d))))
(check-sat)
```

`vampire --input_syntax smtlib2 -newcnf on` answers `Satisfiable`, on master and with this branch alike, where the default clausifier answers `Unsatisfiable`. A single Boolean `$let` is fine in both. Worth its own issue, and I am happy to file one with the reduction if that helps.

The regression tests below therefore use one Boolean `$let` per file, so they pass in all four clausifier configurations instead of encoding the NewCNF bug as expected behaviour.

## Testing

- `checks/theory/let-bool.p` (nullary) and `checks/theory/let-bool-pred.p` (arity 1), each shadowing a global of the same name, both under the default clausifier and `-newcnf on`, with and without `-ile off`. All eight combinations give `Theorem` with the fix and segfault without it. `checks/theory/let-bool-simultaneous.p` covers two symbols bound in one `$let`, so `endLet` builds a definition per symbol; on master that one is a sort error rather than a crash.
- Other shapes I ran by hand, each `Theorem` in default, `-newcnf on` and `-ile off`, each a segfault on master: predicate of arity 2, a Boolean `$let` nested in another one's definition, a Boolean `$let` under an outer quantifier whose definition uses the bound variable, a Boolean `$let` whose body rebinds the same name again, and two Boolean symbols bound simultaneously.
- Two shapes I could not get to the changed code at all: `$let(p: !>[A: $tType]: A > $o, ...)` and its implicit form `$let(p: A > $o, ...)`. Both are rejected earlier with a `User error`, identically on master and on this branch. So the `iTypeArgs` part of the new `args.size()` is not covered by anything I could construct, and I have left that path as it was.
- `checks/sanity` passes, 74 checks, built against Z3 4.14.0.
- Unit tests: 96 of 97 pass. `Inferences_HOL_Injectivity` fails the same way with `Parse/TPTP.cpp` reverted, so it is not from here.
- Debug build, assertions on, over the new tests and the existing `theory/let-*.p` ones. Nothing fires on the new tests. `theory/let-tuple-bool.p` in default mode does trip `Shell/LispParser.hpp:109`, but it does so on master too: the TPTP parser raises its own "set --newcnf on if using tuples" error, auto mode then falls back to SMT-LIB, and the Lisp parser asserts on the way out. That is presumably why `checks/sanity` only runs the tuple tests with `-newcnf on`.
