### PR TITLE
Fix eqModACRect renaming check and Injectivity success_3 expectation

### DIFF
--- a/Test/TestUtils.cpp
+++ b/Test/TestUtils.cpp
@@ -204,7 +204,9 @@ Stack<TermList> collect(unsigned functor, Term* t) {
 template<class Comparisons>
 bool TestUtils::eqModAC_(TermList lhs, TermList rhs, Comparisons comp)
 {
-  if (lhs == rhs) { return true; }
+  // NB: deliberately no `lhs == rhs` fast path. Two syntactically identical
+  // subterms still have to agree with the renaming `comp` is building up, so
+  // returning early here lets an inconsistent renaming through.
   if (lhs.isVar() && rhs.isVar()) {
     return comp.var(lhs.var(), rhs.var());
   } else if (lhs.isTerm() && rhs.isTerm()) {
@@ -270,7 +272,7 @@ bool TestUtils::eqModACRect(Kernel::TermList lhs, Kernel::TermList rhs)
   auto vl = iterTraits(vi(new VariableIterator(lhs))).collect<Stack>();
   vl.sort();
   vl.dedup();
-  auto vr = iterTraits(vi(new VariableIterator(lhs))).collect<Stack>();
+  auto vr = iterTraits(vi(new VariableIterator(rhs))).collect<Stack>();
   vr.sort();
   vr.dedup();
 

--- a/UnitTests/tInferences_HOL_Injectivity.cpp
+++ b/UnitTests/tInferences_HOL_Injectivity.cpp
@@ -110,8 +110,9 @@ TEST_GENERATION(success_2,
       .EXPECTED(exactly(clause({ ap(inv(), {z, ap(f, {x, z})}) == x })))
     )
 
+// f is injective in its second argument, so the inverse takes the first
 TEST_GENERATION(success_3,
     Generation::AsymmetricTest()
       .input( clause({ y.sort(srt) == z, ap(f, {x, z}) != ap(f, {x, y}) }))
-      .EXPECTED(exactly(clause({ ap(inv(), {z, ap(f, {x, z})}) == x })))
+      .EXPECTED(exactly(clause({ ap(inv(), {x, ap(f, {x, z})}) == z })))
     )


### PR DESCRIPTION
Fixes #889.

`TestUtils::eqModAC_` opened with

```cpp
if (lhs == rhs) { return true; }
```

On shared terms that is pointer equality, and it returned without recording the variable renaming, so `eqModACRect` accepted clause pairs that are not equal up to renaming whenever the two happened to share a subterm.

`success_3` in `tInferences_HOL_Injectivity` was riding on that. Its input makes `f` injective in its second argument, so the left inverse is `inv(x, f(x,z)) = z`, but the expectation was copied from `success_2` and says `inv(z, f(x,z)) = x`. Which clause `Injectivity` derives depends on the evaluation order of the two operands of `!=`, because equality arguments are normalised by term id. clang derives `inv(X0, f(X0,X2)) = X2`, which shares `f(X0,X2)` with the expectation and short-circuits, so CI stayed green. gcc derives `inv(X0, f(X0,X1)) = X1`, and the test fails.

Three changes:

* Drop the fast path in `eqModAC_`.
* Correct the `success_3` expectation.
* Fix the `TermList` overload of `eqModACRect`, which collected `vr` from `lhs` and so compared `lhs` against itself in its variable count guard. Nothing in the suite goes through that overload, so it is a separate bug I noticed while reading rather than something this PR needed.

Checked with gcc 15.2, Debug: 97/97 in about 20s, unchanged from before, so no other test was relying on the fast path.

With the fast path gone the old expectation also fails under clang's ordering. I reproduced that ordering under gcc by swapping the written order of the two operands, which builds the same clause but reverses the creation order:

```
[     case ]: { X1 = X2 | ~(f @ X0 @ X2 = f @ X0 @ X1) }
[       is ]: [ { inv_f_0 @ X0 @ (f @ X0 @ X2) = X2 } ]
[ expected ]: exactly: [ { inv_f_0 @ X2 @ (f @ X0 @ X2) = X0 } ]
[ FAIL ] success_3
```

---

Disclosure: I used AI to generate this PR text. The code has been wrote by myself. 
