### PR TITLE
fix wrong answer from -newcnf on with two or more Boolean lets

### DIFF
--- a/Shell/NewCNF.hpp
+++ b/Shell/NewCNF.hpp
@@ -354,11 +354,23 @@ private:
       Occurrences::Iterator occit(*this);
 
       bool negateOccurrenceSign = false;
+      if (f->connective() == NOT) {
+        /**
+         * Generalised clauses store formulas without negations (cf. pushLiteral),
+         * so the negation is dropped here and the sign of every occurrence is
+         * flipped instead. Otherwise the stored formula would not match the
+         * formula the occurrences are registered under in _occurrences, and
+         * pushLiteral would flip the sign a second time when the generalised
+         * literal is copied to another generalised clause.
+         */
+        f = f->uarg();
+        negateOccurrenceSign = true;
+      }
       if (f->connective() == LITERAL) {
         Literal* l = f->literal();
         if (l->shared() && ((SIGN)l->polarity() != POSITIVE)) {
           f = new AtomicFormula(Literal::complementaryLiteral(l));
-          negateOccurrenceSign = true;
+          negateOccurrenceSign = !negateOccurrenceSign;
         }
       }
 
@@ -369,15 +381,6 @@ private:
         if (negateOccurrenceSign) {
           sign(gl) = OPPOSITE(sign(gl));
         }
-      }
-    }
-
-    void invert() {
-      Occurrences::Iterator occit(*this);
-      while (occit.hasNext()) {
-        Occurrence occ = occit.next();
-        GenLit& gl = occ.gc->_literals[occ.position];
-        sign(gl) = OPPOSITE(sign(gl));
       }
     }
 
@@ -568,19 +571,19 @@ private:
   void nameSubformula(Formula* g, Occurrences &occurrences);
 
   void enqueue(Formula* formula, Occurrences occurrences = Occurrences()) {
-    if ((formula->connective() == LITERAL) && formula->literal()->shared()) return;
-
     if (formula->connective() == NOT) {
       /**
        * Formulas are always stored without negations in genclauses,
-       * therefore it is safe to drop the negation before queueing,
-       * all the occurrences of the formula won't have it either
+       * therefore it is safe to drop the negation before queueing.
+       * The signs of the occurrences are not touched here: whoever puts
+       * a formula into a generalised clause is responsible for dropping
+       * its negation and flipping the sign of the generalised literal
+       * (cf. pushLiteral and Occurrences::replaceBy).
        */
       formula = formula->uarg();
-      ASS_REP(formula->connective() != LITERAL, formula->toString());
-
-      occurrences.invert();
     }
+
+    if ((formula->connective() == LITERAL) && formula->literal()->shared()) return;
 
     if (_occurrences.find(formula)) {
       Occurrences oldOccurrences;

--- a/checks/sanity
+++ b/checks/sanity
@@ -95,6 +95,12 @@ check_szs_status Theorem -ile off theory/let-bool-pred.p
 check_szs_status Theorem -newcnf on -ile off theory/let-bool-pred.p
 check_szs_status Theorem theory/let-bool-simultaneous.p
 check_szs_status Theorem -newcnf on theory/let-bool-simultaneous.p
+check_szs_status Theorem theory/let-bool-twice.p
+check_szs_status Theorem -newcnf on theory/let-bool-twice.p
+check_szs_status Theorem -ile off theory/let-bool-twice.p
+check_szs_status Theorem -newcnf on -ile off theory/let-bool-twice.p
+check_szs_status Unsatisfiable theory/let-bool-twice.smt2
+check_szs_status Unsatisfiable -newcnf on theory/let-bool-twice.smt2
 
 # Arrays
 check_szs_status Unsatisfiable theory/arrays.smt2

--- a/checks/theory/let-bool-twice.p
+++ b/checks/theory/let-bool-twice.p
@@ -1,0 +1,12 @@
+% Two Boolean $lets in one conjecture. NewCNF indexed each inlined definition
+% without its leading negation while the generalised clause kept it, so
+% clausifying one $let copied the other's literal and flipped its sign a
+% second time. Its clauses became tautologies and were dropped, and -newcnf on
+% answered CounterSatisfiable. Both definitions are tautologies, so the
+% conjecture is a theorem.
+tff(q,type,
+    q: $o ).
+
+tff(let_bool_twice,conjecture,
+    ( $let(b: $o, b := ( q | ~ q ), b )
+    & $let(d: $o, d := ( q | ~ q ), d ) ) ).

--- a/checks/theory/let-bool-twice.smt2
+++ b/checks/theory/let-bool-twice.smt2
@@ -1,0 +1,8 @@
+; The same shape as let-bool-twice.p in SMT-LIB. The SMT-LIB parser has
+; always built Boolean let definitions as formulas, so this wrong answer
+; predates Boolean $let support in the TPTP parser. The assertion negates a
+; conjunction of two tautologies, hence unsatisfiable.
+(set-logic ALL)
+(declare-fun q () Bool)
+(assert (not (and (let ((b (or q (not q)))) b) (let ((d (or q (not q)))) d))))
+(check-sat)


### PR DESCRIPTION
Closes #893.

NewCNF stores formulas in generalised clauses with any leading negation stripped and the sign of the generalised literal flipped instead (pushLiteral). `Occurrences::replaceBy` broke that invariant: it wrote the formula in unchanged, and `enqueue` compensated by dropping the negation from the queue key and flipping the occurrence signs. The slot was left holding `~A` with a sign that every later lookup reads as the sign of `A`.

processLet produces that state whenever ennf has pushed a negation into a let body. With one $let the slot is only ever rewritten in place, so nothing shows. With two, clausifying the first copies the second's slot into new generalised clauses through pushLiteral, which strips the negation again and flips the sign a second time. The second definition gets the wrong polarity, its clauses come out as tautologies, and tautologies are deleted, so the whole problem clausifies to nothing and saturation reports a model. On master (9f4717263, Release):

```
$ vampire --input_syntax smtlib2 -newcnf on checks/theory/let-bool-twice.smt2
% SZS status Satisfiable for let-bool-twice
$ vampire -newcnf on checks/theory/let-bool-twice.p
% SZS status CounterSatisfiable for let-bool-twice
$ vampire -newcnf on -ile off checks/theory/let-bool-twice.p
% SZS status Theorem for let-bool-twice
```

`-ile off` was already correct: the naming path never hands replaceBy a negated formula there.

The stale `~A` also breaks the occurrence count that pop maintains by looking the slot formula up in `_occurrences`. A Debug build dies on the same input without printing anything; under gdb:

```
#5  Debug::Assertion::violatedEquality<unsigned int, int> (val1Str="_size", val2Str="0", val1=1, val2=0)
#6  Shell::NewCNF::Occurrences::isNonEmpty at Shell/NewCNF.hpp:327
#7  Shell::NewCNF::process(JunctionFormula*, Occurrences&) at Shell/NewCNF.cpp:449
```

The fix handles the negation where the formula is written into the clause: replaceBy drops it and flips the sign of every occurrence, the same way it already normalises negative shared literals, and enqueue leaves the signs alone. Its invert() helper lost its only caller and is removed. process(QuantifiedFormula*) uses the same replaceBy/enqueue pair on the quantifier body, so it is covered by the same change.

With the fix, Debug build with assertions enabled:

```
PASS: twice.smt2 default
PASS: twice.smt2 newcnf
PASS: twice.smt2 newcnf ile off
PASS: twice.p default
PASS: twice.p newcnf
PASS: twice.p ile off
PASS: twice.p newcnf ile off
PASS: let-bool.p newcnf
PASS: let-bool.p newcnf ile off
PASS: let-bool-pred.p newcnf
PASS: let-bool-pred.p newcnf ile off
PASS: let-bool-simultaneous.p newcnf
PASS: let-function.p newcnf
PASS: let-tuple.p newcnf
PASS: let-tuple-bool.p newcnf
```

Also checked in default, `-newcnf on` and `-newcnf on -ile off`: three sibling lets and nested lets (Unsatisfiable), a satisfiable two-let problem (still Satisfiable), and two $lets under a universal quantifier (Theorem). checks/sanity passes with a Release+Z3 build and ctest is 97/97 with the Debug build. The new checks cover the TPTP and SMT-LIB shape of the problem in the same configurations as the other let-bool files.
