### PR TITLE
Randomized simplifications

### DIFF
--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -15,6 +15,7 @@
 #include "Lib/DHMultiset.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Metaiterators.hpp"
+#include "Lib/Random.hpp"
 #include "Debug/TimeProfiling.hpp"
 #include "Lib/VirtualIterator.hpp"
 
@@ -85,6 +86,14 @@ struct BackwardDemodulation<higherOrder>::ResultFn
   BwSimplificationRecord operator() (pair<TermList,QueryRes<ResultSubstitutionSP, TermLiteralClause>> arg)
   {
     auto qr=arg.second;
+
+    // under randomized simplifications, each candidate rewrite is with this probability
+    // dropped as early as possible (saving also the applicability checks), with the same
+    // probability as in the forward variant (to be tuned)
+    constexpr double RSI_SKIP_PROB = 0.01;
+    if(env.options->randomizedSimplifications() && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+      return BwSimplificationRecord(0);
+    }
 
     if( !ColorHelper::compatible(_cl->color(), qr.data->clause->color()) ) {
       //colors of premises don't match

--- a/Inferences/BackwardSubsumptionAndResolution.cpp
+++ b/Inferences/BackwardSubsumptionAndResolution.cpp
@@ -25,6 +25,7 @@
 
 #include "Kernel/Clause.hpp"
 #include "Lib/List.hpp"
+#include "Lib/Random.hpp"
 #include "Indexing/Index.hpp"
 #include "Indexing/LiteralIndex.hpp"
 #include "Saturation/SaturationAlgorithm.hpp"
@@ -60,6 +61,12 @@ void BackwardSubsumptionAndResolution<higherOrder>::perform(Clause *cl,
   if (!_subsumption && !_subsumptionResolution) {
     return;
   }
+
+  // under randomized simplifications, each subsumption resolution candidate is with this
+  // probability dropped as early as possible (saving also the SR checks); proper
+  // subsumptions are never leaky (the same prob as for the forward variant; to be tuned)
+  constexpr double RSI_SKIP_PROB = 0.02;
+  bool rsi = env.options->randomizedSimplifications();
 
   _checked.reset();
 
@@ -97,6 +104,9 @@ void BackwardSubsumptionAndResolution<higherOrder>::perform(Clause *cl,
         Clause *icl = res.data->clause;
         if (!_checked.insert(icl->number()))
           continue;
+        if (rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+          continue; // drop this candidate early; the next one gets a chance
+        }
         Clause *conclusion = SATSubsumption::SATSubsumptionAndResolution::getSubsumptionResolutionConclusion(icl, res.data->literal, cl, /*forward=*/false);
         ASS(conclusion)
         List<BwSimplificationRecord>::push(BwSimplificationRecord(icl, conclusion), simplificationBuffer);
@@ -144,7 +154,8 @@ void BackwardSubsumptionAndResolution<higherOrder>::perform(Clause *cl,
         continue;
       // check subsumption and setup subsumption resolution at the same time
       bool checkS = _subsumption && !_subsumptionByUnitsOnly;
-      bool checkSR = _subsumptionResolution && !_srByUnitsOnly;
+      bool checkSR = _subsumptionResolution && !_srByUnitsOnly &&
+                    !(rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB);
       if (checkS) {
         if (_satSubs.checkSubsumption(cl, icl, checkSR)) {
           env.statistics->backwardSubsumed++;
@@ -174,6 +185,9 @@ void BackwardSubsumptionAndResolution<higherOrder>::perform(Clause *cl,
       Clause *icl = it.next().data->clause;
       if (!_checked.insert(icl->number()))
         continue;
+      if (rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+        continue; // drop this candidate early; the next one gets a chance
+      }
       // check subsumption resolution
       Clause *conclusion = _satSubs.checkSubsumptionResolution(cl, icl, /*forward=*/false, false);
       if (conclusion) {

--- a/Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
+++ b/Inferences/CodeTreeForwardSubsumptionAndResolution.cpp
@@ -12,6 +12,8 @@
  * Implements class CodeTreeForwardSubsumptionAndResolution.
  */
 
+#include "Lib/Random.hpp"
+
 #include "Saturation/SaturationAlgorithm.hpp"
 
 #include "ProofExtra.hpp"
@@ -33,6 +35,12 @@ bool CodeTreeForwardSubsumptionAndResolution<higherOrder>::perform(Clause *cl, C
     return false;
   }
 
+  // under randomized simplifications, each subsumption resolution match is with this
+  // probability dropped, giving the next match (possibly a proper subsumption, which
+  // is never leaky) a chance instead (to be tuned)
+  constexpr double RSI_SKIP_PROB = 0.02;
+  bool rsi = env.options->randomizedSimplifications();
+
   static typename ClauseCodeTree<higherOrder>::ClauseMatcher cm;
 
   cm.init(_ct, cl, _subsumptionResolution);
@@ -47,6 +55,9 @@ bool CodeTreeForwardSubsumptionAndResolution<higherOrder>::perform(Clause *cl, C
       env.statistics->forwardSubsumed++;
       cm.reset();
       return true;
+    }
+    if (rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+      continue; // drop this candidate; the next match gets a chance
     }
     ASS(satSubs.checkSubsumptionResolutionWithLiteral(premise, cl, resolvedQueryLit));
 

--- a/Inferences/ForwardDemodulation.cpp
+++ b/Inferences/ForwardDemodulation.cpp
@@ -15,6 +15,7 @@
 #include "Lib/DHSet.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/Metaiterators.hpp"
+#include "Lib/Random.hpp"
 #include "Debug/TimeProfiling.hpp"
 #include "Lib/VirtualIterator.hpp"
 
@@ -84,6 +85,12 @@ bool ForwardDemodulation<higherOrder>::perform(Clause* cl, Clause*& replacement,
 {
   TIME_TRACE("forward demodulation");
 
+  // under randomized simplifications, each candidate rewrite is with this probability
+  // dropped as early as possible (saving also the applicability checks), giving a
+  // rewrite by another source (or none) a chance instead (to be tuned)
+  constexpr double RSI_SKIP_PROB = 0.01;
+  bool rsi = env.options->randomizedSimplifications();
+
   //Perhaps it might be a good idea to try to
   //replace subterms in some special order, like
   //the heaviest first...
@@ -118,6 +125,10 @@ bool ForwardDemodulation<higherOrder>::perform(Clause* cl, Clause*& replacement,
       while(git.hasNext()) {
         auto qr=git.next();
         ASS_EQ(qr.data->clause->length(),1);
+
+        if(rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+          continue; // drop this candidate early; the next generalization gets a chance
+        }
 
         if(!ColorHelper::compatible(cl->color(), qr.data->clause->color())) {
           continue;

--- a/Inferences/ForwardSubsumptionAndResolution.cpp
+++ b/Inferences/ForwardSubsumptionAndResolution.cpp
@@ -25,6 +25,7 @@
 #include "Saturation/SaturationAlgorithm.hpp"
 #include "Kernel/ColorHelper.hpp"
 #include "Lib/Environment.hpp"
+#include "Lib/Random.hpp"
 #include "Shell/Statistics.hpp"
 
 #include "Inferences/ForwardSubsumptionAndResolution.hpp"
@@ -50,6 +51,12 @@ bool ForwardSubsumptionAndResolution::perform(Clause *cl,
                                               ClauseIterator &premises)
 {
   TIME_TRACE("forward subsumption");
+
+  // under randomized simplifications, each subsumption resolution candidate is with this
+  // probability dropped as early as possible (saving also the SR checks); proper
+  // subsumptions are never leaky (to be tuned)
+  constexpr double RSI_SKIP_PROB = 0.02;
+  bool rsi = env.options->randomizedSimplifications();
 
   ASS(replacement == nullptr)
 
@@ -109,7 +116,8 @@ bool ForwardSubsumptionAndResolution::perform(Clause *cl,
       }
 
       bool checkSR = _subsumptionResolution && !conclusion &&
-                    (_checkLongerClauses || mcl->length() <= clen);
+                    (_checkLongerClauses || mcl->length() <= clen) &&
+                    !(rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB);
 
       // if mcl is longer than cl, then it cannot subsume cl but still could be resolved
       bool checkS = mcl->length() <= clen;
@@ -163,6 +171,9 @@ bool ForwardSubsumptionAndResolution::perform(Clause *cl,
     Literal *lit = (*cl)[li];
     auto it = _unitIndex->getGeneralizations(lit, true, false);
     if (it.hasNext()) {
+      if (rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+        continue; // drop this candidate early; another literal may still get resolved
+      }
       mcl = it.next().data->clause;
       ASS(mcl->length() == 1)
       replacement = SATSubsumption::SATSubsumptionAndResolution::getSubsumptionResolutionConclusion(cl, lit, mcl, /*forward=*/true);
@@ -185,6 +196,9 @@ bool ForwardSubsumptionAndResolution::perform(Clause *cl,
       }
       if (!_checkLongerClauses && mcl->length() > clen) {
         continue;
+      }
+      if (rsi && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+        continue; // drop this candidate early; the next one gets a chance
       }
       conclusion = satSubs.checkSubsumptionResolution(mcl, cl, /*forward=*/true, false);
       if (conclusion) {

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -20,6 +20,7 @@
 #include "Lib/Environment.hpp"
 #include "Lib/IntUnionFind.hpp"
 #include "Lib/Metaiterators.hpp"
+#include "Lib/Random.hpp"
 #include "Debug/TimeProfiling.hpp"
 #include "Lib/Timer.hpp"
 
@@ -998,6 +999,14 @@ bool Splitter::doSplitting(Clause* cl)
   // fills comps with components, returning if not splittable
   if(!getComponents(cl, comps, _shuffleComponents)) {
     return handleNonSplittable(cl);
+  }
+
+  // under randomized simplifications, each splitting opportunity is with this probability
+  // skipped: the clause stays in the FO loop unsplit, as if splitting was never attempted
+  // (properly non-splittable clauses are still handled above, never leaky) (to be tuned)
+  constexpr double RSI_SKIP_PROB = 0.03;
+  if(env.options->randomizedSimplifications() && Random::getDouble(0.0,1.0) < RSI_SKIP_PROB) {
+    return false;
   }
 
   static SATLiteralStack satClauseLits;

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2331,8 +2331,8 @@ void Options::init()
     _randomPolarities.tag(OptionTag::PREPROCESSING);
 
     _randomizedSimplifications = BoolOptionValue("randomized_simplifications","rsi",false);
-    _randomizedSimplifications.description="Make selected simplification rules of the saturation loop \"leaky\":"
-       " under a coin toss, some of their candidate simplifications are randomly skipped, as a source of noise injection.";
+    _randomizedSimplifications.description="Make selected saturation-loop simplifications (including AVATAR splitting) \"leaky\":"
+       " under a coin toss, some of their candidate operations are randomly skipped, as a source of noise injection.";
     _lookup.insert(&_randomizedSimplifications);
     _randomizedSimplifications.tag(OptionTag::INFERENCES);
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -2330,6 +2330,12 @@ void Options::init()
     _lookup.insert(&_randomPolarities);
     _randomPolarities.tag(OptionTag::PREPROCESSING);
 
+    _randomizedSimplifications = BoolOptionValue("randomized_simplifications","rsi",false);
+    _randomizedSimplifications.description="Make selected simplification rules of the saturation loop \"leaky\":"
+       " under a coin toss, some of their candidate simplifications are randomly skipped, as a source of noise injection.";
+    _lookup.insert(&_randomizedSimplifications);
+    _randomizedSimplifications.tag(OptionTag::INFERENCES);
+
     _questionAnswering = ChoiceOptionValue<QuestionAnsweringMode>("question_answering","qa",QuestionAnsweringMode::AUTO,
                                                                   {"auto","plain","synthesis","off"});
     _questionAnswering.description= "Determines whether (and how) we attempt to answer questions:"

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2183,6 +2183,7 @@ public:
 
   bool shuffleInput() const { return _shuffleInput.actualValue; }
   bool randomPolarities() const { return _randomPolarities.actualValue; }
+  bool randomizedSimplifications() const { return _randomizedSimplifications.actualValue; }
   bool randomAWR() const { return _randomAWR.actualValue; }
   bool randomTraversals() const { return _randomTraversals.actualValue; }
   bool randomizeSeedForPortfolioWorkers() const { return _randomizeSeedForPortfolioWorkers.actualValue; }
@@ -2576,6 +2577,7 @@ private:
   BoolOptionValue _normalize;
   BoolOptionValue _shuffleInput;
   BoolOptionValue _randomPolarities;
+  BoolOptionValue _randomizedSimplifications;
 
   StringOptionValue _printProofToFile;
   BoolOptionValue _printClausifierPremises;


### PR DESCRIPTION
The same spirit as randomized preprocessing.

This "leaks" the core action for `fd`, `fsr`, `bd`, `bsr` and avatar under some small probabilities.