### PR TITLE
Predicate elimination 2

### DIFF
--- a/Debug/Assertion.cpp
+++ b/Debug/Assertion.cpp
@@ -30,6 +30,10 @@ void reportSpiderFail();
 
 [[noreturn]] void Assertion::abortAfterViolation()
 {
+  // terminateImmediately calls std::_Exit, which does not flush stdio buffers.
+  // Without this, the report above is lost whenever stdout is not a terminal
+  // (a pipe -- as under CI or ctest -- is fully buffered), leaving a bare failure.
+  std::cout.flush();
   Shell::reportSpiderFail();
   System::terminateImmediately(VAMP_RESULT_STATUS_UNHANDLED_EXCEPTION);
 }

--- a/Debug/Tracer.cpp
+++ b/Debug/Tracer.cpp
@@ -75,6 +75,12 @@ void Debug::Tracer::printStack() {
   else
     std::cout << "(use '--traceback on' to invoke a debugger and get a human-readable stack trace)\n";
 
+  // With no debugger attached and no handler installed (as under vtest), the default
+  // action for SIGTRAP is to terminate the process -- so anything still sitting in the
+  // stdout buffer is discarded. That silently swallows the whole assertion report
+  // whenever stdout is not a terminal (a pipe, as under ctest or CI, is fully buffered).
+  std::cout.flush();
+
   // usually causes debuggers to break here
   // if not under a debugger, ignored
   std::raise(SIGTRAP);

--- a/FMB/ClauseFlattening.cpp
+++ b/FMB/ClauseFlattening.cpp
@@ -128,14 +128,7 @@ Clause* ClauseFlattening::flatten(Clause* cl)
   cl = resolveNegativeVariableEqualities(cl);
 
   // new, find the maximal variable number
-  unsigned maxVar = 0;
-  VirtualIterator<unsigned> varIt = cl->getVariableIterator();
-  while (varIt.hasNext()) {
-    unsigned var = varIt.next();
-    if (var > maxVar) {
-      maxVar = var;
-    }
-  }
+  unsigned maxVar = cl->maxVar();
 
   // literals to be processed, start with those in clause
   Stack<Literal*> lits;

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -481,7 +481,7 @@ bool BackwardSubsumptionDemodulation<higherOrder>::rewriteCandidate(Clause* side
           // There can be no unbound variables at this point;
           // otherwise we would have excluded the LHS already
           // in the ordering pre-check above
-          auto mclVarIt = sideCl->getVariableIterator();  // includes vars in rhs
+          auto mclVarIt = sideCl->iterVars();  // includes vars in rhs
           while (mclVarIt.hasNext()) {
             unsigned int var = mclVarIt.next();
             ASS(binder.isBound(var));

--- a/Inferences/ForwardSubsumptionDemodulation.cpp
+++ b/Inferences/ForwardSubsumptionDemodulation.cpp
@@ -408,7 +408,7 @@ bool ForwardSubsumptionDemodulation<higherOrder>::perform(Clause* cl, Clause*& r
                 // There can be no unbound variables at this point;
                 // otherwise we would have excluded the LHS already
                 // in the ordering pre-check above
-                auto mclVarIt = mcl->getVariableIterator();  // includes vars in rhs
+                auto mclVarIt = mcl->iterVars();  // includes vars in rhs
                 while (mclVarIt.hasNext()) {
                   unsigned int var = mclVarIt.next();
                   ASS(binder.isBound(var));

--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -272,16 +272,26 @@ bool Clause::isHorn()
 }
 
 /**
- * Return iterator over clause variables
+ * Return iterator over clause variables, each reported exactly once
+ *
+ * Deduplicating means collecting the variables into a set and materialising the result,
+ * so prefer iterVars() (or maxVar()) whenever repetitions do not actually hurt.
  */
 VirtualIterator<unsigned> Clause::getVariableIterator() const
 {
-  return pvi( getUniquePersistentIterator(
-      getMappingIterator(
-	  getMapAndFlattenIterator(
-	      iterLits(),
-	      VariableIteratorFn()),
-	  OrdVarNumberExtractorFn())));
+  return pvi( getUniquePersistentIterator(iterVars()) );
+}
+
+/**
+ * Return iterator over the clause's variable occurrences, i.e. with repetitions
+ */
+VirtualIterator<unsigned> Clause::iterVars() const
+{
+  return pvi( getMappingIterator(
+      getMapAndFlattenIterator(
+	  iterLits(),
+	  VariableIteratorFn()),
+      OrdVarNumberExtractorFn()));
 }
 
 /**
@@ -648,12 +658,16 @@ unsigned Clause::varCnt()
 
 unsigned Clause::maxVar()
 {
+  // a plain scan: a maximum does not care about repetitions, so there is no point
+  // paying for the deduplication (and materialisation) getVariableIterator does
   unsigned max = 0;
-  VirtualIterator<unsigned> it = getVariableIterator();
-
-  while (it.hasNext()) {
-    unsigned n = it.next();
-    max = n > max ? n : max;
+  for (Literal* lit : iterLits()) {
+    VariableIterator vit(lit);
+    while (vit.hasNext()) {
+      TermList var = vit.next();
+      ASS(var.isOrdinaryVar());
+      max = var.var() > max ? var.var() : max;
+    }
   }
   return max;
 }

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -257,7 +257,11 @@ public:
   bool isPropositional();
   bool isHorn();
 
+  /** the clause's variables, each reported exactly once (which costs a set and a
+   * materialised list -- prefer iterVars below when repetitions do no harm) */
   VirtualIterator<unsigned> getVariableIterator() const;
+  /** the clause's variable occurrences, i.e. lazily and with repetitions */
+  VirtualIterator<unsigned> iterVars() const;
 
   bool contains(Literal* lit);
 #if VDEBUG

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -570,11 +570,17 @@ void Options::init()
     _blockedClauseElimination.tag(OptionTag::PREPROCESSING);
     _blockedClauseElimination.addProblemConstraint(notWithCat(Property::UEQ));
 
-    _predicateElimination = BoolOptionValue("predicate_elimination","pel",false);
+    _predicateElimination = ChoiceOptionValue<PredicateElimination>("predicate_elimination","pel",
+                                                                     PredicateElimination::OFF,
+                                                                     {"off","on","multi"});
     _predicateElimination.description=
       "After clausification, eliminate predicates that occur at most once in every clause"
       " by replacing their clauses with all pairwise resolvents (cf. Khasidashvili and Korovin, SAT 2016)."
-      " (See also predicate_elimination_multi_occurrence for a relaxation of the at-most-once condition.)"
+      " With multi, also eliminate a predicate P occurring more than once in a clause, provided P"
+      " never occurs both positively and negatively in a single clause and the multi-occurrence"
+      " clauses all sit on one polarity side. Instead of pairwise resolvents, the replacement clauses"
+      " are then all the hyper-resolvents, each occurrence of a multi-occurrence clause being resolved"
+      " against its own (variable-disjoint) copy of a single-occurrence clause of the opposite polarity."
       " On problems without equality and theories, resolvents are computed with an mgu;"
       " otherwise argument disequalities are introduced via (virtual) flattening,"
       " which may add equality to a problem previously without it.";
@@ -586,30 +592,19 @@ void Options::init()
     _predicateEliminationTotalLimit.description=
       "A predicate elimination step is only performed if the estimated number of clauses afterwards"
       " (current - |S_P| - |S_~P| + the number of resolvents, which is |S_P|*|S_~P| unless"
-      " predicate_elimination_multi_occurrence kicks in) does not exceed the number of clauses"
+      " predicate_elimination is set to multi) does not exceed the number of clauses"
       " before predicate elimination started times this factor.";
     _lookup.insert(&_predicateEliminationTotalLimit);
     _predicateEliminationTotalLimit.tag(OptionTag::PREPROCESSING);
     _predicateEliminationTotalLimit.addConstraint(greaterThanEq(0.0f));
-    _predicateEliminationTotalLimit.onlyUsefulWith(_predicateElimination.is(equal(true)));
+    _predicateEliminationTotalLimit.onlyUsefulWith(_predicateElimination.is(notEqual(PredicateElimination::OFF)));
 
     _predicateEliminationSubsumption = BoolOptionValue("predicate_elimination_subsumption","pels",true);
     _predicateEliminationSubsumption.description=
       "Keep the clause set forward-inter-subsumed and subsumption-resolved during predicate elimination.";
     _lookup.insert(&_predicateEliminationSubsumption);
     _predicateEliminationSubsumption.tag(OptionTag::PREPROCESSING);
-    _predicateEliminationSubsumption.onlyUsefulWith(_predicateElimination.is(equal(true)));
-
-    _predicateEliminationMultiOccurrence = BoolOptionValue("predicate_elimination_multi_occurrence","pelmo",false);
-    _predicateEliminationMultiOccurrence.description=
-      "Also eliminate a predicate P occurring more than once in a clause, provided P never occurs"
-      " both positively and negatively in a single clause and the multi-occurrence clauses all sit"
-      " on one polarity side. Instead of pairwise resolvents, the replacement clauses are then all"
-      " the hyper-resolvents, each occurrence of a multi-occurrence clause being resolved against"
-      " its own (variable-disjoint) copy of a single-occurrence clause of the opposite polarity.";
-    _lookup.insert(&_predicateEliminationMultiOccurrence);
-    _predicateEliminationMultiOccurrence.tag(OptionTag::PREPROCESSING);
-    _predicateEliminationMultiOccurrence.onlyUsefulWith(_predicateElimination.is(equal(true)));
+    _predicateEliminationSubsumption.onlyUsefulWith(_predicateElimination.is(notEqual(PredicateElimination::OFF)));
 
     _distinctGroupExpansionLimit = UnsignedOptionValue("distinct_group_expansion_limit","dgel",140);
     _distinctGroupExpansionLimit.description = "If a distinct group (defined, e.g., via TPTP's $distinct)"

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -574,6 +574,7 @@ void Options::init()
     _predicateElimination.description=
       "After clausification, eliminate predicates that occur at most once in every clause"
       " by replacing their clauses with all pairwise resolvents (cf. Khasidashvili and Korovin, SAT 2016)."
+      " (See also predicate_elimination_multi_occurrence for a relaxation of the at-most-once condition.)"
       " On problems without equality and theories, resolvents are computed with an mgu;"
       " otherwise argument disequalities are introduced via (virtual) flattening,"
       " which may add equality to a problem previously without it.";
@@ -584,7 +585,8 @@ void Options::init()
     _predicateEliminationTotalLimit = FloatOptionValue("predicate_elimination_total_limit","peltl",2.0);
     _predicateEliminationTotalLimit.description=
       "A predicate elimination step is only performed if the estimated number of clauses afterwards"
-      " (current - |S_P| - |S_~P| + |S_P|*|S_~P|) does not exceed the number of clauses"
+      " (current - |S_P| - |S_~P| + the number of resolvents, which is |S_P|*|S_~P| unless"
+      " predicate_elimination_multi_occurrence kicks in) does not exceed the number of clauses"
       " before predicate elimination started times this factor.";
     _lookup.insert(&_predicateEliminationTotalLimit);
     _predicateEliminationTotalLimit.tag(OptionTag::PREPROCESSING);
@@ -597,6 +599,17 @@ void Options::init()
     _lookup.insert(&_predicateEliminationSubsumption);
     _predicateEliminationSubsumption.tag(OptionTag::PREPROCESSING);
     _predicateEliminationSubsumption.onlyUsefulWith(_predicateElimination.is(equal(true)));
+
+    _predicateEliminationMultiOccurrence = BoolOptionValue("predicate_elimination_multi_occurrence","pelmo",true);
+    _predicateEliminationMultiOccurrence.description=
+      "Also eliminate a predicate P occurring more than once in a clause, provided P never occurs"
+      " both positively and negatively in a single clause and the multi-occurrence clauses all sit"
+      " on one polarity side. Instead of pairwise resolvents, the replacement clauses are then all"
+      " the hyper-resolvents, each occurrence of a multi-occurrence clause being resolved against"
+      " its own (variable-disjoint) copy of a single-occurrence clause of the opposite polarity.";
+    _lookup.insert(&_predicateEliminationMultiOccurrence);
+    _predicateEliminationMultiOccurrence.tag(OptionTag::PREPROCESSING);
+    _predicateEliminationMultiOccurrence.onlyUsefulWith(_predicateElimination.is(equal(true)));
 
     _distinctGroupExpansionLimit = UnsignedOptionValue("distinct_group_expansion_limit","dgel",140);
     _distinctGroupExpansionLimit.description = "If a distinct group (defined, e.g., via TPTP's $distinct)"

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -600,7 +600,7 @@ void Options::init()
     _predicateEliminationSubsumption.tag(OptionTag::PREPROCESSING);
     _predicateEliminationSubsumption.onlyUsefulWith(_predicateElimination.is(equal(true)));
 
-    _predicateEliminationMultiOccurrence = BoolOptionValue("predicate_elimination_multi_occurrence","pelmo",true);
+    _predicateEliminationMultiOccurrence = BoolOptionValue("predicate_elimination_multi_occurrence","pelmo",false);
     _predicateEliminationMultiOccurrence.description=
       "Also eliminate a predicate P occurring more than once in a clause, provided P never occurs"
       " both positively and negatively in a single clause and the multi-occurrence clauses all sit"

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2062,6 +2062,7 @@ public:
   bool predicateElimination() const { return _predicateElimination.actualValue; }
   float predicateEliminationTotalLimit() const { return _predicateEliminationTotalLimit.actualValue; }
   bool predicateEliminationSubsumption() const { return _predicateEliminationSubsumption.actualValue; }
+  bool predicateEliminationMultiOccurrence() const { return _predicateEliminationMultiOccurrence.actualValue; }
   unsigned distinctGroupExpansionLimit() const { return _distinctGroupExpansionLimit.actualValue; }
   void setUnusedPredicateDefinitionRemoval(bool newVal) { _unusedPredicateDefinitionRemoval.actualValue = newVal; }
   SatSolver satSolver() const { return _satSolver.actualValue; }
@@ -2715,6 +2716,7 @@ private:
   BoolOptionValue _predicateElimination;
   FloatOptionValue _predicateEliminationTotalLimit;
   BoolOptionValue _predicateEliminationSubsumption;
+  BoolOptionValue _predicateEliminationMultiOccurrence;
   UnsignedOptionValue _distinctGroupExpansionLimit;
 
   OptionChoiceValues _tagNames;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -346,6 +346,15 @@ public:
   };
 
   /**
+   * Possible values for predicate_elimination.
+   */
+  enum class PredicateElimination : unsigned int {
+    OFF = 0,
+    ON = 1,
+    MULTI = 2
+  };
+
+  /**
    * Possible values for the input syntax
    * @since 26/08/2009 Redmond
    */
@@ -2059,10 +2068,10 @@ public:
 
   bool unusedPredicateDefinitionRemoval() const { return _unusedPredicateDefinitionRemoval.actualValue; }
   bool blockedClauseElimination() const { return _blockedClauseElimination.actualValue; }
-  bool predicateElimination() const { return _predicateElimination.actualValue; }
+  PredicateElimination predicateElimination() const { return _predicateElimination.actualValue; }
   float predicateEliminationTotalLimit() const { return _predicateEliminationTotalLimit.actualValue; }
   bool predicateEliminationSubsumption() const { return _predicateEliminationSubsumption.actualValue; }
-  bool predicateEliminationMultiOccurrence() const { return _predicateEliminationMultiOccurrence.actualValue; }
+  bool predicateEliminationMultiOccurrence() const { return _predicateElimination.actualValue == PredicateElimination::MULTI; }
   unsigned distinctGroupExpansionLimit() const { return _distinctGroupExpansionLimit.actualValue; }
   void setUnusedPredicateDefinitionRemoval(bool newVal) { _unusedPredicateDefinitionRemoval.actualValue = newVal; }
   SatSolver satSolver() const { return _satSolver.actualValue; }
@@ -2713,10 +2722,9 @@ private:
   ChoiceOptionValue<URResolution> _unitResultingResolution;
   BoolOptionValue _unusedPredicateDefinitionRemoval;
   BoolOptionValue _blockedClauseElimination;
-  BoolOptionValue _predicateElimination;
+  ChoiceOptionValue<PredicateElimination> _predicateElimination;
   FloatOptionValue _predicateEliminationTotalLimit;
   BoolOptionValue _predicateEliminationSubsumption;
-  BoolOptionValue _predicateEliminationMultiOccurrence;
   UnsignedOptionValue _distinctGroupExpansionLimit;
 
   OptionChoiceValues _tagNames;

--- a/Shell/PredicateElimination.cpp
+++ b/Shell/PredicateElimination.cpp
@@ -39,7 +39,6 @@
 #include "Debug/TimeProfiling.hpp"
 
 #include <algorithm>
-#include <cmath>
 
 namespace Shell {
 
@@ -162,26 +161,19 @@ void PredicateElimination::apply(Problem &prb)
 /**
  * Add (@b add) or remove one clause's worth of occurrences to (from) one side of a PredInfo.
  */
-static void updateSide(bool add, DHMap<Clause *, unsigned> &side, Stack<unsigned> &hist,
+static void updateSide(bool add, DHMap<Clause *, unsigned> &side,
                        unsigned &multi, Clause *cl, unsigned count)
 {
   ASS_G(count, 0);
 
   if (add) {
-    while (hist.size() <= count) {
-      hist.push(0);
-    }
     ALWAYS(side.insert(cl, count));
-    hist[count]++;
     if (count > 1) {
       multi++;
     }
   }
   else {
-    ASS_L(count, hist.size());
     ALWAYS(side.remove(cl).isSome());
-    ASS_G(hist[count], 0);
-    hist[count]--;
     if (count > 1) {
       ASS_G(multi, 0);
       multi--;
@@ -218,10 +210,10 @@ void PredicateElimination::handleClause(Clause *cl)
       }
     }
     else if (p > 0) {
-      updateSide(add, info.pos, info.posHist, info.posMulti, cl, p);
+      updateSide(add, info.pos, info.posMulti, cl, p);
     }
     else {
-      updateSide(add, info.neg, info.negHist, info.negMulti, cl, n);
+      updateSide(add, info.neg, info.negMulti, cl, n);
     }
   }
 }
@@ -238,25 +230,27 @@ bool PredicateElimination::eligible(unsigned pred) const
                           : (info.posMulti == 0 && info.negMulti == 0);
 }
 
-double PredicateElimination::estimatedTotalAfter(unsigned pred) const
+/** @b base to the @b exp-th; cheaper (and more accurate) than std::pow for our small exponents */
+static double dpow(double base, unsigned exp)
 {
-  const PredInfo &info = _preds[pred];
-  double sp = info.pos.size();
-  double sn = info.neg.size();
+  double res = 1.0;
+  while (exp--) {
+    res *= base;
+  }
+  return res;
+}
 
-  // each nucleus with k occurrences spawns |satellites|^k hyper-resolvents
-  bool posNucleus = posIsNucleus(pred);
-  const Stack<unsigned> &hist = posNucleus ? info.posHist : info.negHist;
+// each nucleus with k occurrences spawns |satellites|^k hyper-resolvents
+double PredicateElimination::multiOccurrenceResolvents(PredInfo const &info, double sp, double sn) const
+{
+  bool posNucleus = (info.negMulti == 0);
   double sats = posNucleus ? sn : sp;
 
   double resolvents = 0.0;
-  for (unsigned k = 1; k < hist.size(); k++) { // note: k >= 1, so no 0^0 below
-    if (hist[k] > 0) {
-      resolvents += (double)hist[k] * std::pow(sats, (double)k);
-    }
+  for (const auto& k : iterTraits((posNucleus ? info.pos : info.neg).range())) {
+    resolvents += dpow(sats, k); // note: k >= 1, so no 0^0 here
   }
-  // an overflow to infinity here simply makes the step inadmissible, which is what we want
-  return (double)_curTotal - sp - sn + resolvents;
+  return resolvents;
 }
 
 bool PredicateElimination::admissible(unsigned pred) const
@@ -279,12 +273,18 @@ int PredicateElimination::pickCandidate() const
   int best = -1;
   double bestEst = 0.0;
   for (unsigned pred : order) {
-    if (eligible(pred) && admissible(pred)) {
-      double est = estimatedTotalAfter(pred);
-      if (best < 0 || est < bestEst) {
-        best = pred;
-        bestEst = est;
-      }
+    if (!eligible(pred)) {
+      continue;
+    }
+    // admissible(pred), but sharing the estimate with the comparison below rather
+    // than computing it twice for every candidate of every round
+    double est = estimatedTotalAfter(pred);
+    if (est > (double)_origTotal * _totalLimit) {
+      continue;
+    }
+    if (best < 0 || est < bestEst) {
+      best = pred;
+      bestEst = est;
     }
   }
   return best;
@@ -352,8 +352,6 @@ void PredicateElimination::eliminate(Problem &prb, unsigned pred)
   // and the nuclei (the only clauses pred occurs in) simply go away below
   if (satellites.isNonEmpty()) {
     Stack<unsigned> nucIdxs;
-    ClauseStack tuple;
-    LiteralStack tupleLits;
     DArray<unsigned> choice;
     for (Clause *c : nuclei) {
       nucIdxs.reset();
@@ -363,13 +361,7 @@ void PredicateElimination::eliminate(Problem &prb, unsigned pred)
       // an odometer over all the |satellites|^|nucIdxs| assignments of satellites to occurrences
       choice.init(nucIdxs.size(), 0);
       for (;;) {
-        tuple.reset();
-        tupleLits.reset();
-        for (unsigned j = 0; j < choice.size(); j++) {
-          tuple.push(satellites[choice[j]]);
-          tupleLits.push(satelliteLits[choice[j]]);
-        }
-        Clause *r = buildResolvent(c, nucIdxs, tuple, tupleLits);
+        Clause *r = buildResolvent(c, nucIdxs, satellites, satelliteLits, choice);
         if (r && _useSubsumption) {
           r = forwardSimplify(r);
         }
@@ -429,13 +421,14 @@ void PredicateElimination::eliminate(Problem &prb, unsigned pred)
 }
 
 Clause *PredicateElimination::buildResolvent(Clause *nucleus, Stack<unsigned> const &nucIdxs,
-                                             ClauseStack const &sats, LiteralStack const &satLits)
+                                             ClauseStack const &sats, LiteralStack const &satLits,
+                                             DArray<unsigned> const &choice)
 {
   if (_equational) {
-    return buildResolventEq(nucleus, nucIdxs, sats, satLits);
+    return buildResolventEq(nucleus, nucIdxs, sats, satLits, choice);
   }
   else {
-    return buildResolventMgu(nucleus, nucIdxs, sats, satLits);
+    return buildResolventMgu(nucleus, nucIdxs, sats, satLits, choice);
   }
 }
 
@@ -460,17 +453,18 @@ static void pushNucleusRest(LiteralStack &lits, Clause *nucleus, Stack<unsigned>
 }
 
 Clause *PredicateElimination::buildResolventMgu(Clause *nucleus, Stack<unsigned> const &nucIdxs,
-                                                ClauseStack const &sats, LiteralStack const &satLits)
+                                                ClauseStack const &sats, LiteralStack const &satLits,
+                                                DArray<unsigned> const &choice)
 {
-  ASS_EQ(nucIdxs.size(), sats.size());
+  ASS_EQ(nucIdxs.size(), choice.size());
 
   static RobSubstitution subst;
   subst.reset();
   // variable bank 0 is the nucleus', bank j+1 the j-th satellite's; picking the same satellite
   // twice thus automatically resolves against two variable-disjoint variants of it.
   // Each unification proceeds modulo the bindings accumulated so far, so chaining is correct.
-  for (unsigned j = 0; j < sats.size(); j++) {
-    if (!subst.unifyArgs((*nucleus)[nucIdxs[j]], 0, satLits[j], j + 1)) {
+  for (unsigned j = 0; j < choice.size(); j++) {
+    if (!subst.unifyArgs((*nucleus)[nucIdxs[j]], 0, satLits[choice[j]], j + 1)) {
       return nullptr; // sound to drop, since there is no equality (and no theories) around
     }
   }
@@ -478,20 +472,22 @@ Clause *PredicateElimination::buildResolventMgu(Clause *nucleus, Stack<unsigned>
   static LiteralStack lits;
   lits.reset();
   pushNucleusRest(lits, nucleus, nucIdxs, [&](Literal *lit) { return subst.apply(lit, 0); });
-  for (unsigned j = 0; j < sats.size(); j++) {
-    for (const auto& lit : *sats[j]) {
-      if (lit != satLits[j]) {
+  for (unsigned j = 0; j < choice.size(); j++) {
+    Literal *plit = satLits[choice[j]];
+    for (const auto& lit : *sats[choice[j]]) {
+      if (lit != plit) {
         lits.push(subst.apply(lit, j + 1));
       }
     }
   }
-  return assembleClause(lits, nucleus, sats);
+  return assembleClause(lits, nucleus, sats, choice);
 }
 
 Clause *PredicateElimination::buildResolventEq(Clause *nucleus, Stack<unsigned> const &nucIdxs,
-                                               ClauseStack const &sats, LiteralStack const &satLits)
+                                               ClauseStack const &sats, LiteralStack const &satLits,
+                                               DArray<unsigned> const &choice)
 {
-  ASS_EQ(nucIdxs.size(), sats.size());
+  ASS_EQ(nucIdxs.size(), choice.size());
 
   static LiteralStack lits;
   lits.reset();
@@ -499,24 +495,27 @@ Clause *PredicateElimination::buildResolventEq(Clause *nucleus, Stack<unsigned> 
 
   // each satellite gets a variable range of its own, disjoint from the nucleus's and the others'
   unsigned off = nucleus->maxVar() + 1;
-  for (unsigned j = 0; j < sats.size(); j++) {
-    Literal *plit = (*nucleus)[nucIdxs[j]];
-    ASS_EQ(plit->arity(), satLits[j]->arity());
+  for (unsigned j = 0; j < choice.size(); j++) {
+    Literal *nlit = (*nucleus)[nucIdxs[j]];
+    Literal *plit = satLits[choice[j]];
+    ASS_EQ(nlit->arity(), plit->arity());
 
     VarShiftApplicator shift{off};
-    for (const auto& lit : *sats[j]) {
-      if (lit != satLits[j]) {
+    for (const auto& lit : *sats[choice[j]]) {
+      if (lit != plit) {
         lits.push(SubstHelper::apply(lit, shift));
       }
     }
     // this is where the "virtual flattening" happens
-    for (unsigned i = 0; i < plit->arity(); i++) {
+    for (unsigned i = 0; i < nlit->arity(); i++) {
       lits.push(Literal::createEquality(false,
-                                        *plit->nthArgument(i),
-                                        SubstHelper::apply(*satLits[j]->nthArgument(i), shift),
-                                        SortHelper::getArgSort(plit, i)));
+                                        *nlit->nthArgument(i),
+                                        SubstHelper::apply(*plit->nthArgument(i), shift),
+                                        SortHelper::getArgSort(nlit, i)));
     }
-    off += sats[j]->maxVar() + 1;
+    if (j + 1 < choice.size()) { // the last satellite's successor offset is never used
+      off += sats[choice[j]]->maxVar() + 1;
+    }
   }
 
   // exhaustive equality substitution (note: no decomposition, so this is weaker than unification)
@@ -555,10 +554,11 @@ Clause *PredicateElimination::buildResolventEq(Clause *nucleus, Stack<unsigned> 
     }
   }
 
-  return assembleClause(lits, nucleus, sats);
+  return assembleClause(lits, nucleus, sats, choice);
 }
 
-Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *nucleus, ClauseStack const &sats)
+Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *nucleus,
+                                             ClauseStack const &sats, DArray<unsigned> const &choice)
 {
   static DHSet<Literal *> seen;
   seen.reset();
@@ -594,16 +594,18 @@ Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *nucleus
   _keptDisequality |= keptDiseq;
   _keptVarVarDisequality |= keptVarVarDiseq;
 
-  ASS(sats.isNonEmpty());
-  if (sats.size() == 1) { // the classical binary case; keep its inference binary too
-    return Clause::fromStack(out, NonspecificInference2(InferenceRule::PREDICATE_ELIMINATION, nucleus, sats[0]));
+  ASS_G(choice.size(), 0);
+  if (choice.size() == 1) { // the classical binary case; keep its inference binary too
+    return Clause::fromStack(out,
+        NonspecificInference2(InferenceRule::PREDICATE_ELIMINATION, nucleus, sats[choice[0]]));
   }
 
   // a satellite picked more than once is still just one premise
   static DHSet<Clause *> premiseSeen;
   premiseSeen.reset();
   UnitList *premises = UnitList::empty();
-  for (Clause *d : sats) {
+  for (unsigned j = 0; j < choice.size(); j++) {
+    Clause *d = sats[choice[j]];
     if (premiseSeen.insert(d)) {
       UnitList::push(d, premises);
     }

--- a/Shell/PredicateElimination.cpp
+++ b/Shell/PredicateElimination.cpp
@@ -39,6 +39,7 @@
 #include "Debug/TimeProfiling.hpp"
 
 #include <algorithm>
+#include <cmath>
 
 namespace Shell {
 
@@ -158,10 +159,40 @@ void PredicateElimination::apply(Problem &prb)
   }
 }
 
+/**
+ * Add (@b add) or remove one clause's worth of occurrences to (from) one side of a PredInfo.
+ */
+static void updateSide(bool add, DHMap<Clause *, unsigned> &side, Stack<unsigned> &hist,
+                       unsigned &multi, Clause *cl, unsigned count)
+{
+  ASS_G(count, 0);
+
+  if (add) {
+    while (hist.size() <= count) {
+      hist.push(0);
+    }
+    ALWAYS(side.insert(cl, count));
+    hist[count]++;
+    if (count > 1) {
+      multi++;
+    }
+  }
+  else {
+    ASS_L(count, hist.size());
+    ALWAYS(side.remove(cl).isSome());
+    ASS_G(hist[count], 0);
+    hist[count]--;
+    if (count > 1) {
+      ASS_G(multi, 0);
+      multi--;
+    }
+  }
+}
+
 template<bool add>
 void PredicateElimination::handleClause(Clause *cl)
 {
-  static DHMap<unsigned, int> occ;
+  static DHMap<unsigned, std::pair<unsigned, unsigned>> occ; // pred -> (positive, negative) count
   occ.reset();
 
   for (const auto& lit : *cl) {
@@ -169,37 +200,28 @@ void PredicateElimination::handleClause(Clause *cl)
     if (env.signature->getPredicate(pred)->protectedSymbol()) {
       continue;
     }
-    int *val;
-    if (occ.getValuePtr(pred, val)) {
-      *val = lit->isPositive() ? 1 : -1;
-    }
-    else {
-      *val = 2;
-    }
+    std::pair<unsigned, unsigned> *val;
+    occ.getValuePtr(pred, val, {0, 0});
+    (lit->isPositive() ? val->first : val->second)++;
   }
 
-  for (const auto& [pred, val] : iterTraits(occ.items())) {
-    if constexpr (add) {
-      if (val == 2) {
-        _preds[pred].blockers++;
-      }
-      else if (val == 1) {
-        _preds[pred].pos.insert(cl);
-      }
-      else {
-        _preds[pred].neg.insert(cl);
-      }
-    } else {
-      if (val == 2) {
-        ASS_G(_preds[pred].blockers, 0);
-        _preds[pred].blockers--;
-      }
-      else if (val == 1) {
-        ALWAYS(_preds[pred].pos.remove(cl));
+  for (const auto& [pred, counts] : iterTraits(occ.items())) {
+    const auto& [p, n] = counts;
+    PredInfo &info = _preds[pred];
+    if (p > 0 && n > 0) { // occurs in both polarities: a hard blocker (condition 1)
+      if constexpr (add) {
+        info.blockers++;
       }
       else {
-        ALWAYS(_preds[pred].neg.remove(cl));
+        ASS_G(info.blockers, 0);
+        info.blockers--;
       }
+    }
+    else if (p > 0) {
+      updateSide(add, info.pos, info.posHist, info.posMulti, cl, p);
+    }
+    else {
+      updateSide(add, info.neg, info.negHist, info.negMulti, cl, n);
     }
   }
 }
@@ -207,14 +229,34 @@ void PredicateElimination::handleClause(Clause *cl)
 bool PredicateElimination::eligible(unsigned pred) const
 {
   const PredInfo &info = _preds[pred];
-  return !info.eliminated && !info.rprSkipped && info.blockers == 0 && (info.pos.size() + info.neg.size() > 0);
+  if (info.eliminated || info.rprSkipped || info.blockers > 0 || info.pos.size() + info.neg.size() == 0) {
+    return false;
+  }
+  // condition 2: multi-occurrence clauses may only sit on one of the two sides
+  // (without multiOccurrence, we insist on no multi-occurrence clause at all)
+  return _multiOccurrence ? (info.posMulti == 0 || info.negMulti == 0)
+                          : (info.posMulti == 0 && info.negMulti == 0);
 }
 
 double PredicateElimination::estimatedTotalAfter(unsigned pred) const
 {
-  double sp = _preds[pred].pos.size();
-  double sn = _preds[pred].neg.size();
-  return (double)_curTotal - sp - sn + sp * sn;
+  const PredInfo &info = _preds[pred];
+  double sp = info.pos.size();
+  double sn = info.neg.size();
+
+  // each nucleus with k occurrences spawns |satellites|^k hyper-resolvents
+  bool posNucleus = posIsNucleus(pred);
+  const Stack<unsigned> &hist = posNucleus ? info.posHist : info.negHist;
+  double sats = posNucleus ? sn : sp;
+
+  double resolvents = 0.0;
+  for (unsigned k = 1; k < hist.size(); k++) { // note: k >= 1, so no 0^0 below
+    if (hist[k] > 0) {
+      resolvents += (double)hist[k] * std::pow(sats, (double)k);
+    }
+  }
+  // an overflow to infinity here simply makes the step inadmissible, which is what we want
+  return (double)_curTotal - sp - sn + resolvents;
 }
 
 bool PredicateElimination::admissible(unsigned pred) const
@@ -248,6 +290,17 @@ int PredicateElimination::pickCandidate() const
   return best;
 }
 
+void PredicateElimination::collectPredLiterals(Clause *cl, unsigned pred, bool polarity,
+                                               Stack<unsigned> &idxs) const
+{
+  for (unsigned i = 0; i < cl->length(); i++) {
+    Literal *lit = (*cl)[i];
+    if (lit->functor() == pred && lit->isPositive() == polarity) {
+      idxs.push(i);
+    }
+  }
+}
+
 Literal *PredicateElimination::findPredLiteral(Clause *cl, unsigned pred, bool polarity) const
 {
   for (const auto& lit : *cl) {
@@ -266,36 +319,77 @@ void PredicateElimination::eliminate(Problem &prb, unsigned pred)
   ClauseStack posCls;
   ClauseStack negCls;
   {
-    for (const auto& cl : iterTraits(_preds[pred].pos.iter())) {
+    for (const auto& cl : iterTraits(_preds[pred].pos.domain())) {
       posCls.push(cl);
     }
-    for (const auto& cl : iterTraits(_preds[pred].neg.iter())) {
+    for (const auto& cl : iterTraits(_preds[pred].neg.domain())) {
       negCls.push(cl);
     }
   }
+
+  // the side that may carry multi-occurrence clauses acts as the nuclei of the hyper-resolutions;
+  // note that with all multiplicities equal to 1 this keeps the positives the outer loop, as before
+  bool posNucleus = posIsNucleus(pred);
+  ClauseStack const &nuclei = posNucleus ? posCls : negCls;
+  ClauseStack const &satellites = posNucleus ? negCls : posCls;
 
   if (env.options->showPreprocessing()) {
     cout << "[PP] pel eliminating " << env.signature->predicateName(pred)
          << " (|S_P| = " << posCls.size() << ", |S_~P| = " << negCls.size() << ")" << endl;
   }
 
-  // record the model-repairing definition while S_P is still at hand
+  // record the model-repairing definition while both sides are still at hand
   recordElimination(prb, pred, posCls, negCls);
 
+  // each satellite holds exactly one pred-literal (of the polarity opposite to the nuclei')
+  LiteralStack satelliteLits;
+  for (Clause *d : satellites) {
+    satelliteLits.push(findPredLiteral(d, pred, !posNucleus));
+  }
+
   ClauseStack resolvents;
-  for (Clause *c : posCls) {
-    Literal *plitC = findPredLiteral(c, pred, true);
-    for (Clause *d : negCls) {
-      Literal *plitD = findPredLiteral(d, pred, false);
-      Clause *r = buildResolvent(c, plitC, d, plitD);
-      if (r && _useSubsumption) {
-        r = forwardSimplify(r);
-      }
-      if (r) {
-        resolvents.push(r);
-        env.statistics->predicateEliminationResolvents++;
-        if (env.options->showPreprocessing()) {
-          cout << "[PP] pel resolvent: " << r->toString() << endl;
+  // note: with no satellites around, pred is pure, there is nothing to derive,
+  // and the nuclei (the only clauses pred occurs in) simply go away below
+  if (satellites.isNonEmpty()) {
+    Stack<unsigned> nucIdxs;
+    ClauseStack tuple;
+    LiteralStack tupleLits;
+    DArray<unsigned> choice;
+    for (Clause *c : nuclei) {
+      nucIdxs.reset();
+      collectPredLiterals(c, pred, posNucleus, nucIdxs);
+      ASS_G(nucIdxs.size(), 0);
+
+      // an odometer over all the |satellites|^|nucIdxs| assignments of satellites to occurrences
+      choice.init(nucIdxs.size(), 0);
+      for (;;) {
+        tuple.reset();
+        tupleLits.reset();
+        for (unsigned j = 0; j < choice.size(); j++) {
+          tuple.push(satellites[choice[j]]);
+          tupleLits.push(satelliteLits[choice[j]]);
+        }
+        Clause *r = buildResolvent(c, nucIdxs, tuple, tupleLits);
+        if (r && _useSubsumption) {
+          r = forwardSimplify(r);
+        }
+        if (r) {
+          resolvents.push(r);
+          env.statistics->predicateEliminationResolvents++;
+          if (env.options->showPreprocessing()) {
+            cout << "[PP] pel resolvent: " << r->toString() << endl;
+          }
+        }
+
+        unsigned j = 0;
+        for (; j < choice.size(); j++) {
+          if (++choice[j] < satellites.size()) {
+            break;
+          }
+          choice[j] = 0;
+        }
+        if (j == choice.size()) {
+          break;
         }
       }
     }
@@ -334,63 +428,95 @@ void PredicateElimination::eliminate(Problem &prb, unsigned pred)
   env.statistics->eliminatedPredicates++;
 }
 
-Clause *PredicateElimination::buildResolvent(Clause *c, Literal *plitC, Clause *d, Literal *plitD)
+Clause *PredicateElimination::buildResolvent(Clause *nucleus, Stack<unsigned> const &nucIdxs,
+                                             ClauseStack const &sats, LiteralStack const &satLits)
 {
   if (_equational) {
-    return buildResolventEq(c, plitC, d, plitD);
+    return buildResolventEq(nucleus, nucIdxs, sats, satLits);
   }
   else {
-    return buildResolventMgu(c, plitC, d, plitD);
+    return buildResolventMgu(nucleus, nucIdxs, sats, satLits);
   }
 }
 
-Clause *PredicateElimination::buildResolventMgu(Clause *c, Literal *plitC, Clause *d, Literal *plitD)
+/**
+ * Push those literals of @b nucleus that are not among the resolved-upon ones
+ * (@b nucIdxs, which collectPredLiterals delivers in increasing order) onto @b lits,
+ * having applied @b transform to each.
+ */
+template<class Transform>
+static void pushNucleusRest(LiteralStack &lits, Clause *nucleus, Stack<unsigned> const &nucIdxs,
+                            Transform transform)
 {
+  unsigned next = 0;
+  for (unsigned i = 0; i < nucleus->length(); i++) {
+    if (next < nucIdxs.size() && nucIdxs[next] == i) {
+      next++;
+      continue;
+    }
+    lits.push(transform((*nucleus)[i]));
+  }
+  ASS_EQ(next, nucIdxs.size());
+}
+
+Clause *PredicateElimination::buildResolventMgu(Clause *nucleus, Stack<unsigned> const &nucIdxs,
+                                                ClauseStack const &sats, LiteralStack const &satLits)
+{
+  ASS_EQ(nucIdxs.size(), sats.size());
+
   static RobSubstitution subst;
   subst.reset();
-  if (!subst.unifyArgs(plitC, 0, plitD, 1)) {
-    return nullptr; // sound to drop, since there is no equality (and no theories) around
+  // variable bank 0 is the nucleus', bank j+1 the j-th satellite's; picking the same satellite
+  // twice thus automatically resolves against two variable-disjoint variants of it.
+  // Each unification proceeds modulo the bindings accumulated so far, so chaining is correct.
+  for (unsigned j = 0; j < sats.size(); j++) {
+    if (!subst.unifyArgs((*nucleus)[nucIdxs[j]], 0, satLits[j], j + 1)) {
+      return nullptr; // sound to drop, since there is no equality (and no theories) around
+    }
   }
 
   static LiteralStack lits;
   lits.reset();
-  for (const auto& lit : *c) {
-    if (lit != plitC) {
-      lits.push(subst.apply(lit, 0));
+  pushNucleusRest(lits, nucleus, nucIdxs, [&](Literal *lit) { return subst.apply(lit, 0); });
+  for (unsigned j = 0; j < sats.size(); j++) {
+    for (const auto& lit : *sats[j]) {
+      if (lit != satLits[j]) {
+        lits.push(subst.apply(lit, j + 1));
+      }
     }
   }
-  for (const auto& lit : *d) {
-    if (lit != plitD) {
-      lits.push(subst.apply(lit, 1));
-    }
-  }
-  return assembleClause(lits, c, d);
+  return assembleClause(lits, nucleus, sats);
 }
 
-Clause *PredicateElimination::buildResolventEq(Clause *c, Literal *plitC, Clause *d, Literal *plitD)
+Clause *PredicateElimination::buildResolventEq(Clause *nucleus, Stack<unsigned> const &nucIdxs,
+                                               ClauseStack const &sats, LiteralStack const &satLits)
 {
-  ASS_EQ(plitC->arity(), plitD->arity());
-
-  VarShiftApplicator shift{c->maxVar() + 1};
+  ASS_EQ(nucIdxs.size(), sats.size());
 
   static LiteralStack lits;
   lits.reset();
-  for (const auto& lit : *c) {
-    if (lit != plitC) {
-      lits.push(lit);
+  pushNucleusRest(lits, nucleus, nucIdxs, [](Literal *lit) { return lit; });
+
+  // each satellite gets a variable range of its own, disjoint from the nucleus's and the others'
+  unsigned off = nucleus->maxVar() + 1;
+  for (unsigned j = 0; j < sats.size(); j++) {
+    Literal *plit = (*nucleus)[nucIdxs[j]];
+    ASS_EQ(plit->arity(), satLits[j]->arity());
+
+    VarShiftApplicator shift{off};
+    for (const auto& lit : *sats[j]) {
+      if (lit != satLits[j]) {
+        lits.push(SubstHelper::apply(lit, shift));
+      }
     }
-  }
-  for (const auto& lit : *d) {
-    if (lit != plitD) {
-      lits.push(SubstHelper::apply(lit, shift));
+    // this is where the "virtual flattening" happens
+    for (unsigned i = 0; i < plit->arity(); i++) {
+      lits.push(Literal::createEquality(false,
+                                        *plit->nthArgument(i),
+                                        SubstHelper::apply(*satLits[j]->nthArgument(i), shift),
+                                        SortHelper::getArgSort(plit, i)));
     }
-  }
-  // this is where the "virtual flattening" happens
-  for (unsigned i = 0; i < plitC->arity(); i++) {
-    lits.push(Literal::createEquality(false,
-                                      *plitC->nthArgument(i),
-                                      SubstHelper::apply(*plitD->nthArgument(i), shift),
-                                      SortHelper::getArgSort(plitC, i)));
+    off += sats[j]->maxVar() + 1;
   }
 
   // exhaustive equality substitution (note: no decomposition, so this is weaker than unification)
@@ -429,10 +555,10 @@ Clause *PredicateElimination::buildResolventEq(Clause *c, Literal *plitC, Clause
     }
   }
 
-  return assembleClause(lits, c, d);
+  return assembleClause(lits, nucleus, sats);
 }
 
-Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *c, Clause *d)
+Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *nucleus, ClauseStack const &sats)
 {
   static DHSet<Literal *> seen;
   seen.reset();
@@ -468,7 +594,22 @@ Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *c, Clau
   _keptDisequality |= keptDiseq;
   _keptVarVarDisequality |= keptVarVarDiseq;
 
-  return Clause::fromStack(out, NonspecificInference2(InferenceRule::PREDICATE_ELIMINATION, c, d));
+  ASS(sats.isNonEmpty());
+  if (sats.size() == 1) { // the classical binary case; keep its inference binary too
+    return Clause::fromStack(out, NonspecificInference2(InferenceRule::PREDICATE_ELIMINATION, nucleus, sats[0]));
+  }
+
+  // a satellite picked more than once is still just one premise
+  static DHSet<Clause *> premiseSeen;
+  premiseSeen.reset();
+  UnitList *premises = UnitList::empty();
+  for (Clause *d : sats) {
+    if (premiseSeen.insert(d)) {
+      UnitList::push(d, premises);
+    }
+  }
+  UnitList::push(nucleus, premises);
+  return Clause::fromStack(out, NonspecificInferenceMany(InferenceRule::PREDICATE_ELIMINATION, premises));
 }
 
 void PredicateElimination::recordElimination(Problem &prb, unsigned pred,
@@ -483,10 +624,6 @@ void PredicateElimination::recordElimination(Problem &prb, unsigned pred,
     return;
   }
 
-  /* Following the model construction from the proof (cf. the paper):
-   * P(x0,...,xn-1) <=> \/_{D \/ P(ts) in S_P} exists ys. (x0 = ts[0] /\ ... /\ xn-1 = ts[n-1] /\ ~D)
-   * where each clause's variables ys are renamed away from the head variables x0,...,xn-1.
-   */
   unsigned ar = env.signature->predicateArity(pred);
 
   TermStack hargs;
@@ -495,44 +632,69 @@ void PredicateElimination::recordElimination(Problem &prb, unsigned pred,
   }
   Literal *head = Literal::create(pred, ar, true, hargs.begin());
 
+  // the primal definition below needs every clause of S_P to be P-free apart from its
+  // single P-literal; when that fails, condition 2) guarantees S_~P is all-single instead,
+  // and we can build the dual definition from it
+  bool fromPos = (_preds[pred].posMulti == 0);
+  Formula *body = definitionBody(pred, fromPos ? posCls : negCls, fromPos);
+
+  prb.addEliminatedPredicate(pred, new BinaryFormula(IFF, new AtomicFormula(head), body));
+}
+
+/**
+ * Following the model construction from the proof (cf. the paper), with @b fromPos:
+ *   P(x0,...,xn-1) <=> \/_{C \/ P(ts) in S_P} exists ys. (x0 = ts[0] /\ ... /\ xn-1 = ts[n-1] /\ ~C)
+ * and, dually, with !fromPos:
+ *   P(x0,...,xn-1) <=> /\_{D \/ ~P(ss) in S_~P} forall ys. (x0 != ss[0] \/ ... \/ xn-1 != ss[n-1] \/ D)
+ * where each clause's variables ys are renamed away from the head variables x0,...,xn-1.
+ *
+ * The first makes P as false as satisfying S_P permits, the second as true as S_~P permits.
+ * Correspondingly, the first is only correct when every clause of S_P holds exactly one
+ * P-literal (so that the C above is P-free), the second dtto for S_~P; condition 2)
+ * guarantees at least one of the two applies.
+ */
+Formula *PredicateElimination::definitionBody(unsigned pred, ClauseStack const &cls, bool fromPos)
+{
+  unsigned ar = env.signature->predicateArity(pred);
+
   VarShiftApplicator shift{ar}; // clause variables become >= ar, i.e. disjoint from the head's
 
-  FormulaList *disjuncts = FormulaList::empty();
-  for (const auto& c : iterTraits(ClauseStack::ConstIterator(posCls))) {
-    Literal *plit = findPredLiteral(c, pred, true);
+  FormulaList *juncts = FormulaList::empty();
+  for (const auto& c : iterTraits(ClauseStack::ConstIterator(cls))) {
+    Literal *plit = findPredLiteral(c, pred, fromPos);
 
-    FormulaList *conjuncts = FormulaList::empty();
+    FormulaList *inner = FormulaList::empty();
     for (unsigned i = 0; i < ar; i++) {
-      FormulaList::push(new AtomicFormula(Literal::createEquality(true,
+      FormulaList::push(new AtomicFormula(Literal::createEquality(fromPos,
                                                                   TermList::var(i),
                                                                   SubstHelper::apply(*plit->nthArgument(i), shift),
                                                                   SortHelper::getArgSort(plit, i))),
-                        conjuncts);
+                        inner);
     }
     for (const auto& lit : *c) {
       if (lit != plit) {
-        FormulaList::push(new AtomicFormula(
-                              Literal::complementaryLiteral(SubstHelper::apply(lit, shift))),
-                          conjuncts);
+        Literal *l = SubstHelper::apply(lit, shift);
+        FormulaList::push(new AtomicFormula(fromPos ? Literal::complementaryLiteral(l) : l), inner);
       }
     }
-    Formula *inner = JunctionFormula::generalJunction(AND, conjuncts);
+    Formula *junct = JunctionFormula::generalJunction(fromPos ? AND : OR, inner);
 
-    // existentially close over the (shifted) clause variables
+    // existentially (resp. universally) close over the (shifted) clause variables
     DHMap<unsigned, TermList> varSorts;
-    SortHelper::collectVariableSorts(inner, varSorts);
+    SortHelper::collectVariableSorts(junct, varSorts);
     VSList *vs = VSList::empty();
     for (const auto& [var, sort] : iterTraits(varSorts.items())) {
       if (var >= ar) { // skip the head variables
         VSList::push(VarSort(var, sort), vs);
       }
     }
-    Formula *disjunct = vs ? (Formula *)new QuantifiedFormula(EXISTS, vs, inner) : inner;
-    FormulaList::push(disjunct, disjuncts);
+    if (vs) {
+      junct = new QuantifiedFormula(fromPos ? EXISTS : FORALL, vs, junct);
+    }
+    FormulaList::push(junct, juncts);
   }
 
-  Formula *body = JunctionFormula::generalJunction(OR, disjuncts);
-  prb.addEliminatedPredicate(pred, new BinaryFormula(IFF, new AtomicFormula(head), body));
+  return JunctionFormula::generalJunction(fromPos ? OR : AND, juncts);
 }
 
 Clause *PredicateElimination::forwardSimplify(Clause *cl)

--- a/Shell/PredicateElimination.hpp
+++ b/Shell/PredicateElimination.hpp
@@ -45,8 +45,28 @@ using namespace Kernel;
  * sound (and avoids introducing equality) to use an mgu instead and drop
  * the non-unifiable pairs.
  *
- * Elimination steps are subject to clause-growth limits estimated
- * SAT-style as |S_P|*|S_~P| resolvents replacing |S_P|+|S_~P| clauses.
+ * With multiOccurrence enabled, the self-referentiality condition is relaxed to:
+ * 1) P never occurs both positively and negatively in a single clause, and
+ * 2) clauses with more than one occurrence of P sit on at most one polarity side,
+ *    i.e. every clause of S_P has exactly one P-literal, or every clause of S_~P does.
+ * Calling the (possibly) multi-occurrence side the nuclei and the (necessarily)
+ * single-occurrence side the satellites, the replacement clauses are then all the
+ * hyper-resolvents: a nucleus with k occurrences of P is resolved against a k-tuple
+ * of satellites, over all |S_satellite|^k ordered tuples (the same satellite may be
+ * picked twice, in which case two variable-disjoint variants of it are used).
+ * Condition 2) is what makes the P-resolution closure finite: resolving a clause with
+ * two positive occurrences against one with two negative occurrences would yield a
+ * clause violating condition 1), which could then keep resolving with itself.
+ * It is also what keeps the model reconstruction possible, the definition of P having
+ * to be built from the satellite side (see definitionBody, which does it in either
+ * direction, the multiplicities deciding which one).
+ * Note that no factoring is needed: the resolvent obtained by first factoring
+ * P(s) \/ P(t) is an instance (modulo duplicate literal removal) of a hyper-resolvent,
+ * and is therefore subsumed by it.
+ *
+ * Elimination steps are subject to clause-growth limits estimated SAT-style as
+ * sum over nuclei of |S_satellite|^k resolvents replacing |S_P|+|S_~P| clauses
+ * (which is just |S_P|*|S_~P| when all the multiplicities k are 1).
  */
 class PredicateElimination {
 public:
@@ -59,18 +79,30 @@ public:
    *        number of clauses afterwards does not exceed the initial number times this factor
    * @param useSubsumption  keep the clause set forward-inter-subsumed and
    *        subsumption-resolved
+   * @param multiOccurrence  also eliminate predicates occurring more than once
+   *        in a clause, as long as conditions 1) and 2) above hold
    */
-  PredicateElimination(bool forceEquationally, float totalLimit, bool useSubsumption)
+  PredicateElimination(bool forceEquationally, float totalLimit, bool useSubsumption,
+                       bool multiOccurrence)
       : _forceEquationally(forceEquationally),
-        _totalLimit(totalLimit), _useSubsumption(useSubsumption) {}
+        _totalLimit(totalLimit), _useSubsumption(useSubsumption),
+        _multiOccurrence(multiOccurrence) {}
 
   void apply(Kernel::Problem &prb);
 
 private:
   struct PredInfo {
-    Lib::DHSet<Clause *> pos; // S_P: clauses in which P occurs exactly once, positively
-    Lib::DHSet<Clause *> neg; // S_~P: dtto, negatively
-    unsigned blockers = 0;    // number of clauses in which P occurs more than once
+    // S_P: clauses in which P occurs only positively, mapped to the number of occurrences;
+    // S_~P: dtto, negatively (clauses with both polarities are counted as blockers instead)
+    Lib::DHMap<Clause *, unsigned> pos;
+    Lib::DHMap<Clause *, unsigned> neg;
+    unsigned blockers = 0; // number of clauses in which P occurs both positively and negatively
+    unsigned posMulti = 0; // number of clauses of pos with more than one occurrence
+    unsigned negMulti = 0; // dtto, for neg
+    // posHist[k] is the number of clauses of pos with exactly k occurrences (index 0 unused);
+    // maintained just to keep estimatedTotalAfter cheap
+    Lib::Stack<unsigned> posHist;
+    Lib::Stack<unsigned> negHist;
     bool eliminated = false;
     bool rprSkipped = false;  // under randomized preprocessing: picked but skipped, never to be reconsidered
   };
@@ -79,6 +111,7 @@ private:
   const bool _forceEquationally;
   const float _totalLimit;
   const bool _useSubsumption;
+  const bool _multiOccurrence;
 
   // clause set state
   ClauseStack _all;     // all clauses ever seen, in insertion order
@@ -95,21 +128,33 @@ private:
   void handleClause(Clause *cl);
 
   bool eligible(unsigned pred) const;
+  /** which side carries the (possible) multi-occurrence clauses, i.e. plays the nuclei;
+   * the satellites, all with exactly one occurrence, then come from the other side */
+  bool posIsNucleus(unsigned pred) const { return _preds[pred].negMulti == 0; }
   double estimatedTotalAfter(unsigned pred) const;
   bool admissible(unsigned pred) const;
   int pickCandidate() const;
 
   void eliminate(Problem &prb, unsigned pred);
+  /** the indices of the literals of @b cl with the given predicate and polarity */
+  void collectPredLiterals(Clause *cl, unsigned pred, bool polarity, Lib::Stack<unsigned> &idxs) const;
   Literal *findPredLiteral(Clause *cl, unsigned pred, bool polarity) const;
 
-  // resolvent construction; nullptr means no clause results (tautology / non-unifiable pair)
-  Clause *buildResolvent(Clause *c, Literal *plitC, Clause *d, Literal *plitD);
-  Clause *buildResolventMgu(Clause *c, Literal *plitC, Clause *d, Literal *plitD);
-  Clause *buildResolventEq(Clause *c, Literal *plitC, Clause *d, Literal *plitD);
-  Clause *assembleClause(LiteralStack &lits, Clause *c, Clause *d);
+  // (hyper-)resolvent construction; nullptr means no clause results (tautology / non-unifiable tuple).
+  // satLits[j], the unique pred-literal of sats[j], gets resolved against (*nucleus)[nucIdxs[j]]
+  Clause *buildResolvent(Clause *nucleus, Lib::Stack<unsigned> const &nucIdxs,
+                         ClauseStack const &sats, LiteralStack const &satLits);
+  Clause *buildResolventMgu(Clause *nucleus, Lib::Stack<unsigned> const &nucIdxs,
+                            ClauseStack const &sats, LiteralStack const &satLits);
+  Clause *buildResolventEq(Clause *nucleus, Lib::Stack<unsigned> const &nucIdxs,
+                           ClauseStack const &sats, LiteralStack const &satLits);
+  Clause *assembleClause(LiteralStack &lits, Clause *nucleus, ClauseStack const &sats);
 
   // model reconstruction
   void recordElimination(Problem &prb, unsigned pred, ClauseStack const &posCls, ClauseStack const &negCls);
+  /** the shared body of the two model reconstruction directions (see above);
+   * @param fromPos selects the primal (built from S_P) or the dual (from S_~P) one */
+  Formula *definitionBody(unsigned pred, ClauseStack const &cls, bool fromPos);
 
   // forward subsumption (and subsumption resolution) machinery, only used with _useSubsumption;
   // the backward direction (new clauses simplifying older ones) is left as future work

--- a/Shell/PredicateElimination.hpp
+++ b/Shell/PredicateElimination.hpp
@@ -99,10 +99,6 @@ private:
     unsigned blockers = 0; // number of clauses in which P occurs both positively and negatively
     unsigned posMulti = 0; // number of clauses of pos with more than one occurrence
     unsigned negMulti = 0; // dtto, for neg
-    // posHist[k] is the number of clauses of pos with exactly k occurrences (index 0 unused);
-    // maintained just to keep estimatedTotalAfter cheap
-    Lib::Stack<unsigned> posHist;
-    Lib::Stack<unsigned> negHist;
     bool eliminated = false;
     bool rprSkipped = false;  // under randomized preprocessing: picked but skipped, never to be reconsidered
   };
@@ -131,7 +127,27 @@ private:
   /** which side carries the (possible) multi-occurrence clauses, i.e. plays the nuclei;
    * the satellites, all with exactly one occurrence, then come from the other side */
   bool posIsNucleus(unsigned pred) const { return _preds[pred].negMulti == 0; }
-  double estimatedTotalAfter(unsigned pred) const;
+
+  /** the number of hyper-resolvents when at least one side does have multiplicities;
+   * out of line, and out of estimatedTotalAfter's body, only to keep that one inlinable */
+  double multiOccurrenceResolvents(PredInfo const &info, double sp, double sn) const;
+  /**
+   * Estimate the clause count after eliminating @b pred. This sits in the innermost loop of
+   * pickCandidate, which rescans the whole signature on every elimination round, so the
+   * overwhelmingly common all-multiplicities-are-1 case must stay just a few loads and a
+   * multiply -- and must stay small enough for the compiler to inline it.
+   */
+  double estimatedTotalAfter(unsigned pred) const
+  {
+    const PredInfo &info = _preds[pred];
+    double sp = info.pos.size();
+    double sn = info.neg.size();
+    // an overflow to infinity below simply makes the step inadmissible, which is what we want
+    double resolvents = (info.posMulti == 0 && info.negMulti == 0)
+                            ? sp * sn
+                            : multiOccurrenceResolvents(info, sp, sn);
+    return (double)_curTotal - sp - sn + resolvents;
+  }
   bool admissible(unsigned pred) const;
   int pickCandidate() const;
 
@@ -141,14 +157,19 @@ private:
   Literal *findPredLiteral(Clause *cl, unsigned pred, bool polarity) const;
 
   // (hyper-)resolvent construction; nullptr means no clause results (tautology / non-unifiable tuple).
-  // satLits[j], the unique pred-literal of sats[j], gets resolved against (*nucleus)[nucIdxs[j]]
+  // choice[j] picks, out of sats/satLits, the satellite whose (unique) pred-literal gets
+  // resolved against (*nucleus)[nucIdxs[j]]; the same satellite may be picked more than once
   Clause *buildResolvent(Clause *nucleus, Lib::Stack<unsigned> const &nucIdxs,
-                         ClauseStack const &sats, LiteralStack const &satLits);
+                         ClauseStack const &sats, LiteralStack const &satLits,
+                         Lib::DArray<unsigned> const &choice);
   Clause *buildResolventMgu(Clause *nucleus, Lib::Stack<unsigned> const &nucIdxs,
-                            ClauseStack const &sats, LiteralStack const &satLits);
+                            ClauseStack const &sats, LiteralStack const &satLits,
+                            Lib::DArray<unsigned> const &choice);
   Clause *buildResolventEq(Clause *nucleus, Lib::Stack<unsigned> const &nucIdxs,
-                           ClauseStack const &sats, LiteralStack const &satLits);
-  Clause *assembleClause(LiteralStack &lits, Clause *nucleus, ClauseStack const &sats);
+                           ClauseStack const &sats, LiteralStack const &satLits,
+                           Lib::DArray<unsigned> const &choice);
+  Clause *assembleClause(LiteralStack &lits, Clause *nucleus,
+                         ClauseStack const &sats, Lib::DArray<unsigned> const &choice);
 
   // model reconstruction
   void recordElimination(Problem &prb, unsigned pred, ClauseStack const &posCls, ClauseStack const &negCls);

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -483,7 +483,8 @@ void Preprocess::preprocess(Problem& prb)
 
        PredicateElimination pel(/*forceEquationally=*/_options.saturationAlgorithm() == Options::SaturationAlgorithm::FINITE_MODEL_BUILDING,
                                 _options.predicateEliminationTotalLimit(),
-                                _options.predicateEliminationSubsumption());
+                                _options.predicateEliminationSubsumption(),
+                                _options.predicateEliminationMultiOccurrence());
        pel.apply(prb);
      }
    }

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -470,7 +470,7 @@ void Preprocess::preprocess(Problem& prb)
      bce.apply(prb);
    }
 
-   if (_options.predicateElimination()) {
+   if (_options.predicateElimination() != Options::PredicateElimination::OFF) {
      if (prb.isHigherOrder() || prb.hasPolymorphicSym()) { // in both cases, predicates could hide inside terms, breaking the occurrence counting
        if (outputAllowed()) {
          addCommentSignForSZS(std::cout);

--- a/Shell/TheoryFlattening.cpp
+++ b/Shell/TheoryFlattening.cpp
@@ -100,14 +100,7 @@ bool TheoryFlattening::apply(ClauseList*& clauses)
 Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
 {
   // Find the max variable. This will be used to introduce new variables.
-  unsigned maxVar = 0;
-  VirtualIterator<unsigned> varIt = cl->getVariableIterator();
-  while (varIt.hasNext()) {
-    unsigned var = varIt.next();
-    if (var > maxVar) {
-      maxVar = var;
-    }
-  }
+  unsigned maxVar = cl->maxVar();
 
   // The resultant lits
   Stack<Literal*> result;

--- a/UnitTests/tPredicateElimination.cpp
+++ b/UnitTests/tPredicateElimination.cpp
@@ -35,7 +35,12 @@ static Problem *problemFromClauses(std::initializer_list<Clause *> cls)
   for (Clause *cl : cls) {
     UnitList::push(cl, units);
   }
-  return new Problem(units);
+  Problem *prb = new Problem(units);
+  // as UIHelper does for a parsed input: without this, env never learns that these
+  // problems are typed, and printing a definition that quantifies over a declared
+  // sort trips the "initially untyped problems stay untyped" assertion in Formula
+  env.setMainProblem(prb);
+  return prb;
 }
 
 static ClauseStack collectClauses(Problem &prb)

--- a/UnitTests/tPredicateElimination.cpp
+++ b/UnitTests/tPredicateElimination.cpp
@@ -8,7 +8,10 @@
  * and in the source directory
  */
 
+#include <algorithm>
 #include <initializer_list>
+#include <string>
+#include <vector>
 
 #include "Test/UnitTesting.hpp"
 #include "Test/SyntaxSugar.hpp"
@@ -17,6 +20,7 @@
 #include "Shell/Statistics.hpp"
 
 #include "Kernel/Clause.hpp"
+#include "Kernel/Formula.hpp"
 #include "Kernel/Inference.hpp"
 #include "Kernel/Problem.hpp"
 
@@ -72,12 +76,38 @@ static Clause *theClauseOfLength(const ClauseStack &cls, unsigned len)
 static ClauseStack runPE(std::initializer_list<Clause *> cls,
                              bool forceEquationally = false,
                              float totalLimit = 2.0,
-                             bool useSubsumption = false)
+                             bool useSubsumption = false,
+                             bool multiOccurrence = true)
 {
   Problem *prb = problemFromClauses(cls);
-  PredicateElimination pe(forceEquationally, totalLimit, useSubsumption);
+  PredicateElimination pe(forceEquationally, totalLimit, useSubsumption, multiOccurrence);
   pe.apply(*prb);
   return collectClauses(*prb);
+}
+
+/** the predicate elimination resolvent -- expected to exist and be unique */
+static Clause *theResolvent(const ClauseStack &cls)
+{
+  Clause *found = nullptr;
+  for (Clause *cl : cls) {
+    if (cl->inference().rule() == InferenceRule::PREDICATE_ELIMINATION) {
+      ASS(!found);
+      found = cl;
+    }
+  }
+  ASS(found);
+  return found;
+}
+
+/** the clauses' literals, sorted, so that a test does not depend on the derivation order */
+static std::vector<std::string> clauseStrings(const ClauseStack &cls)
+{
+  std::vector<std::string> res;
+  for (Clause *cl : cls) {
+    res.push_back(cl->literalsOnlyToString());
+  }
+  std::sort(res.begin(), res.end());
+  return res;
 }
 
 /* Note: many tests below include the clause {q(y) \/ ~q(f(y))}, in which q is
@@ -186,11 +216,143 @@ TEST_FUN(self_referential_skipped)
 {
   MY_SYNTAX_SUGAR
 
-  // p occurs twice in the first clause, so it must survive
-  auto res = runPE({clause({p(x), p(f(x))}), clause({~p(a)})});
+  // p occurs twice in the first clause, so without multiOccurrence it must survive
+  auto res = runPE({clause({p(x), p(f(x))}), clause({~p(a)})},
+                   /*forceEquationally=*/false, /*totalLimit=*/2.0,
+                   /*useSubsumption=*/false, /*multiOccurrence=*/false);
 
   ASS_EQ(res.size(), 2);
   ASS(containsPredicate(res, p.functor()));
+}
+
+TEST_FUN(multi_occurrence_nonunifiable_tuple_dropped)
+{
+  MY_SYNTAX_SUGAR
+
+  // with multiOccurrence, p goes: the only tuple (the satellite paired with itself)
+  // would need x = a and f(x) = a at once, so it yields no resolvent -- correctly,
+  // since {p(x) \/ p(f(x))}, {~p(a)} is satisfiable
+  auto res = runPE({clause({p(x), p(f(x))}), clause({~p(a)})});
+
+  ASS_EQ(res.size(), 0);
+}
+
+TEST_FUN(mixed_polarity_still_blocked)
+{
+  MY_SYNTAX_SUGAR
+
+  // p occurs in both polarities in one clause (violating condition 1), so it stays
+  auto res = runPE({clause({p(x), ~p(f(x))}), clause({~p(a)})});
+
+  ASS_EQ(res.size(), 2);
+  ASS(containsPredicate(res, p.functor()));
+}
+
+TEST_FUN(multi_occurrence_on_both_sides_blocked)
+{
+  MY_SYNTAX_SUGAR
+
+  // multi-occurrence on both sides violates condition 2, so p stays
+  auto res = runPE({clause({p(a), p(b)}), clause({~p(x), ~p(y)})});
+
+  ASS_EQ(res.size(), 2);
+  ASS(containsPredicate(res, p.functor()));
+}
+
+TEST_FUN(multi_occurrence_positive_nucleus)
+{
+  MY_SYNTAX_SUGAR
+
+  // {p(a) \/ p(b)} is the nucleus; its two occurrences are resolved against
+  // two variable-disjoint copies of the only satellite ---> {q(a) \/ q(b)}
+  Problem *prb = problemFromClauses({clause({p(a), p(b)}), clause({~p(x), q(x)}),
+                                     clause({q(y), ~q(f(y))})});
+  PredicateElimination pe(false, 2.0, false, true);
+  pe.apply(*prb);
+  auto res = collectClauses(*prb);
+
+  ASS_EQ(res.size(), 2);
+  ASS(!containsPredicate(res, p.functor()));
+  ASS_EQ(theResolvent(res)->literalsOnlyToString(), "q(a) | q(b)");
+
+  // the multiplicity sits on the positive side, so the model-repairing definition of p
+  // must have been recorded in the dual direction, i.e. built from S_~P
+  ASS(prb->interferences.isNonEmpty());
+  auto *pd = static_cast<Problem::PredDef *>(prb->interferences.top());
+  ASS(pd->_kind == Problem::IntereferenceKind::PRED_DEF);
+  ASS_EQ(pd->_head->functor(), p.functor());
+  ASS(pd->_body->connective() == FORALL); // the dual shape (the primal one is EXISTS/OR)
+  ASS(pd->_body->toString().find("p(") == std::string::npos); // and it is p-free
+}
+
+TEST_FUN(multi_occurrence_negative_nucleus)
+{
+  MY_SYNTAX_SUGAR
+
+  // the mirror image: {~p(a) \/ ~p(b)} is the nucleus ---> {q(a) \/ q(b)}
+  auto res = runPE({clause({~p(a), ~p(b)}), clause({p(x), q(x)}),
+                    clause({q(y), ~q(f(y))})});
+
+  ASS_EQ(res.size(), 2);
+  ASS(!containsPredicate(res, p.functor()));
+  ASS_EQ(theResolvent(res)->literalsOnlyToString(), "q(a) | q(b)");
+}
+
+TEST_FUN(multi_occurrence_all_tuples_enumerated)
+{
+  MY_SYNTAX_SUGAR
+
+  // two occurrences against two satellites: all 2^2 assignments are needed
+  auto res = runPE({clause({p(a), p(b)}),
+                    clause({~p(x), q(x)}), clause({~p(y), r(y)}),
+                    clause({q(y), ~q(f(y))}), clause({r(y), ~r(f(y))})});
+
+  ASS_EQ(res.size(), 6); // 4 resolvents plus the two anchors
+  ASS(!containsPredicate(res, p.functor()));
+  auto strs = clauseStrings(res);
+  ASS(std::find(strs.begin(), strs.end(), "q(a) | q(b)") != strs.end());
+  ASS(std::find(strs.begin(), strs.end(), "q(a) | r(b)") != strs.end());
+  ASS(std::find(strs.begin(), strs.end(), "r(a) | q(b)") != strs.end());
+  ASS(std::find(strs.begin(), strs.end(), "r(a) | r(b)") != strs.end());
+}
+
+TEST_FUN(multi_occurrence_copies_are_variable_disjoint)
+{
+  MY_SYNTAX_SUGAR
+
+  // the two copies of the satellite must not share variables, i.e. the resolvent
+  // is {q(X) \/ q(Y)} with X and Y distinct -- and not the collapsed {q(X)}
+  for (bool equationally : {false, true}) {
+    auto res = runPE({clause({p(x), p(y)}), clause({~p(z), q(z)}),
+                      clause({q(y), ~q(f(y))})},
+                     /*forceEquationally=*/equationally);
+
+    ASS_EQ(res.size(), 2);
+    ASS(!containsPredicate(res, p.functor()));
+    Clause *resolvent = theResolvent(res);
+    ASS_EQ(resolvent->length(), 2);
+    ASS_NEQ((*resolvent)[0], (*resolvent)[1]);
+  }
+}
+
+TEST_FUN(multi_occurrence_growth_limits_respected)
+{
+  MY_SYNTAX_SUGAR
+
+  // one nucleus with 2 occurrences and 2 satellites means 2^2 = 4 resolvents
+  // replacing 3 clauses, i.e. 4 - 1 - 2 + 4 = 5 clauses estimated out of 4
+  std::initializer_list<Clause *> cls = {
+      clause({p(a), p(b)}), clause({~p(x), q(x)}), clause({~p(a)}),
+      clause({q(y), ~q(f(y))})};
+
+  auto res = runPE(cls, false, /*totalLimit=*/1.0);
+  ASS_EQ(res.size(), 4);
+  ASS(containsPredicate(res, p.functor()));
+
+  // with a benevolent limit p goes; 2 of the 4 tuples fail to unify
+  auto res2 = runPE(cls, false, /*totalLimit=*/2.0);
+  ASS_EQ(res2.size(), 3);
+  ASS(!containsPredicate(res2, p.functor()));
 }
 
 TEST_FUN(pure_predicate_clauses_deleted)
@@ -199,7 +361,7 @@ TEST_FUN(pure_predicate_clauses_deleted)
 
   // p occurs only positively: its clause can simply be deleted
   Problem *prb = problemFromClauses({clause({p(a), q(b)}), clause({q(y), ~q(f(y))})});
-  PredicateElimination pe(false, 2.0, false);
+  PredicateElimination pe(false, 2.0, false, true);
   pe.apply(*prb);
   auto res = collectClauses(*prb);
 

--- a/samplers/samplerFNT.smp
+++ b/samplers/samplerFNT.smp
@@ -34,16 +34,13 @@ $ins=Z > ins ~cat 0:1
 $ins=NZ > ins ~sgd 0.4,1
 
 # predicate_elimination
-> pel ~cat off:1,on:1
-
-# predicate_elimination_multi_occurrence
-pel=on > pelmo ~cat on:1,off:1
+> pel ~cat off:2,on:1,multi:1
 
 # predicate_elimination_subsumption
-pel=on > pels ~cat on:4,off:1
+pel!=off > pels ~cat on:4,off:1
 
 # predicate_elimination_total_limit
-pel=on > peltl ~uf 0.9,5.0
+pel!=off > peltl ~uf 0.9,5.0
 
 # random_polarities
 > rp ~cat off:3,on:1

--- a/samplers/samplerFNT.smp
+++ b/samplers/samplerFNT.smp
@@ -36,6 +36,9 @@ $ins=NZ > ins ~sgd 0.4,1
 # predicate_elimination
 > pel ~cat off:1,on:1
 
+# predicate_elimination_multi_occurrence
+pel=on > pelmo ~cat on:1,off:1
+
 # predicate_elimination_subsumption
 pel=on > pels ~cat on:4,off:1
 

--- a/samplers/samplerFOL.smp
+++ b/samplers/samplerFOL.smp
@@ -41,6 +41,9 @@ $ins=NZ > ins ~sgd 0.4,1
 # predicate_elimination
 > pel ~cat off:1,on:1
 
+# predicate_elimination_multi_occurrence
+pel=on > pelmo ~cat off:4,on:1
+
 # predicate_elimination_subsumption
 pel=on > pels ~cat on:4,off:1
 

--- a/samplers/samplerFOL.smp
+++ b/samplers/samplerFOL.smp
@@ -39,16 +39,13 @@ $ins=Z > ins ~cat 0:1
 $ins=NZ > ins ~sgd 0.4,1
 
 # predicate_elimination
-> pel ~cat off:1,on:1
-
-# predicate_elimination_multi_occurrence
-pel=on > pelmo ~cat off:4,on:1
+> pel ~cat off:5,on:4,multi:1
 
 # predicate_elimination_subsumption
-pel=on > pels ~cat on:4,off:1
+pel!=off > pels ~cat on:4,off:1
 
 # predicate_elimination_total_limit
-pel=on > peltl ~uf 0.9,5.0
+pel!=off > peltl ~uf 0.9,5.0
 
 # random_polarities
 > rp ~cat off:3,on:1

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -41,6 +41,9 @@ $ins=NZ > ins ~sgd 0.4,1
 # predicate_elimination
 > pel ~cat off:1,on:1
 
+# predicate_elimination_multi_occurrence
+pel=on > pelmo ~cat off:4,on:1
+
 # predicate_elimination_subsumption
 pel=on > pels ~cat on:4,off:1
 

--- a/samplers/samplerHOL.smp
+++ b/samplers/samplerHOL.smp
@@ -39,16 +39,13 @@ $ins=Z > ins ~cat 0:1
 $ins=NZ > ins ~sgd 0.4,1
 
 # predicate_elimination
-> pel ~cat off:1,on:1
-
-# predicate_elimination_multi_occurrence
-pel=on > pelmo ~cat off:4,on:1
+> pel ~cat off:5,on:4,multi:1
 
 # predicate_elimination_subsumption
-pel=on > pels ~cat on:4,off:1
+pel!=off > pels ~cat on:4,off:1
 
 # predicate_elimination_total_limit
-pel=on > peltl ~uf 0.9,5.0
+pel!=off > peltl ~uf 0.9,5.0
 
 # random_polarities
 > rp ~cat off:3,on:1

--- a/samplers/samplerIND.smp
+++ b/samplers/samplerIND.smp
@@ -34,16 +34,13 @@ $ins=Z > ins ~cat 0:1
 $ins=NZ > ins ~sgd 0.4,1
 
 # predicate_elimination
-> pel ~cat off:1,on:1
-
-# predicate_elimination_multi_occurrence
-pel=on > pelmo ~cat off:4,on:1
+> pel ~cat off:5,on:4,multi:1
 
 # predicate_elimination_subsumption
-pel=on > pels ~cat on:4,off:1
+pel!=off > pels ~cat on:4,off:1
 
 # predicate_elimination_total_limit
-pel=on > peltl ~uf 0.9,5.0
+pel!=off > peltl ~uf 0.9,5.0
 
 # random_polarities
 > rp ~cat off:3,on:1

--- a/samplers/samplerIND.smp
+++ b/samplers/samplerIND.smp
@@ -36,6 +36,9 @@ $ins=NZ > ins ~sgd 0.4,1
 # predicate_elimination
 > pel ~cat off:1,on:1
 
+# predicate_elimination_multi_occurrence
+pel=on > pelmo ~cat off:4,on:1
+
 # predicate_elimination_subsumption
 pel=on > pels ~cat on:4,off:1
 

--- a/samplers/samplerSMT.smp
+++ b/samplers/samplerSMT.smp
@@ -39,6 +39,9 @@ $ins=NZ > ins ~sgd 0.4,1
 # predicate_elimination
 > pel ~cat off:1,on:1
 
+# predicate_elimination_multi_occurrence
+pel=on > pelmo ~cat off:4,on:1
+
 # predicate_elimination_subsumption
 pel=on > pels ~cat on:4,off:1
 

--- a/samplers/samplerSMT.smp
+++ b/samplers/samplerSMT.smp
@@ -37,16 +37,13 @@ $ins=Z > ins ~cat 0:1
 $ins=NZ > ins ~sgd 0.4,1
 
 # predicate_elimination
-> pel ~cat off:1,on:1
-
-# predicate_elimination_multi_occurrence
-pel=on > pelmo ~cat off:4,on:1
+> pel ~cat off:5,on:4,multi:1
 
 # predicate_elimination_subsumption
-pel=on > pels ~cat on:4,off:1
+pel!=off > pels ~cat on:4,off:1
 
 # predicate_elimination_total_limit
-pel=on > peltl ~uf 0.9,5.0
+pel!=off > peltl ~uf 0.9,5.0
 
 # random_polarities
 > rp ~cat off:3,on:1


### PR DESCRIPTION
Implements (behind an option) an extension suggested by Andrei:

      "Also eliminate a predicate P occurring more than once in a clause, provided P never occurs"
      " both positively and negatively in a single clause and the multi-occurrence clauses all sit"
      " on one polarity side. Instead of pairwise resolvents, the replacement clauses are then all"
      " the hyper-resolvents, each occurrence of a multi-occurrence clause being resolved against"
      " its own (variable-disjoint) copy of a single-occurrence clause of the opposite polarity."
      
In addition, performance has been tuned and improved (also for the non-pelmo case).
(Sneakily, `cl->maxVar` no longer uses the expensive `getUniquePersistentIterator` which positively impacts other places too.)