### PR TITLE
ALASCA integer conversion: give the integrality axiom a sound Inference, and refresh the problem property

### DIFF
--- a/Kernel/ALASCA/Preprocessor.hpp
+++ b/Kernel/ALASCA/Preprocessor.hpp
@@ -258,6 +258,10 @@ public:
         }
       }
     }
+    // the conversion rewrites every unit and adds new ones (in particular equalities,
+    // which the original problem need not have contained), so nothing cached about the
+    // problem survives it
+    prb.invalidateEverything();
   }
 };
 

--- a/Kernel/ALASCA/Preprocessor.hpp
+++ b/Kernel/ALASCA/Preprocessor.hpp
@@ -24,7 +24,7 @@
 
 namespace Kernel {
 
-class AlascaPreprocessor 
+class AlascaPreprocessor
 {
   const InequalityNormalizer& _norm;
   Map<unsigned, unsigned> _preds;
@@ -40,12 +40,12 @@ class AlascaPreprocessor
   {
     auto lit = _norm.normalizedLiteral(l);
     // AlascaState::globalState->normalizer->normalizedLiteral()
-    auto impl = [&]() { 
+    auto impl = [&]() {
       if (lit->isEquality()) {
         auto sort = SortHelper::getEqualityArgumentSort(lit);
-        return Literal::createEquality(lit->polarity(), 
-            integerConversion(TypedTermList(lit->termArg(0), sort)), 
-            integerConversion(TypedTermList(lit->termArg(1), sort)), 
+        return Literal::createEquality(lit->polarity(),
+            integerConversion(TypedTermList(lit->termArg(0), sort)),
+            integerConversion(TypedTermList(lit->termArg(1), sort)),
             integerConversion(TypedTermList(sort, AtomicSort::superSort())));
       } else {
         auto ff = integerPredicateConversion(lit->functor());
@@ -63,7 +63,7 @@ class AlascaPreprocessor
     return out;
   }
 
-  TermList integerConversion(TypedTermList t) 
+  TermList integerConversion(TypedTermList t)
   {
     return BottomUpEvaluation<TypedTermList, TermList>()
       .function([this](TypedTermList t, TermList* args) -> TermList {
@@ -100,7 +100,7 @@ class AlascaPreprocessor
   unsigned integerPredicateConversion(unsigned f)
   {
 
-    return _preds.getOrInit(f, [&]() { 
+    return _preds.getOrInit(f, [&]() {
       using Z = IntTraits;
       using R = RealTraits;
       if (Z::isLess(f)) return R::lessF();
@@ -112,8 +112,8 @@ class AlascaPreprocessor
       auto sym = env.signature->getPredicate(f);
       auto ty = sym->predType();
       auto sorts_changed = false;
-      auto intConv= [&](auto x) { 
-        auto out = integerConversion(TypedTermList(x, AtomicSort::superSort())); 
+      auto intConv= [&](auto x) {
+        auto out = integerConversion(TypedTermList(x, AtomicSort::superSort()));
         sorts_changed |= out != x;
         return out;
       };
@@ -136,7 +136,7 @@ class AlascaPreprocessor
 
   unsigned integerFunctionConversion(unsigned f)
   {
-    return _funcs.getOrInit(f, [&]() { 
+    return _funcs.getOrInit(f, [&]() {
       if (Z::isAdd(f)) return R::addF();
       if (Z::isMul(f)) return R::mulF();
       if (Z::isMinus(f)) return R::minusF();
@@ -155,8 +155,8 @@ class AlascaPreprocessor
 #undef ASS_NOT
 
       auto sorts_changed = false;
-      auto intConv= [&](auto x) { 
-        auto out = integerConversion(TypedTermList(x, AtomicSort::superSort())); 
+      auto intConv= [&](auto x) {
+        auto out = integerConversion(TypedTermList(x, AtomicSort::superSort()));
         sorts_changed |= out != x;
         return out;
       };
@@ -189,13 +189,13 @@ class AlascaPreprocessor
 
   Clause* integerConversion(Clause* clause)
   {
-    auto notInt = [&](auto t) -> Option<Literal*> { 
+    auto notInt = [&](auto t) -> Option<Literal*> {
       if (auto q = R::tryNumeral(t)) {
         if (q->isInt()) {
           return {};
         }
       }
-      return some(R::eq(false, t, R::floor(t))); 
+      return some(R::eq(false, t, R::floor(t)));
     };
     auto change = false;
     Recycled<Stack<Literal*>> res;
@@ -230,7 +230,7 @@ class AlascaPreprocessor
 public:
 
 
-  AlascaPreprocessor(const InequalityNormalizer& norm) 
+  AlascaPreprocessor(const InequalityNormalizer& norm)
     : _norm(norm)
     , _preds()
     , _funcs() {}
@@ -243,15 +243,15 @@ public:
     if (!_useFloor) {
       for (auto& func : iterTraits(_funcs.iter())) {
         auto orig_sym = env.signature->getFunction(func.key());
-        if (!theory->isInterpretedFunction(func.value()) 
+        if (!theory->isInterpretedFunction(func.value())
             && !R::isNumeral(func.value())
             && !R::isLinMul(func.value())
             ) {
           auto sym = env.signature->getFunction(func.value());
           if (orig_sym->fnType()->result() == Z::sort()) {
             auto t = TermList(Term::createFromIter(func.value(), range(0, sym->arity()).map([](auto x) { return TermList::var(x); })));
-            // TODO use something else than NonspecificInferenceMany
-            auto inf = Inference(NonspecificInferenceMany(INF_RULE, nullptr));
+            auto inf = Inference(NonspecificInference0(UnitInputType::AXIOM,
+                  InferenceRule::ALASCA_INTEGRALITY_AXIOM));
             auto cl = Clause::fromLiterals({R::eq(true, R::floor(t), t)}, inf);
             UnitList::push(cl, prb.units());
           }
@@ -261,7 +261,7 @@ public:
   }
 };
 
-class QuotientEPreproc 
+class QuotientEPreproc
 {
   bool _addedITE = false;
   using Z = IntTraits;
@@ -270,12 +270,12 @@ class QuotientEPreproc
 
   Literal* proc(Literal* lit)
   {
-    auto impl = [&]() { 
+    auto impl = [&]() {
       if (lit->isEquality()) {
         auto sort = SortHelper::getEqualityArgumentSort(lit);
-        return Literal::createEquality(lit->polarity(), 
-            proc(TypedTermList(lit->termArg(0), sort)), 
-            proc(TypedTermList(lit->termArg(1), sort)), 
+        return Literal::createEquality(lit->polarity(),
+            proc(TypedTermList(lit->termArg(0), sort)),
+            proc(TypedTermList(lit->termArg(1), sort)),
             sort);
       } else {
         auto ff = lit->functor();
@@ -321,7 +321,7 @@ class QuotientEPreproc
     }
   }
 
-  TermList proc(TypedTermList t) 
+  TermList proc(TypedTermList t)
   {
     auto trans = TermTrans(*this);
     return t.isVar() ? t : TermList(trans.transform(t.term()));
@@ -346,18 +346,18 @@ class QuotientEPreproc
   struct TermTrans : public TermTransformer {
     QuotientEPreproc& _self;
     TermTrans(QuotientEPreproc& self) : _self(self) {}
-    TermList transformSubterm(TermList t) override 
+    TermList transformSubterm(TermList t) override
     { return _self.transformSubterm(t); }
   };
 
-  FormulaUnit* proc(FormulaUnit* unit) 
-  { 
+  FormulaUnit* proc(FormulaUnit* unit)
+  {
     auto trans = TermTrans(*this);
     auto inf = Inference(FormulaClauseTransformation(INF_RULE, unit));
     return new FormulaUnit(TermTransformingFormulaTransformer(trans).transform(unit->formula()), inf); 
   }
   Unit* proc(Unit* unit) {
-    return unit->isClause() 
+    return unit->isClause()
       ? (Unit*)proc(static_cast<Clause*>(unit))
       : (Unit*)proc(static_cast<FormulaUnit*>(unit));
   }
@@ -376,6 +376,6 @@ public:
 
 
 } // namespace Kernel
- 
+
 #endif // __ALASCA_Preprocessor__
 

--- a/Kernel/Inference.cpp
+++ b/Kernel/Inference.cpp
@@ -608,6 +608,8 @@ std::string Kernel::ruleName(InferenceRule rule)
     return "equality proxy definition";
   case InferenceRule::EQUALITY_PROXY_AXIOM:
     return "equality proxy axiom";
+  case InferenceRule::ALASCA_INTEGRALITY_AXIOM:
+    return "alasca integrality axiom";
   case InferenceRule::EXTENSIONALITY_RESOLUTION:
     return "extensionality resolution";
   case InferenceRule::DEFINITION_UNFOLDING:

--- a/Kernel/Inference.hpp
+++ b/Kernel/Inference.hpp
@@ -382,6 +382,10 @@ enum class InferenceRule : unsigned char {
   EQUALITY_PROXY_DEFINITION,
   /** equality proxy axioms such as E(x,x) or ~E(x,y) \/ x=y */
   EQUALITY_PROXY_AXIOM,
+  /** floor(f(X0,...,Xn)) = f(X0,...,Xn), stating that a symbol f introduced by the
+   * ALASCA integer conversion is integer-valued; not a theory axiom, as it is only
+   * valid for the freshly introduced f (a conservative extension) */
+  ALASCA_INTEGRALITY_AXIOM,
   /** unfolding by definitions f(x1,...,xn)=t */
   DEFINITION_UNFOLDING,
 

--- a/checks/sanity
+++ b/checks/sanity
@@ -138,6 +138,7 @@ check_szs_status Theorem -t 1d -to lpo -sas z3 Problems/ARI/ARI637_1.p
 check_szs_status Theorem -t 1d -sas z3 Problems/ARI/ARI700_1.p
 check_szs_status Theorem -t 1d -sas z3 Problems/ARI/ARI724_1.p
 check_szs_status Theorem -t 1d -sas z3 -nwc 5.0 -br off Problems/DAT/DAT005_1.p
+check_szs_status Unsatisfiable -t 1d -alasca on -alascai on theory/alasca-integer-conversion.p
 check_szs_status Theorem -t 1d -alasca on -alascai on -thf on Problems/DAT/DAT023_1.p
 check_szs_status Theorem -t 1d -tha off Problems/DAT/DAT042_1.p
 check_szs_status Theorem -t 5d -s 1010 -thsq on -thsqr 8,1 -thsqc 64 -thsqd 64 -canc force Problems/DAT/DAT043_1.p

--- a/checks/theory/alasca-integer-conversion.p
+++ b/checks/theory/alasca-integer-conversion.p
@@ -1,0 +1,12 @@
+% Regression: the ALASCA int->real conversion (-alascai) appends an integrality
+% axiom floor(f(X)) = f(X) for every int-valued symbol it replaces. That clause
+% has no premise, so it must not be built with a premise-carrying Inference kind.
+%
+% The conversion turns the two axioms below into
+%   f'(c') != $floor(f'(c')) | $greater(f'(c'), 0)
+%   f'(c') != $floor(f'(c')) | $less(f'(c'), 1)
+% so the contradiction is reachable only via the integrality axioms.
+tff(c_type, type, c: $int).
+tff(f_type, type, f: $int > $int).
+tff(a1, axiom, $greater(f(c), 0)).
+tff(a2, axiom, $less(f(c), 1)).


### PR DESCRIPTION
Two small commits, each with its reproducer in the commit message.

**1. Fix the Inference kind of the ALASCA integrality axiom.**
`AlascaPreprocessor::integerConversion` appends a premise-free clause `floor(f(X)) = f(X)` for every
fresh real-sorted symbol that replaced an int-valued one, but built it as
`NonspecificInferenceMany(ALASCA_INTEGER_TRANSFORMATION, nullptr)` — a rule from the
formula-clause-transformation interval, passed to a premise-carrying constructor. Debug builds now
abort on `isNonSpecificInferenceRule`; the `FormulaClauseTransformation(rule, nullptr)` spelling
segfaults outright. New `ALASCA_INTEGRALITY_AXIOM` in the non-specific interval, built with
`NonspecificInference0(UnitInputType::AXIOM, ...)`. Deliberately *not* a theory axiom: it is not
valid in the theory of reals, it only constrains the freshly introduced symbol.

**2. Invalidate the cached Problem property after the conversion.**
The conversion rewrote every unit and added clauses without telling `Problem`, so a later
`getProperty()` returned the pre-conversion `Property` and `hasEquality()` could stay `false` for a
clause set full of equalities.

New `checks/theory/alasca-integer-conversion.p` in `checks/sanity`: its refutation has to go through
the integrality axioms, so the check turns Satisfiable if they ever stop being added.
`checks/sanity` passes against a Release+Z3 build, `ctest` 99/99, and the previously failing
`Problems/DAT/DAT023_1.p -alasca on -alascai on -thf on` is now Theorem.
