### PR TITLE
name the hash explicitly at pointer-keyed containers

### DIFF
--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -272,7 +272,7 @@ private:
   /** Constants corresponding to terms */
   DHMap<TermList,unsigned> _termNames;
   /** Constants corresponding to literals */
-  DHMap<Literal*,unsigned> _litNames;
+  DHMap<Literal*,unsigned, FnvHash, PtrIdentityHash> _litNames;
 
   /**
    * Equality that caused unsatisfiability; if CEq::isInvalid(), there isn't such.

--- a/FMB/DefinitionIntroduction.hpp
+++ b/FMB/DefinitionIntroduction.hpp
@@ -222,8 +222,8 @@ namespace FMB {
     ClauseIterator _cit;
     Stack<Clause*> _processed;
 
-    DHMap<Term*,Term*> _introduced;
-    DHMap<Term*,unsigned> _introducedNG;
+    DHMap<Term*,Term*, FnvHash, PtrIdentityHash> _introduced;
+    DHMap<Term*,unsigned, FnvHash, PtrIdentityHash> _introducedNG;
 
   };
 

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -120,7 +120,7 @@ private:
 
   // the pairs of <constant number, sort>
   DHMap<std::pair<unsigned,unsigned>,Term*> _domainConstants;
-  DHMap<Term*,std::pair<unsigned,unsigned>> _domainConstantsRev;
+  DHMap<Term*,std::pair<unsigned,unsigned>, FnvHash, PtrIdentityHash> _domainConstantsRev;
 public:
 
 

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -45,7 +45,7 @@ static void doCheck(UnitList* units)
   // looking for a domain axiom with a name starting 'finite_domain' (TODO search for something of the right shape)
 
   DHMap<unsigned,unsigned> sortSizes;
-  DHMap<unsigned,std::unique_ptr<Set<Term*>>> domainConstantsPerSort;
+  DHMap<unsigned,std::unique_ptr<Set<Term*, FnvHash>>> domainConstantsPerSort;
 
   // first just search for finite_domain axiom (TODO: do this for every sort!)
   {
@@ -70,7 +70,7 @@ static void doCheck(UnitList* units)
         unsigned curSort = formula->vars()->head().second.term()->functor();
 
         unsigned curModelSize = 0;
-        auto curDomainConstants = std::make_unique<Set<Term*>>();
+        auto curDomainConstants = std::make_unique<Set<Term*, FnvHash>>();
 
         int single_var = -1;
         if (subformula->connective()==Connective::OR) {
@@ -110,8 +110,8 @@ static void doCheck(UnitList* units)
   // TODO can we pass a reference here instead of clone()ing?
   FiniteModelMultiSorted model(sortSizesArray.clone());
 
-  Set<Term*> domainConstants; // union of all the perSort ones
-  DHMap<Term*,unsigned> domainConstantNumber;
+  Set<Term*, FnvHash> domainConstants; // union of all the perSort ones
+  DHMap<Term*,unsigned, FnvHash, PtrIdentityHash> domainConstantNumber;
 
   std::cout << "Detected model with " << sortSizes.size() << " sorts." << std::endl;
   auto it = sortSizes.items();
@@ -124,7 +124,7 @@ static void doCheck(UnitList* units)
     std::cout << ", domain elements are:" << std::endl;
 
     // number the domain constants
-    Set<Term*>::Iterator dit(curDomainConstants);
+    Set<Term*, FnvHash>::Iterator dit(curDomainConstants);
     unsigned count=1;
     while(dit.hasNext()){
       Term* con = dit.next();
@@ -204,7 +204,7 @@ static void doCheck(UnitList* units)
 
 private:
 
-static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domainConstants)
+static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*, FnvHash>& domainConstants)
 {
   if(!l->isEquality()) USER_ERROR("finite_domain is not a domain axiom");
 
@@ -230,8 +230,8 @@ static void checkIsDomainLiteral(Literal* l, int& single_var, Set<Term*>& domain
 }
 
 static void addDefinition(FiniteModelMultiSorted& model,Literal* lit,bool negated,
-                          Set<Term*>& domainConstants,
-                          DHMap<Term*,unsigned>& domainConstantNumber)
+                          Set<Term*, FnvHash>& domainConstants,
+                          DHMap<Term*,unsigned, FnvHash, PtrIdentityHash>& domainConstantNumber)
 {
   if(lit->isEquality()){
     if(!lit->polarity() || negated) USER_ERROR("Cannot have negated function definition");

--- a/Indexing/TermIndex.cpp
+++ b/Indexing/TermIndex.cpp
@@ -78,7 +78,7 @@ void DemodulationSubtermIndex<higherOrder>::handleClause(Clause* c, bool adding)
 {
   TIME_TRACE("backward demodulation index maintenance");
 
-  static DHSet<Term*> inserted;
+  static DHSet<Term*, FnvHash, PtrIdentityHash> inserted;
 
   unsigned cLen=c->length();
   for (unsigned i=0; i<cLen; i++) {
@@ -174,7 +174,7 @@ void InductionTermIndex::handleClause(Clause* c, bool adding)
       continue;
     }
 
-    DHSet<Term*> done;
+    DHSet<Term*, FnvHash, PtrIdentityHash> done;
     NonVariableNonTypeIterator it(lit);
     while (it.hasNext()) {
       Term* t = it.next();
@@ -209,7 +209,7 @@ void StructInductionTermIndex::handleClause(Clause* c, bool adding)
       continue;
     }
 
-    DHSet<Term*> done;
+    DHSet<Term*, FnvHash, PtrIdentityHash> done;
     NonVariableNonTypeIterator it(lit);
     while (it.hasNext()) {
       Term* t = it.next();

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -131,7 +131,7 @@ void BackwardSubsumptionDemodulation<higherOrder>::performWithQueryLit(Clause* s
 
 #if VDEBUG
   // make sure DuplicateLiteralRemovalISE has been run on this
-  DHSet<Literal*> lits;
+  DHSet<Literal*, FnvHash, PtrIdentityHash> lits;
   for (unsigned i = 0; i < sideCl->length(); ++i) {
     ALWAYS(lits.insert((*sideCl)[i]));
   }

--- a/Inferences/FunctionDefinitionRewriting.cpp
+++ b/Inferences/FunctionDefinitionRewriting.cpp
@@ -136,7 +136,7 @@ FunctionDefinitionDemodulation::FunctionDefinitionDemodulation(SaturationAlgorit
 
 bool FunctionDefinitionDemodulation::perform(Clause* cl, Clause*& replacement, ClauseIterator& premises)
 {
-  static DHSet<Term*> attempted;
+  static DHSet<Term*, FnvHash, PtrIdentityHash> attempted;
   attempted.reset();
 
   unsigned cLen = cl->length();

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -114,7 +114,7 @@ public:
   const bool _squashSkolems;
   unsigned& _nextVar; // fresh variable counter supported by caller
 
-  DHMap<Term*, unsigned, SharedTermHash> _skolemToVarMap; // maps terms to their variable replacement
+  DHMap<Term*, unsigned, SharedTermHash, PtrIdentityHash> _skolemToVarMap; // maps terms to their variable replacement
   DHMap<unsigned,TermList> _varsReplacingSkolems;
 
   DHMap<unsigned,unsigned> _renaming; // for renaming free variables

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -245,7 +245,7 @@ Clause* DuplicateLiteralRemovalISE::simplify(Clause* c)
     }
   }
   else {
-    static DHSet<Literal*> seen;
+    static DHSet<Literal*, FnvHash, PtrIdentityHash> seen;
     seen.reset();
     //here we rely on the fact that the iterator traverses the clause from
     //the first to the last literal
@@ -283,9 +283,9 @@ Clause* DuplicateLiteralRemovalISE::simplify(Clause* c)
 
 #if DEBUG_DUPLICATE_LITERALS
   {
-    static DHSet<Literal*> origLits;
+    static DHSet<Literal*, FnvHash, PtrIdentityHash> origLits;
     origLits.reset();
-    static DHSet<Literal*> newLits;
+    static DHSet<Literal*, FnvHash, PtrIdentityHash> newLits;
     newLits.reset();
     origLits.loadFromIterator(c->iterLits());
     newLits.loadFromIterator(d->iterLits());

--- a/Inferences/Instantiation.cpp
+++ b/Inferences/Instantiation.cpp
@@ -104,10 +104,10 @@ void Instantiation::registerClause(Clause* cl)
         TermList sort;
         if(SortHelper::tryGetResultSort(t,sort)){
           if(sort==AtomicSort::defaultSort()) continue;
-          Set<Term*>* cans_check=0;
+          Set<Term*, FnvHash>* cans_check=0;
           Stack<Term*>* cans=0;
           if(sorted_candidates.isEmpty() || !sorted_candidates.find(sort,cans)){
-            cans_check = new Set<Term*>();
+            cans_check = new Set<Term*, FnvHash>();
             cans = new Stack<Term*>();
             sorted_candidates.insert(sort,cans);
             sorted_candidates_check.insert(sort,cans_check);

--- a/Inferences/Instantiation.hpp
+++ b/Inferences/Instantiation.hpp
@@ -47,7 +47,7 @@ private:
   void tryMakeLiteralFalse(Literal*, Stack<Substitution>& subs);
   Term* tryGetDifferentValue(Term* t); 
 
-  DHMap<TermList,Lib::Set<Term*>*> sorted_candidates_check;
+  DHMap<TermList,Lib::Set<Term*, FnvHash>*> sorted_candidates_check;
   DHMap<TermList,Lib::Stack<Term*>*> sorted_candidates;
 
 };

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -172,7 +172,7 @@ protected:
     } else if(!singleSelected) {
       //select multiple maximal literals
       static Stack<Literal*> replaced(16);
-      Set<Literal*> maxSet;
+      Set<Literal*, FnvHash> maxSet;
       unsigned selCnt=0;
 
       for(LiteralList* mit=maximals; mit; mit=mit->tail()) {

--- a/Kernel/Grounder.hpp
+++ b/Kernel/Grounder.hpp
@@ -60,7 +60,7 @@ private:
   SATLiteral groundNormalized(Literal*);
 
   /** Map from positive literals to SAT variable numbers */
-  DHMap<Literal*, unsigned> _asgn;
+  DHMap<Literal*, unsigned, FnvHash, PtrIdentityHash> _asgn;
 
   /** Reference to a SATSolver instance for which the grounded clauses
    * are being prepared. Used to request new variables from the Solver.

--- a/Kernel/InferenceStore.hpp
+++ b/Kernel/InferenceStore.hpp
@@ -94,9 +94,9 @@ private:
   // unit id -> stack of introduced symbols (in order of introduction)
   DHMap<unsigned,SymbolStack> _introducedSymbols;
   // symbol id -> existential variable name (number) that was replaced by the symbol
-  DHMap<Signature::Symbol*, unsigned> _introducedSymbolReplacedVars;
+  DHMap<Signature::Symbol*, unsigned, FnvHash, PtrIdentityHash> _introducedSymbolReplacedVars;
   // symbol id -> the term that is introduced when introducing the skolem symbol
-  DHMap<Signature::Symbol*, Term*> _introducedSkolemSymTerms;
+  DHMap<Signature::Symbol*, Term*, FnvHash, PtrIdentityHash> _introducedSkolemSymTerms;
 
   DHMap<unsigned,std::string> _introducedSplitNames;
 };

--- a/Kernel/PartialOrdering.cpp
+++ b/Kernel/PartialOrdering.cpp
@@ -203,7 +203,7 @@ const PartialOrdering* PartialOrdering::set(const PartialOrdering* po, size_t x,
 
 const PartialOrdering* PartialOrdering::extend(const PartialOrdering* po)
 {
-  static DHMap<const PartialOrdering*, const PartialOrdering*> cache;
+  static DHMap<const PartialOrdering*, const PartialOrdering*, FnvHash, PtrIdentityHash> cache;
 
   const PartialOrdering** ptr;
   if (cache.getValuePtr(po, ptr, nullptr)) {

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -986,7 +986,7 @@ class Signature
 
 private:
   Stack<TermList> _dividesNvalues;
-  DHMap<Term*, int> _formulaCounts;
+  DHMap<Term*, int, FnvHash, PtrIdentityHash> _formulaCounts;
 
   bool _foolConstantsDefined;
   unsigned _foolTrue;

--- a/Kernel/TermOrderingDiagram.cpp
+++ b/Kernel/TermOrderingDiagram.cpp
@@ -725,7 +725,7 @@ std::ostream& operator<<(std::ostream& str, const TermOrderingDiagram& tod)
   Stack<std::pair<const TermOrderingDiagram::Branch*, unsigned>> stack;
   stack.push(std::make_pair(&tod._source,0));
   // Note: using this set we get a more compact representation
-  DHSet<TermOrderingDiagram::Node*> seen;
+  DHSet<TermOrderingDiagram::Node*, FnvHash, PtrIdentityHash> seen;
 
   while (stack.isNonEmpty()) {
     auto kv = stack.pop();

--- a/Lib/ProofExtra.hpp
+++ b/Lib/ProofExtra.hpp
@@ -43,7 +43,7 @@ inline std::ostream &operator<<(std::ostream &out, const InferenceExtra &extra) 
 
 // container for extras
 class ProofExtra {
-  DHMap<Kernel::Unit *, std::unique_ptr<InferenceExtra>> extras;
+  DHMap<Kernel::Unit *, std::unique_ptr<InferenceExtra>, UnitHash, UnitNumberHash> extras;
 
 public:
   // associate `extra` with `unit`, taking ownership of `extra`

--- a/SAT/MinimizingSolver.hpp
+++ b/SAT/MinimizingSolver.hpp
@@ -172,7 +172,7 @@ private:
    * _unsClCnt, when there is more than one way to make clause
    * satisfied.
    */  
-  DHSet<SATClause*> _satisfiedClauses;
+  DHSet<SATClause*, FnvHash, PtrIdentityHash> _satisfiedClauses;
   
 };
 

--- a/SAT/SATInference.hpp
+++ b/SAT/SATInference.hpp
@@ -158,7 +158,7 @@ template<typename Receiver>
 void SATInference::visitFOConversions(SATClause* cl, Receiver receive)
 {
   static Stack<SATClause*> toDo;
-  static DHSet<SATClause*> seen;
+  static DHSet<SATClause*, FnvHash, PtrIdentityHash> seen;
   toDo.reset();
   seen.reset();
 

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -348,7 +348,7 @@ private:
   Option<std::ofstream> _out;
   Map<unsigned, z3::expr> _varNames;
   Map<TermList, z3::expr> _termIndexedConstants;
-  Map<Signature::Symbol*, z3::expr> _constantNames;
+  Map<Signature::Symbol*, z3::expr, FnvHash> _constantNames;
 
   bool     isNamedExpr(unsigned var) const;
   z3::expr getNameExpr(unsigned var);

--- a/SATSubsumption/SATSubsumptionAndResolution.cpp
+++ b/SATSubsumption/SATSubsumptionAndResolution.cpp
@@ -155,7 +155,7 @@ void SATSubsumptionAndResolution::loadProblem(Clause* sidePremise,
   ASS(mainPremise)
 #if VDEBUG
   // Check that two literals are not the same in sidePremise and mainPremise
-  static DHSet<Literal*> lits;
+  static DHSet<Literal*, FnvHash, PtrIdentityHash> lits;
   lits.reset();
   for (unsigned i = 0; i < sidePremise->length(); i++)
     if (!lits.insert((*sidePremise)[i]))

--- a/Saturation/PredicateSplitPassiveClauseContainers.cpp
+++ b/Saturation/PredicateSplitPassiveClauseContainers.cpp
@@ -489,7 +489,7 @@ unsigned numOfAppVarsAndLambdas(TermList t, unsigned lambdaWeight, unsigned appl
   }
   const Term* tt = t.term();
 
-  static DHMap<const Term*,unsigned> cache;
+  static DHMap<const Term*,unsigned, FnvHash, PtrIdentityHash> cache;
   unsigned* cached;
   if (!cache.getValuePtr(tt,cached)) {
     return *cached;

--- a/Shell/AnswerLiteralManager.cpp
+++ b/Shell/AnswerLiteralManager.cpp
@@ -762,7 +762,7 @@ TermList SynthesisALManager::ConjectureSkolemReplacement::transformSubterm(TermL
       for (unsigned i = 0; i < transformed->arity()-1; ++i) {
         // Iterate over cases and replace only the associated skolems in each.
         TermList* narg = transformed->nthArgument(i);
-        DHMap<Term*, TermList>* m = recf->_skolemToTermListForCase.findPtr(i);
+        DHMap<Term*, TermList, FnvHash, PtrIdentityHash>* m = recf->_skolemToTermListForCase.findPtr(i);
         if (narg->isTerm() && m) {
           ssr.setMap(m);
           NonVariableIterator it(narg->term());
@@ -831,7 +831,7 @@ SynthesisALManager::ConjectureSkolemReplacement::Function::Function(unsigned rec
   f->setType(OperatorType::getFunctionType({in}, out));
   // Process SkolemTrackers corresponding to this function:
   // populate the maps mapping skolems to terms they represent.
-  DHMap<Term*, TermList>* caseMap;
+  DHMap<Term*, TermList, FnvHash, PtrIdentityHash>* caseMap;
   const DHMap<unsigned, SkolemTracker>& mapping = replacement->_recursionMappings->get(recFunctor);
   DHMap<unsigned, SkolemTracker>::Iterator it(mapping);
   while (it.hasNext()) {

--- a/Shell/AnswerLiteralManager.hpp
+++ b/Shell/AnswerLiteralManager.hpp
@@ -238,9 +238,9 @@ private:
       DArray<TermList> _cases;
       std::vector<Term*>* _caseHeads;
       // Mappings of skolems to terms they should be replaced with then construcing the functions for each case.
-      DHMap<unsigned, DHMap<Term*, TermList>> _skolemToTermListForCase;
+      DHMap<unsigned, DHMap<Term*, TermList, FnvHash, PtrIdentityHash>> _skolemToTermListForCase;
       // A union of replacements for all cases (for convenience).
-      DHMap<Term*, TermList> _skolemToTermList;
+      DHMap<Term*, TermList, FnvHash, PtrIdentityHash> _skolemToTermList;
     };
 
     void bindSkolemToTermList(Term* t, TermList&& tl);
@@ -259,7 +259,7 @@ private:
    private:
     unsigned _numInputSkolems = 0;
     // Mapping of input skolems to input variables.
-    DHMap<Term*, TermList> _skolemToTermList;
+    DHMap<Term*, TermList, FnvHash, PtrIdentityHash> _skolemToTermList;
     // Map from functions to predicates they represent in answer literal conditions
     DHMap<unsigned, unsigned> _condFnToPred;
     // Recursive functions indexed by their function symbol number.
@@ -268,8 +268,8 @@ private:
     // Term replacement based on a simple mapping with no additional logic.
     class SimpleSkolemReplacement : public TermTransformer {
      public:
-      SimpleSkolemReplacement(DHMap<Term*, TermList>* m) : _skolemToTermList(m) {}
-      void setMap(DHMap<Term*, TermList>* m) { _skolemToTermList = m; }
+      SimpleSkolemReplacement(DHMap<Term*, TermList, FnvHash, PtrIdentityHash>* m) : _skolemToTermList(m) {}
+      void setMap(DHMap<Term*, TermList, FnvHash, PtrIdentityHash>* m) { _skolemToTermList = m; }
      protected:
       TermList transformSubterm(TermList trm) override {
         if (trm.isTerm()) {
@@ -281,7 +281,7 @@ private:
         return trm;
       }
      private:
-      DHMap<Term*, TermList>* _skolemToTermList;
+      DHMap<Term*, TermList, FnvHash, PtrIdentityHash>* _skolemToTermList;
     };
 
   };

--- a/Shell/BlockedClauseElimination.cpp
+++ b/Shell/BlockedClauseElimination.cpp
@@ -336,7 +336,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
 
   VarMaxUpdatingNormalizer clNormalizer(replacements,varMax);
 
-  static DHSet<Literal*> norm_lits;
+  static DHSet<Literal*, FnvHash, PtrIdentityHash> norm_lits;
   norm_lits.reset();
 
   for (unsigned i = 0; i < cl->length(); i++) {
@@ -387,7 +387,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
   varMap.reset();
   RenanigApartNormalizer pclNormalizer(replacements,varMax,varMap);
 
-  static DHSet<Literal*> pcl_lits;
+  static DHSet<Literal*, FnvHash, PtrIdentityHash> pcl_lits;
   pcl_lits.reset();
 
   for (unsigned i = 0; i < pcl->length(); i++) {
@@ -505,7 +505,7 @@ bool BlockedClauseElimination::resolvesToTautologyUn(Clause* cl, Literal* lit, C
     return true; // since they don't resolve
   }
 
-  static DHSet<Literal*> cl_lits;
+  static DHSet<Literal*, FnvHash, PtrIdentityHash> cl_lits;
   cl_lits.reset();
 
   Literal* opslit = 0;
@@ -531,7 +531,7 @@ bool BlockedClauseElimination::resolvesToTautologyUn(Clause* cl, Literal* lit, C
 
   ASS_NEQ(opslit,0);
 
-  static DHSet<Literal*> pcl_lits;
+  static DHSet<Literal*, FnvHash, PtrIdentityHash> pcl_lits;
   pcl_lits.reset();
 
   static RobSubstitution subst_aux;

--- a/Shell/EqualityProxy.cpp
+++ b/Shell/EqualityProxy.cpp
@@ -448,7 +448,7 @@ Clause* EqualityProxy::createEqProxyAxiom(const LiteralStack& literalStack)
     return Clause::fromStack(literalStack, NonspecificInference1(InferenceRule::EQUALITY_PROXY_AXIOM,_defUnit));
   }
 
-  DHSet<Unit*> seen;
+  DHSet<Unit*, UnitHash, UnitNumberHash> seen;
   UnitList* prems = 0;
 
   LiteralStack::ConstIterator it(literalStack);

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -126,7 +126,7 @@ void NewCNF::clausify(FormulaUnit* unit,Stack<Clause*>& output, Substitution* su
   _freeVars.reset();
 
   { // destroy the cached substitution entries
-    DHMap<BindingList*,Substitution*>::DelIterator dIt(_substitutionsByBindings);
+    DHMap<BindingList*,Substitution*, FnvHash, PtrIdentityHash>::DelIterator dIt(_substitutionsByBindings);
     while (dIt.hasNext()) {
       delete dIt.next();
       dIt.del();
@@ -547,7 +547,7 @@ void NewCNF::processBoolVar(SIGN sign, unsigned var, Occurrences &occurrences)
   // Cache binding list lookups: many occurrences share the same BindingList*,
   // so we scan each distinct list at most once for `var`.
   // A cached value of nullptr means "var not found in this list".
-  DHMap<BindingList*, Term*> lookupCache;
+  DHMap<BindingList*, Term*, FnvHash, PtrIdentityHash> lookupCache;
 
   while (occurrences.isNonEmpty()) {
     Occurrence occ = pop(occurrences);
@@ -1108,7 +1108,7 @@ void NewCNF::process(QuantifiedFormula* g, Occurrences &occurrences)
 
   // empty the skolem caches
   _skolemsByBindings.reset();
-  DHMap<VarSet*,BindingList*>::DelIterator dIt(_skolemsByFreeVars);
+  DHMap<VarSet*,BindingList*, FnvHash, PtrIdentityHash>::DelIterator dIt(_skolemsByFreeVars);
   while (dIt.hasNext()) {
     VarSet* vars;
     BindingList* bindings;
@@ -1118,7 +1118,7 @@ void NewCNF::process(QuantifiedFormula* g, Occurrences &occurrences)
   }
 
   _foolSkolemsByBindings.reset();
-  DHMap<VarSet*,BindingList*>::DelIterator fdit(_foolSkolemsByFreeVars);
+  DHMap<VarSet*,BindingList*, FnvHash, PtrIdentityHash>::DelIterator fdit(_foolSkolemsByFreeVars);
   while (fdit.hasNext()) {
     VarSet* vars;
     BindingList* bindings;
@@ -1341,7 +1341,7 @@ void NewCNF::toClauses(SPGenClause gc, Stack<Clause*>& output)
   // the current variable pass through unchanged, keeping the same pointer,
   // so subsequent iterations get O(1) membership checks instead of
   // repeated formula traversals.
-  DHMap<List<GenLit>*, VarSet*> clauseFreeVarCache;
+  DHMap<List<GenLit>*, VarSet*, FnvHash, PtrIdentityHash> clauseFreeVarCache;
 
   unsigned iteCounter = 0;
   while (variables.isNonEmpty()) {

--- a/Shell/NewCNF.hpp
+++ b/Shell/NewCNF.hpp
@@ -215,8 +215,8 @@ private:
    * without it popping the first occurrence of a formula will invalidate the
    * entire generalised clause, and other occurrences will never be seen.
    */
-  DHMap<Literal*, SIGN> _literalsCache;
-  DHMap<Formula*, SIGN> _formulasCache;
+  DHMap<Literal*, SIGN, FnvHash, PtrIdentityHash> _literalsCache;
+  DHMap<Formula*, SIGN, FnvHash, PtrIdentityHash> _formulasCache;
   inline void pushLiteral(SPGenClause gc, GenLit gl) {
     if (formula(gl)->connective() == LITERAL) {
       /**
@@ -527,7 +527,7 @@ private:
     return occ;
   }
 
-  DHMap<Formula*, Occurrences> _occurrences;
+  DHMap<Formula*, Occurrences, FnvHash, PtrIdentityHash> _occurrences;
 
   /** map var --> sort */
   DHMap<unsigned,TermList> _varSorts;
@@ -547,20 +547,20 @@ private:
   bool _forInduction;
 
   // caching of free variables for subformulas
-  DHMap<Formula*,VarSet*> _freeVars;
+  DHMap<Formula*,VarSet*, FnvHash, PtrIdentityHash> _freeVars;
   VarSet* freeVars(Formula* g);
 
   // two level caching scheme for quantifier bindings
   // reset after skolemizing a particular subformula
-  DHMap<BindingList*,BindingList*> _skolemsByBindings;
-  DHMap<VarSet*,BindingList*>      _skolemsByFreeVars;
+  DHMap<BindingList*,BindingList*, FnvHash, PtrIdentityHash> _skolemsByBindings;
+  DHMap<VarSet*,BindingList*, FnvHash, PtrIdentityHash>      _skolemsByFreeVars;
 
-  DHMap<BindingList*,BindingList*> _foolSkolemsByBindings;
-  DHMap<VarSet*,BindingList*>      _foolSkolemsByFreeVars;
+  DHMap<BindingList*,BindingList*, FnvHash, PtrIdentityHash> _foolSkolemsByBindings;
+  DHMap<VarSet*,BindingList*, FnvHash, PtrIdentityHash>      _foolSkolemsByFreeVars;
 
   // caching binding substitutions for the final phase of GenClause -> Clause transformation
   // this saves time, because bindings are potentially shared
-  DHMap<BindingList*,Substitution*> _substitutionsByBindings;
+  DHMap<BindingList*,Substitution*, FnvHash, PtrIdentityHash> _substitutionsByBindings;
 
   void skolemise(QuantifiedFormula* g, BindingList* &bindings, BindingList*& foolBindings);
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3521,7 +3521,7 @@ std::string Options::generateEncodedOptions() const
   Options cur=*this;
 
   // Record options that do not want to be in encoded string
-  static Set<const AbstractOptionValue*> forbidden;
+  static Set<const AbstractOptionValue*, FnvHash> forbidden;
   //we initialize the set if there's nothing inside
   if (forbidden.size()==0) {
     //things we output elsewhere

--- a/Shell/PredicateElimination.cpp
+++ b/Shell/PredicateElimination.cpp
@@ -161,7 +161,7 @@ void PredicateElimination::apply(Problem &prb)
 /**
  * Add (@b add) or remove one clause's worth of occurrences to (from) one side of a PredInfo.
  */
-static void updateSide(bool add, DHMap<Clause *, unsigned> &side,
+static void updateSide(bool add, DHMap<Clause *, unsigned, UnitHash, UnitNumberHash> &side,
                        unsigned &multi, Clause *cl, unsigned count)
 {
   ASS_G(count, 0);
@@ -560,7 +560,7 @@ Clause *PredicateElimination::buildResolventEq(Clause *nucleus, Stack<unsigned> 
 Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *nucleus,
                                              ClauseStack const &sats, DArray<unsigned> const &choice)
 {
-  static DHSet<Literal *> seen;
+  static DHSet<Literal *, FnvHash, PtrIdentityHash> seen;
   seen.reset();
 
   static LiteralStack out;
@@ -601,7 +601,7 @@ Clause *PredicateElimination::assembleClause(LiteralStack &lits, Clause *nucleus
   }
 
   // a satellite picked more than once is still just one premise
-  static DHSet<Clause *> premiseSeen;
+  static DHSet<Clause *, UnitHash, UnitNumberHash> premiseSeen;
   premiseSeen.reset();
   UnitList *premises = UnitList::empty();
   for (unsigned j = 0; j < choice.size(); j++) {

--- a/Shell/PredicateElimination.hpp
+++ b/Shell/PredicateElimination.hpp
@@ -94,8 +94,8 @@ private:
   struct PredInfo {
     // S_P: clauses in which P occurs only positively, mapped to the number of occurrences;
     // S_~P: dtto, negatively (clauses with both polarities are counted as blockers instead)
-    Lib::DHMap<Clause *, unsigned> pos;
-    Lib::DHMap<Clause *, unsigned> neg;
+    Lib::DHMap<Clause *, unsigned, UnitHash, UnitNumberHash> pos;
+    Lib::DHMap<Clause *, unsigned, UnitHash, UnitNumberHash> neg;
     unsigned blockers = 0; // number of clauses in which P occurs both positively and negatively
     unsigned posMulti = 0; // number of clauses of pos with more than one occurrence
     unsigned negMulti = 0; // dtto, for neg
@@ -111,7 +111,7 @@ private:
 
   // clause set state
   ClauseStack _all;     // all clauses ever seen, in insertion order
-  Lib::DHSet<Clause *> _deleted; // those of _all that have been eliminated
+  Lib::DHSet<Clause *, UnitHash, UnitNumberHash> _deleted; // those of _all that have been eliminated
   Lib::DArray<PredInfo> _preds;
   size_t _curTotal = 0;
   size_t _origTotal = 0;

--- a/Shell/Skolem.hpp
+++ b/Shell/Skolem.hpp
@@ -93,7 +93,7 @@ private:
     VarSet* exist;
   };
   // stored by the blocks, i.e. those Formulas* with the EXISTS connective
-  typedef DHMap<Formula*,ExVarDepInfo> ExVarDepInfos; 
+  typedef DHMap<Formula*,ExVarDepInfo, FnvHash, PtrIdentityHash> ExVarDepInfos; 
   ExVarDepInfos _varDeps;
 
   // map from an existential variable to its quantified formula (= block of quantifiers)

--- a/Shell/SymbolDefinitionInlining.hpp
+++ b/Shell/SymbolDefinitionInlining.hpp
@@ -45,7 +45,7 @@ class SymbolDefinitionInlining {
     void collectBoundVariables(Term*);
     void collectBoundVariables(Formula*);
 
-    Set<Formula*> _superformulas;
+    Set<Formula*, FnvHash> _superformulas;
 };
 
 #endif // __SymbolDefinitionInlining__

--- a/Shell/TheoryFlattening.cpp
+++ b/Shell/TheoryFlattening.cpp
@@ -116,7 +116,7 @@ Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
     else{ result.push(lit); }
   }
   
-  DHMap<Term*,unsigned> abstracted;
+  DHMap<Term*,unsigned, FnvHash, PtrIdentityHash> abstracted;
 
   // process lits
   while(!lits.isEmpty()){
@@ -158,7 +158,7 @@ Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
  * @author Giles
  */
  Literal* TheoryFlattening::replaceTopTerms(Literal* lit, Stack<Literal*>& newLits,unsigned& maxVar,
-                                            DHMap<Term*,unsigned>& abstracted)
+                                            DHMap<Term*,unsigned, FnvHash, PtrIdentityHash>& abstracted)
 {
   //cout << "replaceTopTerms " << lit->toString() << endl;
 
@@ -245,7 +245,7 @@ Clause* TheoryFlattening::apply(Clause*& cl,Stack<Literal*>& target)
  */
  Term* TheoryFlattening::replaceTopTermsInTerm(Term* term, Stack<Literal*>& newLits,
                                                unsigned& maxVar,bool interpreted,
-                                               DHMap<Term*,unsigned>& abstracted)
+                                               DHMap<Term*,unsigned, FnvHash, PtrIdentityHash>& abstracted)
 {
   //cout << "replaceTopTermsInTerm " << term->toString() << endl;
 

--- a/Shell/TheoryFlattening.hpp
+++ b/Shell/TheoryFlattening.hpp
@@ -42,10 +42,10 @@ public:
   }
 private:
   Literal* replaceTopTerms(Literal* lit, Stack<Literal*>& newLits,unsigned& maxVar,
-                           DHMap<Term*,unsigned>& abstracted);
+                           DHMap<Term*,unsigned, FnvHash, PtrIdentityHash>& abstracted);
   Term* replaceTopTermsInTerm(Term* term, Stack<Literal*>& newLits,
                               unsigned& maxVar,bool interpreted,
-                              DHMap<Term*,unsigned>& abstracted);
+                              DHMap<Term*,unsigned, FnvHash, PtrIdentityHash>& abstracted);
 
   bool _recursive;
   bool _sharing;

--- a/Shell/TweeGoalTransformation.cpp
+++ b/Shell/TweeGoalTransformation.cpp
@@ -64,7 +64,7 @@ class Definizator : public BottomUpTermTransformer {
     UnitList* premises;
 
     // for each relevant term, cache the introduced symbol and the corresponding definition
-    DHMap<Term*,std::pair<unsigned,Clause*>> _cache;
+    DHMap<Term*,std::pair<unsigned,Clause*>, FnvHash, PtrIdentityHash> _cache;
 
     Definizator(bool groundOnly) : newUnits(UnitList::empty()), _groundOnly(groundOnly) {}
   private:


### PR DESCRIPTION
Second PR of the series in #898, on top of #899.

Every container keyed on a pointer now names its hash functors instead of relying on DefaultHash/DefaultHash2. Pointers into the Kernel::Unit hierarchy (Clause*, Kernel::Unit*) take UnitHash and UnitNumberHash; every other pointer takes FnvHash and PtrIdentityHash. Map and Set have one hash slot and need equals() from it, so they take FnvHash alone. These are the functors the DefaultHash branches already delegate to since #899, so the hash values are unchanged and the edit is a spelling change at the use site. 76 sites across 36 files; every changed line is the old line plus one template argument.

The compiler checks the mapping: FnvHash and PtrIdentityHash static_assert that the key is not Unit-derived, and UnitHash::hash takes a const Kernel::Unit*, so a key routed to the wrong functor fails to compile in either direction.

Inferences/Induction.hpp:117 already named SharedTermHash as its primary hash. Only the empty secondary slot was filled, with the PtrIdentityHash that DefaultHash2 was resolving to.

Nine pointer-keyed sites stay on the defaults. Eight are commented-out code (FMB/ClauseFlattening.cpp:148-149 and Inferences/Instantiation.cpp:70-72). The ninth is Lib/InverseLookup.hpp:58, DHMap<T*, size_t> inside a class template: T can be Unit-derived, so naming FnvHash there would change values for those instantiations. Generic sites are stage 6.

Tested: debug and release builds clean, ctest 99/99, checks/sanity on the release binary exits 0. Output was also compared against master byte for byte under -stat full over 158 problems (MPTP2078 bushy, typed TPTP, and the checks/ corpus) and 34 strategy configurations. The cleanest pass bounds the saturation loop by -al 1000 rather than by the clock, so a run that hits the limit still stops in the same place twice: every comparable job is identical, and no job differs against the branch that a control run of master against itself could reproduce.

One caveat on that comparison, since it bounds what the sweep can claim. perf_event_open is unavailable on this kernel, so -i is silently ignored and wall-clock-bounded runs stop in a different place each time. Every sweep therefore ran twice, master against branch and master against itself, and only jobs the self-comparison reproduced count as evidence.
