### PR TITLE
name the hash explicitly at scalar-keyed containers

### DIFF
--- a/CASC/PortfolioMode.cpp
+++ b/CASC/PortfolioMode.cpp
@@ -392,7 +392,7 @@ std::optional<fs::path> PortfolioMode::runSchedule(Schedule schedule) {
   pid_t me = getpid();
   Schedule::BottomFirstIterator it(schedule);
   pid_t successful = 0; // PID 0 should be invalid
-  Set<pid_t> processes;
+  Set<pid_t, FnvHash> processes;
   int remainingTime;
   bool scheduleRepeat = false;
   while(remainingTime = env.remainingTime() / 100, remainingTime > 0) {

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -239,7 +239,7 @@ private:
   };
 
   struct ConstOrderingComparator;  
-  typedef DHMap<unsigned,TermList> NFMap;
+  typedef DHMap<unsigned,TermList, FnvHash, IdentityHash> NFMap;
   void computeConstsNormalForm(unsigned c, NFMap& normalForms);
   
 #if VDEBUG

--- a/FMB/CliqueFinder.hpp
+++ b/FMB/CliqueFinder.hpp
@@ -21,7 +21,7 @@ namespace FMB {
 
   class CliqueFinder {
   public:
-    static unsigned findMaxCliqueSize(DHMap<unsigned,DHSet<unsigned>*>* Ngraph)
+    static unsigned findMaxCliqueSize(DHMap<unsigned,DHSet<unsigned, FnvHash, IdentityHash>*, FnvHash, IdentityHash>* Ngraph)
     {
       //std::cout << "findMaxCliqueSize with " << Ngraph->size() << std::endl;
 
@@ -29,10 +29,10 @@ namespace FMB {
       DArray<Stack<unsigned>> atleast;
       atleast.ensure(Ngraph->size()+1); // the +1 is to protect against a self-loop sneaking in
 
-      DHMap<unsigned,DHSet<unsigned>*>::Iterator miter(*Ngraph);
+      DHMap<unsigned,DHSet<unsigned, FnvHash, IdentityHash>*, FnvHash, IdentityHash>::Iterator miter(*Ngraph);
       while(miter.hasNext()){
         unsigned c;
-        DHSet<unsigned>* nbs;
+        DHSet<unsigned, FnvHash, IdentityHash>* nbs;
         miter.next(c,nbs);
         unsigned size = nbs->size();
         //std::cout << ">> " << c << ": " << size << std::endl;
@@ -89,7 +89,7 @@ namespace FMB {
   private:
 
     // check if a clique is a clique
-    static bool checkClique(DHMap<unsigned,DHSet<unsigned>*>* Ngraph, Stack<unsigned>& clique)
+    static bool checkClique(DHMap<unsigned,DHSet<unsigned, FnvHash, IdentityHash>*, FnvHash, IdentityHash>* Ngraph, Stack<unsigned>& clique)
     {
       //std::cout << "CHECK "; for(unsigned j=0;j<clique.size();j++){ std::cout << clique[j] << " ";}; std::cout << std::endl;
 

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -422,7 +422,7 @@ void FiniteModelBuilder::init()
   );
 
   // Store distinct constants by type
-  DArray<DHMap<unsigned,DHSet<unsigned>*>*> _distinctConstants;
+  DArray<DHMap<unsigned,DHSet<unsigned, FnvHash, IdentityHash>*, FnvHash, IdentityHash>*> _distinctConstants;
   _distinctConstants.ensure(env.signature->typeCons());
   for(unsigned i=0;i<env.signature->typeCons();i++){ _distinctConstants[i]=0; }
 
@@ -449,23 +449,23 @@ void FiniteModelBuilder::init()
           unsigned srt = srtT.term()->functor();
           auto map = _distinctConstants[srt];
           if(map==0){
-            map = new DHMap<unsigned,DHSet<unsigned>*>();
+            map = new DHMap<unsigned,DHSet<unsigned, FnvHash, IdentityHash>*, FnvHash, IdentityHash>();
             _distinctConstants[srt]=map;
           }
           unsigned lnum = left->term()->functor();
           unsigned rnum = right->term()->functor();
           {
-            DHSet<unsigned>* set;
+            DHSet<unsigned, FnvHash, IdentityHash>* set;
             if(!map->find(lnum,set)){
-              set = new DHSet<unsigned>();
+              set = new DHSet<unsigned, FnvHash, IdentityHash>();
               map->insert(lnum,set);
             }
             set->insert(rnum);
           }
           {
-            DHSet<unsigned>* set;
+            DHSet<unsigned, FnvHash, IdentityHash>* set;
             if(!map->find(rnum,set)){
-              set = new DHSet<unsigned>();
+              set = new DHSet<unsigned, FnvHash, IdentityHash>();
               map->insert(rnum,set);
             }
             set->insert(lnum);

--- a/FMB/FiniteModelBuilder.hpp
+++ b/FMB/FiniteModelBuilder.hpp
@@ -135,7 +135,7 @@ private:
   DArray<bool> del_p;
 
   // Store monotonicity_info (see Monotonicity::check) for every sort detected (or made) monotonic
-  DHMap<unsigned,DArray<signed char>*> _monotonic_vampire_sorts;
+  DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash> _monotonic_vampire_sorts;
   Stack<unsigned> _sortFunctions; // sort functions to remember - need to be eliminated from the model in the end
   Stack<unsigned> _sortPredicates; // sort predicates to remember - need to be eliminated from the model in the end
 
@@ -161,7 +161,7 @@ private:
   DArray<unsigned> _fminbound;
   // Record for each clause the sorts of the variables
   // As clauses are normalized variables will be numbered 0,1,...
-  DHMap<unsigned,DArray<unsigned>*> _clauseVariableSorts;
+  DHMap<unsigned,DArray<unsigned>*, FnvHash, IdentityHash> _clauseVariableSorts;
 
   // There is a implicit mapping from ground terms to SAT variables
   // These offsets give the SAT variable for the *first* grounding of each function or predicate symbol

--- a/FMB/FiniteModelMultiSorted.cpp
+++ b/FMB/FiniteModelMultiSorted.cpp
@@ -419,7 +419,7 @@ pModelLabel:
   return modelStm.str();
 }
 
-unsigned FiniteModelMultiSorted::evaluateTerm(TermList tl, const DHMap<unsigned,unsigned>& subst)
+unsigned FiniteModelMultiSorted::evaluateTerm(TermList tl, const DHMap<unsigned,unsigned, FnvHash, IdentityHash>& subst)
 {
   if (tl.isVar()) {
     // TODO: maybe error, if the variable is not in the map?
@@ -483,7 +483,7 @@ unsigned FiniteModelMultiSorted::evaluateGroundTerm(Term* term)
   return _f_interpretation[var];
 }
 
-bool FiniteModelMultiSorted::evaluateLiteral(Literal* lit, const DHMap<unsigned,unsigned>& subst)
+bool FiniteModelMultiSorted::evaluateLiteral(Literal* lit, const DHMap<unsigned,unsigned, FnvHash, IdentityHash>& subst)
 {
   unsigned p = lit->functor();
   unsigned arity = env.signature->predicateArity(p);
@@ -576,9 +576,9 @@ void FiniteModelMultiSorted::eliminateSortFunctionsAndPredicates(const Stack<uns
     ASS_EQ(elim_symb->arity(),1)
     unsigned srt = elim_symb->fnType()->result().term()->functor();
 
-    DHSet<unsigned> f_range;
-    DHMap<unsigned,unsigned> new_to_old;
-    DHMap<unsigned,unsigned> old_to_new;
+    DHSet<unsigned, FnvHash, IdentityHash> f_range;
+    DHMap<unsigned,unsigned, FnvHash, IdentityHash> new_to_old;
+    DHMap<unsigned,unsigned, FnvHash, IdentityHash> old_to_new;
 
     unsigned origSize = _sizes[srt];
     unsigned newSize = 0;
@@ -721,8 +721,8 @@ void FiniteModelMultiSorted::eliminateSortFunctionsAndPredicates(const Stack<uns
 
     // cout << "Eliminate p = " << elim_p << endl;
 
-    DHMap<unsigned,unsigned> new_to_old;
-    DHMap<unsigned,unsigned> old_to_new;
+    DHMap<unsigned,unsigned, FnvHash, IdentityHash> new_to_old;
+    DHMap<unsigned,unsigned, FnvHash, IdentityHash> old_to_new;
 
     unsigned origSize = _sizes[srt];
     unsigned newSize = 0;
@@ -873,7 +873,7 @@ void FiniteModelMultiSorted::restoreEliminatedFunDef(Problem::FunDef* fd)
 
   static DArray<unsigned> args;
   args.ensure(arity);
-  static DHMap<unsigned,unsigned> subst;
+  static DHMap<unsigned,unsigned, FnvHash, IdentityHash> subst;
   subst.reset();
   // start with all 1s
   for(unsigned i=0;i<arity;i++){
@@ -942,7 +942,7 @@ void FiniteModelMultiSorted::restoreEliminatedPredDef(Problem::PredDef* pd)
 
   static DArray<unsigned> args;
   args.ensure(arity);
-  static DHMap<unsigned,unsigned> subst;
+  static DHMap<unsigned,unsigned, FnvHash, IdentityHash> subst;
   subst.reset();
   // start with all 1s
   for(unsigned i=0;i<arity;i++){
@@ -1037,7 +1037,7 @@ void FiniteModelMultiSorted::restoreViaCondFlip(Problem::CondFlip* cf)
 {
   // cf->outputDefinition(cout);
 
-  DHMap<unsigned,TermList> sortMap;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> sortMap;
   SortHelper::collectVariableSorts(cf->_val,sortMap);
   SortHelper::collectVariableSorts(cf->_cond,sortMap); // in bce, cond can have extra variables; we could treat them existentially, but this may be wrong for _fixedPoint-ers
   unsigned arity = sortMap.size();
@@ -1077,7 +1077,7 @@ void FiniteModelMultiSorted::restoreViaCondFlip(Problem::CondFlip* cf)
   sorts.ensure(arity);
 
   unsigned i = 0;
-  DHMap<unsigned,TermList>::Iterator it(sortMap); // non-deterministic order OK?
+  DHMap<unsigned,TermList, FnvHash, IdentityHash>::Iterator it(sortMap); // non-deterministic order OK?
   while (it.hasNext()) {
     unsigned var;
     TermList srt;
@@ -1091,7 +1091,7 @@ void FiniteModelMultiSorted::restoreViaCondFlip(Problem::CondFlip* cf)
   do {
     flipped = false;
 
-    static DHMap<unsigned,unsigned> subst;
+    static DHMap<unsigned,unsigned, FnvHash, IdentityHash> subst;
     static DArray<unsigned> args;
     args.ensure(arity);
     // start with all 1s
@@ -1198,7 +1198,7 @@ bool FiniteModelMultiSorted::evaluate(Unit* unit, bool expectingPartial)
   formula = partialEvaluate(formula);
   formula = SimplifyFalseTrue::simplify(formula);
 
-  DHMap<unsigned,unsigned> subst;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> subst;
   bool res = evaluateFormula(formula,subst);
   if (!expectingPartial && (_implicitlyEliminatedFunctions.size() > 0 || _implicitlyEliminatedPredicates.size() > 0)) {
     USER_ERROR("Encountered an undefined symbol while evaluating a Unit");
@@ -1211,7 +1211,7 @@ bool FiniteModelMultiSorted::evaluate(Unit* unit, bool expectingPartial)
  * TODO: This is recursive, which could be problematic in the long run
  *
  */
-bool FiniteModelMultiSorted::evaluateFormula(Formula* formula, DHMap<unsigned,unsigned>& subst)
+bool FiniteModelMultiSorted::evaluateFormula(Formula* formula, DHMap<unsigned,unsigned, FnvHash, IdentityHash>& subst)
 {
   bool isAnd = false;
   bool isImp = false;

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -95,17 +95,17 @@ public:
   std::string toString();
 
 private:
-  unsigned evaluateTerm(TermList, const DHMap<unsigned,unsigned>& subst);
-  bool evaluateLiteral(Literal*, const DHMap<unsigned,unsigned>& subst);
-  bool evaluateFormula(Formula*, DHMap<unsigned,unsigned>& subst);
+  unsigned evaluateTerm(TermList, const DHMap<unsigned,unsigned, FnvHash, IdentityHash>& subst);
+  bool evaluateLiteral(Literal*, const DHMap<unsigned,unsigned, FnvHash, IdentityHash>& subst);
+  bool evaluateFormula(Formula*, DHMap<unsigned,unsigned, FnvHash, IdentityHash>& subst);
 
   // if term evaluation encounters a missing record, it assumes the corresponding symbol has been implicitly eliminated
   // (e.g., eliminated unused function definition f(X) = g(X,c) might have eliminated c, if it did not occur anywhere else)
   // such symbols are restored (just after restoreEliminatedDefinitions; although, formally it should happen before) in the simplest possible way:
   // functions == 1 (the first domain element of the respective sort) everywhere
   // predicates == false everywhere
-  Set<unsigned> _implicitlyEliminatedFunctions;
-  Set<unsigned> _implicitlyEliminatedPredicates;
+  Set<unsigned, FnvHash> _implicitlyEliminatedFunctions;
+  Set<unsigned, FnvHash> _implicitlyEliminatedPredicates;
 
   void restoreEliminatedFunDef(Problem::FunDef*);
   void restoreImplicitlyEliminatedFun(unsigned f);

--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -246,7 +246,7 @@ void FunctionRelationshipInference::addClaimForFunction(TermList x, TermList y, 
     if(existential){
       // Build VSList from existential VList - need to determine sorts from function type
       // For now, collect from the formulas
-      DHMap<unsigned, TermList> varSorts;
+      DHMap<unsigned, TermList, FnvHash, IdentityHash> varSorts;
       SortHelper::collectVariableSorts(injective, varSorts);
       SortHelper::collectVariableSorts(surjective, varSorts);
       VSList::FIFO vsfifo;

--- a/FMB/FunctionRelationshipInference.hpp
+++ b/FMB/FunctionRelationshipInference.hpp
@@ -51,8 +51,8 @@ void addClaimForFunction(TermList x, TermList y, TermList fx, TermList fy,
 void addClaim(Formula* conjecture, ClauseList*& newClauses);
 Formula* getName(TermList fromSort, TermList toSort, bool strict);
 
-DHMap<unsigned,std::pair<unsigned,unsigned>> _labelMap_nonstrict;
-DHMap<unsigned,std::pair<unsigned,unsigned>> _labelMap_strict;
+DHMap<unsigned,std::pair<unsigned,unsigned>, FnvHash, IdentityHash> _labelMap_nonstrict;
+DHMap<unsigned,std::pair<unsigned,unsigned>, FnvHash, IdentityHash> _labelMap_strict;
 
 };
 

--- a/FMB/ModelCheck.hpp
+++ b/FMB/ModelCheck.hpp
@@ -44,8 +44,8 @@ static void doCheck(UnitList* units)
   // find model size
   // looking for a domain axiom with a name starting 'finite_domain' (TODO search for something of the right shape)
 
-  DHMap<unsigned,unsigned> sortSizes;
-  DHMap<unsigned,std::unique_ptr<Set<Term*, FnvHash>>> domainConstantsPerSort;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> sortSizes;
+  DHMap<unsigned,std::unique_ptr<Set<Term*, FnvHash>>, FnvHash, IdentityHash> domainConstantsPerSort;
 
   // first just search for finite_domain axiom (TODO: do this for every sort!)
   {

--- a/FMB/Monotonicity.cpp
+++ b/FMB/Monotonicity.cpp
@@ -167,7 +167,7 @@ bool Monotonicity::guards(Literal* l, unsigned var, Stack<SATLiteral>& slits)
 
 
 void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<bool>& del_f,
-  DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_predicates) // may write into these
+  DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash>& monotonic_vampire_sorts, Stack<unsigned>& sort_predicates) // may write into these
 {
   // First compute the monotonic sorts
   DArray<bool> isMonotonic(env.signature->typeCons());
@@ -261,7 +261,7 @@ void Monotonicity::addSortPredicates(bool withMon, ClauseList*& clauses, const D
     static Stack<std::pair<unsigned,unsigned>> sortedVariables;
     sortedVariables.reset();
 
-    DHMap<unsigned,TermList> varSorts;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
     SortHelper::collectVariableSorts(cl,varSorts);
     for(unsigned v=0;v<cl->varCnt();v++){
       TermList vsrt;
@@ -328,7 +328,7 @@ public:
 };
 
 void Monotonicity::addSortFunctions(bool withMon, ClauseList*& clauses,
-  DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_functions) // may write into these
+  DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash>& monotonic_vampire_sorts, Stack<unsigned>& sort_functions) // may write into these
 {
   // First compute the monotonic sorts
   DArray<bool> isMonotonic(env.signature->typeCons());

--- a/FMB/Monotonicity.hpp
+++ b/FMB/Monotonicity.hpp
@@ -49,9 +49,9 @@ public:
   DArray<signed char>* check();
 
   static void addSortPredicates(bool withMon, ClauseList*& clauses, const DArray<bool>& del_f,
-    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_predicates);
+    DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash>& monotonic_vampire_sorts, Stack<unsigned>& sort_predicates);
   static void addSortFunctions(bool withMon, ClauseList*& clauses,
-    DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts, Stack<unsigned>& sort_functions);
+    DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash>& monotonic_vampire_sorts, Stack<unsigned>& sort_functions);
 
 private:
   void monotone(Clause* c, Literal* l);
@@ -69,8 +69,8 @@ private:
   // the constructor computes the result
   bool _result;
 
-  DHMap<unsigned,SATLiteral> _pF;
-  DHMap<unsigned,SATLiteral> _pT;
+  DHMap<unsigned,SATLiteral, FnvHash, IdentityHash> _pF;
+  DHMap<unsigned,SATLiteral, FnvHash, IdentityHash> _pT;
 
   ScopedPtr<SATSolver> _solver;
 };

--- a/FMB/SortInference.cpp
+++ b/FMB/SortInference.cpp
@@ -224,7 +224,7 @@ void SortInference::doInference()
   IntUnionFind unionFind(count);
   ZIArray<unsigned> posEqualitiesOnPos;
   Stack<unsigned> varEqualityVampireSorts;
-  DHMap<unsigned,unsigned> vampireSortMax;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> vampireSortMax;
 
   ClauseIterator cit = pvi(ClauseList::Iterator(_clauses));
 
@@ -413,7 +413,7 @@ void SortInference::doInference()
 
   // We will normalize the resulting sorts as we go
   // translate maps the components from union find to these new sorts
-  DHMap<int,unsigned> translate;
+  DHMap<int,unsigned, FnvHash, IdentityHash> translate;
   unsigned seen = 0;
 
   // True if there is a positive equality on a position with this sort
@@ -489,7 +489,7 @@ void SortInference::doInference()
     cout << comps << " inferred subsorts" << endl;
   }
   unsigned firstFreshConstant = UINT_MAX;
-  DHMap<unsigned,unsigned> freshMap;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> freshMap;
   for(unsigned s=0;s<comps;s++){
 #if DEBUG_SORT_INFERENCE
     if(!_posEqualitiesOnSort[s]){ cout << "No positive equalities for subsort " << s << endl; }
@@ -790,7 +790,7 @@ void SortInference::doInference()
   // Let the sorted signature know about the sort bounds found by the { X = t_i } scenario
   // To do this we need to map from vampire sorts to the sorts of the sorted signature
   // via the notion of distinct sort
-  DHMap<unsigned,unsigned>::Iterator vmax(vampireSortMax);
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash>::Iterator vmax(vampireSortMax);
   while(vmax.hasNext()){
     unsigned vsrt;
     unsigned max;
@@ -815,7 +815,7 @@ unsigned SortInference::getDistinctSort(unsigned subsort, unsigned realVampireSo
   // oink, oink
   static bool firstMonotonicSortSeen = false;
   static unsigned firstMonotonicSort = 0;
-  static DHMap<unsigned,unsigned> ourDistinctSorts;
+  static DHMap<unsigned,unsigned, FnvHash, IdentityHash> ourDistinctSorts;
 
   unsigned vampireSort = realVampireSort;
   if(_expandSubsorts){

--- a/FMB/SortInference.hpp
+++ b/FMB/SortInference.hpp
@@ -56,15 +56,15 @@ struct SortedSignature{
 
     // Map the distinct sorts back to their vampire parents
     // A distinct sort may merge multiple vampire sorts (due to monotonicity)
-    DHMap<unsigned,Stack<unsigned>*> distinctToVampire;
+    DHMap<unsigned,Stack<unsigned>*, FnvHash, IdentityHash> distinctToVampire;
     // A vampire sort can only be mapped to more than one distinct sort under certain conditions i.e. when
     // (i) the option for fmbSortInference = expand
     // (ii) at most one sort has non-monotonic subsorts and that is called parent
     // (iii) additional constraints have been added making expanded <= parent
-    DHMap<unsigned,Stack<unsigned>*> vampireToDistinct;
+    DHMap<unsigned,Stack<unsigned>*, FnvHash, IdentityHash> vampireToDistinct;
     // This maps to the distinct parent
     // invariant: domain of the two maps are the same and the second maps to something in the stack of the first
-    DHMap<unsigned,unsigned> vampireToDistinctParent;
+    DHMap<unsigned,unsigned, FnvHash, IdentityHash> vampireToDistinctParent;
 
     // has size distinctSorts
     // is 1 if that distinct sort is monotonic
@@ -77,7 +77,7 @@ public:
                 const DArray<bool>& del_f,
                 const DArray<bool>& del_p,
                 Stack<std::pair<unsigned,unsigned>>& distinct_sort_constraints,
-                DHMap<unsigned,DArray<signed char>*>& monotonic_vampire_sorts) :
+                DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash>& monotonic_vampire_sorts) :
                 _clauses(clauses), _del_f(del_f), _del_p(del_p),
                 // these two are essentially output arguments
                 _sort_constraints(distinct_sort_constraints),
@@ -130,7 +130,7 @@ private:
   // these two actually live in FiniteModelBuilder and serve as output arguments of this sort inference
   // (see more explanations there)
   Stack<std::pair<unsigned,unsigned>>& _sort_constraints;
-  DHMap<unsigned,DArray<signed char>*>& _monotonic_vampire_sorts;
+  DHMap<unsigned,DArray<signed char>*, FnvHash, IdentityHash>& _monotonic_vampire_sorts;
 };
 
 }

--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -36,6 +36,8 @@ typedef List<int> IntList;
 
 class DefaultHash;
 class DefaultHash2;
+struct FnvHash;
+struct IdentityHash;
 template <typename Key, typename Val,class Hash=DefaultHash> class Map;
 template<class A, class B, class HashA=DefaultHash, class HashB=DefaultHash> class BiMap;
 template <typename Key, typename Val, class Hash1=DefaultHash, class Hash2=DefaultHash2> class DHMap;

--- a/Indexing/ClauseVariantIndex.cpp
+++ b/Indexing/ClauseVariantIndex.cpp
@@ -106,7 +106,7 @@ HashingClauseVariantIndex::~HashingClauseVariantIndex()
   ClauseList* maxval = 0;
   */
 
-  DHMap<unsigned, ClauseList*>::Iterator iit(_entries);
+  DHMap<unsigned, ClauseList*, FnvHash, IdentityHash>::Iterator iit(_entries);
   while(iit.hasNext()){
     ClauseList* lst = iit.next();
 

--- a/Indexing/ClauseVariantIndex.hpp
+++ b/Indexing/ClauseVariantIndex.hpp
@@ -58,7 +58,7 @@ public:
 private:
   struct VariableIgnoringComparator;
 
-  typedef DHMap<unsigned, unsigned char> VarCounts; // overflows allowed
+  typedef DHMap<unsigned, unsigned char, FnvHash, IdentityHash> VarCounts; // overflows allowed
 
   unsigned termFunctorHash(Term* t, unsigned hash_begin) {
     unsigned func = t->functor();
@@ -85,7 +85,7 @@ private:
 
   unsigned computeHash(Literal* const * lits, unsigned length);
 
-  DHMap<unsigned, ClauseList*> _entries;
+  DHMap<unsigned, ClauseList*, FnvHash, IdentityHash> _entries;
 };
 
 };

--- a/Indexing/CodeTree.hpp
+++ b/Indexing/CodeTree.hpp
@@ -308,7 +308,7 @@ public:
     Stack<CodeOp*>* firstsInBlocks;
     size_t initFIBDepth;
     bool matchingClauses;
-    DHSet<unsigned> range;
+    DHSet<unsigned, FnvHash, IdentityHash> range;
   };
 
   struct NonRemovingBase {};
@@ -453,7 +453,7 @@ public:
 
   //////////// insertion //////////////
 
-  typedef DHMap<unsigned,unsigned> VarMap;
+  typedef DHMap<unsigned,unsigned, FnvHash, IdentityHash> VarMap;
 
   template<bool forLits>
   struct Compiler

--- a/Indexing/LiteralIndex.hpp
+++ b/Indexing/LiteralIndex.hpp
@@ -154,7 +154,7 @@ private:
   void handleEquivalence(Clause* c, Literal* cgr, Clause* d, Literal* dgr, bool adding);
 
   LiteralSubstitutionTree<LiteralClause> _partialIndex;
-  DHMap<unsigned,Clause*> _counterparts;
+  DHMap<unsigned,Clause*, FnvHash, IdentityHash> _counterparts;
   Ordering& _ordering;
 };
 

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -539,7 +539,7 @@ public:
       Binding(int v,TermList t) : var(v), term(t) {}
     }; // class SubstitutionTree::Binding
 
-    typedef DHMap<unsigned,TermList,IdentityHash,DefaultHash> BindingMap;
+    typedef DHMap<unsigned,TermList,IdentityHash,FnvHash> BindingMap;
     typedef Stack<unsigned> VarStack;
 
     Leaf* findLeaf(BindingMap& svBindings)

--- a/Inferences/ALASCA/BwdDemodulation.cpp
+++ b/Inferences/ALASCA/BwdDemodulation.cpp
@@ -51,7 +51,7 @@ void BwdDemodulation::perform(Clause* premise, BwSimplificationRecordIterator& s
   for (auto lhs : Lhs::iter(_shared, premise)) {
     DEBUG_CODE(cnt++;)
     Stack<BwSimplificationRecord> simpls;
-    Set<unsigned> simplified;
+    Set<unsigned, FnvHash> simplified;
     for (auto rhs : _index->instances(lhs.biggerSide())) {
         auto toSimpl = rhs.data->clause;
         if (simplified.contains(toSimpl->number())) {

--- a/Inferences/ALASCA/VIRAS.cpp
+++ b/Inferences/ALASCA/VIRAS.cpp
@@ -79,8 +79,8 @@ template<class NumTraits>
 Option<SimplifyingGeneratingInference::ClauseGenerationResult> VirasQuantifierElimination::generateSimplify(NumTraits n, Clause* premise) {
   DEBUG(0, *premise)
   auto viras = viras::viras(VampireVirasConfig<NumTraits>{});
-  Recycled<DHSet<unsigned>> shieldedVars;
-  Recycled<DHSet<unsigned>> candidateVars;
+  Recycled<DHSet<unsigned, FnvHash, IdentityHash>> shieldedVars;
+  Recycled<DHSet<unsigned, FnvHash, IdentityHash>> candidateVars;
   Recycled<Stack<Literal*>> toElim;
   Recycled<Stack<Literal*>> otherLits;
   auto noteShielded = [&](Term* t) {
@@ -91,7 +91,7 @@ Option<SimplifyingGeneratingInference::ClauseGenerationResult> VirasQuantifierEl
     }
   };
 
-  Recycled<DHSet<unsigned>> topLevelVars;
+  Recycled<DHSet<unsigned, FnvHash, IdentityHash>> topLevelVars;
   for (auto l : premise->iterLits()) {
     Option<AlascaLiteral<NumTraits>> norm = _shared.norm().tryNormalizeInterpreted(l)
       .flatMap([](auto l) { return l.template as<AlascaLiteral<NumTraits>>().toOwned(); })

--- a/Inferences/BackwardDemodulation.cpp
+++ b/Inferences/BackwardDemodulation.cpp
@@ -68,7 +68,7 @@ struct Applicator : SubstApplicator {
 template<bool higherOrder>
 struct BackwardDemodulation<higherOrder>::ResultFn
 {
-  typedef DHMultiset<unsigned> ClauseSet;
+  typedef DHMultiset<unsigned, FnvHash, IdentityHash> ClauseSet;
 
   ResultFn(Clause* cl, BackwardDemodulation& parent, const DemodulationHelper& helper)
   : _cl(cl), _helper(helper), _ordering(parent._ord)

--- a/Inferences/BackwardSubsumptionAndResolution.hpp
+++ b/Inferences/BackwardSubsumptionAndResolution.hpp
@@ -46,7 +46,7 @@ private:
   /// @brief SAT-based subsumption and subsumption resolution engine
   SATSubsumption::SATSubsumptionAndResolution _satSubs;
   /// @brief Set of clauses that have already been checked for subsumption and/or subsumption resolution
-  Lib::DHSet<unsigned> _checked;
+  Lib::DHSet<unsigned, FnvHash, IdentityHash> _checked;
 
 };
 

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -108,7 +108,7 @@ void DefinitionIntroduction<higherOrder>::introduceDefinitionFor(Term *t) {
     return;
 
   // compute domain and range sorts
-  DHMap<unsigned, TermList> domain_sorts;
+  DHMap<unsigned, TermList, FnvHash, IdentityHash> domain_sorts;
   TermList range_sort = SortHelper::getResultSort(t);
   SortHelper::collectVariableSorts(t, domain_sorts);
 

--- a/Inferences/DemodulationHelper.hpp
+++ b/Inferences/DemodulationHelper.hpp
@@ -30,12 +30,12 @@ public:
 
   template<typename Object>
   static bool isRenamingOn(const SubstApplicator* applicator, Object obj) {
-    DHSet<unsigned> domain;
-    DHSet<unsigned> range;
+    DHSet<unsigned, FnvHash, IdentityHash> domain;
+    DHSet<unsigned, FnvHash, IdentityHash> range;
     return isRenamingOn(applicator, obj, domain, range);
   }
   template<typename Object>
-  static bool isRenamingOn(const SubstApplicator* applicator, Object obj, DHSet<unsigned>& domain, DHSet<unsigned>& range)
+  static bool isRenamingOn(const SubstApplicator* applicator, Object obj, DHSet<unsigned, FnvHash, IdentityHash>& domain, DHSet<unsigned, FnvHash, IdentityHash>& range)
   {
     for (const auto& v : iterTraits(VariableIterator(obj))) {
       ASS(v.isVar());

--- a/Inferences/EquationalTautologyRemoval.cpp
+++ b/Inferences/EquationalTautologyRemoval.cpp
@@ -35,7 +35,7 @@ Clause* EquationalTautologyRemoval::simplify(Clause* cl)
   bool has_pos_eq = false;
   bool has_complement = false;
 
-  static DHSet<int> preds;
+  static DHSet<int, FnvHash, IdentityHash> preds;
   preds.reset();
 
   for (unsigned i = 0; i < cl->length(); i++) {

--- a/Inferences/FastCondensation.cpp
+++ b/Inferences/FastCondensation.cpp
@@ -38,7 +38,7 @@ namespace {
 template<bool higherOrder>
 struct CondensationBinder
 {
-  void init(DHMap<unsigned, int>* varMap_)
+  void init(DHMap<unsigned, int, FnvHash, IdentityHash>* varMap_)
   {
     varMap=varMap_;
   }
@@ -67,8 +67,8 @@ struct CondensationBinder
   void specVar(unsigned var, TermList term)
   { ASSERTION_VIOLATION; }
 private:
-  DHMap<unsigned, int>* varMap;
-  DHMap<unsigned, TermList> bindings;
+  DHMap<unsigned, int, FnvHash, IdentityHash>* varMap;
+  DHMap<unsigned, TermList, FnvHash, IdentityHash> bindings;
 };
 
 }
@@ -85,7 +85,7 @@ Clause* FastCondensation<higherOrder>::simplify(Clause* cl)
 
   //if variable is present in only one literal, the map contains its index,
   //otherwise it contains -1
-  static DHMap<unsigned, int> varLits;
+  static DHMap<unsigned, int, FnvHash, IdentityHash> varLits;
   varLits.reset();
 
   for(unsigned i=0;i<clen;i++) {

--- a/Inferences/ForwardGroundJoinability.cpp
+++ b/Inferences/ForwardGroundJoinability.cpp
@@ -59,7 +59,7 @@ bool ForwardGroundJoinability<higherOrder>::perform(Clause* cl, Clause*& replace
   if (!lit->isEquality() || lit->isNegative()) {
     return false;
   }
-  DHMap<unsigned, Clause*> premiseSet;
+  DHMap<unsigned, Clause*, FnvHash, IdentityHash> premiseSet;
 
   if (EqHelper::isEqTautology(lit)) {
     premises = ClauseIterator::getEmpty();

--- a/Inferences/ForwardSubsumptionAndResolution.cpp
+++ b/Inferences/ForwardSubsumptionAndResolution.cpp
@@ -44,7 +44,7 @@ ForwardSubsumptionAndResolution::ForwardSubsumptionAndResolution(SaturationAlgor
 {}
 
 /// @brief Set of clauses that were already checked
-static DHSet<unsigned> checkedClauses;
+static DHSet<unsigned, FnvHash, IdentityHash> checkedClauses;
 
 bool ForwardSubsumptionAndResolution::perform(Clause *cl,
                                               Clause *&replacement,

--- a/Inferences/GlobalSubsumption.hpp
+++ b/Inferences/GlobalSubsumption.hpp
@@ -55,12 +55,12 @@ private:
   /**
    * A map binding split levels to variables assigned to them in our SAT solver.
    */
-  DHMap<unsigned, unsigned> _splits2vars;
+  DHMap<unsigned, unsigned, FnvHash, IdentityHash> _splits2vars;
 
   /**
    * An inverse of the above map, for convenience.
    */
-  DHMap<unsigned, unsigned> _vars2splits;
+  DHMap<unsigned, unsigned, FnvHash, IdentityHash> _vars2splits;
 protected:
   unsigned splitLevelToVar(SplitLevel lev) {
     unsigned* pvar;

--- a/Inferences/HOL/CNFOnTheFly.cpp
+++ b/Inferences/HOL/CNFOnTheFly.cpp
@@ -304,7 +304,7 @@ InferenceRule convert(Proxy cnst, bool simplifying) {
 }
 
 TermList sigmaRemoval(TermList sigmaTerm, TermList expsrt){
-  static DHMap<unsigned,TermList> varSorts;
+  static DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
   varSorts.reset();
 
   if(sigmaTerm.isTerm()){
@@ -331,7 +331,7 @@ TermList sigmaRemoval(TermList sigmaTerm, TermList expsrt){
 
   unsigned var;
   TermList varSort;
-  DHMap<unsigned, TermList>::Iterator mapIt(varSorts);
+  DHMap<unsigned, TermList, FnvHash, IdentityHash>::Iterator mapIt(varSorts);
   while(mapIt.hasNext()) {
     mapIt.next(var, varSort);
     if(varSort == AtomicSort::superSort()){

--- a/Inferences/HOL/NegativeExtensionality.cpp
+++ b/Inferences/HOL/NegativeExtensionality.cpp
@@ -35,7 +35,7 @@ using namespace Kernel;
 using namespace Indexing;
 using namespace Saturation;
 
-void getVarSorts(TypedTermList t, DHMap<unsigned,TermList>& varSorts)
+void getVarSorts(TypedTermList t, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts)
 {
   if (t.isVar()) {
     varSorts.insert(t.var(), t.sort());
@@ -55,7 +55,7 @@ struct NegExtResultFn
     ASS(lit->isEquality());
     ASS(lit->isNegative());
 
-    static DHMap<unsigned,TermList> varSorts;
+    static DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
     varSorts.reset();
 
     auto eqSort = lit->eqArgSort();

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -165,7 +165,7 @@ Formula* InductionContext::getFormula(
   auto right = getFormulaWithSquashedSkolems(ts, nextVar, renamedFreeVars, varsReplacingSkolems, subst);
   auto f = left ? new BinaryFormula(Connective::IMP, left, right) : right;
   if (renamedFreeVars) {
-    DHMap<unsigned, TermList> varSorts;
+    DHMap<unsigned, TermList, FnvHash, IdentityHash> varSorts;
     SortHelper::collectVariableSorts(f, varSorts);
     auto vs = VSList::fromIterator(iterTraits(VList::Iterator(renamedFreeVars))
       .map([&varSorts](unsigned v) -> VarSort { return {v, varSorts.get(v)}; }));

--- a/Inferences/Induction.hpp
+++ b/Inferences/Induction.hpp
@@ -115,10 +115,10 @@ public:
   unsigned& _nextVar; // fresh variable counter supported by caller
 
   DHMap<Term*, unsigned, SharedTermHash, PtrIdentityHash> _skolemToVarMap; // maps terms to their variable replacement
-  DHMap<unsigned,TermList> _varsReplacingSkolems;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> _varsReplacingSkolems;
 
-  DHMap<unsigned,unsigned> _renaming; // for renaming free variables
-  DHSet<unsigned> _renamedFreeVars;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> _renaming; // for renaming free variables
+  DHSet<unsigned, FnvHash, IdentityHash> _renamedFreeVars;
 };
 
 /**

--- a/Inferences/Instantiation.cpp
+++ b/Inferences/Instantiation.cpp
@@ -211,7 +211,7 @@ public:
   DECL_ELEMENT_TYPE(Substitution);
   AllSubstitutionsIterator(Clause* cl,Instantiation* ins)
   {
-    DHMap<unsigned,TermList> sortedVars;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> sortedVars;
     SortHelper::collectVariableSorts(cl,sortedVars);
     auto it = sortedVars.items();
 
@@ -257,8 +257,8 @@ public:
   }
 
 private:
-  DHMap<unsigned,DArray<Term*>*> candidates;
-  DHMap<unsigned,unsigned> current;
+  DHMap<unsigned,DArray<Term*>*, FnvHash, IdentityHash> candidates;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> current;
   VirtualIterator<unsigned> variables;
   unsigned currently;
   bool finished;

--- a/Inferences/SubsumptionEqualityResolution.cpp
+++ b/Inferences/SubsumptionEqualityResolution.cpp
@@ -49,8 +49,8 @@ Clause* SubsumptionEqualityResolution::simplify(Clause* cl)
     }
 
     RStack<Literal*> resLits;
-    DHSet<unsigned> renamingDomain;
-    DHSet<unsigned> renamingRange;
+    DHSet<unsigned, FnvHash, IdentityHash> renamingDomain;
+    DHSet<unsigned, FnvHash, IdentityHash> renamingRange;
     for (const auto& curr : *cl) {
       if (lit == curr) {
         continue;

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -599,7 +599,7 @@ template<class IterLits> TheoryInstAndSimp::SkolemizedLiterals TheoryInstAndSimp
   _instantiationConstants.reset();
   for (auto lit : lits) {
     // replace variables consistently by fresh constants
-    DHMap<unsigned, SortId> srtMap;
+    DHMap<unsigned, SortId, FnvHash, IdentityHash> srtMap;
     SortHelper::collectVariableSorts(lit,srtMap);
     TermVarIterator vit(lit);
     while(vit.hasNext()){
@@ -835,7 +835,7 @@ Stack<Literal*> filterLiterals(Stack<Literal*> lits, Options::TheoryInstSimp mod
 
     case Options::TheoryInstSimp::OVERLAP:
       {
-        Set<unsigned> strongVars;
+        Set<unsigned, FnvHash> strongVars;
 
         for (auto l : lits) {
           if (isStrong(l)) {

--- a/Kernel/ALASCA/Preprocessor.hpp
+++ b/Kernel/ALASCA/Preprocessor.hpp
@@ -27,8 +27,8 @@ namespace Kernel {
 class AlascaPreprocessor
 {
   const InequalityNormalizer& _norm;
-  Map<unsigned, unsigned> _preds;
-  Map<unsigned, unsigned> _funcs;
+  Map<unsigned, unsigned, FnvHash> _preds;
+  Map<unsigned, unsigned, FnvHash> _funcs;
   // TODO create option for this
   bool _useFloor = false;
 

--- a/Kernel/BestLiteralSelector.hpp
+++ b/Kernel/BestLiteralSelector.hpp
@@ -121,7 +121,7 @@ protected:
     ASS_G(eligible, 1); //trivial cases should be taken care of by the base LiteralSelector
 
     static DArray<Literal*> litArr(64);
-    static Set<unsigned> maxTermHeads;
+    static Set<unsigned, FnvHash> maxTermHeads;
     maxTermHeads.reset();
     litArr.initFromArray(eligible,*c);
     litArr.sortInversed(_comp);

--- a/Kernel/Clause.cpp
+++ b/Kernel/Clause.cpp
@@ -77,7 +77,7 @@ Clause::Clause(Literal* const* lits, unsigned length, Inference inf)
 
 #if VDEBUG
   // check that the variable sorts are consistent
-  DHMap<unsigned, TermList> temp;
+  DHMap<unsigned, TermList, FnvHash, IdentityHash> temp;
   SortHelper::collectVariableSorts(this, temp);
 #endif
 
@@ -371,7 +371,7 @@ std::string Clause::toString() const
 {
   std::string quantifier = "";
   if(env.options->proofExtra() != Options::ProofExtra::OFF){
-    DHMap<unsigned,TermList> varSortMap;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> varSortMap;
     SortHelper::collectVariableSorts(const_cast<Clause*>(this),varSortMap);
     auto vars = Stack<unsigned>::fromIterator(varSortMap.domain());
     vars.sort();
@@ -630,13 +630,13 @@ unsigned Clause::computeWeightForClauseSelection(unsigned w, unsigned splitWeigh
   return w * ( !derivedFromGoal ? nongoalWeightCoeffNum : nongoalWeightCoefDenom);
 }
 
-void Clause::collectVars(DHSet<unsigned>& acc)
+void Clause::collectVars(DHSet<unsigned, FnvHash, IdentityHash>& acc)
 {
   collectVars2<VariableIterator>(acc);
 }
 
 template<class VarIt>
-void Clause::collectVars2(DHSet<unsigned>& acc)
+void Clause::collectVars2(DHSet<unsigned, FnvHash, IdentityHash>& acc)
 {
   for (Literal* lit : iterLits()) {
     VarIt vit(lit);
@@ -650,7 +650,7 @@ void Clause::collectVars2(DHSet<unsigned>& acc)
 
 unsigned Clause::varCnt()
 {
-  static DHSet<unsigned> vars;
+  static DHSet<unsigned, FnvHash, IdentityHash> vars;
   vars.reset();
   collectVars(vars);
   return vars.size();

--- a/Kernel/Clause.hpp
+++ b/Kernel/Clause.hpp
@@ -53,7 +53,7 @@ private:
   void operator delete(void* ptr) { ASSERTION_VIOLATION; }
 
   template<class VarIt>
-  void collectVars2(DHSet<unsigned>& acc);
+  void collectVars2(DHSet<unsigned, FnvHash, IdentityHash>& acc);
 public:
   DECL_ELEMENT_TYPE(Literal*);
 
@@ -332,7 +332,7 @@ public:
   unsigned splitWeight() const;
   unsigned getNumeralWeight() const;
 
-  void collectVars(DHSet<unsigned>& acc);
+  void collectVars(DHSet<unsigned, FnvHash, IdentityHash>& acc);
 
 
   unsigned varCnt();

--- a/Kernel/Formula.cpp
+++ b/Kernel/Formula.cpp
@@ -418,7 +418,7 @@ Formula* Formula::createDefinition(Term* lhs, TermList rhs, VList* uVars)
   auto lit = Literal::create(env.signature->getDefPred(), /*polarity*/true, { sort, TermList(lhs), rhs });
   Formula* res = new AtomicFormula(lit);
   if (uVars) {
-    DHMap<unsigned,TermList> varSortMap;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> varSortMap;
     SortHelper::collectVariableSorts(res, varSortMap);
     VSList::FIFO vsfifo;
     VList::Iterator vit(uVars);
@@ -434,13 +434,13 @@ Formula* Formula::createDefinition(Term* lhs, TermList rhs, VList* uVars)
 Formula* Formula::quantify(Formula* f)
 {
 
-  DHMap<unsigned,TermList> tMap;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> tMap;
   SortHelper::collectVariableSorts(f,tMap,/*ignoreBound=*/true);
 
   //we have to quantify the formula
   VSList::FIFO quantifiedVarsWithSorts;
 
-  DHMap<unsigned,TermList>::Iterator tmit(tMap);
+  DHMap<unsigned,TermList, FnvHash, IdentityHash>::Iterator tmit(tMap);
   while(tmit.hasNext()) {
     unsigned v;
     TermList s;

--- a/Kernel/FormulaTransformer.hpp
+++ b/Kernel/FormulaTransformer.hpp
@@ -119,7 +119,7 @@ protected:
   TermList getVarSort(unsigned var) const;
 
 private:
-  Recycled<DHMap<unsigned,TermList>> _varSorts;
+  Recycled<DHMap<unsigned,TermList, FnvHash, IdentityHash>> _varSorts;
   int _polarity;
 };
 

--- a/Kernel/InductionTemplate.cpp
+++ b/Kernel/InductionTemplate.cpp
@@ -55,7 +55,7 @@ InductionUnit::InductionUnit(TermStack&& F_terms, LiteralStack&& conditions, VSt
   ASS(F_terms.isNonEmpty());
 }
 
-void InductionUnit::collectVariableSorts(const DHSet<unsigned>& sortVars, const TermStack& sorts, DHMap<unsigned,TermList>& varSorts) const
+void InductionUnit::collectVariableSorts(const DHSet<unsigned, FnvHash, IdentityHash>& sortVars, const TermStack& sorts, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts) const
 {
   ASS_EQ(sorts.size(), F_terms.size());
   for (unsigned i = 0; i < sorts.size(); i++) {
@@ -108,7 +108,7 @@ InductionTemplate::InductionTemplate(TermStack&& sorts, Stack<InductionCase>&& c
   : sorts(sorts), cases(cases), conclusion(conclusion), rule(rule), maxVar(maxVar)
 {
 #if VDEBUG
-  DHSet<unsigned> sortVars;
+  DHSet<unsigned, FnvHash, IdentityHash> sortVars;
   for (const auto& s : sorts) {
     iterTraits(VariableIterator(s)).forEach([&](const auto& t) {
       sortVars.insert(t.var());
@@ -116,12 +116,12 @@ InductionTemplate::InductionTemplate(TermStack&& sorts, Stack<InductionCase>&& c
   }
 
   // check sorts and vars
-  DHMap<unsigned,TermList> varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
   conclusion.collectVariableSorts(sortVars, sorts, varSorts);
 
   ASS(cases.isNonEmpty());
   for (const auto& c : cases) {
-    DHMap<unsigned,TermList> caseVars;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> caseVars;
     c.conclusion.collectVariableSorts(sortVars, sorts, caseVars);
     for (const auto& h : c.hypotheses) {
       h.collectVariableSorts(sortVars, sorts, caseVars);

--- a/Kernel/InductionTemplate.hpp
+++ b/Kernel/InductionTemplate.hpp
@@ -39,7 +39,7 @@ struct InductionUnit
 {
   InductionUnit(TermStack&& F_terms, LiteralStack&& conditions = LiteralStack(), VStack&& condUnivVars = VStack());
 
-  void collectVariableSorts(const DHSet<unsigned>& sortVars, const TermStack& sorts, DHMap<unsigned,TermList>& varSorts) const;
+  void collectVariableSorts(const DHSet<unsigned, FnvHash, IdentityHash>& sortVars, const TermStack& sorts, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts) const;
 
   friend std::ostream& operator<<(std::ostream& out, const InductionUnit& u);
 

--- a/Kernel/InferenceStore.cpp
+++ b/Kernel/InferenceStore.cpp
@@ -114,7 +114,7 @@ void InferenceStore::recordIntroducedSplitName(Unit* u, std::string name)
  * It is caller's responsibility to ensure that variables in @b vars are unique.
  */
 template<typename VarContainer>
-std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<unsigned,TermList>& t_map, bool innerParentheses=true){
+std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<unsigned,TermList, FnvHash, IdentityHash>& t_map, bool innerParentheses=true){
   VirtualIterator<unsigned> vit=pvi( getContentIterator(vars) );
   std::string varStr;
   bool first=true;
@@ -160,9 +160,9 @@ std::string getQuantifiedStr(const VarContainer& vars, std::string inner, DHMap<
  */
 std::string getQuantifiedStr(Unit* u, List<unsigned>* nonQuantified=0)
 {
-  Set<unsigned> vars;
+  Set<unsigned, FnvHash> vars;
   std::string res;
-  DHMap<unsigned,TermList> t_map;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> t_map;
   SortHelper::collectVariableSorts(u,t_map, /*ignoreBound=*/true);
   if (u->isClause()) {
     Clause* cl=static_cast<Clause*>(u);
@@ -828,7 +828,7 @@ std::string getSkolemizeMap(unsigned unitNumber, It symIt){
 
     //sorts of the clause's variables, so the quantifiers of the definition
     //below are annotated like every other formula in the proof
-    DHMap<unsigned,TermList> t_map;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> t_map;
     SortHelper::collectVariableSorts(us, t_map);
 
     std::string defId=tptpDefId(us);
@@ -1530,7 +1530,7 @@ protected:
   static void output(std::ostream& out, Unit* unit)
   {
     using Sort = TermList;
-    DHMap<unsigned, Sort> vars;
+    DHMap<unsigned, Sort, FnvHash, IdentityHash> vars;
     SortHelper::collectVariableSorts(unit, vars);
     decltype(vars)::Iterator iter(vars);
     if (vars.size() != 0) {
@@ -1686,7 +1686,7 @@ void InferenceStore::outputUnsatCore(std::ostream& out, Unit* refutation)
 
   Stack<Unit*> todo;
   todo.push(refutation);
-  Set<unsigned> visited;
+  Set<unsigned, FnvHash> visited;
   while(!todo.isEmpty()){
 
     Unit* u = todo.pop();

--- a/Kernel/InferenceStore.hpp
+++ b/Kernel/InferenceStore.hpp
@@ -86,19 +86,19 @@ private:
 
   ProofPrinter* createProofPrinter(std::ostream& out);
 
-  DHMultiset<unsigned> _nextClIds;
+  DHMultiset<unsigned, FnvHash, IdentityHash> _nextClIds;
 
-  DHMap<unsigned, Literal*> _splittingNameLiterals;
+  DHMap<unsigned, Literal*, FnvHash, IdentityHash> _splittingNameLiterals;
 
   typedef Stack<Signature::Symbol*> SymbolStack;
   // unit id -> stack of introduced symbols (in order of introduction)
-  DHMap<unsigned,SymbolStack> _introducedSymbols;
+  DHMap<unsigned,SymbolStack, FnvHash, IdentityHash> _introducedSymbols;
   // symbol id -> existential variable name (number) that was replaced by the symbol
   DHMap<Signature::Symbol*, unsigned, FnvHash, PtrIdentityHash> _introducedSymbolReplacedVars;
   // symbol id -> the term that is introduced when introducing the skolem symbol
   DHMap<Signature::Symbol*, Term*, FnvHash, PtrIdentityHash> _introducedSkolemSymTerms;
 
-  DHMap<unsigned,std::string> _introducedSplitNames;
+  DHMap<unsigned,std::string, FnvHash, IdentityHash> _introducedSplitNames;
 };
 
 };

--- a/Kernel/KBO.hpp
+++ b/Kernel/KBO.hpp
@@ -202,7 +202,7 @@ private:
   {
     int _weightDiff;
     /** The variable counters */
-    DHMap<unsigned, int, IdentityHash, DefaultHash> _varDiffs;
+    DHMap<unsigned, int, IdentityHash, FnvHash> _varDiffs;
     /** Number of variables, that occur more times in the first literal */
     int _posNum;
     /** Number of variables, that occur more times in the second literal */

--- a/Kernel/LiteralComparators.hpp
+++ b/Kernel/LiteralComparators.hpp
@@ -266,8 +266,8 @@ struct NormalizedLinearComparatorByWeight : public LiteralComparator
       }
     }
 
-    static DHMap<unsigned, unsigned> firstNums;
-    static DHMap<unsigned, unsigned> secondNums;
+    static DHMap<unsigned, unsigned, FnvHash, IdentityHash> firstNums;
+    static DHMap<unsigned, unsigned, FnvHash, IdentityHash> secondNums;
     firstNums.reset();
     secondNums.reset();
 

--- a/Kernel/MLMatcher.hpp
+++ b/Kernel/MLMatcher.hpp
@@ -42,7 +42,7 @@ inline std::ostream& operator<<(std::ostream& os, MLMatchStats const& stats)
   return os;
 }
 
-typedef DHMap<unsigned,unsigned, IdentityHash, DefaultHash> UUMap;
+typedef DHMap<unsigned,unsigned, IdentityHash, FnvHash> UUMap;
 
 /**
  * Binder that stores bindings into a specified array. To be used

--- a/Kernel/MLVariant.cpp
+++ b/Kernel/MLVariant.cpp
@@ -37,7 +37,7 @@ namespace Kernel
 
 using namespace Lib;
 
-typedef DHMap<unsigned,unsigned, IdentityHash, DefaultHash> UUMap;
+typedef DHMap<unsigned,unsigned, IdentityHash, FnvHash> UUMap;
 
 namespace MLVariant_AUX
 {

--- a/Kernel/Matcher.cpp
+++ b/Kernel/Matcher.cpp
@@ -55,8 +55,8 @@ bool MatchingUtils::haveReversedVariantArgs(Term* l1, Term* l2)
   ASS_EQ(l1->arity(), 2);
   ASS_EQ(l2->arity(), 2);
 
-  static DHMap<unsigned,unsigned,IdentityHash,DefaultHash> leftToRight;
-  static DHMap<unsigned,unsigned,IdentityHash,DefaultHash> rightToLeft;
+  static DHMap<unsigned,unsigned,IdentityHash,FnvHash> leftToRight;
+  static DHMap<unsigned,unsigned,IdentityHash,FnvHash> rightToLeft;
   leftToRight.reset();
   rightToLeft.reset();
 
@@ -110,8 +110,8 @@ bool MatchingUtils::haveVariantArgs(Term* l1, Term* l2)
     return true;
   }
 
-  static DHMap<unsigned,unsigned,IdentityHash,DefaultHash> leftToRight;
-  static DHMap<unsigned,unsigned,IdentityHash,DefaultHash> rightToLeft;
+  static DHMap<unsigned,unsigned,IdentityHash,FnvHash> leftToRight;
+  static DHMap<unsigned,unsigned,IdentityHash,FnvHash> rightToLeft;
   leftToRight.reset();
   rightToLeft.reset();
 

--- a/Kernel/Renaming.cpp
+++ b/Kernel/Renaming.cpp
@@ -162,7 +162,7 @@ TermList Renaming::normalize(TermList trm)
 
 void Renaming::assertValid() const
 {
-  Set<unsigned> range;
+  Set<unsigned, FnvHash> range;
   VariableMap::Iterator mit(_data);
   while(mit.hasNext()) {
     unsigned to = mit.next();

--- a/Kernel/Renaming.hpp
+++ b/Kernel/Renaming.hpp
@@ -107,7 +107,7 @@ private:
     Renaming* _parent;
   };
 
-  typedef DHMap<unsigned, unsigned, IdentityHash, DefaultHash> VariableMap;
+  typedef DHMap<unsigned, unsigned, IdentityHash, FnvHash> VariableMap;
   VariableMap _data;
   unsigned _nextVar;
   bool _identity;

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -657,7 +657,7 @@ class Signature
     return _choiceSymbols.contains(fun);
   }
 
-  DHSet<unsigned>* getChoiceOperators(){
+  DHSet<unsigned, FnvHash, IdentityHash>* getChoiceOperators(){
     return &_choiceSymbols;
   }
 
@@ -1002,7 +1002,7 @@ private:
   Stack<Symbol*> _typeCons;
 
   // TODO(HOL): these two don't belong in the signature
-  DHSet<unsigned> _choiceSymbols;
+  DHSet<unsigned, FnvHash, IdentityHash> _choiceSymbols;
   DHSet<TermList> _instantiations;
 
   SymbolMap _funNames;
@@ -1031,7 +1031,7 @@ private:
    * the Interpretation value already determines whether we deal with a function
    * or a predicate.
    */
-  DHMap<Theory::Interpretation, unsigned> _iSymbols;
+  DHMap<Theory::Interpretation, unsigned, FnvHash, IdentityHash> _iSymbols;
 
   /** the number of string constants */
   unsigned _strings;
@@ -1049,8 +1049,8 @@ private:
   unsigned _choiceFun;
   unsigned _placeholderFun;
   unsigned _defPred;
-  DHSet<unsigned> _fnDefPreds;
-  DHMap<unsigned,unsigned> _boolDefPreds;
+  DHSet<unsigned, FnvHash, IdentityHash> _fnDefPreds;
+  DHMap<unsigned,unsigned, FnvHash, IdentityHash> _boolDefPreds;
 
   /**
    * Map from type constructor functor to the associated term algebra, if applicable for the sort.
@@ -1058,7 +1058,7 @@ private:
    * For a term algebra instance, this map gives the general term algebra based on the top-level
    * functor of its sort, the ctors and dtors still have to be instantiated to the right instances.
    */
-  DHMap<unsigned, Shell::TermAlgebra*> _termAlgebras;
+  DHMap<unsigned, Shell::TermAlgebra*, FnvHash, IdentityHash> _termAlgebras;
 
   //TODO Why are these here? They are not used anywhere. AYB
   //void defineOptionTermAlgebra(unsigned optionSort);

--- a/Kernel/SortHelper.cpp
+++ b/Kernel/SortHelper.cpp
@@ -151,7 +151,7 @@ bool SortHelper::tryGetResultSort(const TermList t, TermList& result)
 /**
  * This function works also for special terms
  */
-TermList SortHelper::getResultSort(TermList t, DHMap<unsigned,TermList>& varSorts)
+TermList SortHelper::getResultSort(TermList t, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts)
 {
   TermList res;
   TermList masterVar;
@@ -335,7 +335,7 @@ bool SortHelper::tryGetVariableSort(unsigned var, Formula* f, TermList& res)
  * @since 13/02/2017 Vienna
  * @author Martin Suda
  */
-static void collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermList>& map, bool ignoreBound = false)
+static void collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map, bool ignoreBound = false)
 {
   Stack<CollectTask> todo;
   ZIArray<unsigned> bound;
@@ -580,7 +580,7 @@ static void collectVariableSortsIter(CollectTask task, DHMap<unsigned,TermList>&
  * @since 15/05/2015 Gothenburg, FOOL support added
  * @author Andrei Voronkov, Evgeny Kotelnikov
  */
-void SortHelper::collectVariableSorts(Term* term, DHMap<unsigned,TermList>& map)
+void SortHelper::collectVariableSorts(Term* term, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map)
 {
   CollectTask t(term->isSpecial() ? COLLECT_SPECIALTERM : COLLECT_TERM);
   t.t = term;
@@ -593,7 +593,7 @@ void SortHelper::collectVariableSorts(Term* term, DHMap<unsigned,TermList>& map)
  * is in map already (or appears multiple times), assert that
  * the sorts are equal.
  */
-void SortHelper::collectVariableSorts(Formula* f, DHMap<unsigned,TermList>& map, bool ignoreBound)
+void SortHelper::collectVariableSorts(Formula* f, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map, bool ignoreBound)
 {
   CollectTask task(COLLECT_FORMULA);
   task.f = f;
@@ -606,7 +606,7 @@ void SortHelper::collectVariableSorts(Formula* f, DHMap<unsigned,TermList>& map,
  * is in map already (or appears multiple times), assert that
  * the sorts are equal.
  */
-void SortHelper::collectVariableSorts(Unit* u, DHMap<unsigned,TermList>& map, bool ignoreBound)
+void SortHelper::collectVariableSorts(Unit* u, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map, bool ignoreBound)
 {
   if (!u->isClause()) {
     FormulaUnit* fu = static_cast<FormulaUnit*>(u);
@@ -900,7 +900,7 @@ TermList SortHelper::getInnerSort(TermList arraySort)
  */
 bool SortHelper::areSortsValid(Clause* cl)
 {
-  static DHMap<unsigned,TermList> varSorts;
+  static DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
   varSorts.reset();
 
   unsigned clen = cl->length();
@@ -913,7 +913,7 @@ bool SortHelper::areSortsValid(Clause* cl)
 }
 bool SortHelper::areSortsValid(Term* t0)
 {
-  DHMap<unsigned,TermList> varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
   return areSortsValid(t0, varSorts);
 }
 
@@ -924,7 +924,7 @@ bool SortHelper::areSortsValid(Term* t0)
  * @since 04/05/2013 Manchester, new NonVariableIterator is used
  * @author Andrei Voronkov
  */
-bool SortHelper::areSortsValid(Term* t0, DHMap<unsigned,TermList>& varSorts)
+bool SortHelper::areSortsValid(Term* t0, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts)
 {
   NonVariableIterator sit(t0,true);
   while (sit.hasNext()) {

--- a/Kernel/SortHelper.hpp
+++ b/Kernel/SortHelper.hpp
@@ -23,7 +23,7 @@ class SortHelper {
 public:
   static TermList getResultSort(const Term* t);
   static TermList getResultSortMono(const Term* t);
-  static TermList getResultSort(TermList t, DHMap<unsigned,TermList>& varSorts);
+  static TermList getResultSort(TermList t, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts);
   static TermList getArgSort(Term const* t, unsigned argIndex);
   static TermList getTermArgSort(Term const* t, unsigned argIndex);
 
@@ -39,9 +39,9 @@ public:
   // DEPRECATED: this function eventually calls tryGetVariableSort above
   static TermList getVariableSort(TermList var, Term* t);
 
-  static void collectVariableSorts(Unit* u, DHMap<unsigned,TermList>& map, bool ignoreBound = false);
-  static void collectVariableSorts(Term* t, DHMap<unsigned,TermList>& map);
-  static void collectVariableSorts(Formula* f, DHMap<unsigned,TermList>& map, bool ignoreBound = false);
+  static void collectVariableSorts(Unit* u, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map, bool ignoreBound = false);
+  static void collectVariableSorts(Term* t, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map);
+  static void collectVariableSorts(Formula* f, DHMap<unsigned,TermList, FnvHash, IdentityHash>& map, bool ignoreBound = false);
 
   static bool areImmediateSortsValidPoly(Term* t);
   static bool areImmediateSortsValidMono(Term* t);
@@ -71,7 +71,7 @@ public:
 
   static bool areSortsValid(Clause* cl);
   static bool areSortsValid(Term* t);
-  static bool areSortsValid(Term* t, DHMap<unsigned,TermList>& varSorts);
+  static bool areSortsValid(Term* t, DHMap<unsigned,TermList, FnvHash, IdentityHash>& varSorts);
 private:
   static bool tryGetVariableSortTerm(TermList var, Term* t, TermList& result, bool recurseToSubformulas);
 };

--- a/Kernel/Substitution.hpp
+++ b/Kernel/Substitution.hpp
@@ -114,7 +114,7 @@ public:
   }
 
 private:
-  DHMap<unsigned,TermList> _map;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> _map;
 }; // class Substitution
 } // namespace Kernel
 

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -1383,7 +1383,7 @@ TermList AtomicSort::tupleSort(unsigned arity, TermList* sorts)
 
 unsigned Term::computeDistinctVars() const
 {
-  Set<unsigned> vars;
+  Set<unsigned, FnvHash> vars;
   VariableIterator vit(this);
   while (vit.hasNext()) {
     vars.insert(vit.next().var());

--- a/Kernel/UnificationWithAbstraction.cpp
+++ b/Kernel/UnificationWithAbstraction.cpp
@@ -1080,7 +1080,7 @@ struct FloorUwaState {
   };
 
   auto buckets() const {
-    Recycled<Map<unsigned, Bucket>> buckets;
+    Recycled<Map<unsigned, Bucket, FnvHash>> buckets;
     ASS(ratVars->isEmpty())
     ASS(intVars->isEmpty())
     ASS(mixVars->isEmpty())

--- a/Kernel/Unit.cpp
+++ b/Kernel/Unit.cpp
@@ -238,7 +238,7 @@ UnitIterator Unit::getParents() const
 bool Unit::minimizeAncestorsAndUpdateSelectedStats()
 {
   Stack<std::pair<Unit*,bool>> todo;
-  DHSet<unsigned> done;
+  DHSet<unsigned, FnvHash, IdentityHash> done;
   bool seenInputInference = false;
 
   todo.push(make_pair(this,false));

--- a/Lib/Environment.hpp
+++ b/Lib/Environment.hpp
@@ -46,7 +46,7 @@ public:
 
   unsigned char maxSineLevel;
 
-  DHMap<unsigned, unsigned>* predicateSineLevels;
+  DHMap<unsigned, unsigned, FnvHash, IdentityHash>* predicateSineLevels;
 
   ProofExtra proofExtra;
 

--- a/Lib/Numbering.hpp
+++ b/Lib/Numbering.hpp
@@ -92,7 +92,7 @@ public:
   }
 private:
   DHMap<T, unsigned> _map;
-  DHMap<unsigned, T> _rev;
+  DHMap<unsigned, T, FnvHash, IdentityHash> _rev;
 
   unsigned _nextNum;
 };

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -1408,7 +1408,7 @@ void SMTLIB2::parseLetPrepareLookup(LExpr* exp)
     }
 
     ASS(t.isTerm());
-    DHMap<unsigned,TermList> vs;
+    DHMap<unsigned,TermList, FnvHash, IdentityHash> vs;
     SortHelper::collectVariableSorts(t.term(),vs);
     TermStack args;
     TermStack varSorts;

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -60,8 +60,8 @@ static VSList* zipVarsSorts(VList* vars, SList* sorts) {
 
 #define DEBUG_SHOW_UNITS 0
 #define DEBUG_SOURCE 0
-DHMap<unsigned, std::pair<std::string, std::filesystem::path>> TPTP::_axiomNames;
-DHMap<unsigned, Map<unsigned,std::string>> TPTP::_questionVariableNames;
+DHMap<unsigned, std::pair<std::string, std::filesystem::path>, FnvHash, IdentityHash> TPTP::_axiomNames;
+DHMap<unsigned, Map<unsigned,std::string, FnvHash>, FnvHash, IdentityHash> TPTP::_questionVariableNames;
 
 //Numbers chosen to avoid clashing with connectives.
 //Unlikely to ever have 100 connectives, so this should be ok.
@@ -2350,7 +2350,7 @@ void TPTP::endLetTypes()
   std::string name = _strings.pop();
   Type* t = _types.pop();
   // Implicit type variables may appear in $let declarations, see below.
-  DHSet<unsigned> iTypeVars;
+  DHSet<unsigned, FnvHash, IdentityHash> iTypeVars;
   OperatorType* type = constructOperatorType(t, nullptr, &iTypeVars);
 
   unsigned arity = type->arity();
@@ -3642,7 +3642,7 @@ void TPTP::endFof()
 #if DEBUG_SOURCE
   else{
     // create fake map
-    _unitSources = new DHMap<unsigned,SourceRecord*>();
+    _unitSources = new DHMap<unsigned,SourceRecord*, FnvHash, IdentityHash>();
     source = getSource();
   }
 #endif
@@ -3879,7 +3879,7 @@ void TPTP::endTff()
 } // endTff
 
 
-OperatorType* TPTP::constructOperatorType(Type* t, VList* vars, DHSet<unsigned>* ivars)
+OperatorType* TPTP::constructOperatorType(Type* t, VList* vars, DHSet<unsigned, FnvHash, IdentityHash>* ivars)
 {
   TermList resultSort;
   Stack<TermList> argumentSorts;

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -346,7 +346,7 @@ public:
   std::string currentPath(){ return currentFile.path; }
 
   // careful: the returned pointer will be invalidated if _questionVariableNames is changed
-  static Map<unsigned,std::string>* findQuestionVars(unsigned questionNumber) {
+  static Map<unsigned,std::string, FnvHash>* findQuestionVars(unsigned questionNumber) {
     return _questionVariableNames.findPtr(questionNumber);
   }
   static bool seenQuestions() {
@@ -582,7 +582,7 @@ private:
   /** name table for variable names */
   Map<std::string, unsigned> _vars;
   /** When parsing a question, make note of the inverse mapping to _vars, i.e. from the ints back to the vstrings, for better user reporting */
-  Map<unsigned,std::string> _curQuestionVarNames;
+  Map<unsigned,std::string, FnvHash> _curQuestionVarNames;
   /** parsed types */
   Stack<Type*> _types;
   /** various type tags saved during parsing */
@@ -590,7 +590,7 @@ private:
   /**  */
   Stack<TheoryFunction> _theoryFunctions;
   /** bindings of variables to sorts */
-  Map<unsigned,SList*> _variableSorts;
+  Map<unsigned,SList*, FnvHash> _variableSorts;
   /** current color, if the input contains colors */
   Color _currentColor;
   /** a robsubstitution object to be used temporarily that is kept around to safe memory allocation time  */
@@ -805,7 +805,7 @@ private:
 
   /* If ivars is non-null, the function collects into it the
    * implicit (non-quantified) type variables (needed in $lets). */
-  OperatorType* constructOperatorType(Type* t, VList* vars = 0, DHSet<unsigned>* ivars = nullptr);
+  OperatorType* constructOperatorType(Type* t, VList* vars = 0, DHSet<unsigned, FnvHash, IdentityHash>* ivars = nullptr);
 
 public:
 
@@ -849,7 +849,7 @@ public:
     InferenceSourceRecord(std::string n) : name(n) {}
   };
 
-  void setUnitSourceMap(DHMap<unsigned,SourceRecord*>* m){
+  void setUnitSourceMap(DHMap<unsigned,SourceRecord*, FnvHash, IdentityHash>* m){
     _unitSources = m;
   }
   SourceRecord* getSource();
@@ -857,10 +857,10 @@ public:
   void setFilterReserved(){ _filterReserved=true; }
 
 private:
-  DHMap<unsigned,SourceRecord*>* _unitSources;
+  DHMap<unsigned,SourceRecord*, FnvHash, IdentityHash>* _unitSources;
 
   /** This field stores names of input units (and their file names) */
-  static DHMap<unsigned, std::pair<std::string, std::filesystem::path>> _axiomNames;
+  static DHMap<unsigned, std::pair<std::string, std::filesystem::path>, FnvHash, IdentityHash> _axiomNames;
 
   /**
    * During question parsing, we store the mapping from int variables
@@ -871,7 +871,7 @@ private:
    *
    * (Can there be more than one question? Yes, e.g., in the interactive mode.)
    */
-  static DHMap<unsigned, Map<unsigned,std::string>> _questionVariableNames;
+  static DHMap<unsigned, Map<unsigned,std::string, FnvHash>, FnvHash, IdentityHash> _questionVariableNames;
 
   /** Stores the type arities of function symbols */
   DHMap<std::string, unsigned> _typeArities;

--- a/SAT/MinisatInterfacing.cpp
+++ b/SAT/MinisatInterfacing.cpp
@@ -180,7 +180,7 @@ SATClauseList* MinisatInterfacing<MinisatSolver>::minimizePremiseList(SATClauseL
 {
   MinisatSolver solver;
 
-  static DHMap<int,SATClause*> var2prem;
+  static DHMap<int,SATClause*, FnvHash, IdentityHash> var2prem;
   var2prem.reset();
 
   static vec<Lit> ass; // assumptions for the final call

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -346,7 +346,7 @@ private:
 
   BiMap<SATLiteral, z3::expr, DefaultHash, Z3Hash> _assumptionLookup;
   Option<std::ofstream> _out;
-  Map<unsigned, z3::expr> _varNames;
+  Map<unsigned, z3::expr, FnvHash> _varNames;
   Map<TermList, z3::expr> _termIndexedConstants;
   Map<Signature::Symbol*, z3::expr, FnvHash> _constantNames;
 

--- a/SATSubsumption/subsat/SubstitutionTheory.hpp
+++ b/SATSubsumption/subsat/SubstitutionTheory.hpp
@@ -364,7 +364,7 @@ private:
   // TODO: replace bindings_by_pos by a single contiguous vector, and instead of VampireVarPos; use an index/length into that vector.
   //       (probably only makes sense if we construct that data lazily? in the current version we'd need an extra loop to determine counts for each variable first.)
   //       OTOH the current version isn't that bad, since we do map the vampire variables into a contiguous range first. so the vectors in m_bindings_by_pos are being reused anyway.
-  Lib::DHMap<VampireVar, VampireVarPos, Kernel::IdentityHash> m_var_pos;
+  Lib::DHMap<VampireVar, VampireVarPos, Kernel::IdentityHash, Lib::IdentityHash> m_var_pos;
   vector_map<VampireVarPos, vector<std::pair<subsat::Var, VampireTerm>>> m_bindings_by_pos;
 };
 

--- a/Saturation/ClauseContainer.hpp
+++ b/Saturation/ClauseContainer.hpp
@@ -216,7 +216,7 @@ protected:
   friend PassiveClauseContainer;
   void onLimitsUpdated(PassiveClauseContainer* limits);
 private:
-  DHMap<unsigned, Clause*> _clauses;
+  DHMap<unsigned, Clause*, FnvHash, IdentityHash> _clauses;
   // const Shell::Options& _opt;
 };
 

--- a/Saturation/PredicateSplitPassiveClauseContainers.hpp
+++ b/Saturation/PredicateSplitPassiveClauseContainers.hpp
@@ -103,7 +103,7 @@ private:
    * The hashamp is populated lazily be recursing to parents as needed in the computeTheoryFeatures method above.
    * See Bernhard Gleiss, Martin Suda: Layered Clause Selection for Theory Reasoning - (Short Paper). IJCAR (1) 2020: 402-409
   */
-  mutable DHMap<unsigned, std::pair<float,float>> _teoryFeatureCache;
+  mutable DHMap<unsigned, std::pair<float,float>, FnvHash, IdentityHash> _teoryFeatureCache;
 };
 
 class HoFeaturesMultiSplitPassiveClauseContainer : public PredicateSplitPassiveClauseContainer

--- a/Saturation/Splitter.cpp
+++ b/Saturation/Splitter.cpp
@@ -915,7 +915,7 @@ bool Splitter::getComponents(Clause* cl, Stack<LiteralStack>& acc, bool shuffle)
 
   //Master literal of an variable is the literal
   //with lowest index, in which it appears.
-  static DHMap<unsigned, unsigned, IdentityHash, DefaultHash> varMasters;
+  static DHMap<unsigned, unsigned, IdentityHash, FnvHash> varMasters;
   varMasters.reset();
   IntUnionFind components(clen);
 
@@ -1681,7 +1681,7 @@ void Splitter::removeComponents(const SplitLevelStack& toRemove)
  */
 UnitList* Splitter::preprendCurrentlyAssumedComponentClauses(UnitList* clauses)
 {
-  DHSet<unsigned> seen;
+  DHSet<unsigned, FnvHash, IdentityHash> seen;
 
   // to keep the nice order
   UnitList::FIFO res;

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -281,7 +281,7 @@ private:
    * Definitions of ground components C and ~C are shared and placed at the slot of C.
    * (So the key here is never odd!)
    **/
-  DHMap<SplitLevel,Unit*> _defs;
+  DHMap<SplitLevel,Unit*, FnvHash, IdentityHash> _defs;
 
   /** true if there was a clause added to the SAT solver since last call to onAllProcessed */
   bool _clausesAdded;

--- a/Saturation/SymElOutput.cpp
+++ b/Saturation/SymElOutput.cpp
@@ -158,7 +158,7 @@ void SymElOutput::checkForPreprocessorSymbolElimination(Clause* cl)
 
   Color inputColor=COLOR_TRANSPARENT;
 
-  static DHMap<unsigned, Color> inputFormulaColors;
+  static DHMap<unsigned, Color, FnvHash, IdentityHash> inputFormulaColors;
   static Stack<Unit*> units;
   units.reset();
   units.push(cl);

--- a/Saturation/SymElOutput.hpp
+++ b/Saturation/SymElOutput.hpp
@@ -63,7 +63,7 @@ private:
    * It is used so that we output symbol eliminating clauses
    * after they are simplified and shown to be non-redundant.
    */
-  DHMap<unsigned,Clause*> _symElRewrites;
+  DHMap<unsigned,Clause*, FnvHash, IdentityHash> _symElRewrites;
 
   /**
    * Contains record of colors that were aliminated in
@@ -71,7 +71,7 @@ private:
    *
    * Is reset in the call to the @b onAllProcessed method.
    */
-  DHMap<unsigned,Color> _symElColors;
+  DHMap<unsigned,Color, FnvHash, IdentityHash> _symElColors;
 
 
   SaturationAlgorithm* _sa;

--- a/Shell/AnswerLiteralManager.cpp
+++ b/Shell/AnswerLiteralManager.cpp
@@ -150,7 +150,7 @@ Unit* AnswerLiteralManager::tryAddingAnswerLiteral(Unit* unit)
   Formula* out = new NegatedFormula(new QuantifiedFormula(EXISTS, eVarSorts, new JunctionFormula(AND, conjArgs)));
 
   if (skolemise) {
-    Map<unsigned,std::string>* questionVars = Parse::TPTP::findQuestionVars(unit->number());
+    Map<unsigned,std::string, FnvHash>* questionVars = Parse::TPTP::findQuestionVars(unit->number());
 
     VSList* fVarSorts = subNot->vars();
     Substitution subst;
@@ -201,7 +201,7 @@ void AnswerLiteralManager::tryOutputAnswer(Clause* refutation, std::ostream& out
     return;
   }
 
-  DHSet<unsigned> seenSkolems;
+  DHSet<unsigned, FnvHash, IdentityHash> seenSkolems;
 
   out << "% SZS answers Tuple [";
 
@@ -235,7 +235,7 @@ void AnswerLiteralManager::tryOutputAnswer(Clause* refutation, std::ostream& out
       vss << "[";
       unsigned arity = aLit->arity();
 
-      Map<unsigned,std::string>* questionVars = 0;
+      Map<unsigned,std::string, FnvHash>* questionVars = 0;
       std::pair<Unit*,Literal*> unitAndLiteral;
       if (_originUnitsAndInjectedLiterals.find(aLit->functor(),unitAndLiteral)) {
         questionVars = Parse::TPTP::findQuestionVars(unitAndLiteral.first->number());
@@ -280,7 +280,7 @@ void AnswerLiteralManager::tryOutputAnswer(Clause* refutation, std::ostream& out
   out << "|_] for " << env.options->problemName() << endl;
 
   // recall what the skolems mean:
-  DHSet<unsigned>::Iterator it(seenSkolems);
+  DHSet<unsigned, FnvHash, IdentityHash>::Iterator it(seenSkolems);
   while (it.hasNext()) {
     unsigned f = it.next();
     const std::pair<unsigned,Unit*>& origin = _skolemsOrigin.get(f);
@@ -448,7 +448,7 @@ std::string PlainALManager::postprocessAnswerString(std::string answer)
 // SynthesisALManager
 //
 
-void SynthesisALManager::getNeededUnits(Clause* refutation, ClauseStack& premiseClauses, Stack<Unit*>& conjectures, DHSet<unsigned>& allProofUnitNums)
+void SynthesisALManager::getNeededUnits(Clause* refutation, ClauseStack& premiseClauses, Stack<Unit*>& conjectures, DHSet<unsigned, FnvHash, IdentityHash>& allProofUnitNums)
 {
   Stack<Unit*> toDo;
   toDo.push(refutation);
@@ -495,7 +495,7 @@ bool SynthesisALManager::tryGetAnswer(Clause* refutation, Stack<Clause*>& answer
 
   ClauseStack premiseClauses;
   Stack<Unit*> conjectures;
-  DHSet<unsigned> proofNums;
+  DHSet<unsigned, FnvHash, IdentityHash> proofNums;
   getNeededUnits(refutation, premiseClauses, conjectures, proofNums);
 
   // We iterate through the stored _answerPairs. An answer pair p is relevant if:
@@ -568,7 +568,7 @@ Clause* SynthesisALManager::recordAnswerAndReduce(Clause* cl) {
   // represents any answer.
   bool removeDefaultAnsLit = true;
   Literal* ansLit = cl->getAnswerLiteral();
-  Set<unsigned> vars;
+  Set<unsigned, FnvHash> vars;
   for (unsigned i = 0; i < ansLit->numTermArguments(); ++i) {
     TermList* tl = ansLit->nthArgument(i);
     if (!tl->isVar()) {
@@ -834,8 +834,8 @@ SynthesisALManager::ConjectureSkolemReplacement::Function::Function(unsigned rec
   // Process SkolemTrackers corresponding to this function:
   // populate the maps mapping skolems to terms they represent.
   DHMap<Term*, TermList, FnvHash, PtrIdentityHash>* caseMap;
-  const DHMap<unsigned, SkolemTracker>& mapping = replacement->_recursionMappings->get(recFunctor);
-  DHMap<unsigned, SkolemTracker>::Iterator it(mapping);
+  const DHMap<unsigned, SkolemTracker, FnvHash, IdentityHash>& mapping = replacement->_recursionMappings->get(recFunctor);
+  DHMap<unsigned, SkolemTracker, FnvHash, IdentityHash>::Iterator it(mapping);
   while (it.hasNext()) {
     unsigned var;
     SkolemTracker& st = it.nextRef(var);
@@ -857,7 +857,7 @@ void SynthesisALManager::ConjectureSkolemReplacement::Function::addCases(Term* t
 
 void SynthesisALManager::printSkolemTrackers() {
   cout << "Skolem mappings:" << endl;
-  DHMap<unsigned, SkolemTracker*>::Iterator it(_skolemTrackers);
+  DHMap<unsigned, SkolemTracker*, FnvHash, IdentityHash>::Iterator it(_skolemTrackers);
   while (it.hasNext()) {
     SkolemTracker* st = it.next();
     cout << st->toString() << endl;
@@ -872,7 +872,7 @@ void SynthesisALManager::printRecursionMappings() {
     unsigned recFn;
     auto& m = rit.nextRef(recFn);
     cout << "  recFn " << recFn << ":" << endl; 
-    DHMap<unsigned, SkolemTracker>::Iterator mit(m);
+    DHMap<unsigned, SkolemTracker, FnvHash, IdentityHash>::Iterator mit(m);
     while (mit.hasNext()) {
       SkolemTracker& s = mit.nextRef(v);
       cout << v << ": " << s.toString() << endl;
@@ -913,7 +913,7 @@ void SynthesisALManager::registerSkolemSymbols(Term* recTerm, const Substitution
   ALWAYS(_functionHeads.insert(recFnId, std::move(functionHeads)));
 
   // Finalize SkolemTrackers and store them.
-  DHMap<unsigned, SkolemTracker>* mapping;
+  DHMap<unsigned, SkolemTracker, FnvHash, IdentityHash>* mapping;
   ALWAYS(_recursionMappings.getValuePtr(recFnId, mapping));
   for (SkolemTracker& st : incompleteTrackers) {
     ASS_EQ(st.binding.second, nullptr);
@@ -960,7 +960,7 @@ bool SynthesisALManager::isPredicateComputable(unsigned functor) const {
     (!s->introduced() && !_annotatedUncomputable.contains(make_pair(functor, true)));
 }
 
-bool SynthesisALManager::computableOrVarHelper(const Term* t, DHMap<unsigned, unsigned>* recAncestors) const {
+bool SynthesisALManager::computableOrVarHelper(const Term* t, DHMap<unsigned, unsigned, FnvHash, IdentityHash>* recAncestors) const {
   ASS(t);
   unsigned f = t->functor();
   Signature::Symbol* symbol = env.signature->getFunction(f);
@@ -1013,7 +1013,7 @@ bool SynthesisALManager::computableOrVarHelper(const Term* t, DHMap<unsigned, un
 }
 
 bool SynthesisALManager::isComputableOrVar(const Term* t) const {
-  DHMap<unsigned, unsigned> recAncestors;
+  DHMap<unsigned, unsigned, FnvHash, IdentityHash> recAncestors;
   return computableOrVarHelper(t, &recAncestors);
 }
 

--- a/Shell/AnswerLiteralManager.hpp
+++ b/Shell/AnswerLiteralManager.hpp
@@ -114,11 +114,11 @@ private:
    * (which, in particular, has the variables for arguments
    * as they were in the conecture).
    */
-  DHMap<unsigned, std::pair<Unit*,Literal*>> _originUnitsAndInjectedLiterals;
+  DHMap<unsigned, std::pair<Unit*,Literal*>, FnvHash, IdentityHash> _originUnitsAndInjectedLiterals;
 
-  DHMap<unsigned, Clause*> _resolverClauses;
+  DHMap<unsigned, Clause*, FnvHash, IdentityHash> _resolverClauses;
 
-  DHMap<unsigned,std::pair<unsigned,Unit*>> _skolemsOrigin;
+  DHMap<unsigned,std::pair<unsigned,Unit*>, FnvHash, IdentityHash> _skolemsOrigin;
 };
 
 class PlainALManager : public AnswerLiteralManager
@@ -167,7 +167,7 @@ struct SkolemTracker { // used for tracking skolem terms in the structural induc
 class SynthesisALManager : public AnswerLiteralManager
 {
 private:
-  typedef DHMap<unsigned /*recFnId*/, DHMap<unsigned /*var*/, SkolemTracker>> RecursionMappings;
+  typedef DHMap<unsigned /*recFnId*/, DHMap<unsigned /*var*/, SkolemTracker, FnvHash, IdentityHash>, FnvHash, IdentityHash> RecursionMappings;
 public:
   bool tryGetAnswer(Clause* refutation, Stack<Clause*>& answer) override;
   void onNewClause(Clause* cl) override;
@@ -238,7 +238,7 @@ private:
       DArray<TermList> _cases;
       std::vector<Term*>* _caseHeads;
       // Mappings of skolems to terms they should be replaced with then construcing the functions for each case.
-      DHMap<unsigned, DHMap<Term*, TermList, FnvHash, PtrIdentityHash>> _skolemToTermListForCase;
+      DHMap<unsigned, DHMap<Term*, TermList, FnvHash, PtrIdentityHash>, FnvHash, IdentityHash> _skolemToTermListForCase;
       // A union of replacements for all cases (for convenience).
       DHMap<Term*, TermList, FnvHash, PtrIdentityHash> _skolemToTermList;
     };
@@ -246,11 +246,11 @@ private:
     void bindSkolemToTermList(Term* t, TermList&& tl);
     TermList transformTermList(TermList tl, TermList sort);
     void addCondPair(unsigned fn, unsigned pred) { _condFnToPred.insert(fn, pred); }
-    void associateRecMappings(RecursionMappings* m, DHMap<unsigned, std::vector<Term*>>* f) { _recursionMappings = m; _functionHeads = f;}
+    void associateRecMappings(RecursionMappings* m, DHMap<unsigned, std::vector<Term*>, FnvHash, IdentityHash>* f) { _recursionMappings = m; _functionHeads = f;}
     unsigned numInputSkolems() { return _numInputSkolems; }
     void outputRecursiveFunctions();
 
-    DHMap<unsigned, std::vector<Term*>>* _functionHeads;
+    DHMap<unsigned, std::vector<Term*>, FnvHash, IdentityHash>* _functionHeads;
     const RecursionMappings* _recursionMappings;
 
    protected:
@@ -261,9 +261,9 @@ private:
     // Mapping of input skolems to input variables.
     DHMap<Term*, TermList, FnvHash, PtrIdentityHash> _skolemToTermList;
     // Map from functions to predicates they represent in answer literal conditions
-    DHMap<unsigned, unsigned> _condFnToPred;
+    DHMap<unsigned, unsigned, FnvHash, IdentityHash> _condFnToPred;
     // Recursive functions indexed by their function symbol number.
-    DHMap<unsigned, Function*> _functions; 
+    DHMap<unsigned, Function*, FnvHash, IdentityHash> _functions; 
 
     // Term replacement based on a simple mapping with no additional logic.
     class SimpleSkolemReplacement : public TermTransformer {
@@ -286,9 +286,9 @@ private:
 
   };
 
-  bool computableOrVarHelper(const Term* t, DHMap<unsigned, unsigned>* recAncestors) const;
+  bool computableOrVarHelper(const Term* t, DHMap<unsigned, unsigned, FnvHash, IdentityHash>* recAncestors) const;
 
-  void getNeededUnits(Clause* refutation, ClauseStack& premiseClauses, Stack<Unit*>& conjectures, DHSet<unsigned>& allProofUnitNums);
+  void getNeededUnits(Clause* refutation, ClauseStack& premiseClauses, Stack<Unit*>& conjectures, DHSet<unsigned, FnvHash, IdentityHash>& allProofUnitNums);
 
   Formula* getConditionFromClause(Clause* cl);
 
@@ -316,9 +316,9 @@ private:
   // All SkolemTrackers created during the proof search indexed first by the rec-function symbol number and then by the variable number.
   RecursionMappings _recursionMappings;
   // All SkolemTrackers created during the proof search indexed by the skolem function symbol number.
-  DHMap<unsigned, SkolemTracker*> _skolemTrackers;
+  DHMap<unsigned, SkolemTracker*, FnvHash, IdentityHash> _skolemTrackers;
   // Function heads corresponding to all rec-symbols created in Induction, indexed by the rec-function symbol number.
-  DHMap<unsigned, std::vector<Term*>> _functionHeads;
+  DHMap<unsigned, std::vector<Term*>, FnvHash, IdentityHash> _functionHeads;
 
   // Sets of <functor, isPredicate> pairs representing symbols that are:
   // 1. Marked as uncomputable in the input file

--- a/Shell/BlockedClauseElimination.cpp
+++ b/Shell/BlockedClauseElimination.cpp
@@ -228,7 +228,7 @@ private:
 
 class RenanigApartNormalizer : public TermTransformer {
 public:
-  RenanigApartNormalizer(const Lib::DHMap<TermList, TermList>& replacements, int varMax, Lib::DHMap<unsigned, unsigned>& varMap)
+  RenanigApartNormalizer(const Lib::DHMap<TermList, TermList>& replacements, int varMax, Lib::DHMap<unsigned, unsigned, FnvHash, IdentityHash>& varMap)
     : _repls(replacements), _varMax(varMax), _varMap(varMap) {}
 protected:
   TermList transformSubterm(TermList trm) override {
@@ -249,7 +249,7 @@ protected:
 private:
   const Lib::DHMap<TermList, TermList>& _repls;
   int _varMax;
-  Lib::DHMap<unsigned, unsigned>& _varMap;
+  Lib::DHMap<unsigned, unsigned, FnvHash, IdentityHash>& _varMap;
 };
 
 
@@ -383,7 +383,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
     }
   }
 
-  static Lib::DHMap<unsigned, unsigned> varMap;
+  static Lib::DHMap<unsigned, unsigned, FnvHash, IdentityHash> varMap;
   varMap.reset();
   RenanigApartNormalizer pclNormalizer(replacements,varMax,varMap);
 

--- a/Shell/EqResWithDeletion.hpp
+++ b/Shell/EqResWithDeletion.hpp
@@ -45,7 +45,7 @@ private:
 
   /** The substitution induced by resolved inequalities
    * (It is reset with each clause). */
-  DHMap<unsigned, TermList, IdentityHash, DefaultHash> _subst;
+  DHMap<unsigned, TermList, IdentityHash, FnvHash> _subst;
   Literal* _ansLit = nullptr;
 };
 

--- a/Shell/EqualityProxy.hpp
+++ b/Shell/EqualityProxy.hpp
@@ -101,7 +101,7 @@ private:
    */
   DHMap<TermList, unsigned, SharedTermListHash, SharedTermListHash2> _proxyPredicates;
   /** equality proxy predicate sorts */
-  DHMap<unsigned, TermList> _proxyPredicateSorts;
+  DHMap<unsigned, TermList, FnvHash, IdentityHash> _proxyPredicateSorts;
   /** the definitions E_sigma(x,y) <=> x = y, indexed by the sort sigma */
   DHMap<TermList, Unit*, SharedTermListHash, SharedTermListHash2> _proxyPremises;
 };

--- a/Shell/FOOLElimination.hpp
+++ b/Shell/FOOLElimination.hpp
@@ -56,7 +56,7 @@ private:
   void addDefinition(FormulaUnit* unit);
 
   /** Lexical scope of the current unit */
-  DHMap<unsigned,TermList> _varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> _varSorts;
 
   /** Process a given part of the unit */
   FormulaList* process(FormulaList* fs);

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -488,7 +488,7 @@ void FunctionDefinition::assignArgOccursData(Def* updDef)
 	    "FunctionDefinition::Def::argOccurs"));
   std::memset(updDef->argOccurs, 0, updDef->lhs->arity() * sizeof(bool));
 
-  static DHMap<unsigned, unsigned, IdentityHash, DefaultHash> var2argIndex;
+  static DHMap<unsigned, unsigned, IdentityHash, FnvHash> var2argIndex;
   var2argIndex.reset();
   int argIndex=0;
   for (TermList* ts = updDef->lhs->args(); ts->isNonEmpty(); ts=ts->next()) {

--- a/Shell/FunctionDefinition.hpp
+++ b/Shell/FunctionDefinition.hpp
@@ -96,7 +96,7 @@ private:
 //   void apply (TermList& ls,UnitList& parents);
 //   void apply (Term& l,UnitList& parents);
 
-  typedef DHMap<int, Def*, IdentityHash, DefaultHash> Fn2DefMap;
+  typedef DHMap<int, Def*, IdentityHash, FnvHash> Fn2DefMap;
   Fn2DefMap _defs;
 
   /** stack where definitions are put when they're marked as blocked */

--- a/Shell/FunctionDefinitionHandler.cpp
+++ b/Shell/FunctionDefinitionHandler.cpp
@@ -261,7 +261,7 @@ bool RecursionTemplate::finalize()
   for (const auto& b : _branches) {
     // we need this sophisticated renaming due to
     // already fixed sort variables coming from _type
-    static DHMap<unsigned,unsigned> renaming;
+    static DHMap<unsigned,unsigned, FnvHash, IdentityHash> renaming;
     renaming.reset();
     auto renameTerm = [&](TermList t, TermList sort) {
       if (t.isVar()) {

--- a/Shell/GeneralSplitting.cpp
+++ b/Shell/GeneralSplitting.cpp
@@ -114,15 +114,15 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
     return false;
   }
 
-  Set<unsigned> vars;
+  Set<unsigned, FnvHash> vars;
   //only edges from lower to higher variable are included
   DHMultiset<pair<unsigned, unsigned> > connections;
-  DHMultiset<unsigned> degrees;
+  DHMultiset<unsigned, FnvHash, IdentityHash> degrees;
 
 
   for(unsigned i=0;i<clen;i++) {
     Literal* lit=(*cl)[i];
-    Set<unsigned> litVars;
+    Set<unsigned, FnvHash> litVars;
 
     VariableIterator vit(lit);
     while(vit.hasNext()) {
@@ -132,12 +132,12 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
     //TODO can move varCnt check to here!
 
     //we insert a complete graph containing variables from the literal
-    Set<unsigned>::Iterator sit(litVars);
+    Set<unsigned, FnvHash>::Iterator sit(litVars);
     while(sit.hasNext()) {
       unsigned v1=sit.next();
       vars.insert(v1);
 
-      Set<unsigned>::Iterator sit2=sit;
+      Set<unsigned, FnvHash>::Iterator sit2=sit;
       while(sit2.hasNext()) {
   unsigned v2=sit2.next();
   ASS_NEQ(v1,v2);
@@ -164,7 +164,7 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
 
   unsigned minDegVar = 0; // to silence a gcc warning (we overwrite the value below anyway, at least where it matters)
   unsigned minDeg=varCnt-1;
-  Set<unsigned>::Iterator vit(vars);
+  Set<unsigned, FnvHash>::Iterator vit(vars);
   while(vit.hasNext()) {
     unsigned var=vit.next();
     unsigned deg=degrees.multiplicity(var);
@@ -202,10 +202,10 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
   static TermStack argSorts;
   argSorts.reset();
 
-  DHMap<unsigned,TermList> varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
   SortHelper::collectVariableSorts(cl, varSorts);
 
-  DHMultiset<unsigned>::SetIterator nivit(degrees); //iterating just over non-isolated vars
+  DHMultiset<unsigned, FnvHash, IdentityHash>::SetIterator nivit(degrees); //iterating just over non-isolated vars
   while(nivit.hasNext()) {
     unsigned var=nivit.next();
     if(minDegVar==var) {

--- a/Shell/Interpolants.cpp
+++ b/Shell/Interpolants.cpp
@@ -395,7 +395,7 @@ namespace Shell
     void Interpolants::removeConjectureNodesFromRefutation(Unit* refutation)
     {
         Stack<Unit*> todo;
-        DHSet<unsigned> seen;
+        DHSet<unsigned, FnvHash, IdentityHash> seen;
 
         todo.push(refutation);
         while (todo.isNonEmpty()) {
@@ -431,7 +431,7 @@ namespace Shell
     Unit* Interpolants::formulifyRefutation(Unit* refutation)
     {
     Stack<Unit*> todo;
-    DHMap<unsigned,Unit*> translate; // for caching results (we deal with a DAG in general), but also to distinguish the first call from the next
+    DHMap<unsigned,Unit*, FnvHash, IdentityHash> translate; // for caching results (we deal with a DAG in general), but also to distinguish the first call from the next
 
     todo.push(refutation);
     while (todo.isNonEmpty()) {

--- a/Shell/Naming.cpp
+++ b/Shell/Naming.cpp
@@ -1083,7 +1083,7 @@ std::pair<Literal*, Signature::Symbol*> Naming::getDefinitionLiteral(Formula* f,
   static TermStack termVarSorts;
   static TermStack termVars;
   static TermStack typeVars;
-  static DHMap<unsigned, TermList> varSorts;
+  static DHMap<unsigned, TermList, FnvHash, IdentityHash> varSorts;
   termVarSorts.reset();
   termVars.reset();
   typeVars.reset();
@@ -1174,7 +1174,7 @@ Formula* Naming::introduceDefinition(Formula* f, bool iff) {
     def = new JunctionFormula(OR, fs);
   }
   if (VList::isNonEmpty(vs)) {
-    DHMap<unsigned, TermList> varSorts;
+    DHMap<unsigned, TermList, FnvHash, IdentityHash> varSorts;
     SortHelper::collectVariableSorts(def, varSorts);
     VSList::FIFO vsfifo;
     VList::Iterator vit(vs);

--- a/Shell/NewCNF.cpp
+++ b/Shell/NewCNF.cpp
@@ -749,13 +749,13 @@ void NewCNF::processLet(Term* term, Occurrences &occurrences)
 TermList NewCNF::nameLetBinding(Term* bindingLhs, TermList bindingRhs, TermList body, VSList* bindingBoundVars)
 {
   // Build a set of bound variable indices for fast membership checks
-  DHSet<unsigned> boundVarSet;
+  DHSet<unsigned, FnvHash, IdentityHash> boundVarSet;
   VSList::Iterator boundIt(bindingBoundVars);
   while (boundIt.hasNext()) {
     boundVarSet.insert(boundIt.next().first);
   }
 
-  DHSet<unsigned> bindingFreeVars;
+  DHSet<unsigned, FnvHash, IdentityHash> bindingFreeVars;
   for (const auto& var : iterTraits(FormulaVarIterator(bindingRhs))) {
     if (!boundVarSet.contains(var)) {
       bindingFreeVars.insert(var);

--- a/Shell/NewCNF.hpp
+++ b/Shell/NewCNF.hpp
@@ -533,7 +533,7 @@ private:
   DHMap<Formula*, Occurrences, FnvHash, PtrIdentityHash> _occurrences;
 
   /** map var --> sort */
-  DHMap<unsigned,TermList> _varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> _varSorts;
   bool _collectedVarSorts;
   unsigned _maxVar;
 

--- a/Shell/PartialRedundancyHandler.cpp
+++ b/Shell/PartialRedundancyHandler.cpp
@@ -192,7 +192,7 @@ private:
   template<class Applicator>
   TermStack getInstances(Applicator applicator) const
   {
-    DHMap<unsigned,TermList>::Iterator vit(_varSorts);
+    DHMap<unsigned,TermList, FnvHash, IdentityHash>::Iterator vit(_varSorts);
     TermStack res;
     while (vit.hasNext()) {
       auto v = vit.nextKey();
@@ -201,7 +201,7 @@ private:
     return res;
   }
 
-  DHMap<unsigned,TermList> _varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> _varSorts;
 
   PartialRedundancyEntry* createEntry(const TermStack& ts, Splitter* splitter, OrderingConstraints&& ordCons, LiteralSet&& lits, SplitSet* splits) const
   {
@@ -359,7 +359,7 @@ PartialRedundancyHandler::ConstraintIndex** PartialRedundancyHandler::getDataPtr
   return ptr;
 }
 
-DHMap<unsigned,typename PartialRedundancyHandler::ConstraintIndex*> PartialRedundancyHandler::clauseData;
+DHMap<unsigned,typename PartialRedundancyHandler::ConstraintIndex*, FnvHash, IdentityHash> PartialRedundancyHandler::clauseData;
 
 // PartialRedundancyHandlerImpl
 

--- a/Shell/PartialRedundancyHandler.hpp
+++ b/Shell/PartialRedundancyHandler.hpp
@@ -116,7 +116,7 @@ protected:
   static ConstraintIndex** getDataPtr(Clause* cl, bool doAllocate);
 
   // this contains the redundancy information associated with each clause
-  static DHMap<unsigned,ConstraintIndex*> clauseData;
+  static DHMap<unsigned,ConstraintIndex*, FnvHash, IdentityHash> clauseData;
 };
 
 template<bool enabled, bool orderingConstraints, bool avatarConstraints, bool literalConstraints>

--- a/Shell/PredicateDefinition.cpp
+++ b/Shell/PredicateDefinition.cpp
@@ -54,7 +54,7 @@ using namespace Kernel;
 struct PredicateDefinition::PredData
 {
   /** Units that contain the predicate. */
-  Map<unsigned, Unit*> containingUnits;
+  Map<unsigned, Unit*, FnvHash> containingUnits;
 
   bool builtIn;
   int pred;
@@ -263,7 +263,7 @@ void PredicateDefinition::replacePurePred(unsigned pred, ReplMap& replacements)
   if(_processedPrb) {
     _processedPrb->addTrivialPredicate(pred, pd.nocc==0);
   }
-  Map<unsigned, Unit*>::Iterator uit(pd.containingUnits);
+  Map<unsigned, Unit*, FnvHash>::Iterator uit(pd.containingUnits);
   while(uit.hasNext()) {
     Unit* u=uit.next().value();
     if(replacements.find(u->number())) {
@@ -349,7 +349,7 @@ void PredicateDefinition::removeUnusedDefinitionsAndPurePredicates(Problem& prb)
 
 void PredicateDefinition::removeUnusedDefinitionsAndPurePredicates(UnitList*& units)
 {
-  static DHMap<unsigned, Unit*> replacements;
+  static DHMap<unsigned, Unit*, FnvHash, IdentityHash> replacements;
   replacements.reset();
 
   collectReplacements(units, replacements);

--- a/Shell/PredicateDefinition.hpp
+++ b/Shell/PredicateDefinition.hpp
@@ -40,7 +40,7 @@ using namespace Kernel;
 class PredicateDefinition
 {
 public:
-  typedef DHMap<unsigned, Unit*> ReplMap;
+  typedef DHMap<unsigned, Unit*, FnvHash, IdentityHash> ReplMap;
 
   PredicateDefinition();
   ~PredicateDefinition();
@@ -83,8 +83,8 @@ private:
   unsigned _predCnt;
   PredData* _preds;
 
-  DHMap<unsigned, Def*> _defs;
-  DHMap<unsigned, bool> _purePreds;
+  DHMap<unsigned, Def*, FnvHash, IdentityHash> _defs;
+  DHMap<unsigned, bool, FnvHash, IdentityHash> _purePreds;
   Stack<int> _eliminable;
   Stack<int> _pureToReplace;
 };

--- a/Shell/PredicateElimination.cpp
+++ b/Shell/PredicateElimination.cpp
@@ -184,7 +184,7 @@ static void updateSide(bool add, DHMap<Clause *, unsigned, UnitHash, UnitNumberH
 template<bool add>
 void PredicateElimination::handleClause(Clause *cl)
 {
-  static DHMap<unsigned, std::pair<unsigned, unsigned>> occ; // pred -> (positive, negative) count
+  static DHMap<unsigned, std::pair<unsigned, unsigned>, FnvHash, IdentityHash> occ; // pred -> (positive, negative) count
   occ.reset();
 
   for (const auto& lit : *cl) {
@@ -682,7 +682,7 @@ Formula *PredicateElimination::definitionBody(unsigned pred, ClauseStack const &
     Formula *junct = JunctionFormula::generalJunction(fromPos ? AND : OR, inner);
 
     // existentially (resp. universally) close over the (shifted) clause variables
-    DHMap<unsigned, TermList> varSorts;
+    DHMap<unsigned, TermList, FnvHash, IdentityHash> varSorts;
     SortHelper::collectVariableSorts(junct, varSorts);
     VSList *vs = VSList::empty();
     for (const auto& [var, sort] : iterTraits(varSorts.items())) {

--- a/Shell/Preprocess.cpp
+++ b/Shell/Preprocess.cpp
@@ -214,7 +214,7 @@ void Preprocess::preprocess(Problem& prb)
     env.statistics->phase=ExecutionPhase::SINE_SELECTION;
 
     if (_options.sineToPredLevels() != Options::PredicateSineLevels::OFF) {
-      env.predicateSineLevels = new DHMap<unsigned,unsigned>();
+      env.predicateSineLevels = new DHMap<unsigned,unsigned, FnvHash, IdentityHash>();
     }
 
     // just to initialize ``env.clauseSineLevels'' or ``env.predicateSineLevels''

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -238,7 +238,7 @@ void Property::scan(Unit* unit)
     }
   }
 
-  DHSet<int>::Iterator it(_symbolsInFormula);
+  DHSet<int, FnvHash, IdentityHash>::Iterator it(_symbolsInFormula);
   while(it.hasNext()){
     int symbol = it.next();
     if(symbol >= 0){

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -298,7 +298,7 @@ public:
   /** Symbols in this formula, used during counting
       Functions are positive, predicates stored in the negative part
   **/
-  DHSet<int> _symbolsInFormula;
+  DHSet<int, FnvHash, IdentityHash> _symbolsInFormula;
 
   /** Bitwise OR of all properties of this problem */
   uint64_t _props;

--- a/Shell/Rectify.cpp
+++ b/Shell/Rectify.cpp
@@ -63,7 +63,7 @@ std::pair<Formula*,FormulaUnit*> Rectify::closeOverGivenVars(VList* vars, Formul
 {
   ASS(VList::isNonEmpty(vars))
 
-  DHMap<unsigned, TermList> varSorts;
+  DHMap<unsigned, TermList, FnvHash, IdentityHash> varSorts;
   SortHelper::collectVariableSorts(f, varSorts);
   VSList::FIFO vsfifo;
   VList::Iterator vit(vars);
@@ -185,7 +185,7 @@ Term* Rectify::rectifySpecialTerm(Term* t)
     ASS_EQ(t->arity(),0);
 #if VDEBUG
     { // removing duplicates from LambdaVars would change its type, so better assert it never happens
-      DHSet<unsigned> seenVars;
+      DHSet<unsigned, FnvHash, IdentityHash> seenVars;
       VSList::Iterator dbgIt(sd->getLambdaVars());
       while (dbgIt.hasNext()) {
         ASS(seenVars.insert(dbgIt.next().first));
@@ -525,7 +525,7 @@ VSList* Rectify::rectifyBoundVars(VSList* vs)
 
   VSList* res = VSList::empty();
 
-  DHSet<int> seen;
+  DHSet<int, FnvHash, IdentityHash> seen;
   while (args.isNonEmpty()) {
     vs = args.pop();
 

--- a/Shell/SMTCheck.cpp
+++ b/Shell/SMTCheck.cpp
@@ -37,7 +37,7 @@
 
 using namespace Kernel;
 using Indexing::Splitter;
-using SortMap = DHMap<unsigned, TermList>;
+using SortMap = DHMap<unsigned, TermList, FnvHash, IdentityHash>;
 
 // get first N parents of a unit
 template <unsigned N, typename T>

--- a/Shell/SineUtils.cpp
+++ b/Shell/SineUtils.cpp
@@ -58,7 +58,7 @@ SineSymbolExtractor::SymId SineSymbolExtractor::getSymIdBound()
          max(env.signature->functions()*3, env.signature->typeCons()*3));
 }
 
-void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId>& ids)
+void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId, FnvHash, IdentityHash>& ids)
 {
   if (!term->shared()) {
     if (term->isSpecial()) {
@@ -113,7 +113,7 @@ void SineSymbolExtractor::addSymIds(Term* term, DHSet<SymId>& ids)
  * @since 04/05/2013 Manchester, argument polarity removed
  * @author Andrei Voronkov
  */
-void SineSymbolExtractor::addSymIds(Literal* lit,DHSet<SymId>& ids)
+void SineSymbolExtractor::addSymIds(Literal* lit,DHSet<SymId, FnvHash, IdentityHash>& ids)
 {
   SymId predId=lit->functor()*3;
   ids.insert(predId);
@@ -165,7 +165,7 @@ bool SineSymbolExtractor::validSymId(SymId s)
  * @since 04/05/2013 Manchester, argument polarity removed, made non-recursive
  * @author Andrei Voronkov
  */
-void SineSymbolExtractor::extractFormulaSymbols(Formula* f,DHSet<SymId>& itms)
+void SineSymbolExtractor::extractFormulaSymbols(Formula* f,DHSet<SymId, FnvHash, IdentityHash>& itms)
 {
   Stack<Formula*> fs;
   fs.push(f);
@@ -220,7 +220,7 @@ void SineSymbolExtractor::extractFormulaSymbols(Formula* f,DHSet<SymId>& itms)
  */
 SineSymbolExtractor::SymIdIterator SineSymbolExtractor::extractSymIds(Unit* u)
 {
-  static DHSet<SymId> itms;
+  static DHSet<SymId, FnvHash, IdentityHash> itms;
   itms.reset();
 
   if (u->isClause()) {
@@ -235,7 +235,7 @@ SineSymbolExtractor::SymIdIterator SineSymbolExtractor::extractSymIds(Unit* u)
     extractFormulaSymbols(fu->formula(),itms);
   }
   Stack<SymId> ids(itms.size());
-  DHSet<SymId>::Iterator iter(itms);
+  DHSet<SymId, FnvHash, IdentityHash>::Iterator iter(itms);
   ids.loadFromIterator(iter);
   std::sort(ids.begin(), ids.end()); // <- make order deterministic
   return pvi(arrayIter(std::move(ids)));
@@ -378,7 +378,7 @@ bool SineSelector::perform(UnitList*& units)
 
   SymId symIdBound=_symExtr.getSymIdBound();
 
-  Set<unsigned> selected;
+  Set<unsigned, FnvHash> selected;
   Stack<Unit*> selectedStack; //on this stack there are Units in the order they were selected
   Deque<Unit*> newlySelected;
 
@@ -624,8 +624,8 @@ void SineTheorySelector::perform(UnitList*& units)
   }
 
   UnitList* res=0;
-  DHSet<SymId> addedSymIds;
-  DHSet<unsigned> selected;
+  DHSet<SymId, FnvHash, IdentityHash> addedSymIds;
+  DHSet<unsigned, FnvHash, IdentityHash> selected;
   Deque<Unit*> newlySelected;
 
   bool sineOnIncluded=_opt.sineSelection()==Options::SineSelection::INCLUDED;

--- a/Shell/SineUtils.hpp
+++ b/Shell/SineUtils.hpp
@@ -38,9 +38,9 @@ public:
   static void decodeSymId(SymId s, bool& pred, unsigned& functor);
   bool validSymId(SymId s);
 private:
-  void addSymIds(Term* term,DHSet<SymId>& ids);
-  void addSymIds(Literal* lit,DHSet<SymId>& ids);
-  void extractFormulaSymbols(Formula* f,DHSet<SymId>& itms);
+  void addSymIds(Term* term,DHSet<SymId, FnvHash, IdentityHash>& ids);
+  void addSymIds(Literal* lit,DHSet<SymId, FnvHash, IdentityHash>& ids);
+  void extractFormulaSymbols(Formula* f,DHSet<SymId, FnvHash, IdentityHash>& itms);
 };
 
 

--- a/Shell/Skolem.hpp
+++ b/Shell/Skolem.hpp
@@ -80,7 +80,7 @@ private:
     BoolList* occurs_below;
   };
   // from vars to their VarOccInfo
-  typedef DHMap<unsigned,VarOccInfo> VarOccInfos;
+  typedef DHMap<unsigned,VarOccInfo, FnvHash, IdentityHash> VarOccInfos;
   /* starts empty at the top level, and fininshes also empty 
      after bubbling up from the recursion;
      Only used temporarily during preskolemise! */
@@ -97,10 +97,10 @@ private:
   ExVarDepInfos _varDeps;
 
   // map from an existential variable to its quantified formula (= block of quantifiers)
-  DHMap<unsigned, Formula*> _blockLookup;
+  DHMap<unsigned, Formula*, FnvHash, IdentityHash> _blockLookup;
 
   /** map var --> sort */
-  DHMap<unsigned,TermList> _varSorts;
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> _varSorts;
 
   // for some heuristic evaluations after we are done
   

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -83,7 +83,7 @@ std::string TPTPPrinter::getBodyStr(Unit* u, bool includeSplitLevels)
 {
   std::ostringstream res;
 
-  typedef DHMap<unsigned,TermList> SortMap;
+  typedef DHMap<unsigned,TermList, FnvHash, IdentityHash> SortMap;
   static SortMap varSorts;
   varSorts.reset();
   SortHelper::collectVariableSorts(u, varSorts);

--- a/Shell/TweeGoalTransformation.cpp
+++ b/Shell/TweeGoalTransformation.cpp
@@ -79,7 +79,7 @@ class Definizator : public BottomUpTermTransformer {
     // a helper function to collect terms variables and their sorts
     // all stored in the above private fields to be looked up by transformSubterm
     void scanVars(Term* t) {
-      static DHSet<unsigned> varSeen;
+      static DHSet<unsigned, FnvHash, IdentityHash> varSeen;
       varSeen.reset();
       _typeArity = 0;
       _typeVars.reset();

--- a/Test/TestUtils.hpp
+++ b/Test/TestUtils.hpp
@@ -84,7 +84,7 @@ private:
   {
     class Inner {
       unsigned cnt = 0;
-      Map<unsigned, unsigned> _self;
+      Map<unsigned, unsigned, FnvHash> _self;
     public:
       unsigned get(unsigned var) 
       { return _self.getOrInit(std::move(var), [&](){ return cnt++; }); }

--- a/UnitTests/tDHMap.cpp
+++ b/UnitTests/tDHMap.cpp
@@ -11,7 +11,7 @@
 #include "Lib/DHMap.hpp"
 #include "Test/UnitTesting.hpp"
 
-typedef DHMap<unsigned, unsigned> MyMap;
+typedef DHMap<unsigned, unsigned, FnvHash, IdentityHash> MyMap;
 
 TEST_FUN(dhmap1)
 {

--- a/UnitTests/tDHMultiset.cpp
+++ b/UnitTests/tDHMultiset.cpp
@@ -32,7 +32,7 @@ public:
 };
 
 //typedef DHMultiset<int, ConstHash, IdHash> MySet;
-typedef DHMultiset<int> MySet;
+typedef DHMultiset<int, FnvHash, IdentityHash> MySet;
 
 TEST_FUN(dhmultiset1)
 {

--- a/UnitTests/tIndexManager.cpp
+++ b/UnitTests/tIndexManager.cpp
@@ -24,7 +24,7 @@ struct TestIndex : public Index
       ALWAYS(cls.remove(c->number()));
     }
   }
-  DHSet<unsigned> cls;
+  DHSet<unsigned, FnvHash, IdentityHash> cls;
 };
 
 GEN_INDEX_IMPL(TestIndex)

--- a/UnitTests/tKBO.cpp
+++ b/UnitTests/tKBO.cpp
@@ -26,8 +26,8 @@ using namespace Kernel;
 
 KBO kbo(unsigned introducedSymbolWeight, 
     unsigned variableWeight, 
-    const Map<unsigned, KboWeight>& funcs, 
-    const Map<unsigned, KboWeight>& preds) {
+    const Map<unsigned, KboWeight, FnvHash>& funcs, 
+    const Map<unsigned, KboWeight, FnvHash>& preds) {
  
   return KBO(toWeightMap<FuncSigTraits>(introducedSymbolWeight, { 
           ._variableWeight = variableWeight ,
@@ -50,7 +50,7 @@ KBO kbo(unsigned introducedSymbolWeight,
 }
 
 
-KBO kbo(const Map<unsigned, KboWeight>& funcs, const Map<unsigned, KboWeight>& preds) {
+KBO kbo(const Map<unsigned, KboWeight, FnvHash>& funcs, const Map<unsigned, KboWeight, FnvHash>& preds) {
   return kbo(1, 1, funcs, preds);
 }
 

--- a/UnitTests/tKBO.hpp
+++ b/UnitTests/tKBO.hpp
@@ -20,7 +20,7 @@
 using namespace Kernel;
 
 template<class SigTraits>
-inline KboWeightMap<SigTraits> toWeightMap(unsigned introducedSymbolWeight, KboSpecialWeights<SigTraits> ws, const Map<unsigned, KboWeight>& xs, unsigned sz) 
+inline KboWeightMap<SigTraits> toWeightMap(unsigned introducedSymbolWeight, KboSpecialWeights<SigTraits> ws, const Map<unsigned, KboWeight, FnvHash>& xs, unsigned sz) 
 {
   auto df = KboWeightMap<SigTraits>::dflt(/* qkbo */ false);
   df._specialWeights = ws;
@@ -37,18 +37,18 @@ inline KboWeightMap<SigTraits> toWeightMap(unsigned introducedSymbolWeight, KboS
   };
 }
 
-inline void __weights(Map<unsigned, KboWeight>& ws) {
+inline void __weights(Map<unsigned, KboWeight, FnvHash>& ws) {
 }
 
 template<class A, class... As>
-inline void __weights(Map<unsigned, KboWeight>& ws, std::pair<A, KboWeight> a, std::pair<As, KboWeight>... as) {
+inline void __weights(Map<unsigned, KboWeight, FnvHash>& ws, std::pair<A, KboWeight> a, std::pair<As, KboWeight>... as) {
   ws.insert(std::get<0>(a).functor(), std::get<1>(a));
   __weights(ws, as...);
 }
 
 template<class... As>
-inline Map<unsigned, KboWeight> weights(std::pair<As, KboWeight>... as) {
-  Map<unsigned, KboWeight> out;
+inline Map<unsigned, KboWeight, FnvHash> weights(std::pair<As, KboWeight>... as) {
+  Map<unsigned, KboWeight, FnvHash> out;
   __weights(out, as...);
   return out;
 }

--- a/UnitTests/tSet.cpp
+++ b/UnitTests/tSet.cpp
@@ -14,7 +14,7 @@
 
 TEST_FUN(find_remove_contains)
 {
-  Set<int> *test_set = new Set<int>();
+  Set<int, FnvHash> *test_set = new Set<int, FnvHash>();
   int test_num = 42;
   int found_num = 0;
   test_set->insert(test_num);
@@ -37,7 +37,7 @@ TEST_FUN(find_remove_contains)
 
 TEST_FUN(reset)
 {
-  Set<int> *test_set = new Set<int>();
+  Set<int, FnvHash> *test_set = new Set<int, FnvHash>();
   test_set->insert(42);
   ASS_EQ(test_set->size(), 1);
   test_set->reset();

--- a/UnitTests/tSkipList.cpp
+++ b/UnitTests/tSkipList.cpp
@@ -28,7 +28,7 @@ TEST_FUN(skiplist1)
   SkipList<StoredType, Int> sl1;
   SkipList<StoredType, Int> sl2;
   DArray<StoredType> darr(cnt);
-  DHMultiset<StoredType> ms;
+  DHMultiset<StoredType, FnvHash, IdentityHash> ms;
 
   for(int i=0;i<cnt;i++)
   {


### PR DESCRIPTION
Third PR of the series in #898, rebased onto master now that #904 has merged, so the diff here is this stage alone.

Every container keyed on an arithmetic or enumeration type now names its hash functors: FnvHash primary and IdentityHash secondary, or FnvHash alone where Map and Set have a single slot. As in #904 these are the functors DefaultHash and DefaultHash2 already delegate to, so the values are unchanged and the edit is a spelling change at the use site. 301 sites across 112 files. The keys are unsigned, int, pid_t, the enum Theory::Interpretation, and the typedefs SymId, SplitLevel, StoredType and VampireVar.

Thirteen of those sites already named IdentityHash as their primary and DefaultHash as their secondary, swapping the usual arrangement because variable numbers distribute well under identity. Their DefaultHash becomes the FnvHash it was resolving to, which puts FnvHash in the secondary slot, the reverse of every other site in this diff. They are in Kernel/Matcher.cpp, MLMatcher.hpp, MLVariant.cpp, Renaming.hpp and KBO.hpp, Indexing/SubstitutionTree.hpp, Saturation/Splitter.cpp, and Shell/FunctionDefinition.cpp, FunctionDefinition.hpp and EqResWithDeletion.hpp.

Forwards.hpp gains forward declarations of FnvHash and IdentityHash next to the existing ones for DefaultHash and DefaultHash2. Kernel/SortHelper.hpp and Kernel/InductionTemplate.hpp name these containers in declarations while including only Forwards.hpp, and including Lib/Hash.hpp there would pull Kernel/Unit.hpp in with it, which is why Forwards.hpp forward-declares hashes at all.

Master moved two of these sites since the branch was cut. EqualityProxyMono was merged into EqualityProxy, which turns its s_proxyPredicateSorts into the member _proxyPredicateSorts in Shell/EqualityProxy.hpp; that site is converted here and the two in the old files are gone. PredicateElimination's occ map changed value type upstream and carries the functors in its new form.

Three scalar-keyed sites stay on the defaults, all commented-out code: FMB/CliqueFinder.hpp:40 and :100, and Parse/TPTP.cpp:5167, the last of which is stale text naming a member that has since changed type. Three explicit DefaultHash uses also remain, all of them applying it to a type with a defaultHash() method: DerefPtrHash<DefaultHash> in Kernel/TermOrderingDiagram.cpp:496 and Saturation/Splitter.hpp:302, and the SATLiteral BiMap in SAT/Z3Interfacing.hpp:347. Those belong to stage 5.

SATSubsumption/subsat/SubstitutionTheory.hpp:367 now reads DHMap<VampireVar, VampireVarPos, Kernel::IdentityHash, Lib::IdentityHash>, the same functor in both slots, which Lib/Hash.hpp:380 advises against. DefaultHash2 was resolving to IdentityHash there already, so the pair was degenerate before this PR and fixing it would change the values. Worth a follow-up issue.

Tested: debug and release builds clean, ctest 99/99, checks/sanity on the release binary exits 0. The thirteen sites above swap DefaultHash for FnvHash in a secondary slot, and UnitTests/tHash.cpp already asserts that FnvHash::hash equals DefaultHash::hash for unsigned and for int, so that substitution is checked by the test suite rather than by sampling. Output was also compared against master byte for byte over 161 problems in 10 strategy configurations, each bounded by -al 1000 rather than by the clock: 1607 of 1610 jobs identical. Two of the other three are wall-clock noise that a control run of master against itself reproduces, and the third is a pre-existing crash on hol/hol1.p under -qa plain that both binaries hit in the same place, where the only difference left is the commit hash in the version banner.
