### PR TITLE
name the hash explicitly at string-, pair- and tuple-keyed containers

### DIFF
--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -263,9 +263,9 @@ private:
   /**
    * Map from signature symbols to the local constant numbers.
    */
-  DHMap<std::pair<unsigned,SignatureKind>,unsigned> _sigConsts;
+  DHMap<std::pair<unsigned,SignatureKind>,unsigned, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> _sigConsts;
 
-  typedef DHMap<CPair,unsigned> PairMap;
+  typedef DHMap<CPair,unsigned, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> PairMap;
   /** Names of constant pairs (modulo the congruence!)*/
   PairMap _pairNames;
 

--- a/FMB/FiniteModelBuilder.cpp
+++ b/FMB/FiniteModelBuilder.cpp
@@ -390,8 +390,8 @@ void FiniteModelBuilder::init()
 
   env.statistics->phase = ExecutionPhase::FMB_PREPROCESSING;
 
-  DHSet<std::pair<unsigned,unsigned>> vampire_sort_constraints_nonstrict;
-  DHSet<std::pair<unsigned,unsigned>> vampire_sort_constraints_strict;
+  DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> vampire_sort_constraints_nonstrict;
+  DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> vampire_sort_constraints_strict;
   if(env.options->fmbDetectSortBounds()){
     FunctionRelationshipInference inf;
     inf.findFunctionRelationships(
@@ -583,7 +583,7 @@ void FiniteModelBuilder::init()
     // now we have a mapping between vampire sorts and distinct sorts we can translate
     // the sort constraints, if any
     {
-      DHSet<std::pair<unsigned,unsigned>>::Iterator it(vampire_sort_constraints_nonstrict);
+      DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>::Iterator it(vampire_sort_constraints_nonstrict);
       while(it.hasNext()){
         std::pair<unsigned,unsigned> vconstraint = it.next();
         ASS(_sortedSignature->vampireToDistinctParent.find(vconstraint.first));
@@ -596,7 +596,7 @@ void FiniteModelBuilder::init()
       }
     }
     {
-      DHSet<std::pair<unsigned,unsigned>>::Iterator it(vampire_sort_constraints_strict);
+      DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>::Iterator it(vampire_sort_constraints_strict);
       while(it.hasNext()){
         std::pair<unsigned,unsigned> vconstraint = it.next();
         ASS(_sortedSignature->vampireToDistinctParent.find(vconstraint.first));

--- a/FMB/FiniteModelMultiSorted.hpp
+++ b/FMB/FiniteModelMultiSorted.hpp
@@ -119,7 +119,7 @@ private:
   bool evaluateOld(Formula* formula,unsigned depth=0);
 
   // the pairs of <constant number, sort>
-  DHMap<std::pair<unsigned,unsigned>,Term*> _domainConstants;
+  DHMap<std::pair<unsigned,unsigned>,Term*, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> _domainConstants;
   DHMap<Term*,std::pair<unsigned,unsigned>, FnvHash, PtrIdentityHash> _domainConstantsRev;
 public:
 

--- a/FMB/FunctionRelationshipInference.cpp
+++ b/FMB/FunctionRelationshipInference.cpp
@@ -46,8 +46,8 @@ using namespace std;
 using namespace Shell;
 
 void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator clauses,
-                 DHSet<std::pair<unsigned,unsigned>>& nonstrict_cons,
-                 DHSet<std::pair<unsigned,unsigned>>& strict_cons)
+                 DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>& nonstrict_cons,
+                 DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>& strict_cons)
 {
   bool print = env.options->showFMBsortInfo();
 
@@ -82,8 +82,8 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
 
   if(foundLabels.size()>0 && print){ cout << "Found constraints:" << endl; }
 
-  DHSet<std::pair<unsigned,unsigned>> nonstrict_constraints;
-  DHSet<std::pair<unsigned,unsigned>> strict_constraints;
+  DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> nonstrict_constraints;
+  DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> strict_constraints;
   Stack<unsigned>::Iterator it(foundLabels);
   while(it.hasNext()){
     unsigned l = it.next();
@@ -102,7 +102,7 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
   // Normalise constraints
   unsigned constraint_count = 0;
   {
-    DHSet<std::pair<unsigned,unsigned>>::Iterator it1(nonstrict_constraints);
+    DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>::Iterator it1(nonstrict_constraints);
     while(it1.hasNext()){ 
       constraint_count++;
       std::pair<unsigned,unsigned> con = it1.next();
@@ -120,7 +120,7 @@ void FunctionRelationshipInference::findFunctionRelationships(ClauseIterator cla
   }
   constraint_count = 0;
   {
-    DHSet<std::pair<unsigned,unsigned>>::Iterator it1(strict_constraints);
+    DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>::Iterator it1(strict_constraints);
     while(it1.hasNext()){
       constraint_count++;
       std::pair<unsigned,unsigned> con = it1.next();

--- a/FMB/FunctionRelationshipInference.hpp
+++ b/FMB/FunctionRelationshipInference.hpp
@@ -36,8 +36,8 @@ class FunctionRelationshipInference {
 public:
 
 void findFunctionRelationships(ClauseIterator clauses,
-                               DHSet<std::pair<unsigned,unsigned>>& nonstrict_cons,
-                               DHSet<std::pair<unsigned,unsigned>>& strict_cons);
+                               DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>& nonstrict_cons,
+                               DHSet<std::pair<unsigned,unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>& strict_cons);
 
 private:
 

--- a/Forwards.hpp
+++ b/Forwards.hpp
@@ -38,6 +38,7 @@ class DefaultHash;
 class DefaultHash2;
 struct FnvHash;
 struct IdentityHash;
+struct LengthHash;
 template <typename Key, typename Val,class Hash=DefaultHash> class Map;
 template<class A, class B, class HashA=DefaultHash, class HashB=DefaultHash> class BiMap;
 template <typename Key, typename Val, class Hash1=DefaultHash, class Hash2=DefaultHash2> class DHMap;

--- a/Indexing/AcyclicityIndex.hpp
+++ b/Indexing/AcyclicityIndex.hpp
@@ -70,7 +70,7 @@ private:
   struct CycleSearchTreeNode;
   struct CycleSearchIterator;
   typedef std::pair<Kernel::Literal*, Kernel::Clause*> ULit;
-  typedef Lib::DHMap<ULit, IndexEntry*> SIndex;
+  typedef Lib::DHMap<ULit, IndexEntry*, Lib::PairHash<Lib::FnvHash, Lib::UnitHash>, Lib::PairHash<Lib::PtrIdentityHash, Lib::UnitNumberHash>> SIndex;
 
   Lib::DHMap<TermList, SIndex*> _sIndexes;
   TermIndexingStructure* _tis;

--- a/Indexing/InductionFormulaIndex.hpp
+++ b/Indexing/InductionFormulaIndex.hpp
@@ -71,7 +71,7 @@ public:
 
   bool findOrInsert(const Inferences::InductionContext& context, Entry*& e, Literal* bound1 = nullptr, Literal* bound2 = nullptr);
 private:
-  DHMap<Key,Entry> _map;
+  DHMap<Key,Entry, PairHash<StackHash<StackHash<FnvHash>>,PairHash<FnvHash,FnvHash>>, PairHash<LengthHash,PairHash<PtrIdentityHash,PtrIdentityHash>>> _map;
 };
 
 }

--- a/Inferences/ALASCA/InequalityFactoring.cpp
+++ b/Inferences/ALASCA/InequalityFactoring.cpp
@@ -206,7 +206,7 @@ ClauseIterator InequalityFactoring::generateClauses(Clause* premise)
 #endif
         .template collect<Stack>());
 
-  auto selIdx = Lib::make_shared(Set<std::pair<unsigned, unsigned>>());
+  auto selIdx = Lib::make_shared(Set<std::pair<unsigned, unsigned>, PairHash<FnvHash,FnvHash>>());
   auto key = [&](auto& s) { return std::make_pair(s.litIdx, s.termIdx()); };
 
   DEBUG("selected summands:")

--- a/Kernel/OrderingUtils.hpp
+++ b/Kernel/OrderingUtils.hpp
@@ -253,7 +253,7 @@ namespace Kernel {
     template<class Cmp, class GetElem>
     static auto maxElems(unsigned nElems, Cmp cmp_, GetElem get, SelectionCriterion sel, bool dedup = false)
     {
-      auto cmpCache = Lib::make_shared(Map<std::pair<unsigned, unsigned>, Ordering::Result>());
+      auto cmpCache = Lib::make_shared(Map<std::pair<unsigned, unsigned>, Ordering::Result, PairHash<FnvHash,FnvHash>>());
 
       auto cmp = [=](unsigned l, unsigned r) {
         ASS_NEQ(l, r)

--- a/Kernel/PartialOrdering.cpp
+++ b/Kernel/PartialOrdering.cpp
@@ -171,7 +171,7 @@ const PartialOrdering* PartialOrdering::set(const PartialOrdering* po, size_t x,
     return po;
   }
 
-  static DHMap<std::tuple<const PartialOrdering*, size_t, size_t, PoComp>, const PartialOrdering*> cache;
+  static DHMap<std::tuple<const PartialOrdering*, size_t, size_t, PoComp>, const PartialOrdering*, TupleHash<FnvHash,FnvHash,FnvHash,FnvHash>, TupleHash<PtrIdentityHash,IdentityHash,IdentityHash,IdentityHash>> cache;
 
   const PartialOrdering** ptr;
   if (cache.getValuePtr(make_tuple(po, x, y, v), ptr, nullptr)) {

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -1009,7 +1009,7 @@ private:
   SymbolMap _predNames;
   SymbolMap _typeConNames;
   /** Map for the arity_check options: maps symbols to their arities */
-  Map<std::string, unsigned> _arityCheck;
+  Map<std::string, unsigned, FnvHash> _arityCheck;
   /** Last number used for fresh functions and predicates */
   int _nextFreshSymbolNumber;
 

--- a/Lib/Hash.hpp
+++ b/Lib/Hash.hpp
@@ -242,12 +242,21 @@ struct VectorHash {
   }
 };
 
-template<class InnerHash> 
-struct TupleHash 
+// combine the hashes of a tuple's elements, one functor per element
+template<class... ElementHashes>
+struct TupleHash
 {
   template<typename... T>
+  static bool equals(std::tuple<T...> const& o1, std::tuple<T...> const& o2)
+  { return o1 == o2; }
+
+  template<typename... T>
   static unsigned hash(std::tuple<T...> const& s)
-  { return std::apply([](auto... args) { return HashUtils::combine(InnerHash::hash(args)...); }, s); }
+  {
+    static_assert(sizeof...(ElementHashes) == sizeof...(T),
+      "TupleHash takes one hash functor per tuple element");
+    return std::apply([](T... args) { return HashUtils::combine(ElementHashes::hash(args)...); }, s);
+  }
 };
 
 // combine HashFst of the first and HashSnd of the second element of a pair
@@ -365,9 +374,10 @@ public:
 
 
 
+  // std::tuple combines default hashes of its elements
   template<typename... T>
-  static unsigned hash(std::tuple<T...> const& s) 
-  { return TupleHash<DefaultHash>::hash(s); }
+  static unsigned hash(std::tuple<T...> const& s)
+  { return std::apply([](T... args) { return HashUtils::combine(DefaultHash::hash(args)...); }, s); }
 
   template<typename T>
   static unsigned hash(Lib::Option<T> const& o) 
@@ -431,9 +441,10 @@ public:
   template<typename T, typename U>
   static unsigned hash(const std::pair<T, U> &pp)
   { return PairHash<DefaultHash2, DefaultHash2>::hash(pp); }
+  // std::tuple combines default secondary hashes of its elements
   template<typename... T>
-  static unsigned hash(std::tuple<T...> const& s) 
-  { return TupleHash<DefaultHash2>::hash(s); }
+  static unsigned hash(std::tuple<T...> const& s)
+  { return std::apply([](T... args) { return HashUtils::combine(DefaultHash2::hash(args)...); }, s); }
 
   template<typename T>
   static unsigned hash(Lib::Option<T> const& o) 

--- a/Lib/StringUtils.cpp
+++ b/Lib/StringUtils.cpp
@@ -180,7 +180,7 @@ bool StringUtils::readEquality(const char* str, char eqChar, std::string& lhs, s
 /**
  * If str doesn't contain equalities, false is returned and the content of pairs is undefined.
  */
-bool StringUtils::readEqualities(const char* str, char delimiter, char eqChar, DHMap<std::string,std::string>& pairs)
+bool StringUtils::readEqualities(const char* str, char delimiter, char eqChar, DHMap<std::string,std::string, FnvHash, LengthHash>& pairs)
 {
   static Stack<std::string> parts;
   parts.reset();

--- a/Lib/StringUtils.hpp
+++ b/Lib/StringUtils.hpp
@@ -40,7 +40,7 @@ public:
   static void splitStr(const char* str, char delimiter, Stack<std::string>& strings);
   static void dropEmpty(Stack<std::string>& strings);
   static bool readEquality(const char* str, char eqChar, std::string& lhs, std::string& rhs);
-  static bool readEqualities(const char* str, char delimiter, char eqChar, DHMap<std::string,std::string>& pairs);
+  static bool readEqualities(const char* str, char delimiter, char eqChar, DHMap<std::string,std::string, FnvHash, LengthHash>& pairs);
   template<class A>
   static A parse(std::string const& str)
   { return StringParser<A>{}(str); }

--- a/Parse/SMTLIB2.hpp
+++ b/Parse/SMTLIB2.hpp
@@ -118,7 +118,7 @@ private:
    * Maps smtlib name of a defined sort to its arity and its sort term.
    * The sort term is assumed to contain X1,...,Xn where n is the arity.
    */
-  DHMap<std::string,std::pair<unsigned,TermList>> _sortDefinitions;
+  DHMap<std::string,std::pair<unsigned,TermList>, FnvHash, LengthHash> _sortDefinitions;
 
   /**
    * Handle "define-sort" entry.
@@ -231,8 +231,8 @@ private:
   /** <vampire signature id, predicate> */
   typedef std::pair<unsigned,bool> DeclaredSymbol;
   /** symbols are implicitly declared also when they are defined (see below) */
-  DHMap<std::string, DeclaredSymbol> _declaredSymbols;
-  DHMap<std::string, unsigned> _declaredSorts;
+  DHMap<std::string, DeclaredSymbol, FnvHash, LengthHash> _declaredSymbols;
+  DHMap<std::string, unsigned, FnvHash, LengthHash> _declaredSorts;
 
   /**
    * Given a symbol name, range sort (which can be Bool) and argSorts,

--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -2559,7 +2559,7 @@ void TPTP::symbolDefinition()
  */
 void TPTP::tupleDefinition()
 {
-  Set<std::string> uniqueConstants;
+  Set<std::string, FnvHash> uniqueConstants;
   Stack<unsigned> symbols;
   TermStack sorts;
 

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -580,7 +580,7 @@ private:
   /** term lists */
   Stack<TermList> _termLists;
   /** name table for variable names */
-  Map<std::string, unsigned> _vars;
+  Map<std::string, unsigned, FnvHash> _vars;
   /** When parsing a question, make note of the inverse mapping to _vars, i.e. from the ints back to the vstrings, for better user reporting */
   Map<unsigned,std::string, FnvHash> _curQuestionVarNames;
   /** parsed types */
@@ -874,8 +874,8 @@ private:
   static DHMap<unsigned, Map<unsigned,std::string, FnvHash>, FnvHash, IdentityHash> _questionVariableNames;
 
   /** Stores the type arities of function symbols */
-  DHMap<std::string, unsigned> _typeArities;
-  DHMap<std::string, unsigned> _typeConstructorArities;
+  DHMap<std::string, unsigned, FnvHash, LengthHash> _typeArities;
+  DHMap<std::string, unsigned, FnvHash, LengthHash> _typeConstructorArities;
 
   bool _filterReserved;
 

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -110,10 +110,10 @@ namespace ProblemExport {
   struct ApiCalls {
     std::ofstream out;
     z3::context& _ctxt;
-    Map<std::string, std::string> _escapedNames; // <- maps string -> unique string that can be used as c++ variable
-    Map<std::string, Map<std::string, unsigned>> _escapePrefixes; // <- maps c++ variable prefix of _escapedNames -> strings that have been escaped to it
+    Map<std::string, std::string, FnvHash> _escapedNames; // <- maps string -> unique string that can be used as c++ variable
+    Map<std::string, Map<std::string, unsigned, FnvHash>, FnvHash> _escapePrefixes; // <- maps c++ variable prefix of _escapedNames -> strings that have been escaped to it
 
-    Set<std::string> _predeclaredConstants; // <- c++ variable names of been declared using declare_const
+    Set<std::string, FnvHash> _predeclaredConstants; // <- c++ variable names of been declared using declare_const
     ApiCalls(ApiCalls &&) = default;
     ApiCalls(std::ofstream out, z3::context& context) : out(std::move(out)), _ctxt(context) {}
 

--- a/Shell/AnswerLiteralManager.hpp
+++ b/Shell/AnswerLiteralManager.hpp
@@ -322,9 +322,9 @@ private:
 
   // Sets of <functor, isPredicate> pairs representing symbols that are:
   // 1. Marked as uncomputable in the input file
-  DHSet<std::pair<unsigned, bool>> _annotatedUncomputable;
+  DHSet<std::pair<unsigned, bool>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> _annotatedUncomputable;
   // 2. symbols introduced during proving, yet computable
-  DHSet<std::pair<unsigned, bool>> _introducedComputable;
+  DHSet<std::pair<unsigned, bool>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> _introducedComputable;
 };
 
 }

--- a/Shell/FunctionDefinition.cpp
+++ b/Shell/FunctionDefinition.cpp
@@ -546,8 +546,8 @@ void FunctionDefinition::assignArgOccursData(Def* updDef)
 
 
 typedef pair<unsigned,unsigned> BindingSpec;
-typedef DHMap<BindingSpec, TermList> BindingMap;
-typedef DHMap<BindingSpec, bool> UnfoldedSet;
+typedef DHMap<BindingSpec, TermList, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> BindingMap;
+typedef DHMap<BindingSpec, bool, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> UnfoldedSet;
 
 Term* FunctionDefinition::applyDefinitions(Literal* lit, Stack<Def*>* usedDefs)
 {

--- a/Shell/FunctionDefinitionHandler.cpp
+++ b/Shell/FunctionDefinitionHandler.cpp
@@ -150,7 +150,7 @@ void FunctionDefinitionHandler::initAndPreprocessLate(Problem& prb,const Options
     }
   }
 
-  DHMap<pair<unsigned,SymbolType>,RecursionTemplate>::DelIterator tIt(_templates);
+  DHMap<pair<unsigned,SymbolType>,RecursionTemplate, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>>::DelIterator tIt(_templates);
   while (tIt.hasNext()) {
     auto k = tIt.nextKey();
     auto ptr = _templates.findPtr(k);

--- a/Shell/FunctionDefinitionHandler.hpp
+++ b/Shell/FunctionDefinitionHandler.hpp
@@ -112,7 +112,7 @@ public:
 
 private:
   ScopedPtr<CodeTreeTIS</*higherOrder=*/false, TermLiteralClause>> _is;
-  DHMap<std::pair<unsigned, SymbolType>, RecursionTemplate> _templates;
+  DHMap<std::pair<unsigned, SymbolType>, RecursionTemplate, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash>> _templates;
 };
 
 /**

--- a/Shell/GeneralSplitting.cpp
+++ b/Shell/GeneralSplitting.cpp
@@ -116,7 +116,7 @@ bool GeneralSplitting::apply(Clause*& cl, UnitList*& resultStack)
 
   Set<unsigned, FnvHash> vars;
   //only edges from lower to higher variable are included
-  DHMultiset<pair<unsigned, unsigned> > connections;
+  DHMultiset<pair<unsigned, unsigned>, PairHash<FnvHash,FnvHash>, PairHash<IdentityHash,IdentityHash> > connections;
   DHMultiset<unsigned, FnvHash, IdentityHash> degrees;
 
 

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -3073,7 +3073,7 @@ bool Options::TimeLimitOptionValue::setValue(const std::string& value)
  * An optname starting with $ is not meant to be a real option, but a fake one.
  * Fakes get stored in the map fakes and can be referenced later, during the sampling process.
  */
-void Options::strategySamplingAssign(std::string optname, std::string value, DHMap<std::string,std::string>& fakes)
+void Options::strategySamplingAssign(std::string optname, std::string value, DHMap<std::string,std::string, FnvHash, LengthHash>& fakes)
 {
   // dollar sign signifies fake options
   if (optname[0] == '$') {
@@ -3099,7 +3099,7 @@ void Options::strategySamplingAssign(std::string optname, std::string value, DHM
  * An optname starting with $ is not meant to be a real option, but a fake one.
  * Fakes get read from the given map fakes.
  */
-std::string Options::strategySamplingLookup(std::string optname, DHMap<std::string,std::string>& fakes)
+std::string Options::strategySamplingLookup(std::string optname, DHMap<std::string,std::string, FnvHash, LengthHash>& fakes)
 {
   if (optname[0] == '$' || optname[0] == '@') {
     std::string* foundVal = fakes.findPtr(optname);
@@ -3118,7 +3118,7 @@ std::string Options::strategySamplingLookup(std::string optname, DHMap<std::stri
   return "";
 }
 
-void Options::sampleStrategy(const std::string& strategySamplerFilename, DHMap<std::string,std::string> fakes)
+void Options::sampleStrategy(const std::string& strategySamplerFilename, DHMap<std::string,std::string, FnvHash, LengthHash> fakes)
 {
   std::ifstream input(strategySamplerFilename.c_str());
 

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -130,7 +130,7 @@ public:
      * and if $nm is set to NZ, samples from a shifted geometric distribution with p=0.07 and a shift=2. (So 2 gets selected with a probability p,
      * 3 with a probability p(1-p), ... and 2+i with a probability p(1-p)^i).
      */
-    void sampleStrategy(const std::string& samplerFileName, DHMap<std::string,std::string> fakes = DHMap<std::string,std::string>());
+    void sampleStrategy(const std::string& samplerFileName, DHMap<std::string,std::string, FnvHash, LengthHash> fakes = DHMap<std::string,std::string, FnvHash, LengthHash>());
 
     /**
      * Return the problem name
@@ -755,8 +755,8 @@ public:
     // The details are explained in comments below
 private:
     // helper function of sampleStrategy
-    void strategySamplingAssign(std::string optname, std::string value, DHMap<std::string,std::string>& fakes);
-    std::string strategySamplingLookup(std::string optname, DHMap<std::string,std::string>& fakes);
+    void strategySamplingAssign(std::string optname, std::string value, DHMap<std::string,std::string, FnvHash, LengthHash>& fakes);
+    std::string strategySamplingLookup(std::string optname, DHMap<std::string,std::string, FnvHash, LengthHash>& fakes);
 
     /**
      * These store the names of the choices for an option.
@@ -2363,8 +2363,8 @@ private:
         }
 
     private:
-        DHMap<std::string,AbstractOptionValue*> _longMap;
-        DHMap<std::string,AbstractOptionValue*> _shortMap;
+        DHMap<std::string,AbstractOptionValue*, FnvHash, LengthHash> _longMap;
+        DHMap<std::string,AbstractOptionValue*, FnvHash, LengthHash> _shortMap;
     };
 
     LookupWrapper _lookup;

--- a/Shell/Property.cpp
+++ b/Shell/Property.cpp
@@ -1182,9 +1182,9 @@ std::string Property::toSpider(const std::string& problemName) const
  * as a dictionary of key-valey (string) pairs. In particular,
  * Options::sampleStrategy is eagerly waiting for this to be able to do property-conditioned sampling.
  */
-DHMap<std::string,std::string> Property::toDict() const
+DHMap<std::string,std::string, FnvHash, LengthHash> Property::toDict() const
 {
-  DHMap<std::string,std::string> result;
+  DHMap<std::string,std::string, FnvHash, LengthHash> result;
   result.set("@hasFormulas",Int::toString(hasFormulas()));
   result.set("@hasEquality",Int::toString(equalityAtoms()>0));
   result.set("@hasFOOL",Int::toString(hasFOOL()));

--- a/Shell/Property.hpp
+++ b/Shell/Property.hpp
@@ -157,7 +157,7 @@ public:
   std::string toString() const;
   std::string toSpider(const std::string& problemName) const;
 
-  DHMap<std::string,std::string> toDict() const;
+  DHMap<std::string,std::string, FnvHash, LengthHash> toDict() const;
 
   /** Total number of clauses in the problem. */
   int clauses() const { return _goalClauses + _axiomClauses; }

--- a/UnitTests/tHash.cpp
+++ b/UnitTests/tHash.cpp
@@ -8,10 +8,13 @@
  * and in the source directory
  */
 
+#include <cstdint>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "Lib/Hash.hpp"
+#include "Lib/Stack.hpp"
 #include "Test/UnitTesting.hpp"
 
 using namespace Lib;
@@ -26,6 +29,8 @@ TEST_FUN(fnvReferenceVectors)
 }
 
 enum TestColour { RED = 5, GREEN = 17 };
+
+enum class TestNarrowColour : std::uint8_t { BLUE = 3 };
 
 // the named functors compute exactly what DefaultHash/DefaultHash2 resolve to;
 // keeps hash values pinned while call sites move to the named functors
@@ -61,4 +66,31 @@ TEST_FUN(namedFunctorsMatchDefaultHash)
   using SecondaryPairHash = PairHash<IdentityHash, LengthHash>;
   ASS_EQ(PrimaryPairHash::hash(pr), DefaultHash::hash(pr));
   ASS_EQ(SecondaryPairHash::hash(pr), DefaultHash2::hash(pr));
+
+  // the elements of a tuple need not agree on a functor: here the pointer takes
+  // PtrIdentityHash, the unsigned IdentityHash and the string LengthHash
+  auto tp = std::make_tuple(p, u, s);
+  using PrimaryTupleHash = TupleHash<FnvHash, FnvHash, FnvHash>;
+  using SecondaryTupleHash = TupleHash<PtrIdentityHash, IdentityHash, LengthHash>;
+  ASS_EQ(PrimaryTupleHash::hash(tp), DefaultHash::hash(tp));
+  ASS_EQ(SecondaryTupleHash::hash(tp), DefaultHash2::hash(tp));
+
+  // the shape PartialOrdering caches on, which also pins how combine() nests
+  // for four elements
+  auto po = std::make_tuple(p, size_t(1), size_t(2), TestNarrowColour::BLUE);
+  using PrimaryPoHash = TupleHash<FnvHash, FnvHash, FnvHash, FnvHash>;
+  using SecondaryPoHash = TupleHash<PtrIdentityHash, IdentityHash, IdentityHash, IdentityHash>;
+  ASS_EQ(PrimaryPoHash::hash(po), DefaultHash::hash(po));
+  ASS_EQ(SecondaryPoHash::hash(po), DefaultHash2::hash(po));
+
+  // the nested shape InductionFormulaIndex keys on: DefaultHash walks the stacks
+  // element by element, DefaultHash2 takes the outer stack's length
+  Stack<Stack<int*>> outer;
+  outer.push(Stack<int*>());
+  outer.top().push(p);
+  auto nested = std::make_pair(outer, std::make_pair(p, p));
+  using PrimaryNestedHash = PairHash<StackHash<StackHash<FnvHash>>, PairHash<FnvHash, FnvHash>>;
+  using SecondaryNestedHash = PairHash<LengthHash, PairHash<PtrIdentityHash, PtrIdentityHash>>;
+  ASS_EQ(PrimaryNestedHash::hash(nested), DefaultHash::hash(nested));
+  ASS_EQ(SecondaryNestedHash::hash(nested), DefaultHash2::hash(nested));
 }


### PR DESCRIPTION
Stage 4 of #898. Containers keyed on std::string, std::pair or std::tuple now name their hash functors instead of relying on DefaultHash/DefaultHash2. std::string takes FnvHash/LengthHash; a pair takes PairHash<HA,HB> built from what each element resolves to on its own, so ULit (pair<Literal*,Clause*>) takes PairHash<FnvHash,UnitHash>/PairHash<PtrIdentityHash,UnitNumberHash>. Map and Set take the primary alone, which also supplies equals(). Every hash value is unchanged, since these are the functors DefaultHash already delegates to. 53 sites across 29 files.

Three pair keys are spelled as a typedef: BindingSpec is a pair<unsigned,unsigned>, and InductionFormulaIndex's Key is a pair<Stack<LiteralStack>,pair<Literal*,Literal*>>, where DefaultHash walks the stacks element by element and DefaultHash2 takes the outer length.

TupleHash takes one functor per element now and has an equals(). DefaultHash and DefaultHash2 were its only callers and wanted one functor throughout, so they expand the tuple themselves. That moves Kernel/PartialOrdering.cpp:174, whose std::tuple<const PartialOrdering*, size_t, size_t, PoComp> key had no secondary spelling before.

Forwards.hpp gains a declaration of LengthHash, since StringUtils.hpp includes only Forwards.hpp and Lib/Output.hpp.

The six pair and tuple keys left on the defaults all carry a TermList or a TermSpec, and move in stage 5 with those types.

tHash.cpp pins three shapes against both defaults: a mixed three-element tuple, PartialOrdering's four-element one, and Key's nested pair. Beyond that: ctest 99/99, checks/sanity clean on release, and a byte-identical output sweep against master at 1608 of 1608 comparable jobs, plus 483 of 483 each under -fgj on and -ind both -indmd 1, the configurations that reach the PartialOrdering and InductionFormulaIndex caches. The sweep runs a master-against-master control pass and only counts jobs it reproduces; the two it does not are wall-clock-limited and differ in both passes.
