### PR TITLE
always print real constants as `$to_real(D/N)`

### DIFF
--- a/Kernel/Signature.cpp
+++ b/Kernel/Signature.cpp
@@ -213,8 +213,7 @@ OperatorType* Signature::Symbol::predType() const
 }
 
 Signature::RealSymbol::RealSymbol(const RealConstantType& val)
-  : Symbol((env.options->proof() == Shell::Options::Proof::PROOFCHECK) ? Output::toString("$to_real(",val,")")
-                                                                       : Output::toString(val),
+  : Symbol(Output::toString("$to_real(",val,")"),
         /*             arity */ 0,
         /*       interpreted */ true,
         /*    preventQuoting */ false,


### PR DESCRIPTION
Fixes #891 - I think I was just overly cautious when fixing this for `Proof::PROOFCHECK`. New output is as follows:

```
tff(type_def_5, type, 'S1': $tType).
tff(type_def_6, type, 'S2': $tType).
tff(func_def_0, type, f1: 'S1').
tff(func_def_1, type, f2: 'S1').
tff(func_def_2, type, f3: ('S2' * $real) > $real).
tff(func_def_3, type, f4: 'S2').
tff(func_def_4, type, f5: $real).
tff(func_def_5, type, f6: $real).
tff(func_def_8, type, sLF0: $real).
tff(pred_def_2, type, ':=': !>[X0: $tType]:((X0 * X0) > $o)).
cnf(u22,axiom,
    $uminus($uminus(X0)) = X0).

cnf(u21,axiom,
    $less(X0,X1) | $less(X1,$sum(X0,$to_real(1/1)))).

cnf(u20,axiom,
    ~$less(X0,X1) | $less($sum(X0,X2),$sum(X1,X2))).

cnf(u19,axiom,
    $less(X0,X1) | $less(X1,X0) | X0 = X1).

cnf(u18,axiom,
    ~$less(X0,X1) | ~$less(X1,X2) | $less(X0,X2)).

cnf(u17,axiom,
    ~$less(X0,X0)).

cnf(u16,axiom,
    $to_real(0/1) = $sum(X0,$uminus(X0))).

cnf(u15,axiom,
    $uminus($sum(X0,X1)) = $sum($uminus(X1),$uminus(X0))).

cnf(u14,axiom,
    $sum(X0,$to_real(0/1)) = X0).

cnf(u13,axiom,
    $sum(X0,$sum(X1,X2)) = $sum($sum(X0,X1),X2)).

cnf(u12,axiom,
    $sum(X0,X1) = $sum(X1,X0)).

cnf(u30,hypothesis,
    f2 != f1).

cnf(u31,hypothesis,
    $to_real(0/1) = f3(f4,$sum(f5,$uminus(f6)))).

cnf(u32,hypothesis,
    $less($to_real(0/1),$sum(f5,$uminus(f6)))).

cnf(u33,hypothesis,
    $less($sum(f5,$uminus(f6)),f6)).

cnf(u34,hypothesis,
    $less($sum(f5,$uminus(f6)),f6)).

cnf(u36,hypothesis,
    $less($to_real(0/1),f3(f4,X0)) | ~$less(X0,f6) | ~$less($to_real(0/1),X0)).
```

which looks better to me, @konstantin-korovin ?

```
tff(pred_def_2, type, ':=': !>[X0: $tType]:((X0 * X0) > $o)).
```

looks weird to me but that's probably some other issue.