### PR TITLE
Propagate uncomputable annotation to constructed ITE conditions

### DIFF
--- a/Shell/AnswerLiteralManager.cpp
+++ b/Shell/AnswerLiteralManager.cpp
@@ -672,6 +672,8 @@ Term* SynthesisALManager::translateToSynthesisConditionTerm(Literal* l)
       }
       if (isPredicateComputable(l->functor())) {
         ALWAYS(_introducedComputable.insert(make_pair(fn, /*isPredicate=*/false)));
+      } else {
+        ALWAYS(_annotatedUncomputable.insert(make_pair(fn, /*isPredicate=*/false)));
       }
     }
     sym->setType(OperatorType::getFunctionType(arity, argSorts.begin(), AtomicSort::defaultSort()));


### PR DESCRIPTION
In synthesis, we sometimes construct an term representing a condition. If the predicate in the condition is uncomputable, so should be the newly constructed term.