### PR TITLE
fix newcnf crash on a Boolean let bound to another let

### DIFF
--- a/Shell/NewCNF.hpp
+++ b/Shell/NewCNF.hpp
@@ -468,6 +468,20 @@ private:
     SPGenClause gc = occ.gc;
     unsigned position = occ.position;
 
+    /**
+     * The formula being expanded can occupy more than one generalised literal
+     * of gc: Occurrences::replaceBy writes into generalised clauses directly
+     * and so bypasses pushLiteral, which normally keeps one formula from being
+     * stored twice. Two distinct subformulas replaced by the same formula are
+     * enough, as happens when a let-bound symbol occurring twice is inlined.
+     * The other generalised literals say the same thing as the one occ points
+     * at, so they are dropped instead of copied over. A copy would stay in the
+     * new clause unprocessed forever, because a formula is out of _occurrences
+     * while it is being processed, so registerGenClause registers nothing
+     * for it.
+     */
+    GenLit expanded = gc->_literals[position];
+
     unsigned size = gc->size() + List<GenLit>::length(gls) - 1;
     SPGenClause newGc = SPGenClause(new GenClause(size, gc->bindings, gc->foolBindings));
 
@@ -482,6 +496,11 @@ private:
         List<GenLit>::Iterator glit(gls);
         while (glit.hasNext()) {
           pushLiteral(newGc, glit.next());
+        }
+      } else if (formula(gl) == formula(expanded)) {
+        if (sign(gl) != sign(expanded)) {
+          // the clause holds both the formula and its negation
+          newGc->valid = false;
         }
       } else {
         pushLiteral(newGc, gl);
@@ -514,8 +533,14 @@ private:
     occ.gc->valid = false;
     _genClauses.erase(occ.gc->iter);
 
+    // the formula whose occurrence was popped can occupy further generalised
+    // literals of the clause (see introduceExtendedGenClause). Those are
+    // counted by `occurrences`, not by an entry of _occurrences: dequeue
+    // removed that when the formula was taken out for processing.
+    Formula* popped = formula(occ.gc->_literals[occ.position]);
+
     GenClause::Iterator glit = occ.gc->genLiterals();
-    while (glit.hasNext()) {
+    for (unsigned position = 0; glit.hasNext(); position++) {
       GenLit gl = glit.next();
       Formula* f = formula(gl);
 
@@ -524,6 +549,8 @@ private:
       Occurrences* fOccurrences = _occurrences.findPtr(f);
       if (fOccurrences) {
         fOccurrences->decrement();
+      } else if (f == popped && position != occ.position) {
+        occurrences.decrement();
       }
     }
 

--- a/checks/sanity
+++ b/checks/sanity
@@ -101,6 +101,12 @@ check_szs_status Theorem -ile off theory/let-bool-twice.p
 check_szs_status Theorem -newcnf on -ile off theory/let-bool-twice.p
 check_szs_status Unsatisfiable theory/let-bool-twice.smt2
 check_szs_status Unsatisfiable -newcnf on theory/let-bool-twice.smt2
+check_szs_status Unsatisfiable theory/let-nested-bool.p
+check_szs_status Unsatisfiable -newcnf on theory/let-nested-bool.p
+check_szs_status Unsatisfiable -ile off theory/let-nested-bool.p
+check_szs_status Unsatisfiable -newcnf on -ile off theory/let-nested-bool.p
+check_szs_status Satisfiable theory/let-nested-bool.smt2
+check_szs_status Satisfiable -newcnf on theory/let-nested-bool.smt2
 
 # Arrays
 check_szs_status Unsatisfiable theory/arrays.smt2

--- a/checks/theory/let-nested-bool.p
+++ b/checks/theory/let-nested-bool.p
@@ -1,0 +1,26 @@
+% A Boolean $let bound to another Boolean $let, with the bound symbol occurring
+% twice in the same disjunction. Inlining put the same formula into two
+% generalised literals of one generalised clause and NewCNF expanded only one
+% of them, so the other survived clausification as a non-literal and -newcnf on
+% crashed on it. The axiom clausifies to ~q | r and ~q | p, so together with q
+% and ~r the problem is unsatisfiable.
+tff(p,type,
+    p: $o ).
+
+tff(q,type,
+    q: $o ).
+
+tff(r,type,
+    r: $o ).
+
+tff(let_nested_bool,axiom,
+    $let(b: $o,
+      b := $let(c: $o, c := ( r & p ), c ),
+      ( ( q => b )
+      | b ) ) ).
+
+tff(q_holds,axiom,
+    q ).
+
+tff(r_fails,axiom,
+    ~ r ).

--- a/checks/theory/let-nested-bool.smt2
+++ b/checks/theory/let-nested-bool.smt2
@@ -1,0 +1,9 @@
+; The shape reported in #908, the same as let-nested-bool.p in SMT-LIB. The
+; assertion clausifies to ~q | r and ~q | p, so it is satisfiable on its own.
+; -newcnf on used to segfault while clausifying it.
+(set-logic ALL)
+(declare-fun p () Bool)
+(declare-fun q () Bool)
+(declare-fun r () Bool)
+(assert (let ((b (let ((c (and r p))) c))) (or (=> q b) b)))
+(check-sat)


### PR DESCRIPTION
NewCNF segfaults on a Boolean `$let` bound to another `$let` when the bound symbol occurs twice in one clause (#908).

Both occurrences are inlined separately and, with a nested binding, come out as the same formula, so it lands in two generalised literals of one generalised clause: `Occurrences::replaceBy` writes into the clauses directly and so bypasses `pushLiteral`. Only the one the popped occurrence points at was expanded, and the copy left behind sat in no `_occurrences` entry, so nothing ever expanded it and it reached `toClause` as a non-literal, where a release build reads a formula as a literal.

`introduceExtendedGenClause` now drops the other generalised literals holding the formula it expands, and discards the clause as a tautology when one of them has the opposite sign. `pop()` accounts for them. Checks added in `checks/theory/let-nested-bool.{p,smt2}`.

Closes #908.
