### PR TITLE
Propage FromInput to some exotic locations (to prevent assertion violations)

### DIFF
--- a/Shell/Interpolants.cpp
+++ b/Shell/Interpolants.cpp
@@ -421,7 +421,7 @@ namespace Shell
             ASS(!pars.hasNext()); // negating a conjecture should have exactly one parent
 
             cur->inference().destroy();
-            cur->inference() = Inference(NonspecificInference0(UnitInputType::NEGATED_CONJECTURE,InferenceRule::NEGATED_CONJECTURE)); // negated conjecture without a parent (non-standard, but nobody will see it)
+            cur->inference() = FromInput(UnitInputType::NEGATED_CONJECTURE); // negated conjecture without a parent (non-standard, but nobody will see it)
             }
 
             todo.loadFromIterator(cur->getParents());

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -411,7 +411,7 @@ void clausifyMode(Problem* problem, bool theory)
         Literal::create(p, /* polarity */ true , {}),
         Literal::create(p, /* polarity */ false, {})
       }, 
-      NonspecificInference0(UnitInputType::NEGATED_CONJECTURE,InferenceRule::INPUT));
+      FromInput(UnitInputType::NEGATED_CONJECTURE));
     std::cout << TPTPPrinter::toString(c) << "\n";
   }
 


### PR DESCRIPTION
UnitInputType::NEGATED_CONJECTURE inferences should newly go via FromInput