### PR TITLE
support the TPTP tcf dialect, on input and on output

### DIFF
--- a/Parse/TPTP.cpp
+++ b/Parse/TPTP.cpp
@@ -80,7 +80,7 @@ Unit* TPTP::parseFormulaFromString(const std::string& str)
   std::stringstream input(str+")."); // to fake endFOF, which creates the clause
   Parse::TPTP parser(input, "<string>");
   parser._lastInputType = UnitInputType::AXIOM;
-  parser._bools.push(true);     // true is what fof/tff normally pushes (but we start "from the middle")
+  parser._lastDialect = Dialect::FOF; // what fof/tff normally records (but we start "from the middle")
   parser._strings.push("dummy_name");
   parser._states.push(END_FOF);  // this is what does the clause building
   parser.parseImpl(FORMULA);
@@ -95,6 +95,7 @@ TPTP::TPTP(std::istream &in, std::filesystem::path path, UnitList::FIFO unitBuff
   : _containsConjecture(false),
     currentFile { &in, {}, path, 1 },
     _units(unitBuffer),
+    _lastDialect(Dialect::FOF),
     _isThf(false),
     _containsPolymorphism(false),
     _currentColor(COLOR_TRANSPARENT),
@@ -151,8 +152,13 @@ void TPTP::parseImpl(State initialState)
       break;
     case THF:
       _isThf = true;
+      tff(false);
+      break;
     case TFF:
-      tff();
+      tff(false);
+      break;
+    case TCF:
+      tff(true);
       break;
     case CNF:
       fof(false);
@@ -1222,7 +1228,7 @@ void TPTP::unitList()
     return;
   }
   if (tok.tag != T_NAME) {
-    PARSE_ERROR_TOK("cnf(), fof(), vampire() or include() expected",tok);
+    PARSE_ERROR_TOK("cnf(), fof(), tcf(), vampire() or include() expected",tok);
   }
   std::string name(tok.content);
   _states.push(UNIT_LIST);
@@ -1246,6 +1252,11 @@ void TPTP::unitList()
     resetToks();
     return;
   }
+  if (name == "tcf") {
+    _states.push(TCF);
+    resetToks();
+    return;
+  }
   if (name == "vampire") {
     _states.push(VAMPIRE);
     resetToks();
@@ -1256,7 +1267,7 @@ void TPTP::unitList()
     resetToks();
     return;
   }
-  PARSE_ERROR_TOK("cnf(), fof(), vampire() or include() expected",tok);
+  PARSE_ERROR_TOK("cnf(), fof(), tcf(), vampire() or include() expected",tok);
 }
 
 /**
@@ -1266,13 +1277,13 @@ void TPTP::unitList()
  *  <li>save the input type to _lastInputType</li>
  *  <li>add unit name to _strings</li>
  *  <li>add to _states END_FOF,FORMULA</li>
- *  <li>adds to _bools true, if fof and false, if cnf</li>
+ *  <li>records in _lastDialect whether this is fof or cnf</li>
  * </ol>
  * @since 10/04/2011 Manchester
  */
 void TPTP::fof(bool fo)
 {
-  _bools.push(fo);
+  _lastDialect = fo ? Dialect::FOF : Dialect::CNF;
   consumeToken(T_LPAR);
   // save the name of this unit
   Token& tok = getTok(0);
@@ -1338,18 +1349,20 @@ void TPTP::fof(bool fo)
 } // fof()
 
 /**
- * Process fof() or cnf() declaration. Does the following:
+ * Process tff(), thf() or tcf() declaration. Does the following:
  * <ol>
  *  <li>add 0 to _formulas</li>
  *  <li>save the input type to _lastInputType</li>
  *  <li>add unit name to _strings</li>
  *  <li>add to _states END_FOF,FORMULA</li>
- *  <li>adds to _bools true, if fof and false, if cnf</li>
+ *  <li>records in _lastDialect whether this is tcf (which must end up a clause) or not</li>
  * </ol>
+ * A tcf() unit is read exactly as a tff() one; that it really is a (universally closed)
+ * clause is only checked at the very end, in endFof().
  * @since 10/04/2011 Manchester
  * @author Andrei Voronkov
  */
-void TPTP::tff()
+void TPTP::tff(bool tcf)
 {
   consumeToken(T_LPAR);
   // save the name of this unit
@@ -1418,7 +1431,7 @@ void TPTP::tff()
     return;
   }
 
-  _bools.push(true); // to denote that it is an FOF formula
+  _lastDialect = tcf ? Dialect::TCF : Dialect::FOF;
   _isQuestion = false;
   if(_modelDefinition){
     _lastInputType = UnitInputType::MODEL_DEFINITION;
@@ -3651,27 +3664,39 @@ void TPTP::endFof()
   consumeToken(T_DOT);
 
   _vars.reset();
-  bool isFof = _bools.pop();
+  // fof/tff/thf formulas must be closed, cnf ones may have free variables;
+  // tcf is both closed and a clause
+  const bool mustBeClosed = _lastDialect != Dialect::CNF;
+  const bool mustBeClause = _lastDialect != Dialect::FOF;
   Formula* f = _formulas.pop();
   std::string nm = _strings.pop(); // unit name
   if (!currentFile.allowedNames.empty() && !currentFile.allowedNames.count(nm)) {
     return;
   }
 
+  if (mustBeClosed && freeVariables(f)) {
+    USER_ERROR("unquantified variable detected for a formula named '",nm,"'");
+  }
+
   Unit *unit, *original;
-  if (isFof) { // fof() or tff()
-    if (freeVariables(f)) {
-      USER_ERROR("unquantified variable detected for a formula named '",nm,"'");
-    }
+  if (!mustBeClause) { // fof() or tff()
     original = unit = new FormulaUnit(f,FromInput(_lastInputType));
     unit->setInheritedColor(_currentColor);
   }
-  else { // cnf()
-    // convert the input formula f to a clause
+  else { // cnf() or tcf()
+    Formula* body = f;
+    if (_lastDialect == Dialect::TCF) {
+      // a tcf clause comes wrapped in a universal prefix, which is there to carry
+      // the variable sorts; strict TCF allows exactly one, we tolerate a chain
+      while (body->connective() == FORALL) {
+        body = body->qarg();
+      }
+    }
+    // convert the input formula body to a clause
     Stack<Formula*> forms;
     Stack<Literal*> lits;
     Formula* g = nullptr;
-    forms.push(f);
+    forms.push(body);
     bool needsFlipDocumenting = false;
     while (! forms.isEmpty()) {
       g = forms.pop();
@@ -3737,7 +3762,9 @@ void TPTP::endFof()
 
   switch (_lastInputType) {
   case UnitInputType::CONJECTURE:
-    if(!isFof) USER_ERROR("conjecture is not allowed in cnf");
+    // negating a clause does not give a clause
+    if(mustBeClause) USER_ERROR("conjecture is not allowed in ",
+        _lastDialect == Dialect::CNF ? "cnf" : "tcf");
     {
       ASS_EQ(freeVariables(f),VList::empty())
       f = new NegatedFormula(f);
@@ -5041,6 +5068,8 @@ const char* TPTP::toString(State s)
     return "TFF";
   case THF:
     return "THF";
+  case TCF:
+    return "TCF";
   case TYPE:
     return "TYPE";
   case END_TFF:

--- a/Parse/TPTP.hpp
+++ b/Parse/TPTP.hpp
@@ -226,6 +226,8 @@ public:
     TFF,
     /** THF declaration */
     THF,
+    /** tcf declaration */
+    TCF,
     /** read type declaration */
     TYPE,
     /** after a top-level type declaration */
@@ -551,6 +553,10 @@ private:
   Stack<State> _states;
   /** input type of the last read unit */ // it must be int since -1 can be used as a value
   UnitInputType _lastInputType;
+  /** the top-level dialect the unit currently being read came from;
+   *  CNF and TCF units must end up being clauses, FOF and TCF units must be closed */
+  enum class Dialect { CNF, FOF, TCF };
+  Dialect _lastDialect;
   /** true if the last read unit is a question */
   bool _isQuestion = false;
   /** */
@@ -724,7 +730,7 @@ private:
   static Formula* makeJunction(Connective c,Formula* lhs,Formula* rhs);
   void unitList();
   void fof(bool fo);
-  void tff();
+  void tff(bool tcf);
   void vampire();
   void consumeToken(Tag);
   std::string name();

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -141,7 +141,7 @@ void Options::init()
     "  -casc, casc_sat, smtcomp - like portfolio mode, with competition-specific presets for other options, including output. "
     "If you wish to use e.g. the CASC portfolio without the presets, use --mode portfolio --schedule casc.\n"
     "  -preprocess,axiom_selection,clausify: modes for producing output\n      for other solvers.\n"
-    "  -tpreprocess,tclausify: output modes for theory input (clauses are quantified\n      with sort information).\n"
+    "  -tpreprocess,tclausify: output modes for theory input (clauses are quantified\n      with sort information; tclausify outputs TPTP tcf).\n"
     "  -output,profile: output information about the problem\n"
     "Some modes are not currently maintained (get in touch if interested):\n"
     "  -bpa: perform bound propagation\n"

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -477,7 +477,7 @@ std::string TPTPPrinter::universalPrefix(const Unit* unit)
   vars.sort([&varSorts](unsigned v1, unsigned v2) {
     bool t1 = varSorts.get(v1).isTerm() && varSorts.get(v1).term()->isSuper();
     bool t2 = varSorts.get(v2).isTerm() && varSorts.get(v2).term()->isSuper();
-    return t1 != t2 ? t1 : v1 < v2;
+    return (t1 != t2) ? t1 : (v1 < v2);
   });
 
   std::ostringstream res;

--- a/Shell/TPTPPrinter.cpp
+++ b/Shell/TPTPPrinter.cpp
@@ -17,6 +17,7 @@
 #include "Lib/DHMap.hpp"
 #include "Lib/Environment.hpp"
 #include "Lib/SharedSet.hpp"
+#include "Lib/Stack.hpp"
 
 #include "Kernel/Signature.hpp"
 #include "Kernel/Clause.hpp"
@@ -456,6 +457,42 @@ std::string TPTPPrinter::toString(const Formula* formula)
 }
 
 /**
+ * The universal prefix "![X0 : s,X1 : $i] : " binding, with their sorts, all the
+ * variables of @param unit; the empty std::string if there are none.
+ *
+ * Sorts are always spelled out (even the default $i), since making the sorts explicit
+ * is the whole point of the prefix. Type variables come first, as they must, and the
+ * remaining variables in the order of their numbers, so that the output is stable.
+ */
+std::string TPTPPrinter::universalPrefix(const Unit* unit)
+{
+  DHMap<unsigned,TermList, FnvHash, IdentityHash> varSorts;
+  SortHelper::collectVariableSorts(const_cast<Unit*>(unit), varSorts);
+  if (varSorts.isEmpty()) {
+    return "";
+  }
+
+  Stack<unsigned> vars;
+  vars.loadFromIterator(varSorts.domain());
+  vars.sort([&varSorts](unsigned v1, unsigned v2) {
+    bool t1 = varSorts.get(v1).isTerm() && varSorts.get(v1).term()->isSuper();
+    bool t2 = varSorts.get(v2).isTerm() && varSorts.get(v2).term()->isSuper();
+    return t1 != t2 ? t1 : v1 < v2;
+  });
+
+  std::ostringstream res;
+  res << "![";
+  for (unsigned i = 0; i < vars.size(); i++) {
+    if (i) {
+      res << ',';
+    }
+    res << 'X' << vars[i] << " : " << varSorts.get(vars[i]).toString();
+  }
+  res << "] : ";
+  return res.str();
+}
+
+/**
  * Output unit @param unit in TPTP format as a std::string
  *
  * If the unit is a formula of type @b CONJECTURE, output the
@@ -463,7 +500,7 @@ std::string TPTPPrinter::toString(const Formula* formula)
  * TPTP role conjecture. If it is a clause, just output it as
  * is, with the role negated_conjecture.
  */
-std::string TPTPPrinter::toString (const Unit* unit)
+std::string TPTPPrinter::toString (const Unit* unit, bool typedClauses)
 {
 //  const Inference* inf = unit->inference();
 //  Inference::Rule rule = inf->rule();
@@ -502,8 +539,13 @@ std::string TPTPPrinter::toString (const Unit* unit)
   }
 
   if (unit->isClause()) {
-    prefix = "cnf";
     main = static_cast<const Clause*>(unit)->toTPTPString();
+    if (typedClauses) {
+      prefix = "tcf";
+      main = universalPrefix(unit) + "( " + main + " )";
+    } else {
+      prefix = "cnf";
+    }
   }
   else {
     prefix = "tff";

--- a/Shell/TPTPPrinter.hpp
+++ b/Shell/TPTPPrinter.hpp
@@ -38,7 +38,10 @@ public:
   void printAsClaim(std::string name, Unit* u);
   void printWithRole(std::string name, std::string role, Unit* u, bool includeSplitLevels = true);
 
-  static std::string toString(const Unit*);
+  /** With @b typedClauses, a clause is printed as a tcf() unit, i.e. with an
+   *  explicit universal prefix spelling out the sort of each of its variables;
+   *  without it, as a cnf() unit. Formulas are printed as tff() either way. */
+  static std::string toString(const Unit*, bool typedClauses = false);
   static std::string toString(const Formula*);
   static std::string toString(const Term*);
   static std::string toString(const Literal*);
@@ -46,6 +49,8 @@ public:
 private:
 
   std::string getBodyStr(Unit* u, bool includeSplitLevels);
+
+  static std::string universalPrefix(const Unit* unit);
 
   void ensureHeadersPrinted(Unit* u);
   void outputSymbolTypeDefinitions(unsigned symNumber, SymbolType symType);

--- a/Shell/UIHelper.cpp
+++ b/Shell/UIHelper.cpp
@@ -600,13 +600,13 @@ void UIHelper::outputSatisfiableResult(std::ostream& out)
  * @author Andrei Voronkov
  * @since 03/07/2013 Manchester
  */
-void UIHelper::outputSymbolDeclarations(std::ostream& out)
+void UIHelper::outputSymbolDeclarations(std::ostream& out, bool tcf)
 {
   const Signature& sig = *env.signature;
 
   unsigned typeCons = sig.typeCons();
   for (unsigned i=0; i<typeCons; ++i) {
-    outputSymbolTypeDeclarationIfNeeded(out, false, true, i);
+    outputSymbolTypeDeclarationIfNeeded(out, false, true, i, tcf);
   }
   unsigned funcs = sig.functions();
   for (unsigned i=0; i<funcs; ++i) {
@@ -615,11 +615,11 @@ void UIHelper::outputSymbolDeclarations(std::ostream& out)
         continue;
       }
     }
-    outputSymbolTypeDeclarationIfNeeded(out, true, false, i);
+    outputSymbolTypeDeclarationIfNeeded(out, true, false, i, tcf);
   }
   unsigned preds = sig.predicates();
   for (unsigned i=0; i<preds; ++i) {
-    outputSymbolTypeDeclarationIfNeeded(out, false, false, i);
+    outputSymbolTypeDeclarationIfNeeded(out, false, false, i, tcf);
   }
 } // UIHelper::outputSymbolDeclarations
 
@@ -629,7 +629,7 @@ void UIHelper::outputSymbolDeclarations(std::ostream& out)
  * @author Andrei Voronkov
  * @since 03/07/2013 Manchester
  */
-void UIHelper::outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool function, bool typeCon, unsigned symNumber)
+void UIHelper::outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool function, bool typeCon, unsigned symNumber, bool tcf)
 {
   Signature::Symbol* sym;
 
@@ -689,7 +689,7 @@ void UIHelper::outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool funct
   if(!(function && env.signature->isAppFun(symNumber))){
     //match the fragment used for the proof steps (see
     //InferenceStore's getFofString), so one proof does not mix languages
-    out << (env.initiallyHigherOrder() ? "thf(" : "tff(")
+    out << (env.initiallyHigherOrder() ? "thf(" : (tcf ? "tcf(" : "tff("))
         << (function ? "func" : (typeCon ?  "type" : "pred"))
         << "_def_" << symNumber << ", type, "
         << symName << ": ";

--- a/Shell/UIHelper.hpp
+++ b/Shell/UIHelper.hpp
@@ -77,8 +77,10 @@ public:
   static void outputSaturatedSet(std::ostream& out, UnitIterator uit);
   static void outputInterferences(std::ostream& out, const Problem&);
 
-  static void outputSymbolDeclarations(std::ostream& out);
-  static void outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool function, bool typecon, unsigned symNumber);
+  /** With @b tcf, the declarations are wrapped in tcf() rather than tff(),
+   *  so that they can accompany tcf() clauses (see <tff_atom_typing> in the TCF grammar). */
+  static void outputSymbolDeclarations(std::ostream& out, bool tcf = false);
+  static void outputSymbolTypeDeclarationIfNeeded(std::ostream& out, bool function, bool typecon, unsigned symNumber, bool tcf = false);
 
   /**
    * A hacky global flag distinguishing the parent and the child in portfolio modes.

--- a/checks/parse/SYN000-3.out
+++ b/checks/parse/SYN000-3.out
@@ -1,0 +1,9 @@
+tcf(u4,axiom,
+    ![X0 : $i,X1 : $i,X2 : $i] : ( f(X1) = g(X0,f(X1),X2) | a != f(f(f(b))) | f(X1) = X0 )).
+
+tcf(role_hypothesis,hypothesis,
+    ( p(h) )).
+
+tcf(role_negated_conjecture,negated_conjecture,
+    ![X0 : $i] : ( ~p(X0) )).
+

--- a/checks/parse/SYN000-3.p
+++ b/checks/parse/SYN000-3.p
@@ -1,0 +1,81 @@
+%------------------------------------------------------------------------------
+% File     : SYN000-3 : TPTP v9.3.1. Bugfixed v9.3.0.
+% Domain   : Syntactic
+% Problem  : Typed TPTP CNF syntax
+% Version  : Biased.
+% English  : 
+
+% Refs     :
+% Source   : [TPTP]
+% Names    :
+
+% Status   : Satisfiable
+% Rating   : ? v9.3.0
+% Syntax   : Number of clauses     :    8 (   2 unt;   6 nHn;   0 RR)
+%            Number of literals    :   54 (   3 equ;   8 neg)
+%            Maximal clause size   :    5 (   6 avg)
+%            Maximal term depth    :    1 (   1 avg)
+%            Number of types       :    1 (   0 usr)
+%            Number of type conns  :    0 (   0   >;   0   *;   0   +;   0  <<)
+%            Number of predicates  :   21 (  18 usr;  12 prp; 0-3 aty)
+%            Number of functors    :    0 (   0 usr;   0 con; --- aty)
+%            Number of variables   :   11 (   0 sgn  11   !;   0   ?;  11   :)
+% SPC      : UNK
+
+% Comments :
+% Bugfixes : v9.3.0 - Removed surplus ()s around equalities
+%------------------------------------------------------------------------------
+%----Propositional
+tcf(propositional,axiom,
+    ( p0
+    | ~ q0
+    | r0
+    | ~ s0 ) ).
+
+%----First-order
+tcf(first_order_tcf,axiom,
+    ! [X: $i,Y: $i,Z: $i] :
+      ( p(X)
+      | ~ q(X,a)
+      | r(X,f(Y),g(X,f(Y),Z))
+      | ~ s(f(f(f(b)))) ) ).
+
+%----Equality
+tcf(equality,axiom,
+    ! [X: $i,Y: $i,Z: $i] :
+      ( f(Y) = g(X,f(Y),Z)
+      | f(f(f(b))) != a
+      | X = f(Y) ) ).
+
+%----True and false
+tcf(true_false,axiom,
+    ( $true
+    | $false ) ).
+
+%----Quoted symbols
+tcf(single_quoted,axiom,
+    ! [Y: $i] :
+      ( 'A proposition'
+      | 'A predicate'(Y)
+      | p('A constant')
+      | p('A function'(a))
+      | p('A \'quoted \\ escape\'') ) ).
+
+%----Connectives - seen them all already
+
+%----Annotated formula names
+tcf(123,axiom,
+    ! [X: $i,Y: $i,Z: $i] :
+      ( p(X)
+      | ~ q(X,a)
+      | r(X,f(Y),g(X,f(Y),Z))
+      | ~ s(f(f(f(b)))) ) ).
+
+%----Roles - seen axiom already
+tcf(role_hypothesis,hypothesis,
+    p(h) ).
+
+tcf(role_negated_conjecture,negated_conjecture,
+    ! [X: $i] : ~ p(X) ).
+
+%------------------------------------------------------------------------------

--- a/checks/parse/tcf.out
+++ b/checks/parse/tcf.out
@@ -1,0 +1,23 @@
+tcf(type_def_5, type, colour: $tType).
+tcf(func_def_0, type, red: colour).
+tcf(func_def_1, type, green: colour).
+tcf(func_def_2, type, blue: colour).
+tcf(pred_def_1, type, paint: ($i * colour) > $o).
+tcf(only_two_colours,axiom,
+    ![X0 : colour,X1 : colour,X2 : colour] : ( X0 = X1 | X0 = X2 | X1 = X2 )).
+
+tcf(red_is_not_green,axiom,
+    ( red != green )).
+
+tcf(red_is_not_blue,axiom,
+    ( red != blue )).
+
+tcf(green_is_not_blue,axiom,
+    ( green != blue )).
+
+tcf(everything_is_blue,axiom,
+    ![X0 : $i] : ( paint(X0,blue) )).
+
+tcf(nothing_is_red,axiom,
+    ![X0 : $i] : ( ~paint(X0,red) )).
+

--- a/checks/parse/tcf.p
+++ b/checks/parse/tcf.p
@@ -1,0 +1,43 @@
+%----A tcf() (typed clause form) problem: clauses carrying an explicit universal
+%----prefix that spells out the sort of each variable. Without it, the sort of the
+%----variables of "X = Y" below would be anybody's guess in this two-sorted setting.
+%----Type declarations may be given in tcf() as well (<tff_atom_typing> in the TCF
+%----grammar); our parser is equally happy with tff() ones.
+tcf(colour_type,type,
+    colour: $tType ).
+
+tcf(red_type,type,
+    red: colour ).
+
+tcf(green_type,type,
+    green: colour ).
+
+tcf(blue_type,type,
+    blue: colour ).
+
+tcf(paint_type,type,
+    paint: ( $i * colour ) > $o ).
+
+%----any three colours have two of them equal
+tcf(only_two_colours,axiom,
+    ! [X: colour,Y: colour,Z: colour] :
+      ( X = Y
+      | X = Z
+      | Y = Z ) ).
+
+%----but here are three that are not: a ground clause needs no prefix
+tcf(red_is_not_green,axiom,
+    red != green ).
+
+tcf(red_is_not_blue,axiom,
+    red != blue ).
+
+tcf(green_is_not_blue,axiom,
+    green != blue ).
+
+%----and some clauses over the default type, once with the type left implicit
+tcf(everything_is_blue,axiom,
+    ! [W] : paint(W,blue) ).
+
+tcf(nothing_is_red,axiom,
+    ! [W: $i] : ~ paint(W,red) ).

--- a/checks/sanity
+++ b/checks/sanity
@@ -133,6 +133,15 @@ check_szs_status Unsatisfiable -newcnf on parse/let-bind-variable.smt2
 check_szs_status Unsatisfiable -qa synthesis parse/assert-synth-max5.smt2
 check_szs_status Unsatisfiable parse/define-const.smt2
 
+# TPTP tcf (typed clause form), read and written. parse/SYN000-3.p is the TPTP
+# sample exercising every tcf construct; exact output, because what is under test
+# is that all of it parses and that --mode tclausify prints legal tcf.
+check_exact_output parse/SYN000-3.out --input_syntax tptp --statistics none --mode tclausify parse/SYN000-3.p
+# and the round trip: the printed clauses have to be re-readable, and mean the same
+check_szs_status Unsatisfiable --input_syntax tptp parse/tcf.p
+check_exact_output parse/tcf.out --input_syntax tptp --statistics none --mode tclausify parse/tcf.p
+check_szs_status Unsatisfiable --input_syntax tptp parse/tcf.out
+
 # Arithmetic
 check_szs_status Theorem -t 1d -s 32 -tgt ground -sas z3 -tha some -nm 6 Problems/ANA/ANA135_1.p
 check_szs_status Theorem -t 1d Problems/ARI/ARI045_1.p # alasca can't!

--- a/vampire.cpp
+++ b/vampire.cpp
@@ -379,7 +379,7 @@ void clausifyMode(Problem* problem, bool theory)
 
   //outputSymbolDeclarations deals with sorts as well for now
   //UIHelper::outputSortDeclarations(std::cout);
-  UIHelper::outputSymbolDeclarations(std::cout);
+  UIHelper::outputSymbolDeclarations(std::cout,/*tcf=*/theory);
 
   ClauseIterator cit = prb->clauseIterator();
   bool printed_conjecture = false;
@@ -390,20 +390,8 @@ void clausifyMode(Problem* problem, bool theory)
       continue;
     }
     printed_conjecture |= cl->inputType() == UnitInputType::CONJECTURE || cl->inputType() == UnitInputType::NEGATED_CONJECTURE;
-    if (theory) {
-      Formula* f = Formula::fromClause(cl);
-
-      // CONJECTURE as inputType is evil, as it cannot occur multiple times
-      if (cl->inference().inputType() == UnitInputType::CONJECTURE) {
-        cl->inference().setInputType(UnitInputType::NEGATED_CONJECTURE);
-      }
-
-      FormulaUnit* fu = new FormulaUnit(f,cl->inference()); // we are stealing cl's inference, which is not nice!
-      fu->overwriteNumber(cl->number()); // we are also making sure it's number is the same as that of the original (for Kostya from Russia to CASC, with love, and back again)
-      std::cout << TPTPPrinter::toString(fu) << "\n";
-    } else {
-      std::cout << TPTPPrinter::toString(cl) << "\n";
-    }
+    // with theory, we print tcf(), i.e. the clause quantified with its variables' sorts
+    std::cout << TPTPPrinter::toString(cl,theory) << "\n";
   }
   if(!printed_conjecture && UIHelper::haveConjecture()){
     unsigned p = env.signature->addFreshPredicate(0,"p");
@@ -412,7 +400,7 @@ void clausifyMode(Problem* problem, bool theory)
         Literal::create(p, /* polarity */ false, {})
       }, 
       FromInput(UnitInputType::NEGATED_CONJECTURE));
-    std::cout << TPTPPrinter::toString(c) << "\n";
+    std::cout << TPTPPrinter::toString(c,theory) << "\n";
   }
 
   //we have successfully output all clauses, so we'll terminate with zero return value


### PR DESCRIPTION
A tcf() unit is parsed exactly as a tff() one; only at the end, in endFof(), do we strip its universal prefix and check that what remains is a clause. Unlike cnf(), a tcf() formula must be closed, and a conjecture role is refused, since negating a clause does not give a clause. Type declarations inside tcf() come for free, and so does everything our parser is habitually more liberal about: chained quantifiers, mixed dialects in one file, polymorphic prefixes.

--mode tclausify now prints tcf() rather than a tff() formula faking one. This is what the mode always meant, and it lets clausifyMode drop the Formula::fromClause wrapper along with the overwriteNumber and CONJECTURE-rewriting hacks that went with it. Both TPTPPrinter::toString and UIHelper::outputSymbolDeclarations take the new flag with a default, so every other output mode is unchanged.

checks/parse/SYN000-3.p is the TPTP sample exercising every tcf construct; checks/parse/tcf.p adds a two-sorted problem in which "X = Y" needs the prefix to make sense, and its tclausify output is checked to be re-readable.