### PR TITLE
`-fsanitize=undefined` off by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,9 @@ if(GCC_OR_CLANG)
   # ...or RTTI
   add_compile_options(-fno-rtti)
 
-  if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  option(UBSAN "enable undefined-behaviour sanitizer for Debug builds" OFF)
+  if(CMAKE_BUILD_TYPE STREQUAL Debug AND UBSAN)
+    message(STATUS "UBSAN = 1")
     add_compile_options(-fsanitize=undefined)
     add_link_options(-fsanitize=undefined)
   endif()


### PR DESCRIPTION
I'm trying to improve compile times on my old desktop. I don't personally find that the undefined-behaviour sanitizer catches that many bugs for me, but it's nice to have it in case I'm debugging something.

Make it optional.