### PR TITLE
internal iteration for clause generation

### DIFF
--- a/Inferences/ALASCA/Coherence.hpp
+++ b/Inferences/ALASCA/Coherence.hpp
@@ -223,7 +223,7 @@ struct Coherence : public BinInf<CoherenceConf<NumTraits>> {
 
 
 template<class NumTraits>
-struct CoherenceNormalization : SimplifyingGeneratingInference {
+struct CoherenceNormalization : SimplifyingGeneratingInferenceEngine {
   const AlascaState& _shared;
   CoherenceNormalization(SaturationAlgorithm& salg) : _shared(salg.alascaState()) {}
 

--- a/Inferences/ALASCA/FloorBounds.hpp
+++ b/Inferences/ALASCA/FloorBounds.hpp
@@ -159,6 +159,8 @@ public:
           generateClauses<FourierMotzkin::Rhs>(premise)
     ));
   }
+
+  using GeneratingInferenceEngine::generateClauses; // https://isocpp.org/wiki/faq/strange-inheritance#hiding-rule
 };
 
 } // namespace ALASCA 

--- a/Inferences/ALASCA/InequalityFactoring.hpp
+++ b/Inferences/ALASCA/InequalityFactoring.hpp
@@ -54,6 +54,7 @@ public:
     );
 
   ClauseIterator generateClauses(Clause* premise) final;
+  using GeneratingInferenceEngine::generateClauses; // https://isocpp.org/wiki/faq/strange-inheritance#hiding-rule
 
 private:
 

--- a/Inferences/ALASCA/VIRAS.cpp
+++ b/Inferences/ALASCA/VIRAS.cpp
@@ -76,7 +76,7 @@ void traverseLiraVars(TermList self, F f) {
 
 
 template<class NumTraits>
-Option<SimplifyingGeneratingInference::ClauseGenerationResult> VirasQuantifierElimination::generateSimplify(NumTraits n, Clause* premise) {
+Option<SimplifyingGeneratingInferenceEngine::ClauseGenerationResult> VirasQuantifierElimination::generateSimplify(NumTraits n, Clause* premise) {
   DEBUG(0, *premise)
   auto viras = viras::viras(VampireVirasConfig<NumTraits>{});
   Recycled<DHSet<unsigned, FnvHash, IdentityHash>> shieldedVars;
@@ -146,14 +146,14 @@ Option<SimplifyingGeneratingInference::ClauseGenerationResult> VirasQuantifierEl
   }
 }
 
-Option<SimplifyingGeneratingInference::ClauseGenerationResult> VirasQuantifierElimination::generateSimplify(IntTraits n, Clause* premise) {
+Option<SimplifyingGeneratingInferenceEngine::ClauseGenerationResult> VirasQuantifierElimination::generateSimplify(IntTraits n, Clause* premise) {
   // TODO viras for integers ? (=  cooper)
   return {};
 }
 
 VirasQuantifierElimination::VirasQuantifierElimination(SaturationAlgorithm& salg) : _shared(salg.alascaState()) {}
 
-SimplifyingGeneratingInference::ClauseGenerationResult VirasQuantifierElimination::generateSimplify(Clause* premise) {
+SimplifyingGeneratingInferenceEngine::ClauseGenerationResult VirasQuantifierElimination::generateSimplify(Clause* premise) {
   return 
     forAnyNumTraits([&](auto n) { return generateSimplify(n, premise); })
     .unwrapOrElse([]() {

--- a/Inferences/ALASCA/VIRAS.hpp
+++ b/Inferences/ALASCA/VIRAS.hpp
@@ -29,7 +29,7 @@ using namespace Indexing;
 using namespace Saturation;
 
 class VirasQuantifierElimination
-: public SimplifyingGeneratingInference
+: public SimplifyingGeneratingInferenceEngine
 {
 public:
 
@@ -37,6 +37,7 @@ public:
   explicit VirasQuantifierElimination(SaturationAlgorithm& salg);
 
   ClauseGenerationResult generateSimplify(Clause* premise) final;
+  using SimplifyingGeneratingInferenceEngine::generateSimplify; // https://isocpp.org/wiki/faq/strange-inheritance#hiding-rule
 
 private:
   Option<ClauseGenerationResult> generateSimplify(IntTraits n, Clause* premise);

--- a/Inferences/ALASCA/VariableElimination.cpp
+++ b/Inferences/ALASCA/VariableElimination.cpp
@@ -107,7 +107,7 @@ Option<VariableElimination::AnyFoundVariable> VariableElimination::findUnshielde
   return out;
 }
 
-SimplifyingGeneratingInference::ClauseGenerationResult VariableElimination::generateSimplify(Clause* premise) 
+SimplifyingGeneratingInferenceEngine::ClauseGenerationResult VariableElimination::generateSimplify(Clause* premise) 
 {
   TIME_TRACE("alasca variable elimination generate")
   auto var = this->findUnshieldedVar(premise);

--- a/Inferences/ALASCA/VariableElimination.hpp
+++ b/Inferences/ALASCA/VariableElimination.hpp
@@ -29,7 +29,7 @@ using namespace Indexing;
 using namespace Saturation;
 
 class VariableElimination
-: public SimplifyingGeneratingInference
+: public SimplifyingGeneratingInferenceEngine
 {
 public:
   USE_ALLOCATOR(VariableElimination);

--- a/Inferences/ArithmeticSubtermGeneralization.cpp
+++ b/Inferences/ArithmeticSubtermGeneralization.cpp
@@ -75,7 +75,7 @@ static const auto iterVars = [](Clause* cl) {
 };
 
 template<class EvalFn>
-SimplifyingGeneratingInference1::Result generalizeBottomUp(Clause* cl, EvalFn eval) 
+SimplifyingGeneratingInferenceEngine1::Result generalizeBottomUp(Clause* cl, EvalFn eval) 
 {
   /* apply the selectedGen generalization */
   DEBUG_CODE(bool anyChange = false);
@@ -130,7 +130,7 @@ SimplifyingGeneratingInference1::Result generalizeBottomUp(Clause* cl, EvalFn ev
 
   ASS(anyChange)
   Inference inf(SimplifyingInference1(Kernel::InferenceRule::ARITHMETIC_SUBTERM_GENERALIZATION, cl));
-  return SimplifyingGeneratingInference1::Result{
+  return SimplifyingGeneratingInferenceEngine1::Result{
     .simplified = Clause::fromStack(stack, inf), 
     .premiseRedundant = (allLessEq && oneLess)
   };
@@ -139,7 +139,7 @@ SimplifyingGeneratingInference1::Result generalizeBottomUp(Clause* cl, EvalFn ev
 template<class Generalization>
 struct ArithmeticSubtermGeneralization
 {
-  static SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doCheckOrdering);
+  static SimplifyingGeneratingInferenceEngine1::Result simplify(Clause* cl, bool doCheckOrdering);
 };
 
 /** type to represent the top element in a lattice */
@@ -322,7 +322,7 @@ Stack<C> intersectSortedStack(Stack<C>&& l, Stack<C>&& r)
 #include "ArithmeticSubtermGeneralization/VariableMultiplicationGeneralizationImpl.hpp"
 #include "ArithmeticSubtermGeneralization/VariablePowerGeneralizationImpl.hpp"
 
-SimplifyingGeneratingInference1::Result AdditionGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result AdditionGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
 { 
   return AdditionGeneralizationImpl::applyRule(cl,doOrderingCheck);
 }
@@ -330,13 +330,13 @@ SimplifyingGeneratingInference1::Result AdditionGeneralization::simplify(Clause*
 AdditionGeneralization::~AdditionGeneralization()  {}
 
 
-SimplifyingGeneratingInference1::Result NumeralMultiplicationGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result NumeralMultiplicationGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
 { 
   return NumeralMultiplicationGeneralizationImpl::applyRule(cl, doOrderingCheck);
 }
 
 NumeralMultiplicationGeneralization::~NumeralMultiplicationGeneralization()  {}
-SimplifyingGeneratingInference1::Result VariableMultiplicationGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result VariableMultiplicationGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
 { 
   return VariableMultiplicationGeneralizationImpl::applyRule(cl, doOrderingCheck);
 }
@@ -344,16 +344,16 @@ SimplifyingGeneratingInference1::Result VariableMultiplicationGeneralization::si
 VariableMultiplicationGeneralization::~VariableMultiplicationGeneralization()  { }
 
 
-SimplifyingGeneratingInference1::Result VariablePowerGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result VariablePowerGeneralization::simplify(Clause* cl, bool doOrderingCheck) 
 { 
   return VariablePowerGeneralizationImpl::applyRule(cl, doOrderingCheck);
 }
 
 VariablePowerGeneralization::~VariablePowerGeneralization()  {}
 
-Stack<SimplifyingGeneratingInference1*> allArithmeticSubtermGeneralizations()
+Stack<SimplifyingGeneratingInferenceEngine1*> allArithmeticSubtermGeneralizations()
 { 
-  return Stack<SimplifyingGeneratingInference1*> {
+  return Stack<SimplifyingGeneratingInferenceEngine1*> {
       new VariableMultiplicationGeneralization(),
       new VariablePowerGeneralization(),
       new NumeralMultiplicationGeneralization(),

--- a/Inferences/ArithmeticSubtermGeneralization.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization.hpp
@@ -19,45 +19,45 @@
 namespace Inferences {
 
 class NumeralMultiplicationGeneralization
-: public SimplifyingGeneratingInference1
+: public SimplifyingGeneratingInferenceEngine1
 {
 public:
   ~NumeralMultiplicationGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 
 class VariableMultiplicationGeneralization
-: public SimplifyingGeneratingInference1
+: public SimplifyingGeneratingInferenceEngine1
 {
 public:
   ~VariableMultiplicationGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 
 class VariablePowerGeneralization
-: public SimplifyingGeneratingInference1
+: public SimplifyingGeneratingInferenceEngine1
 {
 public:
   ~VariablePowerGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
 
 class AdditionGeneralization
-: public SimplifyingGeneratingInference1
+: public SimplifyingGeneratingInferenceEngine1
 {
 public:
   ~AdditionGeneralization() override;
 
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 };
 
-Stack<SimplifyingGeneratingInference1*> allArithmeticSubtermGeneralizations();
+Stack<SimplifyingGeneratingInferenceEngine1*> allArithmeticSubtermGeneralizations();
 
 
 } // namespace Inferences

--- a/Inferences/ArithmeticSubtermGeneralization/AdditionGeneralizationImpl.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization/AdditionGeneralizationImpl.hpp
@@ -199,7 +199,7 @@ struct IsBot
 };
 
 /** applies the rule */ 
-SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result applyRule(Clause* cl, bool doOrderingCheck) 
 {
   DEBUG("input clause: ", *cl);
 
@@ -221,7 +221,7 @@ SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingChe
 
   if (selected.isNone()) {
     DEBUG("not applicable")
-    return SimplifyingGeneratingInference1::Result::nop(cl);
+    return SimplifyingGeneratingInferenceEngine1::Result::nop(cl);
   } else {
     auto& e = selected.unwrap();
     DEBUG("selected generalization: ", e.key(), " ", e.value());

--- a/Inferences/ArithmeticSubtermGeneralization/NumeralMultiplicationGeneralizationImpl.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization/NumeralMultiplicationGeneralizationImpl.hpp
@@ -63,7 +63,7 @@ struct Generalize
 const auto isOne = [](auto x) { return decltype(x)(1) == x; };
 
 /** applies the rule */ 
-SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result applyRule(Clause* cl, bool doOrderingCheck) 
 {
   DEBUG("input clause: ", *cl);
 
@@ -112,7 +112,7 @@ SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingChe
 
   if (selected.isNone()) {
     DEBUG("not applicable")
-    return SimplifyingGeneratingInference1::Result::nop(cl);
+    return SimplifyingGeneratingInferenceEngine1::Result::nop(cl);
   } else {
     auto& e = selected.unwrap();
     DEBUG("selected generalization: (", e.key(), ", ", e.value(), ")");

--- a/Inferences/ArithmeticSubtermGeneralization/VariableMultiplicationGeneralizationImpl.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization/VariableMultiplicationGeneralizationImpl.hpp
@@ -225,7 +225,7 @@ struct Generalize
 /** 
  * applies the rule
  */ 
-SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result applyRule(Clause* cl, bool doOrderingCheck) 
 {
   DEBUG("input clause: ", *cl);
   IntMap<Variable> varMap;
@@ -236,7 +236,7 @@ SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingChe
   }
   if (varMap.size() == 0) {
     DEBUG("no variables. generalization not applicable");
-    return SimplifyingGeneratingInference1::Result::nop(cl);
+    return SimplifyingGeneratingInferenceEngine1::Result::nop(cl);
   }
 
   IntUnionFind components(varMap.size());
@@ -280,7 +280,7 @@ SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingChe
   /* apply the substitution `X0 ⋅ X1 ⋅ ... ⋅ Xn ==> X0`  */
   DEBUG("removing variables: ", remove)
   if (remove.isEmpty()) {
-    return SimplifyingGeneratingInference1::Result::nop(cl);
+    return SimplifyingGeneratingInferenceEngine1::Result::nop(cl);
   } else {
     std::sort(remove.begin(), remove.end());
     Generalize gen { remove, doOrderingCheck };

--- a/Inferences/ArithmeticSubtermGeneralization/VariablePowerGeneralizationImpl.hpp
+++ b/Inferences/ArithmeticSubtermGeneralization/VariablePowerGeneralizationImpl.hpp
@@ -100,7 +100,7 @@ struct Generalize
 /** 
  * applies the rule
  */ 
-SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingCheck) 
+SimplifyingGeneratingInferenceEngine1::Result applyRule(Clause* cl, bool doOrderingCheck) 
 {
   DEBUG("input clause: ", *cl);
   PowerMap powers;
@@ -120,7 +120,7 @@ SimplifyingGeneratingInference1::Result applyRule(Clause* cl, bool doOrderingChe
   if (applicable) {
     return generalizeBottomUp(cl, EvaluateMonom<Generalize> { Generalize { powers, doOrderingCheck } });
   } else {
-    return SimplifyingGeneratingInference1::Result::nop(cl);
+    return SimplifyingGeneratingInferenceEngine1::Result::nop(cl);
   }
 }
 

--- a/Inferences/Factoring.cpp
+++ b/Inferences/Factoring.cpp
@@ -12,11 +12,7 @@
  * Implements class Factoring.
  */
 
-#include <utility>
-
 #include "Lib/Environment.hpp"
-#include "Lib/Metaiterators.hpp"
-#include "Lib/VirtualIterator.hpp"
 
 #include "Kernel/Clause.hpp"
 #include "Kernel/Inference.hpp"
@@ -28,94 +24,83 @@
 
 #include "Factoring.hpp"
 
+static RobSubstitution subst;
+
 namespace Inferences
 {
 
 /**
- * This functor given a pair of literal indices
+ * Given a pair of literal indices
  * removes the second literal from the clause specified in constructor,
  * applies the substitution, and returns resulting clause.
  * (Also it records this to statistics as factoring.)
  */
-class Factoring::ResultsFn
-{
-public:
-  ResultsFn(Clause* cl, bool afterCheck, LiteralSelector &sel, Ordering& ord)
-  : _cl(cl), _cLen(cl->length()), _afterCheck(afterCheck), _sel(sel), _ord(ord) {}
-  Clause* operator() (std::pair<unsigned,unsigned> nums)
-  {
-    Literal* l1 = (*_cl)[nums.first];
-    Literal* l2 = (*_cl)[nums.second];
+Clause *Factoring::attemptFactor(Clause *cl, unsigned i, unsigned j) {
+  Literal* l1 = (*cl)[i];
+  Literal* l2 = (*cl)[j];
 
-    //we assume there are no duplicate literals
-    ASS(l1!=l2);
+  //we assume there are no duplicate literals
+  ASS(l1!=l2);
 
-    if(l1->isEquality())
-      //We don't perform factoring with equalities
-      return nullptr;
+  if(l1->isEquality())
+    //We don't perform factoring with equalities
+    return nullptr;
 
-    // check polarity and functor matches
-    if(!Literal::headersMatch(l1, l2, false))
-      return nullptr;
+  // check polarity and functor matches
+  if(!Literal::headersMatch(l1, l2, false))
+    return nullptr;
 
-    if(_sel.isNegativeForSelection(l1)) {
-      //We don't perform factoring on negative literals
-      // (this check only becomes relevant, when there is more than one literal selected
-      // and yet the selected ones are not all positive -- see the check in generateClauses)
-      return nullptr;
-    }
-
-    subst.reset();
-    if(!subst.unify(TermList(l1), 0, TermList(l2), 0))
-      return nullptr;
-
-    RStack<Literal*> resLits;
-
-    Literal *skipped = l2;
-
-    Literal* skippedAfter = 0;
-    if (_afterCheck && _cl->numSelected() > 1) {
-      TIME_TRACE(TimeTrace::LITERAL_ORDER_AFTERCHECK);
-
-      skippedAfter = subst.apply(skipped, 0);
-    }
-
-    for(unsigned i=0;i<_cLen;i++) {
-      Literal* curr=(*_cl)[i];
-      if(curr!=skipped) {
-        Literal* currAfter = subst.apply(curr, 0);
-
-        if (skippedAfter) {
-          TIME_TRACE(TimeTrace::LITERAL_ORDER_AFTERCHECK);
-
-          if (i < _cl->numSelected() && _ord.compare(currAfter,skippedAfter) == Ordering::GREATER) {
-            env.statistics->inferencesBlockedDueToOrderingAftercheck++;
-            return nullptr;
-          }
-        }
-
-        resLits->push(currAfter);
-      }
-    }
-
-    Clause *cl = Clause::fromStack(*resLits, GeneratingInference1(InferenceRule::FACTORING,_cl));
-    if(env.options->proofExtra() == Options::ProofExtra::FULL)
-      env.proofExtra.insert(cl, new FactoringExtra(l1, l2));
-    return cl;
+  const auto &sel = _salg.getLiteralSelector();
+  if(sel.isNegativeForSelection(l1)) {
+    //We don't perform factoring on negative literals
+    // (this check only becomes relevant, when there is more than one literal selected
+    // and yet the selected ones are not all positive -- see the check in generateClauses)
+    return nullptr;
   }
-private:
-  static RobSubstitution subst;
-  Clause* _cl;
-  ///length of the premise clause
-  unsigned _cLen;
-  bool _afterCheck;
-  LiteralSelector& _sel;
-  Ordering& _ord;
-};
-RobSubstitution Factoring::ResultsFn::subst;
+
+  subst.reset();
+  if(!subst.unify(TermList(l1), 0, TermList(l2), 0))
+    return nullptr;
+
+  bool afterCheck = _salg.getOptions().literalMaximalityAftercheck() && _salg.getLiteralSelector().isBGComplete();
+  RStack<Literal*> resLits;
+
+  Literal *skipped = l2;
+
+  Literal* skippedAfter = nullptr;
+  if (afterCheck && cl->numSelected() > 1) {
+    TIME_TRACE(TimeTrace::LITERAL_ORDER_AFTERCHECK);
+
+    skippedAfter = subst.apply(skipped, 0);
+  }
+
+  const auto &ord = _salg.getOrdering();
+  for(unsigned i=0;i<cl->length();i++) {
+    Literal* curr=(*cl)[i];
+    if(curr!=skipped) {
+      Literal* currAfter = subst.apply(curr, 0);
+
+      if (skippedAfter) {
+        TIME_TRACE(TimeTrace::LITERAL_ORDER_AFTERCHECK);
+
+        if (i < cl->numSelected() && ord.compare(currAfter,skippedAfter) == Ordering::GREATER) {
+          env.statistics->inferencesBlockedDueToOrderingAftercheck++;
+          return nullptr;
+        }
+      }
+
+      resLits->push(currAfter);
+    }
+  }
+
+  Clause *genCl = Clause::fromStack(*resLits, GeneratingInference1(InferenceRule::FACTORING,cl));
+  if(env.options->proofExtra() == Options::ProofExtra::FULL)
+    env.proofExtra.insert(genCl, new FactoringExtra(l1, l2));
+  return genCl;
+}
 
 /**
- * Return ClauseIterator, that yields clauses generated from
+ * Produces clauses generated from
  * @b premise by the factoring inference rule.
  *
  * Nothing is generated, when the premise contains only one
@@ -130,24 +115,19 @@ RobSubstitution Factoring::ResultsFn::subst;
  * as when two literals are unifiable, one cannot be maximal and the
  * other non-maximal in the literal ordering.
  */
-ClauseIterator Factoring::generateClauses(Clause* premise)
+void Factoring::generateClauses(Clause *premise, ClauseReceiver receive)
 {
   if(premise->length()<=1) {
-    return ClauseIterator::getEmpty();
+    return;
   }
   if(premise->numSelected()==1 && _salg.getLiteralSelector().isNegativeForSelection((*premise)[0])) {
-    return ClauseIterator::getEmpty();
+    return;
   }
 
-  auto it1 = getCombinationIterator(0u,premise->numSelected(),premise->length());
-
-  auto it2 = getMappingIterator(it1,ResultsFn(premise,
-      _salg.getOptions().literalMaximalityAftercheck() && _salg.getLiteralSelector().isBGComplete(),
-      _salg.getLiteralSelector(), _salg.getOrdering()));
-
-  auto it3 = getFilteredIterator(it2, NonzeroFn());
-
-  return pvi( it3 );
+  for(unsigned i = 0; i < premise->numSelected(); i++)
+    for(unsigned j = i + 1; j < premise->length(); j++)
+      if(Clause *cl = attemptFactor(premise, i, j))
+        receive(cl);
 }
 
 }

--- a/Inferences/Factoring.hpp
+++ b/Inferences/Factoring.hpp
@@ -28,9 +28,11 @@ class Factoring
 {
 public:
   Factoring(SaturationAlgorithm& salg) : _salg(salg) {}
-  ClauseIterator generateClauses(Kernel::Clause* premise) override;
+  ClauseIterator generateClauses(Kernel::Clause *premise) override { NOT_IMPLEMENTED; }
+  void generateClauses(Kernel::Clause *premise, ClauseReceiver receive) override;
+
 private:
-  class ResultsFn;
+  Clause *attemptFactor(Kernel::Clause *premise, unsigned i, unsigned j);
   const SaturationAlgorithm& _salg;
 };
 

--- a/Inferences/GaussianVariableElimination.cpp
+++ b/Inferences/GaussianVariableElimination.cpp
@@ -19,7 +19,7 @@ namespace Inferences {
 
 using Balancer = Kernel::Rebalancing::Balancer<Kernel::Rebalancing::Inverters::NumberTheoryInverter>;
 
-SimplifyingGeneratingInference1::Result GaussianVariableElimination::simplify(Clause* in, bool doCheckOrdering) 
+SimplifyingGeneratingInferenceEngine1::Result GaussianVariableElimination::simplify(Clause* in, bool doCheckOrdering) 
 {
   ASS(in)
 
@@ -45,10 +45,10 @@ SimplifyingGeneratingInference1::Result GaussianVariableElimination::simplify(Cl
     }
   }
 
-  return SimplifyingGeneratingInference1::Result{in, false};
+  return SimplifyingGeneratingInferenceEngine1::Result{in, false};
 }
 
-SimplifyingGeneratingInference1::Result GaussianVariableElimination::rewrite(Clause& cl, TermList find, TermList replace, unsigned skipLiteral, bool doCheckOrdering) const 
+SimplifyingGeneratingInferenceEngine1::Result GaussianVariableElimination::rewrite(Clause& cl, TermList find, TermList replace, unsigned skipLiteral, bool doCheckOrdering) const 
 {
   Inference inf(SimplifyingInference1(Kernel::InferenceRule::GAUSSIAN_VARIABLE_ELIMINIATION, &cl));
 
@@ -74,7 +74,7 @@ SimplifyingGeneratingInference1::Result GaussianVariableElimination::rewrite(Cla
     }
   }
 
-  return SimplifyingGeneratingInference1::Result{Clause::fromStack(*resLits, inf), premiseRedundant};
+  return SimplifyingGeneratingInferenceEngine1::Result{Clause::fromStack(*resLits, inf), premiseRedundant};
 }
 
 } // namespace Inferences 

--- a/Inferences/GaussianVariableElimination.hpp
+++ b/Inferences/GaussianVariableElimination.hpp
@@ -13,12 +13,12 @@
 namespace Inferences {
 
 class GaussianVariableElimination 
-  : public SimplifyingGeneratingInference1 
+  : public SimplifyingGeneratingInferenceEngine1 
 {
 public:
-  SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause *cl, bool doCheckOrdering) override;
 private:
-  SimplifyingGeneratingInference1::Result rewrite(Clause &cl, TermList find, TermList replace,
+  SimplifyingGeneratingInferenceEngine1::Result rewrite(Clause &cl, TermList find, TermList replace,
                   unsigned skipLiteral, bool doOrderingCheck) const;
 
 };

--- a/Inferences/InferenceEngine.cpp
+++ b/Inferences/InferenceEngine.cpp
@@ -89,7 +89,12 @@ ClauseIterator CompositeGIE::generateClauses(Clause* premise)
 	  getMappingIterator(GIList::Iterator(_inners), GeneratingFunctor(premise))) );
 }
 
-void CompositeSGI::push(SimplifyingGeneratingInference* gen)
+void CompositeGIE::generateClauses(Clause* premise, ClauseReceiver receive) {
+  for(auto inner : iterTraits(GIList::Iterator(_inners)))
+    inner->generateClauses(premise, receive);
+}
+
+void CompositeSGI::push(SimplifyingGeneratingInferenceEngine* gen)
 { _simplifiers.push(gen); }
 
 void CompositeSGI::push(GeneratingInferenceEngine* gen)
@@ -99,7 +104,7 @@ CompositeSGI::ClauseGenerationResult CompositeSGI::generateSimplify(Kernel::Clau
 {
   auto redundant = false;
   Stack<ClauseIterator> clauses;
-  /* apply generations as until a redundancy is discovered */
+  /* apply generations until a redundancy is discovered */
   for (auto simpl : _simplifiers) {
     auto res = simpl->generateSimplify(cl);
     clauses.push(std::move(res.clauses));
@@ -118,6 +123,34 @@ CompositeSGI::ClauseGenerationResult CompositeSGI::generateSimplify(Kernel::Clau
     .clauses          = pvi(getFlattenedIterator(arrayIter(std::move(clauses)))),
     .premiseRedundant = redundant,
   };
+}
+
+bool CompositeSGI::generateSimplify(Kernel::Clause* cl, ClauseReceiver receive) {
+ // TODO could consider collecting into e.g. Stack<Clause *> instead
+ // this would enable using internal iteration here too
+  Stack<ClauseIterator> clauses;
+
+  /* apply generations until a redundancy is discovered */
+  for (auto simpl : _simplifiers) {
+    auto res = simpl->generateSimplify(cl);
+    if(res.premiseRedundant) {
+      for(Clause *cl : iterTraits(std::move(res.clauses)))
+        receive(cl);
+      return true;
+    }
+    clauses.push(std::move(res.clauses));
+  }
+
+  // `cl` not redundant, empty the deferred simplifications
+  while(!clauses.isEmpty())
+    for(Clause *cl : iterTraits(clauses.pop()))
+        receive(cl);
+
+  /* apply strictly generating rules if there hasn't been a redundancy */
+  for (auto gen : _generators)
+    gen->generateClauses(cl, receive);
+
+  return false;
 }
 
 CompositeSGI::~CompositeSGI() {
@@ -386,7 +419,7 @@ Clause* TrivialInequalitiesRemovalISE::simplify(Clause* c)
   return Clause::fromStack(*resLits, SimplifyingInference1(InferenceRule::TRIVIAL_INEQUALITY_REMOVAL,c));
 }
 
-Clause* SimplifyingGeneratingInference1::simplify(Clause* cl) 
+Clause* SimplifyingGeneratingInferenceEngine1::simplify(Clause* cl) 
 {
   if (cl->isTheoryAxiom()) {
     DEBUG("skipping theory axiom")
@@ -395,12 +428,12 @@ Clause* SimplifyingGeneratingInference1::simplify(Clause* cl)
   return this->simplify(cl, false).simplified;
 }
 
-ImmediateSimplificationEngine& SimplifyingGeneratingInference1::asISE() 
+ImmediateSimplificationEngine& SimplifyingGeneratingInferenceEngine1::asISE() 
 { return *this; }
 
 
 
-SimplifyingGeneratingInference::ClauseGenerationResult SimplifyingGeneratingInference1::generateSimplify(Clause* cl) {
+SimplifyingGeneratingInferenceEngine::ClauseGenerationResult SimplifyingGeneratingInferenceEngine1::generateSimplify(Clause* cl) {
   auto gen = this->simplify(cl, true);
   auto simpl = gen.simplified;
   auto redundant = gen.premiseRedundant;
@@ -421,7 +454,21 @@ SimplifyingGeneratingInference::ClauseGenerationResult SimplifyingGeneratingInfe
   }
 }
 
-SimplifyingGeneratingInference1::Result SimplifyingGeneratingLiteralSimplification::simplify(Clause* cl_, bool doOrderingCheck) {
+bool SimplifyingGeneratingInferenceEngine1::generateSimplify(Clause* cl, ClauseReceiver receive) {
+  auto gen = this->simplify(cl, true);
+  auto simpl = gen.simplified;
+  bool redundant = gen.premiseRedundant && !cl->isTheoryAxiom();
+
+  if (simpl == cl)
+    return false;
+
+  if (simpl)
+    receive(simpl);
+
+  return redundant;
+}
+
+SimplifyingGeneratingInferenceEngine1::Result SimplifyingGeneratingLiteralSimplification::simplify(Clause* cl_, bool doOrderingCheck) {
   DEBUG("in:  ", *cl_)
   auto& cl = *cl_;
   Stack<Literal*> out(cl.size());
@@ -445,7 +492,7 @@ SimplifyingGeneratingInference1::Result SimplifyingGeneratingLiteralSimplificati
         bool trivialValue = simpl.unwrapConstant();
         if (trivialValue) {
           /* clause is a tautology and can be deleted */
-          return SimplifyingGeneratingInference1::Result::tautology();
+          return SimplifyingGeneratingInferenceEngine1::Result::tautology();
         } else {
           /* do not add the literal to the output stack */
           changed = true;
@@ -482,11 +529,11 @@ SimplifyingGeneratingInference1::Result SimplifyingGeneratingLiteralSimplificati
 
 
   if (!changed) {
-    return SimplifyingGeneratingInference1::Result::nop(cl_);
+    return SimplifyingGeneratingInferenceEngine1::Result::nop(cl_);
   } else {
     auto result = Clause::fromStack(out, SimplifyingInference1(_rule, cl_));
     DEBUG("out: ", *result)
-    return SimplifyingGeneratingInference1::Result{
+    return SimplifyingGeneratingInferenceEngine1::Result{
             .simplified = result, 
             .premiseRedundant = allLessEq && oneLess,
           };

--- a/Inferences/InferenceEngine.hpp
+++ b/Inferences/InferenceEngine.hpp
@@ -34,7 +34,7 @@ using namespace Saturation;
 using namespace Shell;
 
 /** A generating inference that might make its major premise redundant. */
-class SimplifyingGeneratingInference
+class SimplifyingGeneratingInferenceEngine
 {
 public:
 
@@ -49,25 +49,42 @@ public:
     }
   };
 
-  virtual ~SimplifyingGeneratingInference() = default;
+  virtual ~SimplifyingGeneratingInferenceEngine() = default;
   /**
    * Applies this rule to the clause, and returns an iterator over the resulting clauses, 
    * as well as the information whether the premise was made redundant.
    */
   virtual ClauseGenerationResult generateSimplify(Clause* premise)  = 0;
+
+  using ClauseReceiver = std::function<void(Clause *)>;
+  virtual bool generateSimplify(Clause *premise, ClauseReceiver receive) {
+    auto result = generateSimplify(premise);
+    for(Clause *cl : iterTraits(std::move(result.clauses)))
+      receive(cl);
+    return result.premiseRedundant;
+  }
 };
 
 
 class GeneratingInferenceEngine
-: public SimplifyingGeneratingInference
+: public SimplifyingGeneratingInferenceEngine
 {
 
 public:
   virtual ClauseIterator generateClauses(Clause* premise) = 0;
+  virtual void generateClauses(Clause* premise, ClauseReceiver receive) {
+    for(Clause *cl : iterTraits(generateClauses(premise)))
+      receive(cl);
+  }
 
   ClauseGenerationResult generateSimplify(Clause* premise) override
-  { return { .clauses = generateClauses(premise), 
+  { return { .clauses = generateClauses(premise),
              .premiseRedundant = false, }; }
+
+  bool generateSimplify(Clause *premise, ClauseReceiver receive) override {
+    generateClauses(premise, receive);
+    return false;
+  }
 };
 
 class ImmediateSimplificationEngine
@@ -100,8 +117,8 @@ public:
  * Such an inference can be used as ImmediateSimplificationEngine, by calling asISE(). 
  * @warning When used as ISE non-redundant clauses might be deleted from the search space. Therefore completeness might be lost!
  */
-class SimplifyingGeneratingInference1
-: public SimplifyingGeneratingInference
+class SimplifyingGeneratingInferenceEngine1
+: public SimplifyingGeneratingInferenceEngine
 , ImmediateSimplificationEngine
 {
 public:
@@ -119,6 +136,7 @@ public:
   };
 
   ClauseGenerationResult generateSimplify(Clause* cl) override;
+  bool generateSimplify(Clause* cl, ClauseReceiver receive) override;
 
   /** 
    * Turns this SimplifyingGeneratingInference1 into and ImmediateSimplificationEngine. 
@@ -146,7 +164,7 @@ private:
  * A SimplifyingGeneratingInference1 that is applied literal by literal
  */
 class SimplifyingGeneratingLiteralSimplification
-: public SimplifyingGeneratingInference1
+: public SimplifyingGeneratingInferenceEngine1
 {
 
 public:
@@ -170,7 +188,7 @@ public:
 protected:
   SimplifyingGeneratingLiteralSimplification(InferenceRule rule, const Ordering& ordering);
   virtual Result simplifyLiteral(Literal* l) = 0;
-  SimplifyingGeneratingInference1::Result simplify(Clause* cl, bool doOrderingCheck) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause* cl, bool doOrderingCheck) override;
 
 private:
   const Ordering& _ordering;
@@ -295,6 +313,7 @@ public:
   ~CompositeGIE() override;
   void addFront(GeneratingInferenceEngine* fse);
   ClauseIterator generateClauses(Clause* premise) override;
+  void generateClauses(Clause* premise, ClauseReceiver receive) override;
 private:
   typedef List<GeneratingInferenceEngine*> GIList;
   GIList* _inners;
@@ -302,16 +321,17 @@ private:
 
 
 class CompositeSGI
-: public SimplifyingGeneratingInference
+: public SimplifyingGeneratingInferenceEngine
 {
 public:
   CompositeSGI() : _simplifiers(), _generators() {}
   ~CompositeSGI() override;
-  void push(SimplifyingGeneratingInference*);
+  void push(SimplifyingGeneratingInferenceEngine*);
   void push(GeneratingInferenceEngine*);
   ClauseGenerationResult generateSimplify(Clause* premise) override;
+  bool generateSimplify(Clause* premise, ClauseReceiver receive) override;
 private:
-  Stack<SimplifyingGeneratingInference*> _simplifiers;
+  Stack<SimplifyingGeneratingInferenceEngine*> _simplifiers;
   Stack<GeneratingInferenceEngine*> _generators;
 };
 

--- a/Inferences/LfpRule.hpp
+++ b/Inferences/LfpRule.hpp
@@ -43,16 +43,16 @@ public:
 
 template<class Rule>
 class LfpRule
-  : public SimplifyingGeneratingInference1
+  : public SimplifyingGeneratingInferenceEngine1
 {
   Rule _inner;
 public:
   LfpRule(SaturationAlgorithm& salg) {}
-  SimplifyingGeneratingInference1::Result simplify(Clause *cl, bool doCheckOrdering) override;
+  SimplifyingGeneratingInferenceEngine1::Result simplify(Clause *cl, bool doCheckOrdering) override;
 };
 
 template<class Rule> 
-SimplifyingGeneratingInference1::Result LfpRule<Rule>::simplify(Clause *cl, bool doCheckOrdering) 
+SimplifyingGeneratingInferenceEngine1::Result LfpRule<Rule>::simplify(Clause *cl, bool doCheckOrdering) 
 {
   auto splits = cl->splits();
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -876,7 +876,7 @@ unsigned getFreshVar(Clause& clause)
   return freshVar;
 }
 
-SimplifyingGeneratingInference::ClauseGenerationResult TheoryInstAndSimp::generateSimplify(Clause* premise)
+SimplifyingGeneratingInferenceEngine::ClauseGenerationResult TheoryInstAndSimp::generateSimplify(Clause* premise)
 {
   auto empty = ClauseGenerationResult {
     .clauses          = ClauseIterator::getEmpty(),

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -55,6 +55,7 @@ public:
   TheoryInstAndSimp(Splitter* splitter, Options::TheoryInstSimp mode, bool thiTautologyDeletion, bool showZ3, bool generalisation, std::string const& exportSmtlib, Options::ProblemExportSyntax problemExportSyntax);
 
   ClauseGenerationResult generateSimplify(Clause* premise) override;
+  using SimplifyingGeneratingInferenceEngine::generateSimplify;
 
   /**
    * Assuming cl is only built from theory material, this will use an SMT solver

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -44,7 +44,7 @@ private:
 
 
 class TheoryInstAndSimp
-: public SimplifyingGeneratingInference
+: public SimplifyingGeneratingInferenceEngine
 {
 public:
   using SortId = SAT::Z3Interfacing::SortId;

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1149,11 +1149,8 @@ void SaturationAlgorithm::activate(Clause* cl)
 
   _partialRedundancyHandler->checkEquations(cl);
 
-  auto generated = TIME_TRACE_EXPR(TimeTrace::CLAUSE_GENERATION, _generator->generateSimplify(cl));
-  auto toAdd = TIME_TRACE_ITER(TimeTrace::CLAUSE_GENERATION, std::move(generated.clauses));
-
-  while (toAdd.hasNext()) {
-    Clause *genCl = toAdd.next();
+  // TODO time tracing
+  bool premiseRedundant = _generator->generateSimplify(cl, [this](Clause *genCl) {
     addNewClause(genCl);
 
     Inference::Iterator iit = genCl->inference().iterator();
@@ -1167,7 +1164,8 @@ void SaturationAlgorithm::activate(Clause* cl)
         onParenthood(genCl, premCl);
       }
     }
-  }
+    return true;
+  });
 
   _clauseActivationInProgress = false;
 
@@ -1186,7 +1184,7 @@ void SaturationAlgorithm::activate(Clause* cl)
     removeActiveOrPassiveClause(cl);
   }
 
-  if (generated.premiseRedundant) {
+  if (premiseRedundant) {
     _active->remove(cl);
   }
 

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -205,7 +205,7 @@ protected:
   ActiveClauseContainer* _active;
   ExtensionalityClauseContainer* _extensionality;
 
-  ScopedPtr<SimplifyingGeneratingInference> _generator;
+  ScopedPtr<SimplifyingGeneratingInferenceEngine> _generator;
   ScopedPtr<ImmediateSimplificationEngine> _immediateSimplifier;
   CompositeISEMany _immediateSimplifierMany;
 

--- a/Test/AlascaTestUtils.hpp
+++ b/Test/AlascaTestUtils.hpp
@@ -41,6 +41,7 @@ struct AlascaSimplRule
       .premiseRedundant = res.premiseRedundant,
     };
   }
+  using SimplifyingGeneratingInferenceEngine::generateSimplify;
 };
 
 template<class ISE>

--- a/Test/AlascaTestUtils.hpp
+++ b/Test/AlascaTestUtils.hpp
@@ -21,7 +21,7 @@
 
 template<class Rule>
 struct AlascaSimplRule 
-  : public SimplifyingGeneratingInference
+  : public SimplifyingGeneratingInferenceEngine
 {
   Rule _rule;
   ALASCA::Normalization _norm;
@@ -44,7 +44,7 @@ struct AlascaSimplRule
 };
 
 template<class ISE>
-struct ToSgi : SimplifyingGeneratingInference {
+struct ToSgi : SimplifyingGeneratingInferenceEngine {
   ISE self;
 
   ToSgi(SaturationAlgorithm& salg) : self(salg) {}

--- a/Test/GenerationTester.hpp
+++ b/Test/GenerationTester.hpp
@@ -235,19 +235,21 @@ public:
       container->add(_input);
     }
 
-    auto res = rule.generateSimplify(_input);
+    Stack<Kernel::Clause *> sRes;
+    bool premiseWasRedundant = rule.generateSimplify(_input, [&sRes](Clause *cl) {
+      sRes.push(cl);
+    });
 
     // run checks
-    auto sRes = Stack<Kernel::Clause*>::fromIterator(std::move(res.clauses));
     auto sExp = this->_expected.unwrapOrInit(_expectedFn);
 
     if (!sExp.matches(sRes, tester)) {
       testFail(sRes, sExp);
     }
 
-    if (_premiseRedundant != res.premiseRedundant) {
+    if (_premiseRedundant != premiseWasRedundant) {
       auto wrapStr = [](bool b) -> std::string { return b ? "premise is redundant" : "premise is not redundant"; };
-      testFail( wrapStr(res.premiseRedundant), wrapStr(_premiseRedundant));
+      testFail( wrapStr(premiseWasRedundant), wrapStr(_premiseRedundant));
     }
 
     // remove the clauses from the index

--- a/UnitTests/tInferences_ArithmeticSubtermGeneralization.cpp
+++ b/UnitTests/tInferences_ArithmeticSubtermGeneralization.cpp
@@ -40,7 +40,7 @@ struct SimplificationTester : public ImmediateSimplificationEngine
   {
     auto ord = KBO::testKBO();
     Ordering::trySetGlobalOrdering(SmartPtr<Ordering>(&ord, true));
-    auto apply = [](SimplifyingGeneratingInference1& simpl, Kernel::Clause* in) {
+    auto apply = [](SimplifyingGeneratingInferenceEngine1& simpl, Kernel::Clause* in) {
      auto out = simpl.asISE().simplify(in);
      // DEBUG("result: ", pretty(out));
      return out;


### PR DESCRIPTION
Something a little controversial to think about.

Vampire builds massive iterator chains in order to carry out inference. However, all of them end up being consumed and passed through `SaturationAlgorithm` more-or-less unconditionally.

This PR adds a parallel method to e.g. `GeneratingInferenceEngine` that implements [internal iteration](https://en.wikipedia.org/wiki/Iterator#Internal_iterator) rather than constructing a `ClauseIterator`, i.e.

```c++
  virtual ClauseIterator generateClauses(Clause* premise) = 0;
  virtual void generateClauses(Clause* premise, ClauseReceiver receive) {
    for(Clause *cl : iterTraits(generateClauses(premise)))
      receive(cl);
  }
```

I've re-plumbed `SaturationAlgorithm` to use internal iteration at clause activation.

The pay-off for all this is that writing inferences is often much more straightforward, easier to debug and possibly more performant. I've changed `Factoring` as a demonstration.

(also renamed `SimplifyingGeneratingInference` `SimplifyingGeneratingInferenceEngine` because it was confusing me)

This is just a proof of concept and would need more attention if we want to go ahead with it.