### PR TITLE
use named hash functors for types with defaultHash()

### DIFF
--- a/DP/SimpleCongruenceClosure.cpp
+++ b/DP/SimpleCongruenceClosure.cpp
@@ -245,7 +245,7 @@ struct Memo {
     termNames.insert(orig, result);
     return result;
   }
-  DHMap<TermList, unsigned> &termNames;
+  DHMap<TermList, unsigned, TermListHash, TermListHash2> &termNames;
 };
 
 /**
@@ -997,7 +997,7 @@ void SimpleCongruenceClosure::getModel(LiteralStack& model)
     
     //cout << "Outputting for class " << r << " with nf " << nf.toString() << endl;
     
-    static DHSet<TermList> seen;
+    static DHSet<TermList, TermListHash, TermListHash2> seen;
     seen.reset();
     seen.insert(nf); // this way we avoid generating the identity equality
     

--- a/DP/SimpleCongruenceClosure.hpp
+++ b/DP/SimpleCongruenceClosure.hpp
@@ -270,7 +270,7 @@ private:
   PairMap _pairNames;
 
   /** Constants corresponding to terms */
-  DHMap<TermList,unsigned> _termNames;
+  DHMap<TermList,unsigned, TermListHash, TermListHash2> _termNames;
   /** Constants corresponding to literals */
   DHMap<Literal*,unsigned, FnvHash, PtrIdentityHash> _litNames;
 

--- a/Indexing/AcyclicityIndex.hpp
+++ b/Indexing/AcyclicityIndex.hpp
@@ -71,7 +71,7 @@ private:
   typedef std::pair<Kernel::Literal*, Kernel::Clause*> ULit;
   typedef Lib::DHMap<ULit, IndexEntry*, Lib::PairHash<Lib::FnvHash, Lib::UnitHash>, Lib::PairHash<Lib::PtrIdentityHash, Lib::UnitNumberHash>> SIndex;
 
-  Lib::DHMap<TermList, SIndex*> _sIndexes;
+  Lib::DHMap<TermList, SIndex*, TermListHash, TermListHash2> _sIndexes;
   TermSubstitutionTree<TermLiteralClause> _tis;
 };
 

--- a/Indexing/SubstitutionTree.hpp
+++ b/Indexing/SubstitutionTree.hpp
@@ -835,7 +835,7 @@ public:
 
       TermSpec deref(TermList var);
 
-      typedef DHMap<TermList, TermSpec> BindingMap;
+      typedef DHMap<TermList, TermSpec, TermListHash, TermListHash2> BindingMap;
       typedef Stack<TermList> TermStack;
 
       /** Stacks of bindings made on each backtrack level. Backtrack
@@ -849,7 +849,7 @@ public:
        *
        * The map is reset whenever we enter a new leaf
        */
-      DHMap<TermList,TermList> _derefBindings;
+      DHMap<TermList,TermList, TermListHash, TermListHash2> _derefBindings;
 
       struct DerefTask
       {

--- a/Inferences/ALASCA/Abstractions.hpp
+++ b/Inferences/ALASCA/Abstractions.hpp
@@ -288,7 +288,7 @@ public:
 
   // TODO theory make sure that variables can be shielded or unshielded or not top-level contained
 
-  bool simplify(Clause* premise, Path& path, Set<TermList>& topLevelVars) {
+  bool simplify(Clause* premise, Path& path, Set<TermList, TermListHash>& topLevelVars) {
     auto baseDepth = path.depth();
     while (path.nextStep(baseDepth)) {
 #if UNSTABILITY_ABSTRACTION
@@ -306,7 +306,7 @@ public:
     return false;
   }
 
-  void collectTopLevelVars(Path& path, TermList t, Set<TermList>& topLevelVars, RStack<Path>& todoT) {
+  void collectTopLevelVars(Path& path, TermList t, Set<TermList, TermListHash>& topLevelVars, RStack<Path>& todoT) {
     if (t.isVar()) {
       topLevelVars.insert(t);
     } else {
@@ -343,7 +343,7 @@ public:
       // TODO why do we ever get the empty clause here?
       return premise;
     }
-    Set<TermList> topLevelVars;
+    Set<TermList, TermListHash> topLevelVars;
     auto todo = RStack<Path>();
     auto path = Path(premise, 0);
     for (auto lit : premise->iterLits()) {

--- a/Inferences/ALASCA/TautologyDeletion.hpp
+++ b/Inferences/ALASCA/TautologyDeletion.hpp
@@ -37,7 +37,7 @@ public:
 
   Clause* simplify(Clause* premise) override 
   {
-    Map<AnyAlascaLiteral, bool> lits;
+    Map<AnyAlascaLiteral, bool, CoproductHash> lits;
     TIME_TRACE("alasca tautology detection")
     for (auto lit : iterTraits(premise->iterLits())) {
       auto norm_ = _norm.tryNormalizeInterpreted(lit);

--- a/Inferences/BackwardSubsumptionDemodulation.cpp
+++ b/Inferences/BackwardSubsumptionDemodulation.cpp
@@ -427,7 +427,7 @@ bool BackwardSubsumptionDemodulation<higherOrder>::rewriteCandidate(Clause* side
 
 
 
-  static DHSet<TermList> attempted;  // Terms we already attempted to demodulate
+  static DHSet<TermList, TermListHash, TermListHash2> attempted;  // Terms we already attempted to demodulate
   attempted.reset();
 
   for (unsigned dli = 0; dli < mainCl->length(); ++dli) {

--- a/Inferences/DefinitionIntroduction.cpp
+++ b/Inferences/DefinitionIntroduction.cpp
@@ -37,7 +37,7 @@ static Term *lgg(Term *left, Term *right) {
   // remaining parts of the term that should be created
   std::vector<IncompleteFunction> skeleton;
   // map from left-right pairs of subterms to their variables
-  DHMap<std::pair<TermList, TermList>, unsigned> substitution;
+  DHMap<std::pair<TermList, TermList>, unsigned, PairHash<TermListHash,TermListHash>, PairHash<TermListHash2,TermListHash2>> substitution;
 
   // fresh variable where necessary
   unsigned fresh = 0;

--- a/Inferences/ForwardDemodulation.cpp
+++ b/Inferences/ForwardDemodulation.cpp
@@ -73,7 +73,7 @@ bool ForwardDemodulation<higherOrder>::perform(Clause* cl, Clause*& replacement,
   //replace subterms in some special order, like
   //the heaviest first...
 
-  static DHSet<TermList> attempted;
+  static DHSet<TermList, TermListHash, TermListHash2> attempted;
   attempted.reset();
 
   unsigned cLen=cl->length();

--- a/Inferences/ForwardGroundJoinability.cpp
+++ b/Inferences/ForwardGroundJoinability.cpp
@@ -47,7 +47,7 @@ bool ForwardGroundJoinability::perform(Clause* cl, Clause*& replacement, ClauseI
 {
   // cout << "trying " << *cl << endl;
 
-  static DHSet<TermList> attempted;
+  static DHSet<TermList, TermListHash, TermListHash2> attempted;
 
   if (cl->length()>1) {
     return false;

--- a/Inferences/ForwardSubsumptionDemodulation.cpp
+++ b/Inferences/ForwardSubsumptionDemodulation.cpp
@@ -354,7 +354,7 @@ bool ForwardSubsumptionDemodulation<higherOrder>::perform(Clause* cl, Clause*& r
           continue;
         }
 
-        static DHSet<TermList> attempted;  // Terms we already attempted to demodulate
+        static DHSet<TermList, TermListHash, TermListHash2> attempted;  // Terms we already attempted to demodulate
         attempted.reset();
 
         for (unsigned dli = 0; dli < cl->length(); ++dli) {

--- a/Inferences/GlobalSubsumption.cpp
+++ b/Inferences/GlobalSubsumption.cpp
@@ -74,7 +74,7 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
   assumps.reset();
 
   // lookup to retrieve the FO lits later back
-  static DHMap<SATLiteral,Literal*> lookup;
+  static DHMap<SATLiteral,Literal*, SATLiteralHash, SATLiteralHash2> lookup;
   lookup.reset();
 
   // first abstract cl's FO literals using grounder,
@@ -128,7 +128,7 @@ Clause* GlobalSubsumption::perform(Clause* cl, Stack<Unit*>& prems)
       static LiteralStack survivors;
       survivors.reset();
 
-      static Set<SATLiteral> splitAssumps;
+      static Set<SATLiteral, SATLiteralHash> splitAssumps;
       splitAssumps.reset();
 
       for (unsigned i = 0; i < failedFinal.size(); i++) {

--- a/Inferences/Induction.cpp
+++ b/Inferences/Induction.cpp
@@ -69,7 +69,7 @@ Term* ActiveOccurrenceIterator::next()
 
 Term* getPlaceholderForTerm(const Stack<Term*>& ts, unsigned i)
 {
-  static DHMap<pair<TermList,unsigned>,Term*> placeholders;
+  static DHMap<pair<TermList,unsigned>,Term*, PairHash<TermListHash,FnvHash>, PairHash<TermListHash2,IdentityHash>> placeholders;
   TermList srt = SortHelper::getResultSort(ts[i]);
   auto p = make_pair(srt,i);
   if(!placeholders.find(p)){

--- a/Inferences/Instantiation.hpp
+++ b/Inferences/Instantiation.hpp
@@ -47,8 +47,8 @@ private:
   void tryMakeLiteralFalse(Literal*, Stack<Substitution>& subs);
   Term* tryGetDifferentValue(Term* t); 
 
-  DHMap<TermList,Lib::Set<Term*, FnvHash>*> sorted_candidates_check;
-  DHMap<TermList,Lib::Stack<Term*>*> sorted_candidates;
+  DHMap<TermList,Lib::Set<Term*, FnvHash>*, TermListHash, TermListHash2> sorted_candidates_check;
+  DHMap<TermList,Lib::Stack<Term*>*, TermListHash, TermListHash2> sorted_candidates;
 
 };
 

--- a/Inferences/TheoryInstAndSimp.cpp
+++ b/Inferences/TheoryInstAndSimp.cpp
@@ -493,7 +493,7 @@ public:
     f(*this, Literal::createEquality(true, _introduced, definition, SortHelper::getResultSort(_introduced.term())));
   }
 
-  TermList buildGeneralTerm(Set<TermList> const& usedDefs, unsigned& freshVar)
+  TermList buildGeneralTerm(Set<TermList, TermListHash> const& usedDefs, unsigned& freshVar)
   {
     if (usedDefs.contains(_introduced)) {
       Stack<TermList> args(_args.size());
@@ -527,7 +527,7 @@ Option<Substitution> TheoryInstAndSimp::instantiateGeneralised(
     Stack<SATLiteral> theoryLits;
 
     _generalizationConstants.reset();
-    Map<SATLiteral, TermList> definitionLiterals;
+    Map<SATLiteral, TermList, SATLiteralHash> definitionLiterals;
     Stack<GeneralisationTree> gens;
     // unsigned freshVar = 0;
     for (auto v : skolem.vars) {
@@ -552,7 +552,7 @@ Option<Substitution> TheoryInstAndSimp::instantiateGeneralised(
     DEBUG_CODE(auto res =) _solver->solveUnderAssumptionsLimited(theoryLits, 0);
     ASS_EQ(res, Status::UNSATISFIABLE)
 
-    Set<TermList> usedDefs;
+    Set<TermList, TermListHash> usedDefs;
     for (auto& x : _solver->failedAssumptions()) {
       definitionLiterals
         .tryGet(x)

--- a/Inferences/TheoryInstAndSimp.hpp
+++ b/Inferences/TheoryInstAndSimp.hpp
@@ -128,7 +128,7 @@ private:
     };
 
     const char* _prefix;
-    Map<SortId, SortedConstantCache> _inner;
+    Map<SortId, SortedConstantCache, TermListHash> _inner;
 
   public:
     ConstantCache(const char* prefix) : _prefix(prefix), _inner() {}
@@ -143,7 +143,7 @@ private:
   bool const _thiTautologyDeletion;
   SAT2FO _naming;
   std::unique_ptr<Z3Interfacing> _solver;
-  Map<SortId, bool> _supportedSorts;
+  Map<SortId, bool, TermListHash> _supportedSorts;
   bool _generalisation;
   ConstantCache _instantiationConstants;
   ConstantCache _generalizationConstants;

--- a/Kernel/RobSubstitution.cpp
+++ b/Kernel/RobSubstitution.cpp
@@ -237,7 +237,7 @@ void RobSubstitution::bindVar(const VarSpec& var, const VarSpec& to)
 bool RobSubstitution::occurs(VarSpec const& toFind, TermSpec const& ts) 
 {
 
-   Recycled<DHSet<TermSpec>> encountered;
+   Recycled<DHSet<TermSpec, TermSpecHash, TermSpecHash2>> encountered;
    Recycled<Stack<TermSpec>> todo;
    todo->push(std::move(ts));
 
@@ -281,7 +281,7 @@ bool RobSubstitution::unify(TermSpec s, TermSpec t)
 
   // Save encountered unification pairs to avoid
   // recomputing their unification
-  static DHSet<pair<TermSpec, TermSpec>> encountered_;
+  static DHSet<pair<TermSpec, TermSpec>, PairHash<TermSpecHash,TermSpecHash>, PairHash<TermSpecHash2,TermSpecHash2>> encountered_;
   auto encountered = &encountered_;
   encountered->reset();
   

--- a/Kernel/RobSubstitution.hpp
+++ b/Kernel/RobSubstitution.hpp
@@ -56,8 +56,8 @@ struct VarSpec
   auto asTuple() const { return std::tie(_self, index); }
   IMPL_COMPARISONS_FROM_TUPLE(VarSpec)
 
-  unsigned defaultHash () const { return HashUtils::combine(_self.content(), index); }
-  unsigned defaultHash2() const { return HashUtils::combine(index, _self.content()); }
+  unsigned defaultHash () const;
+  unsigned defaultHash2() const;
 };
 
 struct TermSpec {
@@ -68,7 +68,8 @@ struct TermSpec {
 
   auto asTuple() const -> decltype(auto) { return std::tie(term, index); }
   IMPL_COMPARISONS_FROM_TUPLE(TermSpec)
-  IMPL_HASH_FROM_TUPLE(TermSpec)
+  unsigned defaultHash () const;
+  unsigned defaultHash2() const;
 
   TermList term;
   int index;
@@ -199,6 +200,34 @@ struct TermSpec {
   }
 };
 
+// hash a VarSpec by combining the variable's content word with its bank index
+struct VarSpecHash {
+  static bool equals(VarSpec v1, VarSpec v2) { return v1 == v2; }
+  static unsigned hash(VarSpec v) { return HashUtils::combine(v._self.content(), v.index); }
+};
+
+// secondary hash: the same two words the other way round
+struct VarSpecHash2 {
+  static unsigned hash(VarSpec v) { return HashUtils::combine(v.index, v._self.content()); }
+};
+
+// hash a TermSpec by its term and its bank index
+struct TermSpecHash {
+  static bool equals(TermSpec const& s1, TermSpec const& s2) { return s1 == s2; }
+  static unsigned hash(TermSpec const& s)
+  { return TupleHash<TermListHash, FnvHash>::hash(s.asTuple()); }
+};
+
+struct TermSpecHash2 {
+  static unsigned hash(TermSpec const& s)
+  { return TupleHash<TermListHash2, IdentityHash>::hash(s.asTuple()); }
+};
+
+inline unsigned VarSpec::defaultHash () const { return VarSpecHash ::hash(*this); }
+inline unsigned VarSpec::defaultHash2() const { return VarSpecHash2::hash(*this); }
+inline unsigned TermSpec::defaultHash () const { return TermSpecHash ::hash(*this); }
+inline unsigned TermSpec::defaultHash2() const { return TermSpecHash2::hash(*this); }
+
 /** A wrapper around TermSpec that automatically dereferences the TermSpec with respect to some RobSubstition when 
  * used with BottomUpEvaluation.  This means for example if we evaluate some TermSpec * `g(X, Y)` in a context 
  * `{ X -> a, Y -> f(X) }` it behaves as if we would evaluate `g(a,f(a))`.  */
@@ -219,7 +248,7 @@ struct AutoDerefTermSpec
 template<class Result>
 class OnlyMemorizeNonVar 
 {
-  Map<TermSpec, Result> _memo;
+  Map<TermSpec, Result, TermSpecHash> _memo;
 public:
   OnlyMemorizeNonVar(OnlyMemorizeNonVar &&) = default;
   OnlyMemorizeNonVar& operator=(OnlyMemorizeNonVar &&) = default;
@@ -288,12 +317,12 @@ class RobSubstitution
   friend class AbstractingUnifier;
   friend class UnificationConstraint;
  
-  DHMap<VarSpec, TermSpec> _bindings;
-  mutable DHMap<VarSpec, unsigned> _outputVarBindings;
+  DHMap<VarSpec, TermSpec, VarSpecHash, VarSpecHash2> _bindings;
+  mutable DHMap<VarSpec, unsigned, VarSpecHash, VarSpecHash2> _outputVarBindings;
   mutable bool _startedBindingOutputVars;
   mutable unsigned _nextUnboundAvailable;
   mutable unsigned _nextGlueAvailable;
-  DHMap<TermSpec, unsigned> _gluedTerms;
+  DHMap<TermSpec, unsigned, TermSpecHash, TermSpecHash2> _gluedTerms;
   mutable OnlyMemorizeNonVar<TermList> _applyMemo;
 
 public:

--- a/Kernel/Signature.hpp
+++ b/Kernel/Signature.hpp
@@ -58,7 +58,7 @@ class Signature
     , std::pair<Theory::Interpretation, OperatorType*>
     >;
 
-  using SymbolMap = Map<SymbolKey, unsigned>;
+  using SymbolMap = Map<SymbolKey, unsigned, CoproductHash>;
  public:
   /** Function or predicate symbol */
   
@@ -648,7 +648,7 @@ class Signature
     _instantiations.insert(inst);
   }
 
-  DHSet<TermList>* getInstantiations() {
+  DHSet<TermList, TermListHash, TermListHash2>* getInstantiations() {
     return &_instantiations;
   }
 
@@ -947,7 +947,7 @@ private:
 
   // TODO(HOL): these two don't belong in the signature
   DHSet<unsigned, FnvHash, IdentityHash> _choiceSymbols;
-  DHSet<TermList> _instantiations;
+  DHSet<TermList, TermListHash, TermListHash2> _instantiations;
 
   SymbolMap _funNames;
   SymbolMap _predNames;

--- a/Kernel/Term.cpp
+++ b/Kernel/Term.cpp
@@ -472,7 +472,7 @@ size_t Term::countSubtermOccurrences(TermList subterm) {
 
 bool TermList::containsAllVariablesOf(TermList t) const
 {
-  Set<TermList> vars;
+  Set<TermList, TermListHash> vars;
   TermIterator oldVars=Term::getVariableIterator(*this);
   while (oldVars.hasNext()) {
     vars.insert(oldVars.next());
@@ -488,7 +488,7 @@ bool TermList::containsAllVariablesOf(TermList t) const
 
 bool Term::containsAllVariablesOf(Term* t)
 {
-  static DHSet<TermList> vars;
+  static DHSet<TermList, TermListHash, TermListHash2> vars;
   vars.reset();
 
   static VariableIterator vit;

--- a/Kernel/Term.hpp
+++ b/Kernel/Term.hpp
@@ -209,8 +209,8 @@ public:
   /** set the content manually - hazardous, such terms should then only be used as integers */
   void setContent(uint64_t content) { _content = content; }
   /** default hash is to hash the content */
-  unsigned defaultHash() const { return DefaultHash::hash(content()); }
-  unsigned defaultHash2() const { return content(); }
+  unsigned defaultHash() const;
+  unsigned defaultHash2() const;
 
   // TODO this default value is probably the reason we get too many parentheses everywhere
   std::string toString(bool topLevel = false) const;
@@ -1323,12 +1323,26 @@ struct SharedTermHash {
 struct SharedTermListHash {
   static bool equals(TermList t1, TermList t2) { return t1==t2; }
   static unsigned hash(TermList t)
-  { ASS(t.isTerm() && t.term()->shared()); return DefaultHash::hash(t.term()->getId()); }
+  { ASS(t.isTerm() && t.term()->shared()); return FnvHash::hash(t.term()->getId()); }
 };
 struct SharedTermListHash2 {
   static unsigned hash(TermList t)
-  { ASS(t.isTerm() && t.term()->shared()); return DefaultHash2::hash(t.term()->getId()); }
+  { ASS(t.isTerm() && t.term()->shared()); return IdentityHash::hash(t.term()->getId()); }
 };
+
+// hash a TermList by FNV-1a of its content word
+struct TermListHash {
+  static bool equals(TermList t1, TermList t2) { return t1 == t2; }
+  static unsigned hash(TermList t) { return FnvHash::hash(t.content()); }
+};
+
+// cheap secondary hash: the content word itself
+struct TermListHash2 {
+  static unsigned hash(TermList t) { return t.content(); }
+};
+
+inline unsigned TermList::defaultHash() const { return TermListHash::hash(*this); }
+inline unsigned TermList::defaultHash2() const { return TermListHash2::hash(*this); }
 
 /** helper lambda that turns a number into a variable */
 static const auto unsignedToVarFn = [](unsigned var)
@@ -1339,7 +1353,7 @@ static const auto unsignedToVarFn = [](unsigned var)
 template<>
 struct std::hash<Kernel::TermList> {
   size_t operator()(Kernel::TermList const& t) const
-  { return t.defaultHash(); }
+  { return Kernel::TermListHash::hash(t); }
 };
 
 #endif

--- a/Kernel/TermOrderingDiagram.cpp
+++ b/Kernel/TermOrderingDiagram.cpp
@@ -31,7 +31,7 @@ static Ordering::Result kLtPtr = Ordering::LESS;
 
 TermOrderingDiagram* TermOrderingDiagram::createForSingleComparison(const Ordering& ord, TermList lhs, TermList rhs)
 {
-  static Map<tuple<TermList,TermList>,TermOrderingDiagram*> cache; // TODO this leaks now
+  static Map<tuple<TermList,TermList>,TermOrderingDiagram*, TupleHash<TermListHash,TermListHash>> cache; // TODO this leaks now
 
   TermOrderingDiagram** ptr;
   if (cache.getValuePtr({ lhs, rhs }, ptr, nullptr)) {
@@ -493,7 +493,7 @@ TermOrderingDiagram::Branch& TermOrderingDiagram::Node::getBranch(Ordering::Resu
 
 const TermOrderingDiagram::Polynomial* TermOrderingDiagram::Polynomial::get(int constant, const Stack<VarCoeffPair>& varCoeffPairs)
 {
-  static Set<Polynomial*, DerefPtrHash<DefaultHash>> polys;
+  static Set<Polynomial*, DerefPtrHash<PolynomialHash>> polys;
 
   sort(varCoeffPairs.begin(),varCoeffPairs.end(),[](const auto& vc1, const auto& vc2) {
     auto vc1pos = vc1.second>0;
@@ -508,7 +508,7 @@ const TermOrderingDiagram::Polynomial* TermOrderingDiagram::Polynomial::get(int 
   bool unused;
   return polys.rawFindOrInsert(
     [&](){ return new Polynomial(std::move(poly)); },
-    poly.defaultHash(),
+    PolynomialHash::hash(poly),
     [&](Polynomial* p) { return *p == poly; },
     unused);
 }
@@ -590,7 +590,7 @@ TermOrderingDiagram::NodeIterator::NodeIterator(const Ordering&, const SubstAppl
       bps.push({ { { lhs, rhs, Result::LESS    } }, Result::LESS    });
     } else if (lhs.isVar()) {
       ASS(rhs.isTerm());
-      DHSet<TermList> seen;
+      DHSet<TermList, TermListHash, TermListHash2> seen;
       // x ? t[y_1,...,y_n]
       for (const auto& v : iterTraits(VariableIterator(rhs.term()))) {
         if (!seen.insert(v)) {
@@ -602,7 +602,7 @@ TermOrderingDiagram::NodeIterator::NodeIterator(const Ordering&, const SubstAppl
       }
     } else if (rhs.isVar()) {
       ASS(lhs.isTerm());
-      DHSet<TermList> seen;
+      DHSet<TermList, TermListHash, TermListHash2> seen;
       // s[x_1,...,x_n] ? y
       for (const auto& v : iterTraits(VariableIterator(lhs.term()))) {
         if (!seen.insert(v)) {

--- a/Kernel/TermOrderingDiagram.hpp
+++ b/Kernel/TermOrderingDiagram.hpp
@@ -173,7 +173,8 @@ protected:
 
     auto asTuple() const { return std::make_tuple(constant, varCoeffPairs); }
 
-    IMPL_HASH_FROM_TUPLE(Polynomial);
+    unsigned defaultHash () const;
+    unsigned defaultHash2() const;
     IMPL_COMPARISONS_FROM_TUPLE(Polynomial);
 
     int constant;
@@ -181,6 +182,18 @@ protected:
     // (positive first), and then by variable
     // e.g. X1 + 2 ⋅ X4 - 5 ⋅ X0 - X3
     Stack<VarCoeffPair> varCoeffPairs;
+  };
+
+  // hash a Polynomial by its constant and its variable-coefficient pairs
+  struct PolynomialHash {
+    static bool equals(Polynomial const& p1, Polynomial const& p2) { return p1 == p2; }
+    static unsigned hash(Polynomial const& p)
+    { return TupleHash<FnvHash, StackHash<PairHash<FnvHash,FnvHash>>>::hash(p.asTuple()); }
+  };
+
+  struct PolynomialHash2 {
+    static unsigned hash(Polynomial const& p)
+    { return TupleHash<IdentityHash, LengthHash>::hash(p.asTuple()); }
   };
 
   friend std::ostream& operator<<(std::ostream& out, const Node::Tag& t);
@@ -260,6 +273,11 @@ public:
     Traversal<NodeIterator,POStruct> traversal;
   };
 };
+
+inline unsigned TermOrderingDiagram::Polynomial::defaultHash () const
+{ return TermOrderingDiagram::PolynomialHash ::hash(*this); }
+inline unsigned TermOrderingDiagram::Polynomial::defaultHash2() const
+{ return TermOrderingDiagram::PolynomialHash2::hash(*this); }
 
 } // namespace Kernel
 

--- a/Kernel/TermPartialOrdering.cpp
+++ b/Kernel/TermPartialOrdering.cpp
@@ -130,7 +130,7 @@ const TermPartialOrdering* TermPartialOrdering::getEmpty(const Ordering& ord)
 
 const TermPartialOrdering* TermPartialOrdering::set(const TermPartialOrdering* tpo, TermOrderingConstraint con)
 {
-  static DHMap<std::tuple<const TermPartialOrdering*, TermList, TermList, Result>, const TermPartialOrdering*> cache;
+  static DHMap<std::tuple<const TermPartialOrdering*, TermList, TermList, Result>, const TermPartialOrdering*, TupleHash<FnvHash,TermListHash,TermListHash,FnvHash>, TupleHash<PtrIdentityHash,TermListHash2,TermListHash2,IdentityHash>> cache;
   const TermPartialOrdering** ptr;
   if (cache.getValuePtr(make_tuple(tpo, con.lhs, con.rhs, con.rel), ptr, nullptr)) {
     auto res = new TermPartialOrdering(*tpo);
@@ -344,10 +344,10 @@ size_t TermPartialOrdering::getIdExt(TermList t)
 
 ostream& operator<<(ostream& str, const TermPartialOrdering& tpo)
 {
-  typename Map<TermList,size_t>::Iterator it1(tpo._nodes);
+  typename Map<TermList,size_t, TermListHash>::Iterator it1(tpo._nodes);
   while (it1.hasNext()) {
     const auto& e1 = it1.next();
-    typename Map<TermList,size_t>::Iterator it2(tpo._nodes);
+    typename Map<TermList,size_t, TermListHash>::Iterator it2(tpo._nodes);
     while (it2.hasNext()) {
       const auto& e2 = it2.next();
       if (e1.value() >= e2.value()) {

--- a/Kernel/TermPartialOrdering.hpp
+++ b/Kernel/TermPartialOrdering.hpp
@@ -76,7 +76,7 @@ private:
   size_t getIdExt(TermList t);
 
   const Ordering& _ord;
-  Map<TermList,size_t> _nodes;
+  Map<TermList,size_t, TermListHash> _nodes;
   const PartialOrdering* _po;
 };
 

--- a/Kernel/TypedTermList.hpp
+++ b/Kernel/TypedTermList.hpp
@@ -50,7 +50,7 @@ public:
   }
 
   bool containsAllVariablesOf(TypedTermList other) const {
-    Set<TermList> vars;
+    Set<TermList, TermListHash> vars;
     vars.insertFromIterator(varIter());
 
     return iterTraits(other.varIter()).all([&vars](TermList v) {

--- a/Kernel/UnificationWithAbstraction.cpp
+++ b/Kernel/UnificationWithAbstraction.cpp
@@ -668,7 +668,7 @@ AbstractionOracle::AbstractionResult alasca(AbstractingUnifier& au, TermSpec con
     return AbstractionResult(equalIf());
 
   } else if (nVars > 0) {
-     Recycled<DHSet<TermSpec>> shieldedVars;
+     Recycled<DHSet<TermSpec, TermSpecHash, TermSpecHash2>> shieldedVars;
      for (auto i : range(nVars, diff.size())) {
        Recycled<Stack<TermSpec>> todo;
        todo->push(diff[i].first);
@@ -794,10 +794,10 @@ struct FloorUwaState {
   RStack<Monom> mixVars;
   RStack<Monom> ratAtoms;
   RStack<Monom> intAtoms;
-  Recycled<DHSet<VarSpec>> ratVarSet;
-  Recycled<DHSet<VarSpec>> mixVarSet;
-  Recycled<DHSet<VarSpec>> intVarSet;
-  Recycled<DHSet<VarSpec>> shieldedVars;
+  Recycled<DHSet<VarSpec, VarSpecHash, VarSpecHash2>> ratVarSet;
+  Recycled<DHSet<VarSpec, VarSpecHash, VarSpecHash2>> mixVarSet;
+  Recycled<DHSet<VarSpec, VarSpecHash, VarSpecHash2>> intVarSet;
+  Recycled<DHSet<VarSpec, VarSpecHash, VarSpecHash2>> shieldedVars;
 
   bool isShielded(TermSpec t) const { return shieldedVars->find(t.varSpec()); }
   bool isMixVar(VarSpec v) const { return mixVarSet->find(v) || (intVarSet->find(v) && ratVarSet->find(v)); }
@@ -1443,7 +1443,7 @@ bool AbstractingUnifier::unify(TermSpec t1, TermSpec t2, bool& progress)
 
     // Save encountered unification pairs to avoid
     // recomputing their unification
-    Recycled<DHSet<std::pair<TermSpec,TermSpec>>> encountered;
+    Recycled<DHSet<std::pair<TermSpec,TermSpec>, PairHash<TermSpecHash,TermSpecHash>, PairHash<TermSpecHash2,TermSpecHash2>>> encountered;
 
     Option<AbstractionOracle::AbstractionResult> absRes;
     auto doAbstract = [&](auto& l, auto& r) -> bool

--- a/Lib/Coproduct.hpp
+++ b/Lib/Coproduct.hpp
@@ -675,6 +675,21 @@ public:
   inline Coproduct clone() const { return apply([](auto& x){ return Coproduct(x.clone()); }); }
 }; // class Coproduct<As...>
 
+// Hash a Coproduct by its tag and the alternative it holds. The methods still
+// use DefaultHash until generic callers accept explicit hashes for the alternatives.
+struct CoproductHash {
+  template<class... As>
+  static bool equals(Coproduct<As...> const& c1, Coproduct<As...> const& c2) { return c1 == c2; }
+
+  template<class... As>
+  static unsigned hash(Coproduct<As...> const& c) { return c.defaultHash(); }
+};
+
+struct CoproductHash2 {
+  template<class... As>
+  static unsigned hash(Coproduct<As...> const& c) { return c.defaultHash2(); }
+};
+
 
 
 } // Lib

--- a/Parse/SMTLIB2.cpp
+++ b/Parse/SMTLIB2.cpp
@@ -533,7 +533,7 @@ TermList SMTLIB2::parseSort(LExpr* sExpr)
 
 TermStack SMTLIB2::normalizeFunctionSorts(TermStack& argSorts, TermList& resSort)
 {
-  DHSet<TermList> varsSeen;
+  DHSet<TermList, TermListHash, TermListHash2> varsSeen;
   for (auto sort : argSorts) {
     varsSeen.loadFromIterator(VariableIterator(sort));
   }

--- a/SAT/SATClause.hpp
+++ b/SAT/SATClause.hpp
@@ -49,12 +49,7 @@ public:
   void* operator new(size_t,unsigned length);
   void operator delete(void *, size_t);
 
-  unsigned defaultHash() const {
-    unsigned hash = 0;
-    for(unsigned i = 0; i < length(); i++)
-      hash ^= DefaultHash::hash(_literals[i]);
-    return hash;
-  }
+  unsigned defaultHash() const;
 
   bool operator==(const SATClause &other) const {
     if(length() != other.length())
@@ -113,6 +108,23 @@ private:
   // counter for `number`
   static unsigned _lastNumber;
 }; // class SATClause
+
+// Hash a SATClause by XOR of its literals' hashes. Keep the pointer traversal:
+// _literals is declared with one element, and indexing it directly produced
+// different hash values in optimized builds when this loop was moved.
+struct SATClauseHash {
+  static bool equals(SATClause const& c1, SATClause const& c2) { return c1 == c2; }
+
+  static unsigned hash(SATClause const& c) {
+    const SATLiteral* lits = &c[0];
+    unsigned hash = 0;
+    for(unsigned i = 0; i < c.length(); i++)
+      hash ^= SATLiteralHash::hash(lits[i]);
+    return hash;
+  }
+};
+
+inline unsigned SATClause::defaultHash() const { return SATClauseHash::hash(*this); }
 
 std::ostream &operator<<(std::ostream &out, const SATClause &cl);
 

--- a/SAT/SATLiteral.hpp
+++ b/SAT/SATLiteral.hpp
@@ -47,8 +47,8 @@ public:
   bool positive() const { return _lit > 0; }
   SATLiteral opposite() const { return SATLiteral(-_lit); }
 
-  unsigned defaultHash() const { return DefaultHash::hash(_lit); }
-  unsigned defaultHash2() const { return _lit; }
+  unsigned defaultHash() const;
+  unsigned defaultHash2() const;
 
   bool operator==(const SATLiteral& l) const
   { return _lit==l._lit; }
@@ -59,7 +59,24 @@ public:
 
 private:
   int _lit = 0;
+
+  friend struct SATLiteralHash;
+  friend struct SATLiteralHash2;
 };
+
+// hash a SATLiteral by FNV-1a of the signed integer it wraps
+struct SATLiteralHash {
+  static bool equals(SATLiteral l1, SATLiteral l2) { return l1 == l2; }
+  static unsigned hash(SATLiteral l) { return FnvHash::hash(l._lit); }
+};
+
+// cheap secondary hash: that integer itself
+struct SATLiteralHash2 {
+  static unsigned hash(SATLiteral l) { return l._lit; }
+};
+
+inline unsigned SATLiteral::defaultHash() const { return SATLiteralHash::hash(*this); }
+inline unsigned SATLiteral::defaultHash2() const { return SATLiteralHash2::hash(*this); }
 
 inline std::ostream& operator<<(std::ostream &out, const SAT::SATLiteral &lit)
 {
@@ -72,7 +89,7 @@ inline std::ostream& operator<<(std::ostream &out, const SAT::SATLiteral &lit)
 
 template<>
 struct std::hash<SAT::SATLiteral> {
-  unsigned operator()(SAT::SATLiteral l) const { return l.defaultHash(); }
+  unsigned operator()(SAT::SATLiteral l) const { return SAT::SATLiteralHash::hash(l); }
 };
 
 

--- a/SAT/Z3Interfacing.cpp
+++ b/SAT/Z3Interfacing.cpp
@@ -1255,7 +1255,7 @@ void Z3Interfacing::createTermAlgebra(TermList sort)
   if (_createdTermAlgebras.contains(sort)) return;
 
   Stack<TermList> taSorts;        // <- stack of term algebra sorts
-  Map<SortId, unsigned> recSorts; // <- mapping term algeba -> index
+  Map<SortId, unsigned, TermListHash> recSorts; // <- mapping term algeba -> index
 
   auto subsorts = TermAlgebra::subSorts(sort);
   for (auto s : subsorts.iter()) {

--- a/SAT/Z3Interfacing.hpp
+++ b/SAT/Z3Interfacing.hpp
@@ -276,7 +276,7 @@ private:
   void addAssumption(SATLiteral lit);
   void solveModuloAssumptionsAndSetStatus();
 
-  Map<SortId, z3::sort> _sorts;
+  Map<SortId, z3::sort, TermListHash> _sorts;
   struct Z3Hash {
     static unsigned hash(z3::func_decl const& c) { return c.hash(); }
     static unsigned hash(z3::expr const& c) { return c.hash(); }
@@ -285,7 +285,7 @@ private:
   };
   Map<z3::func_decl, FuncOrPredId , Z3Hash > _fromZ3;
   Map<FuncOrPredId,  z3::func_decl, StlHash> _toZ3;
-  Set<SortId> _createdTermAlgebras;
+  Set<SortId, TermListHash> _createdTermAlgebras;
 
   z3::func_decl const& findConstructor(Term* t);
   void createTermAlgebra(TermList sort);
@@ -344,10 +344,10 @@ private:
   Coproduct<ProblemExport::NoExport, ProblemExport::Smtlib, ProblemExport::ApiCalls> _exporter;
 
 
-  BiMap<SATLiteral, z3::expr, DefaultHash, Z3Hash> _assumptionLookup;
+  BiMap<SATLiteral, z3::expr, SATLiteralHash, Z3Hash> _assumptionLookup;
   Option<std::ofstream> _out;
   Map<unsigned, z3::expr, FnvHash> _varNames;
-  Map<TermList, z3::expr> _termIndexedConstants;
+  Map<TermList, z3::expr, TermListHash> _termIndexedConstants;
   Map<Signature::Symbol*, z3::expr, FnvHash> _constantNames;
 
   bool     isNamedExpr(unsigned var) const;

--- a/Saturation/ExtensionalityClauseContainer.cpp
+++ b/Saturation/ExtensionalityClauseContainer.cpp
@@ -62,7 +62,7 @@ Literal* ExtensionalityClauseContainer::addIfExtensionality(Clause* c) {
     //   * Exactly one X=Y
     //   * No inequality of same sort as X=Y
     //   * No equality except X=Y (optional).
-    static DHSet<TermList> negEqSorts;
+    static DHSet<TermList, TermListHash, TermListHash2> negEqSorts;
     negEqSorts.reset();
   
     for (auto l : c->iterLits()) {

--- a/Saturation/ExtensionalityClauseContainer.hpp
+++ b/Saturation/ExtensionalityClauseContainer.hpp
@@ -37,7 +37,7 @@ struct ExtensionalityClause
 
 typedef List<ExtensionalityClause> ExtensionalityClauseList;
 typedef VirtualIterator<ExtensionalityClause> ExtensionalityClauseIterator;
-typedef DHMap<TermList, ExtensionalityClauseList*> ClausesBySort;
+typedef DHMap<TermList, ExtensionalityClauseList*, TermListHash, TermListHash2> ClausesBySort;
 /**
  * Container for tracking extensionality-like clauses, i.e. clauses with exactly
  * one positive equality between variables.

--- a/Saturation/Splitter.hpp
+++ b/Saturation/Splitter.hpp
@@ -299,7 +299,7 @@ private:
 
   // clauses we already added to the SAT solver
   // not just optimisation: also prevents the SAT solver oscillating between two models in some cases
-  Set<SATClause *, DerefPtrHash<DefaultHash>> _already_added;
+  Set<SATClause *, DerefPtrHash<SATClauseHash>> _already_added;
 public:
   static std::string splPrefix;
 

--- a/Shell/BlockedClauseElimination.cpp
+++ b/Shell/BlockedClauseElimination.cpp
@@ -205,7 +205,7 @@ bool BlockedClauseElimination::resolvesToTautology(bool equationally, Clause* cl
 
 class VarMaxUpdatingNormalizer : public TermTransformer {
 public:
-  VarMaxUpdatingNormalizer(const Lib::DHMap<TermList, TermList>& replacements, int& varMax)
+  VarMaxUpdatingNormalizer(const Lib::DHMap<TermList, TermList, TermListHash, TermListHash2>& replacements, int& varMax)
     : _repls(replacements), _varMax(varMax) {}
 protected:
   TermList transformSubterm(TermList trm) override {
@@ -222,13 +222,13 @@ protected:
     return trm;
   }
 private:
-  const Lib::DHMap<TermList, TermList>& _repls;
+  const Lib::DHMap<TermList, TermList, TermListHash, TermListHash2>& _repls;
   int& _varMax;
 };
 
 class RenanigApartNormalizer : public TermTransformer {
 public:
-  RenanigApartNormalizer(const Lib::DHMap<TermList, TermList>& replacements, int varMax, Lib::DHMap<unsigned, unsigned, FnvHash, IdentityHash>& varMap)
+  RenanigApartNormalizer(const Lib::DHMap<TermList, TermList, TermListHash, TermListHash2>& replacements, int varMax, Lib::DHMap<unsigned, unsigned, FnvHash, IdentityHash>& varMap)
     : _repls(replacements), _varMax(varMax), _varMap(varMap) {}
 protected:
   TermList transformSubterm(TermList trm) override {
@@ -247,7 +247,7 @@ protected:
     return trm;
   }
 private:
-  const Lib::DHMap<TermList, TermList>& _repls;
+  const Lib::DHMap<TermList, TermList, TermListHash, TermListHash2>& _repls;
   int _varMax;
   Lib::DHMap<unsigned, unsigned, FnvHash, IdentityHash>& _varMap;
 };
@@ -267,9 +267,9 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
   unsigned n = lit->arity();
 
   IntUnionFind uf(n ? 2*n : 1); // IntUnionFind does not like 0
-  static Lib::DHMap<TermList, unsigned>  litArgIds;
+  static Lib::DHMap<TermList, unsigned, TermListHash, TermListHash2>  litArgIds;
   litArgIds.reset();
-  static Lib::DHMap<TermList, unsigned> plitArgIds;
+  static Lib::DHMap<TermList, unsigned, TermListHash, TermListHash2> plitArgIds;
   plitArgIds.reset();
 
   int varMax = -1;
@@ -312,7 +312,7 @@ bool BlockedClauseElimination::resolvesToTautologyEq(Clause* cl, Literal* lit, C
 
   // to do replacements in cl, we need a mapping for all lit's arguments.
   // As a bonus we also allow ground arguments of plit
-  static Lib::DHMap<TermList, TermList> replacements;
+  static Lib::DHMap<TermList, TermList, TermListHash, TermListHash2> replacements;
   replacements.reset();
   for(unsigned i = 0; i<n; i++) {
     TermList arg = *lit->nthArgument(i);

--- a/Shell/PartialRedundancyHandler.cpp
+++ b/Shell/PartialRedundancyHandler.cpp
@@ -30,7 +30,7 @@ namespace Shell
 template<class T>
 bool checkVars(const TermStack& ts, T s)
 {
-  DHSet<TermList> vars;
+  DHSet<TermList, TermListHash, TermListHash2> vars;
   for (const auto& t : ts) {
     VariableIterator vit(t);
     while (vit.hasNext()) {

--- a/Shell/TermAlgebra.cpp
+++ b/Shell/TermAlgebra.cpp
@@ -76,11 +76,11 @@ unsigned TermAlgebraConstructor::discriminator()
   }
 }
 
-Lib::Set<TermList> TermAlgebra::subSorts(TermList sort)
+Lib::Set<TermList, TermListHash> TermAlgebra::subSorts(TermList sort)
 {
   ASS(sort.isTerm() && sort.term()->isSort());
 
-  Set<TermList> out; 
+  Set<TermList, TermListHash> out;
   /* connected component finding without recursion */
   TermStack work; // <- stack for simulating recursion
   work.push(sort);

--- a/Shell/TermAlgebra.hpp
+++ b/Shell/TermAlgebra.hpp
@@ -135,7 +135,7 @@ namespace Shell {
      *
      * then subSorts(atree(intp)) == { int, nat, intp, atree(intp) }
      */
-    static Lib::Set<TermList> subSorts(TermList sort);
+    static Lib::Set<TermList, TermListHash> subSorts(TermList sort);
 
     bool allowsCyclicTerms() { return _allowsCyclicTerms; }
 

--- a/Test/AlascaTestUtils.hpp
+++ b/Test/AlascaTestUtils.hpp
@@ -95,7 +95,7 @@ struct AlascaTestUtil {
     auto vl = vars(lhs);
     auto vr = vars(rhs);
 
-    Map<TermList, unsigned> rVarIdx;
+    Map<TermList, unsigned, TermListHash> rVarIdx;
     unsigned i = 0;
     for (auto v : vr) {
       rVarIdx.insert(v, i++);

--- a/UnitTests/HOL/tHOL_Unifier.cpp
+++ b/UnitTests/HOL/tHOL_Unifier.cpp
@@ -88,7 +88,7 @@ void testUnifySuccess(TermList lhs, TermList rhs, Stack<ResultSpec> expected) {
     auto hoUnif = wrapper.next();
     auto& e = expected[i];
 
-    DHSet<VarSpec> vars;
+    DHSet<VarSpec, VarSpecHash, VarSpecHash2> vars;
     auto loadVars = [&vars](TermList t, unsigned index) {
       if (t.isVar()) {
         vars.insert(VarSpec(t, index));

--- a/UnitTests/tHash.cpp
+++ b/UnitTests/tHash.cpp
@@ -43,6 +43,10 @@ TEST_FUN(namedFunctorsMatchDefaultHash)
   ASS_EQ(FnvHash::hash(i), DefaultHash::hash(i));
   ASS_EQ(FnvHash::hash(d), DefaultHash::hash(d));
   ASS_EQ(FnvHash::hash(GREEN), DefaultHash::hash(GREEN));
+  // TermList hashes its 64-bit content word, and the secondary hash narrows it
+  uint64_t w = 0x0123456789abcdefULL;
+  ASS_EQ(FnvHash::hash(w), DefaultHash::hash(w));
+  ASS_EQ(IdentityHash::hash(w), DefaultHash2::hash(w));
   ASS_EQ(IdentityHash::hash(u), DefaultHash2::hash(u));
   ASS_EQ(IdentityHash::hash(i), DefaultHash2::hash(i));
   ASS_EQ(IdentityHash::hash(GREEN), DefaultHash2::hash(GREEN));

--- a/UnitTests/tInferences_Induction.cpp
+++ b/UnitTests/tInferences_Induction.cpp
@@ -124,7 +124,7 @@ public:
 
 private:
   bool matchAftercheck() {
-    DHMap<TermList, unsigned> inverse;
+    DHMap<TermList, unsigned, TermListHash, TermListHash2> inverse;
     for (const auto& i : _varsMatched) {
       auto t = _subst.apply(TermList::var(i),EXPECTED_BANK);
       unsigned v;

--- a/UnitTests/tSATClause.cpp
+++ b/UnitTests/tSATClause.cpp
@@ -80,3 +80,21 @@ TEST_FUN(removeDuplicateLiterals_tautology_among_others)
 
   ASS(!result);
 }
+
+// Compute the expected hash from the input literals, independently of the
+// clause's trailing array. Reordering literals must preserve the hash.
+TEST_FUN(hashIsExclusiveOrOverLiterals)
+{
+  auto cl = satClause({ p, ~q, r });
+  unsigned expected = SATLiteralHash::hash(p) ^ SATLiteralHash::hash(~q)
+                    ^ SATLiteralHash::hash(r);
+
+  ASS_EQ(SATClauseHash::hash(*cl), expected);
+  ASS_EQ(cl->defaultHash(), expected);
+
+  auto permuted = satClause({ r, p, ~q });
+  ASS_EQ(SATClauseHash::hash(*permuted), expected);
+
+  cl->destroy();
+  permuted->destroy();
+}


### PR DESCRIPTION
Stage 5 of #898, following #906. Containers keyed on `TermList` (including `SortId`), `VarSpec`, `TermSpec`, `SATLiteral`, `SATClause`, `Coproduct`, and term ordering polynomials now name their hash functors. This includes the pair and tuple keys deferred from stage 4 and the three container sites that explicitly named `DefaultHash`.

The per-type functors hold the hash formulas, and `defaultHash()`/`defaultHash2()` delegate to them. `CoproductHash` and `CoproductHash2` call the existing methods. The method protocol stays until stage 6 threads hashes through generic code and removes `DefaultHash`.

`SATClause` is the exception to identical hash values. Moving its hash loop exposed different results in `-O3` builds when the trailing array declared as `_literals[1]` was indexed directly. `SATClauseHash` uses pointer traversal and computes the XOR of the literal hashes, which can differ from the old optimized loop's result. The regression test derives its expected value from the input literals and checks that permuting them preserves the hash; the output sweeps below check the effect on proof search.

## Checks

- Debug unit tests: 100/100 passed.
- Release build and `checks/sanity` passed.
- `checks/headers` and `git diff --check` passed.
- Output sweeps against `master` (`719d180e2`): 3,768 matching comparisons across 19 configurations, including `-fgj on`, `-ind both -indmd 1`, and `-alasca on`.

Comparisons include full statistics and ignore the version banner, elapsed time, and peak memory. The controls comparing `master` with itself exclude 69 jobs whose output varies between identical builds.

One further timeout mismatch, `int_sum_y_geq_0.smt2` with ALASCA and otter, matched at 300 activations with a time limit of 180 seconds. `NUM919_1` also matched with the longer time limit and its original limit of 1,000 activations. Both reruns included controls.
