### PR TITLE
try bumping actions version to fix cache?

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
         echo "z3_hash=$(git rev-parse HEAD:z3)" >> $GITHUB_OUTPUT
     - name: Restore Z3 build cache
       id: cache-z3
-      uses: actions/cache@v5
+      uses: actions/cache@v6
       with:
         path: z3/build
         key: z3-build-${{ steps.z3hash.outputs.z3_hash }}


### PR DESCRIPTION
CI seems to fail to recover an extant Z3 build from cache, saying (cryptically)

```
Cache hit for: z3-build-3c47fd96cf5645d0c42b2c819d9e9a84380aa721
Warning: Failed to restore: 
Cache not found for input keys: z3-build-3c47fd96cf5645d0c42b2c819d9e9a84380aa721
```

The key does exist. There's a new version of the GitHub `cache` script so let's try that as a first step.