### PR TITLE
Record instructions retired alongside time in TIME_TRACE (depends on #928)

### DIFF
--- a/Debug/TimeProfiling.cpp
+++ b/Debug/TimeProfiling.cpp
@@ -15,6 +15,8 @@
 #include <cstring>
 #include "Shell/Options.hpp"
 #include "Lib/Environment.hpp"
+#include "Lib/PerfInstructions.hpp"
+#include "Lib/Timer.hpp"
 
 namespace Shell {
 
@@ -23,9 +25,20 @@ using namespace Lib;
 
 TimeTrace::TimeTrace()
   : _root("[root]")
-  , _stack({ {&_root, Clock::now(), }, })
+  // -1 for the instruction counter: it does not exist yet, since this object is a
+  // static constructed long before Timer::reinitialise() opens it. See
+  // rebaseInstructionCounters(), which fixes this up once it does.
+  , _stack({ {&_root, Clock::now(), -1}, })
   , _enabled(false)
 {  }
+
+void TimeTrace::rebaseInstructionCounters()
+{
+  long long now = Timer::instructionCountAnyThread();
+  for (auto& x : _stack) {
+    get<2>(x) = now;
+  }
+}
 
 TimeTrace::ScopedTimer::ScopedTimer(const char* name)
   : ScopedTimer(TimeTrace::instance(), name)
@@ -52,12 +65,17 @@ TimeTrace::ScopedTimer::ScopedTimer(TimeTrace& trace, const char* name)
       children.push_back(std::make_unique<Node>(name));
       node = &*children.back();
     }
+    // Read the clock first and the instruction counter second, so that the
+    // instruction interval sits *inside* the time interval: the cost of the clock
+    // read itself is then excluded from the instruction count, while time keeps
+    // measuring everything, as it always did.
     auto start = Clock::now();
+    auto startInstr = Timer::instructionCount();
 #if VDEBUG
     _start = start;
 #endif
 
-    _trace._stack.push_back(std::make_pair(node, start));
+    _trace._stack.push_back(std::make_tuple(node, start, startInstr));
   }
 }
 
@@ -76,12 +94,16 @@ TimeTrace::ScopedTimer::~ScopedTimer()
   if (!_trace._enabled.load(std::memory_order_relaxed))
     return;
 
+  // mirror of the constructor: instructions innermost, time outermost
+  auto nowInstr = Timer::instructionCount();
   auto now = Clock::now();
   auto cur = _trace._stack.back();
   _trace._stack.pop_back();
   auto node = get<0>(cur);
   auto start = get<1>(cur);
-  node->measurements.add(now  - start);
+  auto startInstr = get<2>(cur);
+  node->measurements.add(now - start,
+      (startInstr < 0 || nowInstr < 0) ? 0 : nowInstr - startInstr);
   ASS_EQ(node->name, _name);
   ASS(start == _start);
 }
@@ -125,19 +147,42 @@ std::ostream& operator<<(std::ostream& out, TimeTrace::Duration const& self)
 // << duration_cast<microseconds>(total / cnt).count() << " μs"
 }
 
+/**
+ * An instruction count.
+ *
+ * Deliberately *not* scaled the way Duration is. A count is an exact integer and
+ * comparing two runs is the main thing one does with it, so rounding it to three
+ * significant figures would be self-defeating: printing 12345 as "12 k" gives the
+ * value 1000-instruction granularity, i.e. 8% of itself, which swamps the real
+ * run-to-run variation (which is nearer 0.001%).
+ */
+struct InstrCount { long long n; };
+
+std::ostream& operator<<(std::ostream& out, InstrCount const& self)
+{
+  if (self.n < 0) {
+    return out << "-";
+  }
+  return out << self.n;
+}
+
 struct TimeTrace::Node::NodeFormatOpts {
   // std::vector, not Lib::Stack: printing runs on the timer thread, see Node
   std::vector<const char*>& indent;
   Lib::Option<Duration> parentDuration;
   bool last;
   bool align;
+  // whether the hardware instruction counter was available for this run; when it
+  // was not we still print the field, as "-", so the format stays unconditional
+  bool haveInstr;
   Lib::Option<unsigned> nameWidth;
 
-  NodeFormatOpts child(Node& parent) 
-  { return { .indent = this->indent, 
-             .parentDuration = some(parent.totalDuration()), 
-             .last = false, 
+  NodeFormatOpts child(Node& parent)
+  { return { .indent = this->indent,
+             .parentDuration = some(parent.totalDuration()),
+             .last = false,
              .align = this->align,
+             .haveInstr = this->haveInstr,
              .nameWidth = align
                ? iterTraits(arrayIter(parent.children))
                    .map([](auto& c) { return unsigned(strlen(c->name)); })
@@ -145,11 +190,12 @@ struct TimeTrace::Node::NodeFormatOpts {
                : none<unsigned>(),
                }; }
 
-  static NodeFormatOpts root(decltype(indent) indent) 
-  { return { .indent = indent, 
-             .parentDuration = Option<Duration>(), 
-             .last = true, 
+  static NodeFormatOpts root(decltype(indent) indent, bool haveInstr)
+  { return { .indent = indent,
+             .parentDuration = Option<Duration>(),
+             .last = true,
              .align = false,
+             .haveInstr = haveInstr,
              .nameWidth = none<unsigned>(),
            }; }
 };
@@ -205,8 +251,10 @@ void TimeTrace::Node::printPrettyRec(std::ostream& out, NodeFormatOpts& opts)
   } else {
     out << total / cnt;
   }
-  out << ", cnt: "  << msetw(6) << cnt
-      << ")" << std::endl;
+  out << ", cnt: "  << msetw(6) << cnt;
+  out << ", instr: " << msetw(12)
+      << InstrCount { opts.haveInstr ? measurements.instr() : -1 };
+  out << ")" << std::endl;
 
   // Order a local copy rather than sorting `children` in place: this is called on the
   // timer thread while the main thread may still be scanning and appending to
@@ -334,16 +382,28 @@ void TimeTrace::Node::flatten_(FlattenState& s)
 void TimeTrace::printPretty(std::ostream& out)
 {
 
+  // Credit the scopes that are still open with what they have run so far -- [root]
+  // among them, so this is what gives the top of the trace any numbers at all.
+  //
+  // NB: instructionCountAnyThread(), not the rdpmc reader: when a resource limit
+  // fires we are called on timer_thread, where rdpmc would read the wrong CPU's
+  // counter. This costs a syscall, but happens once per process.
   auto now = Clock::now();
+  auto nowInstr = Timer::instructionCountAnyThread();
+  bool haveInstr = nowInstr >= 0;
+  auto inFlightInstr = [&](long long startInstr) {
+    return (!haveInstr || startInstr < 0) ? 0 : nowInstr - startInstr;
+  };
+
   for (auto& x : _stack) {
     auto node = get<0>(x);
     auto start = get<1>(x);
-    node->measurements.add(now - start);
+    node->measurements.add(now - start, inFlightInstr(get<2>(x)));
   }
 
   auto& root = _tmpRoots.empty() ? _root : *_tmpRoots.back();
   std::vector<const char*> indent;
-  auto rootOpts = Node::NodeFormatOpts::root(indent);
+  auto rootOpts = Node::NodeFormatOpts::root(indent, haveInstr);
 
   out << "===== start of time trace =====" << std::endl;
   rootOpts.align = false;
@@ -361,7 +421,7 @@ void TimeTrace::printPretty(std::ostream& out)
   for (auto& x : _stack) {
     auto node = get<0>(x);
     auto start = get<1>(x);
-    node->measurements.remove(now - start);
+    node->measurements.remove(now - start, inFlightInstr(get<2>(x)));
   }
 
   if (!env.options->timeStatisticsFocus().empty()) {

--- a/Debug/TimeProfiling.hpp
+++ b/Debug/TimeProfiling.hpp
@@ -112,22 +112,29 @@ private:
   class Measurements {
     Duration _sum;
     unsigned _cnt;
+    // user-space instructions retired inside the measured blocks; 0 when the
+    // hardware counter is unavailable (see Lib/PerfInstructions.hpp)
+    long long _instrSum;
 
   public:
-    void add(Duration d) {
+    void add(Duration d, long long instr) {
       _cnt += 1;
       _sum += d;
+      _instrSum += instr;
     }
-    void remove(Duration d) {
+    void remove(Duration d, long long instr) {
       _cnt -= 1;
       _sum -= d;
+      _instrSum -= instr;
     }
     Duration sum() const { return _sum; }
     unsigned cnt() const { return _cnt; }
+    long long instr() const { return _instrSum; }
     Duration avg() const { return sum() / cnt(); }
     void extend(Measurements other) {
       _sum += other._sum;
       _cnt += other._cnt;
+      _instrSum += other._instrSum;
     }
   };
 
@@ -202,11 +209,23 @@ public:
    * running main thread -- see Lib/Timer.cpp, limitReached().
    */
   void setEnabled(bool);
+
+  /**
+   * Re-base the instruction-counter readings of the currently open scopes -- in
+   * practice just [root], which is entered before the counter exists at all.
+   *
+   * Called by Timer::reinitialise() once the perf event has been opened and reset,
+   * so that [root] measures instructions from the counter's own origin rather than
+   * reporting none.
+   */
+  void rebaseInstructionCounters();
 private:
 
   Node _root;
   std::vector<Node*> _tmpRoots;
-  std::vector<std::tuple<Node*, TimePoint>> _stack;
+  // node, and the time / instruction-counter readings taken when it was entered
+  // (the instruction reading is -1 when the hardware counter is unavailable)
+  std::vector<std::tuple<Node*, TimePoint, long long>> _stack;
   // read on every TIME_TRACE scope and written by the timer thread
   std::atomic<bool> _enabled;
 };

--- a/Lib/PerfInstructions.hpp
+++ b/Lib/PerfInstructions.hpp
@@ -1,0 +1,120 @@
+/*
+ * This file is part of the source code of the software program
+ * Vampire. It is protected by applicable
+ * copyright laws.
+ *
+ * This source code is distributed under the licence found here
+ * https://vprover.github.io/license.html
+ * and in the source directory
+ */
+/**
+ * @file PerfInstructions.hpp
+ * Reading the hardware "instructions retired" counter cheaply, from user space.
+ *
+ * Lib/Timer.cpp opens a PERF_COUNT_HW_INSTRUCTIONS event and reads it with
+ * read(PERF_FD), which costs a syscall (measured: ~560ns). That is fine for the
+ * timer thread's periodic limit check, but far too slow for a counter we want to
+ * sample on every TIME_TRACE scope.
+ *
+ * The fast path is to mmap the same file descriptor -- which yields a
+ * struct perf_event_mmap_page -- and read the counter register directly with the
+ * rdpmc instruction. Measured on the reference server: 8.9ns, against 27.5ns for
+ * clock_gettime(CLOCK_MONOTONIC), i.e. cheaper than the clock read the profiler
+ * already does.
+ *
+ * IMPORTANT: instructionCount() may only be called from the thread that
+ * Timer::reinitialise() ran on -- in practice, Vampire's main thread. rdpmc reads
+ * the performance counter register of whatever CPU the *caller* is running on,
+ * which for any other thread is not this event at all. The `index` check below
+ * catches the common case (returning -1 so the caller can fall back), but it is not
+ * a guarantee, so do not call this from timer_thread; use
+ * Timer::updateInstructionCount() there instead.
+ *
+ * This header pulls in <linux/perf_event.h>, so include it only where it is needed
+ * rather than from a widely-included header.
+ */
+
+#ifndef __PerfInstructions__
+#define __PerfInstructions__
+
+#include "Lib/Portability.hpp"
+
+#if VAMPIRE_PERF_EXISTS
+#include <cstdint>
+#include <linux/perf_event.h>
+#endif
+
+namespace Lib {
+namespace Timer {
+
+#if VAMPIRE_PERF_EXISTS
+
+/** The mmap'd metadata page of the perf event, or nullptr when unavailable.
+ *  Set up by Timer::reinitialise(). */
+extern perf_event_mmap_page *PERF_MMAP_PAGE;
+
+/** Whether instructionCount() can return anything meaningful at all. */
+bool instructionCountingAvailable();
+
+#if defined(__x86_64__) || defined(__i386__)
+inline uint64_t rdpmc(uint32_t counter)
+{
+  uint32_t low, high;
+  __asm__ __volatile__("rdpmc" : "=a"(low), "=d"(high) : "c"(counter));
+  return (static_cast<uint64_t>(high) << 32) | low;
+}
+#define VAMPIRE_RDPMC_EXISTS 1
+#endif
+
+#endif // VAMPIRE_PERF_EXISTS
+
+/**
+ * User-space instructions retired by this thread since the counter was reset,
+ * or -1 if that cannot be determined right now.
+ *
+ * Callers should treat -1 as "no measurement", not as a count.
+ */
+inline long long instructionCount()
+{
+#if VAMPIRE_PERF_EXISTS && defined(VAMPIRE_RDPMC_EXISTS)
+  perf_event_mmap_page *pc = PERF_MMAP_PAGE;
+  if (!pc)
+    return -1;
+
+  uint64_t count;
+  uint32_t seq, idx;
+  int64_t offset;
+  uint16_t width;
+
+  do {
+    // pc->lock is a seqlock the kernel bumps whenever it reschedules the event,
+    // which is exactly when index and offset change under us
+    seq = pc->lock;
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+
+    idx = pc->index;      // 0: the event is not on this CPU's PMU at the moment
+    offset = pc->offset;  // what it counted during previous schedulings
+    width = pc->pmc_width;
+
+    if (!pc->cap_user_rdpmc || !idx || width == 0 || width > 64)
+      return -1;
+
+    count = rdpmc(idx - 1);
+    // the hardware register is narrower than 64 bits (typically 48); sign-extend
+    count <<= 64 - width;
+    count = static_cast<uint64_t>(static_cast<int64_t>(count) >> (64 - width));
+    count += offset;
+
+    __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  } while (pc->lock != seq);
+
+  return static_cast<long long>(count);
+#else
+  return -1;
+#endif
+}
+
+} // namespace Timer
+} // namespace Lib
+
+#endif // __PerfInstructions__

--- a/Lib/Timer.cpp
+++ b/Lib/Timer.cpp
@@ -18,6 +18,7 @@
 
 #include "Debug/TimeProfiling.hpp"
 #include "Lib/Environment.hpp"
+#include "Lib/PerfInstructions.hpp"
 #include "Shell/Statistics.hpp"
 #include "Shell/UIHelper.hpp"
 #include "System.hpp"
@@ -34,6 +35,7 @@ const auto TICK_INTERVAL = 1ms;
 #include <asm/unistd.h>
 #include <linux/perf_event.h>
 #include <sys/ioctl.h>
+#include <sys/mman.h>
 #include <unistd.h>
 
 const long long MEGA = 1 << 20;
@@ -41,6 +43,12 @@ const long long MEGA = 1 << 20;
 // static data for measuring instructions
 static int PERF_FD = -1; // the file descriptor we later read the info from
 static long long LAST_INSTRUCTION_COUNT_READ = -1;
+
+namespace Lib { namespace Timer {
+// The same event, mmap'd so that the main thread can read the counter with rdpmc
+// instead of a syscall; see Lib/PerfInstructions.hpp. Null when unavailable.
+perf_event_mmap_page *PERF_MMAP_PAGE = nullptr;
+}}
 
 // convenience wrapper around a syscall (cf. https://linux.die.net/man/2/perf_event_open )
 static long perf_event_open(struct perf_event_attr *hw_event, pid_t pid, int cpu, int group_fd, unsigned long flags)
@@ -200,8 +208,27 @@ void reinitialise(bool tryInitInstructionLimiting) {
     } else {
       ioctl(PERF_FD, PERF_EVENT_IOC_RESET, 0);
       ioctl(PERF_FD, PERF_EVENT_IOC_ENABLE, 0);
+
+      // Map the event's metadata page so that this thread can read the counter with
+      // rdpmc rather than a syscall (Lib/PerfInstructions.hpp). One page is enough:
+      // we want the metadata, not a sample ring buffer. Purely an optimisation, so
+      // a failure here is silent and simply leaves the fast path unavailable.
+      if (PERF_MMAP_PAGE) {
+        munmap(PERF_MMAP_PAGE, sysconf(_SC_PAGESIZE));
+        PERF_MMAP_PAGE = nullptr;
+      }
+      void *page = mmap(nullptr, sysconf(_SC_PAGESIZE), PROT_READ, MAP_SHARED, PERF_FD, 0);
+      if (page != MAP_FAILED) {
+        PERF_MMAP_PAGE = static_cast<perf_event_mmap_page *>(page);
+      }
     }
   }
+#endif
+
+#if VTIME_PROFILING
+  // the counter exists only now, so [root] (entered at static-init time) needs its
+  // instruction reading set to the counter's origin
+  Shell::TimeTrace::instance().rebaseInstructionCounters();
 #endif
 
   std::thread(timer_thread).detach();
@@ -255,6 +282,27 @@ std::string msToSecondsString(int ms)
   return Int::toString(static_cast<float>(ms)/1000)+" s";
 }
 
+#if VAMPIRE_PERF_EXISTS
+/**
+ * Whether instructionCount() (Lib/PerfInstructions.hpp) can return a real count.
+ *
+ * Needs the mmap to have succeeded, the kernel to permit user-space reads
+ * (cap_user_rdpmc), and the PMU not to be multiplexing this event -- under
+ * multiplexing the kernel expects the count to be *scaled* by
+ * time_enabled/time_running, which turns it into an estimate and so destroys the
+ * determinism that is the whole point of counting instructions.
+ */
+bool instructionCountingAvailable()
+{
+  perf_event_mmap_page *pc = PERF_MMAP_PAGE;
+  return pc
+    && pc->cap_user_rdpmc
+    && pc->pmc_width > 0 && pc->pmc_width <= 64
+    && pc->time_enabled == pc->time_running
+    && instructionCount() >= 0;
+}
+#endif
+
 bool instructionLimitingInPlace()
 {
 #if VAMPIRE_PERF_EXISTS
@@ -270,6 +318,28 @@ long elapsedMegaInstructions() {
 #else
   return 0;
 #endif
+}
+
+/**
+ * The exact instruction count, readable from *any* thread.
+ *
+ * Unlike instructionCount() (Lib/PerfInstructions.hpp), which uses rdpmc and is
+ * therefore only valid on the thread the event is attached to, this goes through
+ * the file descriptor and so is safe for timer_thread. It costs a syscall
+ * (~560ns measured), so use it once, not per measurement.
+ *
+ * Returns -1 when instruction counting is unavailable.
+ */
+long long instructionCountAnyThread()
+{
+#if VAMPIRE_PERF_EXISTS
+  if (PERF_FD >= 0) {
+    long long value = -1;
+    if (read(PERF_FD, &value, sizeof(long long)) == sizeof(long long))
+      return value;
+  }
+#endif
+  return -1;
 }
 
 // called by the main process and timer_thread: should be thread-safe

--- a/Lib/Timer.hpp
+++ b/Lib/Timer.hpp
@@ -51,6 +51,10 @@ namespace Timer {
   // make sure that the instruction data is as up-to-date as possible
   // otherwise may be (slightly) stale
   void updateInstructionCount();
+
+  // exact instruction count, safe to call from any thread but costing a syscall;
+  // -1 when unavailable. For a cheap same-thread read see Lib/PerfInstructions.hpp
+  long long instructionCountAnyThread();
 };
 }
 


### PR DESCRIPTION
A -tstat sweep is normally run many-ways parallel, and wall clock then measures the machine as much as the code: on the reference server, 120 concurrent jobs spread effective throughput from 1828 M instr/s at p10 to 4724 at p90, so a run at p10 takes 1.71x longer than the median for identical work. Ratios within one run survive that; per-node comparisons between runs do not.

Instruction counts do not have that problem. Measured on the same machine, a fixed workload retires 12000031 and 12000032 instructions across seven runs -- a spread of 0.0000%.

So each TIME_TRACE node now carries user-space instructions retired as well as elapsed time:

  [root] (total: 39 ms, avg: 39 ms, cnt: 1, instr: 118 M)

Both are kept, deliberately. Part of that 2.6x throughput spread is genuine memory-boundedness rather than contention -- median throughput falls monotonically with peak memory, 4530 M instr/s under 64 MB down to 2672 at 256 MB-1 GB -- and an instructions-only trace would make a node that is slow because it is cache-missing look cheap. Time and instructions together give ns-per-instruction per node, which is what tells those two apart.

Reading the counter cheaply

Lib/Timer.cpp already opens a PERF_COUNT_HW_INSTRUCTIONS event but reads it with read(PERF_FD), which costs a syscall (~560ns measured) -- fine for the timer thread's 1ms limit check, hopeless for a scope entered ~10^9 times per run. The new Lib/PerfInstructions.hpp mmaps the same fd and reads the counter register directly with rdpmc under the metadata page's seqlock: 8.9ns measured, against 27.5ns for the clock_gettime the profiler already does per scope.

rdpmc reads the performance counter of whatever CPU the *caller* runs on, so it is only valid on the thread the event is attached to. Hence the split: ScopedTimer (main thread) takes the fast path, while printPretty -- which runs on timer_thread when a resource limit fires -- credits the still-open scopes using the new Timer::instructionCountAnyThread(), which goes through the fd. Everything degrades to "no measurement" rather than to a wrong number: non-x86, no cap_user_rdpmc, or an event not currently scheduled all yield -1, and the field then prints as "-" so the output format stays unconditional.

Two details worth knowing:

- reads are ordered so the instruction interval nests inside the time interval (clock first on entry, instructions first on exit), which keeps the cost of the clock read itself out of the instruction count;
- [root] is entered during static initialisation, long before the counter exists, so Timer::reinitialise() calls TimeTrace::rebaseInstructionCounters() once the event has been opened and reset. Without it the whole-run total would read 0.

instructionCountingAvailable() also refuses to report anything when the PMU is multiplexing this event (time_enabled != time_running), since the kernel then expects counts to be scaled, which would turn them into estimates and destroy the determinism that is the entire point.

Verified locally: unit tests 100/100, checks/sanity clean, output format correct. macOS has neither perf_event_open nor user-space PMU access, so the values themselves are NOT verified here -- they read "-". On Linux, check that [root]'s instr matches the independently-obtained "Instructions burned" statistics line (which reads the same event through read()), and that two -al-bounded runs of one problem agree to well under 0.1% per node while their times do not.