### PR TITLE
Tuning the LRS code a bit

### DIFF
--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -33,9 +33,9 @@ using namespace Kernel;
 using namespace Shell;
 
 
-void LRS::poppedFromUnprocessed(Clause* c)
+void LRS::afterUnprocessedLoop(unsigned popsElapsed)
 {
-  if(shouldUpdateLimits()) {
+  if(shouldUpdateLimits(popsElapsed)) {
     TIME_TRACE("LRS limit maintenance");
 
     long long estimatedReachable=estimatedReachableCount();
@@ -52,17 +52,17 @@ void LRS::poppedFromUnprocessed(Clause* c)
  * The time of the limit update is determined by a counter
  * of calls of this method.
  */
-bool LRS::shouldUpdateLimits()
+bool LRS::shouldUpdateLimits(unsigned popsElapsed)
 {
+  static unsigned leftoverPops=0;
+  leftoverPops += popsElapsed;
+
   if (env.statistics->activations <= 10)
     return false;
 
-  static unsigned cnt=0;
-  cnt++;
-
   //when there are limits, we check more frequently so we don't skip too much inferences
-  if(cnt==500 || (_passive->limitsActive() && cnt>50 ) ) {
-    cnt=0;
+  if(leftoverPops>500 || (_passive->limitsActive() && leftoverPops>50 )) {
+    leftoverPops = 0;
     return true;
   }
   return false;

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -18,15 +18,11 @@
 #include "Kernel/Clause.hpp"
 #include "Shell/Statistics.hpp"
 #include "Shell/Options.hpp"
+#include "Lib/ScopedPtr.hpp"
 
 #include "LRS.hpp"
 
-#define DETERMINISE_LRS_SAVE 0
-#define DETERMINISE_LRS_LOAD 0
-
-#if DETERMINISE_LRS_SAVE || DETERMINISE_LRS_LOAD
 #include <fstream>
-#endif
 
 namespace Saturation
 {
@@ -78,14 +74,14 @@ bool LRS::shouldUpdateLimits()
  */
 long long LRS::estimatedReachableCount()
 {
-#if DETERMINISE_LRS_LOAD
-  static std::ifstream infile("lrs_data.txt");
-  long long thing;
-  if (infile >> thing) {
-    cout << "reading " << thing << endl;
-    return thing;
+  static ScopedPtr<std::ifstream> infile((!env.options->lrsLoadTraceFile().empty()) ? new std::ifstream(env.options->lrsLoadTraceFile().c_str()) : 0);
+  if (infile) {
+    long long thing;
+    if (*infile >> thing) {
+      // cout << "reading " << thing << endl;
+      return thing;
+    }
   }
-#endif
 
   long currTime = Timer::elapsedMilliseconds();
   // time spent in saturation (parsing, preprocessing, and the initial loading up of the input into passive are excluded)
@@ -144,10 +140,10 @@ long long LRS::estimatedReachableCount()
 
   finish:
 
-#if DETERMINISE_LRS_SAVE
-  static std::ofstream outfile("lrs_data.txt");
-  outfile << result << endl;
-#endif
+  static ScopedPtr<std::ofstream> outfile((!env.options->lrsSaveTraceFile().empty()) ? new std::ofstream(env.options->lrsSaveTraceFile().c_str()) : 0);
+  if (outfile) {
+    (*outfile) << result << std::endl;
+  }
 
   return result;
 }

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -12,12 +12,15 @@
  * Implements class LRS.
  */
 
+#include <chrono>
+
 #include "Lib/Environment.hpp"
 #include "Lib/Timer.hpp"
 #include "Debug/TimeProfiling.hpp"
 #include "Kernel/Clause.hpp"
 #include "Shell/Statistics.hpp"
 #include "Shell/Options.hpp"
+#include "Shell/UIHelper.hpp"
 
 #include "LRS.hpp"
 
@@ -36,31 +39,153 @@ void LRS::afterUnprocessedLoop(unsigned popsElapsed)
   if(shouldUpdateLimits(popsElapsed)) {
     TIME_TRACE("LRS limit maintenance");
 
+    // Charge this update against the maintenance budget. steady_clock rather than
+    // Timer::elapsedMilliseconds(), because a typical update takes a few hundred
+    // microseconds and would round to zero milliseconds.
+    auto startedAt = std::chrono::steady_clock::now();
+    long startInstrs = Timer::elapsedMegaInstructions();
+
     long long estimatedReachable=estimatedReachableCount();
     if(estimatedReachable>=0) {
       _passive->updateLimits(estimatedReachable);
     }
+
+    _maintenanceMicros += std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now() - startedAt).count();
+    // Note this one is coarse: elapsedMegaInstructions() returns a value the timer
+    // thread refreshes on a 1ms tick, so a single update usually sees no change at
+    // all and occasionally sees a jump. The tick advances at the true rate, so the
+    // running total is what converges -- which is why the budget below is checked
+    // cumulatively rather than per update.
+    _maintenanceInstrs += Timer::elapsedMegaInstructions() - startInstrs;
   }
+}
+
+/**
+ * Is the instruction limit the one that will stop this run first?
+ *
+ * estimatedReachableCount() takes the min of a time-based and an instruction-based
+ * estimate, i.e. it is governed by whichever limit binds. The maintenance budget
+ * follows the same rule, since the resource worth conserving is the one that runs
+ * out first. With no instruction limit set, or no way to read the counter, it is
+ * time by default.
+ */
+bool LRS::bindingResourceIsInstructions()
+{
+  long instrLimit = 0; // (in mega-instructions)
+#if VAMPIRE_PERF_EXISTS
+  instrLimit = _opt.simulatedInstructionLimit()
+    ? _opt.simulatedInstructionLimit()
+    : _opt.instructionLimit();
+#endif
+  if (instrLimit <= 0) {
+    return false;
+  }
+  int timeLimitDeci = _opt.simulatedTimeLimit()
+    ? _opt.simulatedTimeLimit()
+    : _opt.timeLimitInDeciseconds();
+  if (timeLimitDeci <= 0) {
+    return true;
+  }
+  // both active: whichever is a larger fraction of the way to its limit
+  long instrsBurned = Timer::elapsedMegaInstructions() - _lrsStartInstrs;
+  long timeSpent = Timer::elapsedMilliseconds() - _lrsStartTime; // (in milliseconds)
+  return instrsBurned * static_cast<long long>(timeLimitDeci) * 100 >
+         timeSpent * static_cast<long long>(instrLimit);
+}
+
+/**
+ * Has limit maintenance stayed inside its share of the saturation budget so far?
+ *
+ * Each update simulates the passive set, at a cost proportional to the number of
+ * clauses it expects to still reach, so it gets more expensive as a run goes on.
+ * Left alone it reaches 90% of the longest runs. Comparing the running cost against
+ * the running total keeps the share near -lmb without needing to predict anything:
+ * after an expensive update this simply stays false until saturation catches up.
+ */
+bool LRS::withinMaintenanceBudget()
+{
+  // double rather than float: on a long run the right-hand side reaches ~1e7
+  // microseconds, which is where float's 24-bit mantissa starts losing units.
+  double budget = _opt.lrsMaintenanceBudget();
+
+  if (bindingResourceIsInstructions()) {
+    long spent = Timer::elapsedMegaInstructions() - _lrsStartInstrs;
+    return _maintenanceInstrs <= budget * spent;
+  }
+  long spent = Timer::elapsedMilliseconds() - _lrsStartTime; // (in milliseconds)
+  return _maintenanceMicros <= budget * spent * 1000.0;
 }
 
 /**
  * Return true if it is time to update age and weight
  * limits of the LRS strategy
  *
- * The time of the limit update is determined by a counter
- * of calls of this method.
+ * The pops counter sets the rate, exactly as before; the budget check can only ever
+ * hold an update back. So this is a pure throttle: where updates are cheap the budget
+ * never binds and the cadence is master's, and only the expensive runs -- the ones
+ * where maintenance had grown to a large share of the run -- see any difference.
  */
 bool LRS::shouldUpdateLimits(unsigned popsElapsed)
 {
+  openTraceFiles();
+
   _leftoverPops += popsElapsed;
+
+  if (replaying()) {
+    // Replay must not consult the clock, the instruction counter or the budget:
+    // that is the whole point of the trace, and it is what lets a run recorded
+    // under one limit be replayed under another. The recorded pop counts are the
+    // only thing driving the cadence here.
+    if (_traceExhausted || !readNextRecord()) {
+      return false;
+    }
+    if (_leftoverPops < _nextRecordPops) {
+      return false;
+    }
+    _leftoverPops = 0;
+    _haveNextRecord = false; // consumed by the update we are about to make
+    return true;
+  }
 
   if (env.statistics->activations <= 10)
     return false;
 
   //when there are limits, we check more frequently so we don't skip too much inferences
   if(_leftoverPops>500 || (_passive->limitsActive() && _leftoverPops>50 )) {
+    if (!withinMaintenanceBudget()) {
+      // Deliberately leave _leftoverPops standing, so that the update happens at the
+      // first opportunity once the budget allows rather than after a further 50 pops.
+      return false;
+    }
+    _popsAtFire = _leftoverPops;
     _leftoverPops = 0;
     return true;
+  }
+  return false;
+}
+
+/**
+ * Ensure _nextRecordPops/_nextRecordResult hold the next unconsumed trace record.
+ *
+ * Returns false once the file runs out, after which no further updates are made:
+ * finishing a replay on the live (clock-driven) logic would silently stop
+ * reproducing the recorded run, which is worse than doing nothing.
+ */
+bool LRS::readNextRecord()
+{
+  if (_haveNextRecord) {
+    return true;
+  }
+  if (*_loadTrace >> _nextRecordPops >> _nextRecordResult) {
+    _haveNextRecord = true;
+    return true;
+  }
+  if (!_traceExhausted) {
+    _traceExhausted = true;
+    addCommentSignForSZS(std::cout);
+    std::cout << "LRS trace file exhausted; limits will no longer be updated"
+              << std::endl;
   }
   return false;
 }
@@ -94,13 +219,10 @@ void LRS::openTraceFiles()
  */
 long long LRS::estimatedReachableCount()
 {
-  openTraceFiles();
-
-  if (_loadTrace) {
-    long long thing;
-    if (*_loadTrace >> thing) {
-      return thing;
-    }
+  if (replaying()) {
+    // shouldUpdateLimits only returns true here having consumed a record, so the
+    // estimate to use is the one that record carried.
+    return _nextRecordResult;
   }
 
   long currTime = Timer::elapsedMilliseconds();
@@ -161,7 +283,7 @@ long long LRS::estimatedReachableCount()
   finish:
 
   if (_saveTrace) {
-    (*_saveTrace) << result << std::endl;
+    (*_saveTrace) << _popsAtFire << " " << result << std::endl;
   }
 
   return result;

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -18,11 +18,9 @@
 #include "Kernel/Clause.hpp"
 #include "Shell/Statistics.hpp"
 #include "Shell/Options.hpp"
-#include "Lib/ScopedPtr.hpp"
 
 #include "LRS.hpp"
 
-#include <fstream>
 
 namespace Saturation
 {
@@ -54,18 +52,40 @@ void LRS::afterUnprocessedLoop(unsigned popsElapsed)
  */
 bool LRS::shouldUpdateLimits(unsigned popsElapsed)
 {
-  static unsigned leftoverPops=0;
-  leftoverPops += popsElapsed;
+  _leftoverPops += popsElapsed;
 
   if (env.statistics->activations <= 10)
     return false;
 
   //when there are limits, we check more frequently so we don't skip too much inferences
-  if(leftoverPops>500 || (_passive->limitsActive() && leftoverPops>50 )) {
-    leftoverPops = 0;
+  if(_leftoverPops>500 || (_passive->limitsActive() && _leftoverPops>50 )) {
+    _leftoverPops = 0;
     return true;
   }
   return false;
+}
+
+/**
+ * Open the trace files named by -lrs_save_trace_file / -lrs_load_trace_file, once.
+ *
+ * Lazily rather than in a constructor because LRS inherits Otter's constructors, and
+ * because a run that sets neither option should not touch the filesystem at all.
+ */
+void LRS::openTraceFiles()
+{
+  if (_traceOpened) {
+    return;
+  }
+  _traceOpened = true;
+
+  const std::string& load = _opt.lrsLoadTraceFile();
+  if (!load.empty()) {
+    _loadTrace = std::make_unique<std::ifstream>(load.c_str());
+  }
+  const std::string& save = _opt.lrsSaveTraceFile();
+  if (!save.empty()) {
+    _saveTrace = std::make_unique<std::ofstream>(save.c_str());
+  }
 }
 
 /**
@@ -74,11 +94,11 @@ bool LRS::shouldUpdateLimits(unsigned popsElapsed)
  */
 long long LRS::estimatedReachableCount()
 {
-  static ScopedPtr<std::ifstream> infile((!env.options->lrsLoadTraceFile().empty()) ? new std::ifstream(env.options->lrsLoadTraceFile().c_str()) : 0);
-  if (infile) {
+  openTraceFiles();
+
+  if (_loadTrace) {
     long long thing;
-    if (*infile >> thing) {
-      // cout << "reading " << thing << endl;
+    if (*_loadTrace >> thing) {
       return thing;
     }
   }
@@ -140,9 +160,8 @@ long long LRS::estimatedReachableCount()
 
   finish:
 
-  static ScopedPtr<std::ofstream> outfile((!env.options->lrsSaveTraceFile().empty()) ? new std::ofstream(env.options->lrsSaveTraceFile().c_str()) : 0);
-  if (outfile) {
-    (*outfile) << result << std::endl;
+  if (_saveTrace) {
+    (*_saveTrace) << result << std::endl;
   }
 
   return result;

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -109,6 +109,16 @@ bool LRS::withinMaintenanceBudget()
   // microseconds, which is where float's 24-bit mantissa starts losing units.
   double budget = _opt.lrsMaintenanceBudget();
 
+  // Maintenance is a subset of the saturation it is measured against, so a budget
+  // of 1.0 or more can never be exceeded and the throttle is off. Short-circuiting
+  // says so exactly rather than nearly: on the time path `spent` is truncated to
+  // whole milliseconds, so without this the comparison could still fail inside the
+  // first millisecond, where maintenance can exceed a `spent` that is still 0.
+  // This makes -lmb 1.0 a clean "as if unthrottled" baseline to measure against.
+  if (budget >= 1.0) {
+    return true;
+  }
+
   if (bindingResourceIsInstructions()) {
     long spent = Timer::elapsedMegaInstructions() - _lrsStartInstrs;
     return _maintenanceInstrs <= budget * spent;

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -100,31 +100,27 @@ bool LRS::bindingResourceIsInstructions()
  * Each update simulates the passive set, at a cost proportional to the number of
  * clauses it expects to still reach, so it gets more expensive as a run goes on.
  * Left alone it reaches 90% of the longest runs. Comparing the running cost against
- * the running total keeps the share near -lmb without needing to predict anything:
- * after an expensive update this simply stays false until saturation catches up.
+ * the running total keeps the share near MAINTENANCE_BUDGET without needing to predict
+ * anything: after an expensive update this simply stays false until saturation catches up.
  */
 bool LRS::withinMaintenanceBudget()
 {
+  // The fraction of the saturation budget -- of time, or of instructions, whichever
+  // limit is the binding one -- that limit maintenance may spend. Tuned by sweeping
+  // the whole TPTP: at 0.05 the cap holds (max 5.45% of wall time per run, the excess
+  // being the one update already in flight when the budget runs out) while moving
+  // maintenance from 15.71% to 2.75% of corpus wall time.
+  //
   // double rather than float: on a long run the right-hand side reaches ~1e7
   // microseconds, which is where float's 24-bit mantissa starts losing units.
-  double budget = _opt.lrsMaintenanceBudget();
-
-  // Maintenance is a subset of the saturation it is measured against, so a budget
-  // of 1.0 or more can never be exceeded and the throttle is off. Short-circuiting
-  // says so exactly rather than nearly: on the time path `spent` is truncated to
-  // whole milliseconds, so without this the comparison could still fail inside the
-  // first millisecond, where maintenance can exceed a `spent` that is still 0.
-  // This makes -lmb 1.0 a clean "as if unthrottled" baseline to measure against.
-  if (budget >= 1.0) {
-    return true;
-  }
+  constexpr double MAINTENANCE_BUDGET = 0.05;
 
   if (bindingResourceIsInstructions()) {
     long spent = Timer::elapsedMegaInstructions() - _lrsStartInstrs;
-    return _maintenanceInstrs <= budget * spent;
+    return _maintenanceInstrs <= MAINTENANCE_BUDGET * spent;
   }
   long spent = Timer::elapsedMilliseconds() - _lrsStartTime; // (in milliseconds)
-  return _maintenanceMicros <= budget * spent * 1000.0;
+  return _maintenanceMicros <= MAINTENANCE_BUDGET * spent * 1000.0;
 }
 
 /**

--- a/Saturation/LRS.cpp
+++ b/Saturation/LRS.cpp
@@ -24,6 +24,7 @@
 
 #include "LRS.hpp"
 
+#include <fstream>
 
 namespace Saturation
 {

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -31,9 +31,9 @@ public:
   using Otter::Otter;
 
 protected:
-  void poppedFromUnprocessed(Clause* c) override;
+  void afterUnprocessedLoop(unsigned popsElapsed) override;
 
-  bool shouldUpdateLimits();
+  bool shouldUpdateLimits(unsigned popsElapsed);
 
   long long estimatedReachableCount();
 };

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -46,12 +46,35 @@ private:
    * solved in one process. */
   unsigned _leftoverPops = 0;
 
+  /** Running cost of limit maintenance, against which the -lmb budget is checked.
+   * Kept in both units because which one matters depends on which limit binds;
+   * see bindingResourceIsInstructions(). */
+  long long _maintenanceMicros = 0;   //< microseconds spent in updates
+  long _maintenanceInstrs = 0;        //< mega-instructions spent in updates
+
+  bool withinMaintenanceBudget();
+  bool bindingResourceIsInstructions();
+
   /** Trace of limit-update decisions, for reproducing an LRS run exactly.
-   * Opened lazily on first use from -lrs_save_trace_file / -lrs_load_trace_file. */
+   * Opened lazily on first use from -lrs_save_trace_file / -lrs_load_trace_file.
+   * Each record is "<pops accumulated when the update fired> <estimate returned>":
+   * the decision has to be recorded as well as its result, because the cadence
+   * consults the clock and so is not reproducible on its own. */
   std::unique_ptr<std::ofstream> _saveTrace;
   std::unique_ptr<std::ifstream> _loadTrace;
   bool _traceOpened = false;
   void openTraceFiles();
+
+  /** Replay state: the next record read ahead from _loadTrace, and the result to
+   * hand back for the update it describes. */
+  bool _haveNextRecord = false;
+  bool _traceExhausted = false;
+  unsigned _nextRecordPops = 0;
+  long long _nextRecordResult = -1;
+  /** Pops that triggered the update currently being made, for _saveTrace. */
+  unsigned _popsAtFire = 0;
+  bool replaying() const { return _loadTrace != nullptr; }
+  bool readNextRecord();
 };
 
 };

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -20,6 +20,9 @@
 
 #include "Otter.hpp"
 
+#include <fstream>
+#include <memory>
+
 namespace Saturation {
 
 using namespace Kernel;
@@ -36,6 +39,19 @@ protected:
   bool shouldUpdateLimits(unsigned popsElapsed);
 
   long long estimatedReachableCount();
+
+private:
+  /** Unprocessed pops seen since the last limit update. Carried across calls, so it
+   * must be per-instance state: a function-local static would leak between Problems
+   * solved in one process. */
+  unsigned _leftoverPops = 0;
+
+  /** Trace of limit-update decisions, for reproducing an LRS run exactly.
+   * Opened lazily on first use from -lrs_save_trace_file / -lrs_load_trace_file. */
+  std::unique_ptr<std::ofstream> _saveTrace;
+  std::unique_ptr<std::ifstream> _loadTrace;
+  bool _traceOpened = false;
+  void openTraceFiles();
 };
 
 };

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -41,9 +41,7 @@ protected:
   long long estimatedReachableCount();
 
 private:
-  /** Unprocessed pops seen since the last limit update. Carried across calls, so it
-   * must be per-instance state: a function-local static would leak between Problems
-   * solved in one process. */
+  /** Unprocessed pops seen since the last limit update. */
   unsigned _leftoverPops = 0;
 
   /** Running cost of limit maintenance, against which the -lmb budget is checked.

--- a/Saturation/LRS.hpp
+++ b/Saturation/LRS.hpp
@@ -20,7 +20,7 @@
 
 #include "Otter.hpp"
 
-#include <fstream>
+#include <iosfwd>
 #include <memory>
 
 namespace Saturation {

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1201,10 +1201,10 @@ void SaturationAlgorithm::doUnprocessedLoop()
   do {
     newClausesToUnprocessed();
 
+    unsigned unprocessedPops = 0;
     while (!_unprocessed->isEmpty()) {
+      unprocessedPops++;
       Clause* c = _unprocessed->pop();
-      poppedFromUnprocessed(c); // tells LRS's it might make sense to update limits
-
       ASS(!isRefutation(c));
 
       if (forwardSimplify(c)) {
@@ -1218,7 +1218,11 @@ void SaturationAlgorithm::doUnprocessedLoop()
       }
 
       newClausesToUnprocessed();
+      // It should not matter that much (from the point of view of the NN) that these new clauses are now unevaluated
+      // (the assumption is that reduced good clause is also good)
     }
+
+    afterUnprocessedLoop(unprocessedPops);
 
     ASS(clausesFlushed());
     onAllProcessed(); // in particular, Splitter has now recomputed model which may have triggered deletions and additions

--- a/Saturation/SaturationAlgorithm.cpp
+++ b/Saturation/SaturationAlgorithm.cpp
@@ -1218,11 +1218,9 @@ void SaturationAlgorithm::doUnprocessedLoop()
       }
 
       newClausesToUnprocessed();
-      // It should not matter that much (from the point of view of the NN) that these new clauses are now unevaluated
-      // (the assumption is that reduced good clause is also good)
     }
 
-    afterUnprocessedLoop(unprocessedPops);
+    afterUnprocessedLoop(unprocessedPops); // may trigger LRS estimate update
 
     ASS(clausesFlushed());
     onAllProcessed(); // in particular, Splitter has now recomputed model which may have triggered deletions and additions

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -171,8 +171,8 @@ protected:
   void onAllProcessed();
   virtual bool isComplete();
   /*
-   * Called at the beginning of doUnprocessedLoop;
-   * will recieve the number of unprocessed pops since last call;
+   * Called once per doUnprocessedLoop iteration, after unprocessed has been drained;
+   * receives the number of unprocessed pops since the last call;
    * used by LRS to potentially update its estimates.
   */
   virtual void afterUnprocessedLoop(unsigned popsElapsed) {};

--- a/Saturation/SaturationAlgorithm.hpp
+++ b/Saturation/SaturationAlgorithm.hpp
@@ -170,7 +170,12 @@ protected:
   virtual void beforeSelectedRemoved(Clause* cl) {};
   void onAllProcessed();
   virtual bool isComplete();
-  virtual void poppedFromUnprocessed(Clause* cl) {}; // mainly for LRS to inherit and update its estimates there
+  /*
+   * Called at the beginning of doUnprocessedLoop;
+   * will recieve the number of unprocessed pops since last call;
+   * used by LRS to potentially update its estimates.
+  */
+  virtual void afterUnprocessedLoop(unsigned popsElapsed) {};
 
 private:
   void passiveRemovedHandler(Clause* cl);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1279,6 +1279,13 @@ void Options::init()
     _lrsLoadTraceFile.tag(OptionTag::LRS);
     _lrsLoadTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
 
+    _lrsMaintenanceBudget = FloatOptionValue("lrs_maintenance_budget","lmb",0.05);
+    _lrsMaintenanceBudget.description = "The fraction of the saturation budget (of time, or of instructions, whichever limit is the binding one) that LRS may spend on maintaining its limits. Each update simulates the passive set, so its cost grows with the run; without a cap, maintenance can reach 90% of a long run. Larger values give more up-to-date limits at a higher price.";
+    _lookup.insert(&_lrsMaintenanceBudget);
+    _lrsMaintenanceBudget.tag(OptionTag::LRS);
+    _lrsMaintenanceBudget.addConstraint(greaterThan(0.0f));
+    _lrsMaintenanceBudget.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
+
   //*********************** Inferences  ***********************
 
 #if VZ3

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1267,6 +1267,18 @@ void Options::init()
     _lrsEstimateCorrectionCoef.addConstraint(greaterThan(0.0f));
     _lrsEstimateCorrectionCoef.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
 
+    _lrsSaveTraceFile = StringOptionValue("lrs_save_trace_file","lstf","");
+    _lrsSaveTraceFile.description = "When set, vampire will output a trace of decistions in the LRS estimate module, which can be used to reproduce a lucky run.";
+    _lookup.insert(&_lrsSaveTraceFile);
+    _lrsSaveTraceFile.tag(OptionTag::LRS);
+    _lrsSaveTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
+
+    _lrsLoadTraceFile = StringOptionValue("lrs_load_trace_file","lltf","");
+    _lrsLoadTraceFile.description = "When set, vampire will load a previously saved trace of decistions of the LRS estimate module, which be used insteado fhte modules logic to guide the estimates.";
+    _lookup.insert(&_lrsLoadTraceFile);
+    _lrsLoadTraceFile.tag(OptionTag::LRS);
+    _lrsLoadTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
+
   //*********************** Inferences  ***********************
 
 #if VZ3
@@ -3530,6 +3542,10 @@ std::string Options::generateEncodedOptions() const
     forbidden.insert(&_selection);
     forbidden.insert(&_ageWeightRatio);
     forbidden.insert(&_timeLimitInDeciseconds);
+
+    // not filenames, please
+    forbidden.insert(&_lrsSaveTraceFile);
+    forbidden.insert(&_lrsLoadTraceFile);
 
     //things we don't want to output (showHelp etc won't get to here anyway)
     forbidden.insert(&_mode);

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1280,7 +1280,7 @@ void Options::init()
     _lrsLoadTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
 
     _lrsMaintenanceBudget = FloatOptionValue("lrs_maintenance_budget","lmb",0.05);
-    _lrsMaintenanceBudget.description = "The fraction of the saturation budget (of time, or of instructions, whichever limit is the binding one) that LRS may spend on maintaining its limits. Each update simulates the passive set, so its cost grows with the run; without a cap, maintenance can reach 90% of a long run. Larger values give more up-to-date limits at a higher price.";
+    _lrsMaintenanceBudget.description = "The fraction of the saturation budget (of time, or of instructions, whichever limit is the binding one) that LRS may spend on maintaining its limits. Each update simulates the passive set, so its cost grows with the run; without a cap, maintenance can reach 90% of a long run. Larger values give more up-to-date limits at a higher price. Maintenance is a subset of what it is measured against, so any value >= 1.0 switches the cap off entirely.";
     _lookup.insert(&_lrsMaintenanceBudget);
     _lrsMaintenanceBudget.tag(OptionTag::LRS);
     _lrsMaintenanceBudget.addConstraint(greaterThan(0.0f));

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1274,7 +1274,7 @@ void Options::init()
     _lrsSaveTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
 
     _lrsLoadTraceFile = StringOptionValue("lrs_load_trace_file","lltf","");
-    _lrsLoadTraceFile.description = "When set, vampire will load a previously saved trace of decistions of the LRS estimate module, which be used insteado fhte modules logic to guide the estimates.";
+    _lrsLoadTraceFile.description = "When set, vampire will load a previously saved trace of decistions of the LRS estimate module, which be used instead of the module's logic to guide the estimates.";
     _lookup.insert(&_lrsLoadTraceFile);
     _lrsLoadTraceFile.tag(OptionTag::LRS);
     _lrsLoadTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));

--- a/Shell/Options.cpp
+++ b/Shell/Options.cpp
@@ -1279,12 +1279,6 @@ void Options::init()
     _lrsLoadTraceFile.tag(OptionTag::LRS);
     _lrsLoadTraceFile.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
 
-    _lrsMaintenanceBudget = FloatOptionValue("lrs_maintenance_budget","lmb",0.05);
-    _lrsMaintenanceBudget.description = "The fraction of the saturation budget (of time, or of instructions, whichever limit is the binding one) that LRS may spend on maintaining its limits. Each update simulates the passive set, so its cost grows with the run; without a cap, maintenance can reach 90% of a long run. Larger values give more up-to-date limits at a higher price. Maintenance is a subset of what it is measured against, so any value >= 1.0 switches the cap off entirely.";
-    _lookup.insert(&_lrsMaintenanceBudget);
-    _lrsMaintenanceBudget.tag(OptionTag::LRS);
-    _lrsMaintenanceBudget.addConstraint(greaterThan(0.0f));
-    _lrsMaintenanceBudget.onlyUsefulWith(_saturationAlgorithm.is(equal(SaturationAlgorithm::LRS)));
 
   //*********************** Inferences  ***********************
 

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2122,6 +2122,7 @@ public:
   int simulatedTimeLimit() const { return _simulatedTimeLimit.actualValue; }
   void setSimulatedTimeLimit(int newVal) { _simulatedTimeLimit.actualValue = newVal; }
   float lrsEstimateCorrectionCoef() const { return _lrsEstimateCorrectionCoef.actualValue; }
+  float lrsMaintenanceBudget() const { return _lrsMaintenanceBudget.actualValue; }
   const std::string& lrsSaveTraceFile() const { return _lrsSaveTraceFile.actualValue; }
   const std::string& lrsLoadTraceFile() const { return _lrsLoadTraceFile.actualValue; }
   TermOrdering termOrdering() const { return _termOrdering.actualValue; }
@@ -2669,6 +2670,7 @@ private:
   BoolOptionValue _useACeval;
   TimeLimitOptionValue _simulatedTimeLimit;
   FloatOptionValue _lrsEstimateCorrectionCoef;
+  FloatOptionValue _lrsMaintenanceBudget;
   StringOptionValue _lrsSaveTraceFile;
   StringOptionValue _lrsLoadTraceFile;
   UnsignedOptionValue _sineDepth;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2122,6 +2122,8 @@ public:
   int simulatedTimeLimit() const { return _simulatedTimeLimit.actualValue; }
   void setSimulatedTimeLimit(int newVal) { _simulatedTimeLimit.actualValue = newVal; }
   float lrsEstimateCorrectionCoef() const { return _lrsEstimateCorrectionCoef.actualValue; }
+  const std::string& lrsSaveTraceFile() const { return _lrsSaveTraceFile.actualValue; }
+  const std::string& lrsLoadTraceFile() const { return _lrsLoadTraceFile.actualValue; }
   TermOrdering termOrdering() const { return _termOrdering.actualValue; }
   SymbolPrecedence symbolPrecedence() const { return _symbolPrecedence.actualValue; }
   SymbolPrecedenceBoost symbolPrecedenceBoost() const { return _symbolPrecedenceBoost.actualValue; }
@@ -2667,6 +2669,8 @@ private:
   BoolOptionValue _useACeval;
   TimeLimitOptionValue _simulatedTimeLimit;
   FloatOptionValue _lrsEstimateCorrectionCoef;
+  StringOptionValue _lrsSaveTraceFile;
+  StringOptionValue _lrsLoadTraceFile;
   UnsignedOptionValue _sineDepth;
   UnsignedOptionValue _sineGeneralityThreshold;
   UnsignedOptionValue _sineToAgeGeneralityThreshold;

--- a/Shell/Options.hpp
+++ b/Shell/Options.hpp
@@ -2122,7 +2122,6 @@ public:
   int simulatedTimeLimit() const { return _simulatedTimeLimit.actualValue; }
   void setSimulatedTimeLimit(int newVal) { _simulatedTimeLimit.actualValue = newVal; }
   float lrsEstimateCorrectionCoef() const { return _lrsEstimateCorrectionCoef.actualValue; }
-  float lrsMaintenanceBudget() const { return _lrsMaintenanceBudget.actualValue; }
   const std::string& lrsSaveTraceFile() const { return _lrsSaveTraceFile.actualValue; }
   const std::string& lrsLoadTraceFile() const { return _lrsLoadTraceFile.actualValue; }
   TermOrdering termOrdering() const { return _termOrdering.actualValue; }
@@ -2670,7 +2669,6 @@ private:
   BoolOptionValue _useACeval;
   TimeLimitOptionValue _simulatedTimeLimit;
   FloatOptionValue _lrsEstimateCorrectionCoef;
-  FloatOptionValue _lrsMaintenanceBudget;
   StringOptionValue _lrsSaveTraceFile;
   StringOptionValue _lrsLoadTraceFile;
   UnsignedOptionValue _sineDepth;

--- a/checks/.gitignore
+++ b/checks/.gitignore
@@ -1,0 +1,6 @@
+# scratch files written by the sanity script
+vampire-stdout
+vampire-stderr
+lrs-trace
+lrs-recorded
+lrs-replayed

--- a/checks/.gitignore
+++ b/checks/.gitignore
@@ -1,6 +1,0 @@
-# scratch files written by the sanity script
-vampire-stdout
-vampire-stderr
-lrs-trace
-lrs-recorded
-lrs-replayed

--- a/checks/sanity
+++ b/checks/sanity
@@ -93,9 +93,17 @@ check_szs_status() {
 	fi
 }
 
-# strip the lines of a statistics block that legitimately differ between two runs
+# The SATURATION block of a -stat full report, without its two rule-off lines. These
+# counters -- activations, passive size, final active/passive, discarded non-redundant
+# clauses -- are precisely what LRS's limits move, so two runs agreeing on all of them
+# have taken the same path. Selecting the lines we care about is deliberate: an earlier
+# version of this check listed the lines to *exclude* instead, and combined with -p off
+# (which suppresses the statistics entirely) it compared two near-empty files and passed
+# no matter what.
 lrs_fingerprint() {
-	grep '^%' $1 | grep -vE 'Time elapsed|Instructions burned|Peak memory usage|Version|Termination reason|trace file exhausted'
+	awk '/^% SATURATION/ {b=1; next}
+	     b && /^% ---/  {if (++seps == 2) exit; next}
+	     b              {print}' $1
 }
 
 # LRS decides when to refresh its limits partly from the clock, so an LRS run is only
@@ -103,22 +111,57 @@ lrs_fingerprint() {
 # triggered it) and its estimate, -lltf replays them without consulting any clock.
 # Recording then replaying must reproduce the run exactly.
 #
-# Choose the problem and -al with care, or this checks nothing: the limits have to
-# actually change the search. On SWW620_2.p that starts at -al 6000 -- below it, -sa
-# lrs and -sa otter give identical statistics and so would any broken replay. The two
-# runs also use different -t, which is free but is not what makes the check bite: for
-# the time limit to reach LRS's estimates the run has to approach it, and a run that
-# does is too nondeterministic to belong here.
-# The caller passes no -t; this appends one, so it must come last to win.
+# Three runs, because both the activation limit and the time limit have to be chosen
+# with care or the check compares two runs that were never going to differ:
+#
+#  1. a 1-second run, purely to learn how fast this machine is on this problem. Hard-
+#     coding an activation limit would make the check machine-dependent: too high and
+#     the recording run runs out of time, too low and the limits never bind.
+#  2. record, bounded by -al at 90% of that count, so the bound is deterministic.
+#  3. replay the trace at the same -al but a different -t.
+#
+# The differing -t is what makes the check bite. At a fixed -al on SWW620_2.p, -t 2 and
+# -t 4 reach the same 6200 activations by visibly different routes (33 341 against
+# 52 416 passive clauses, 1.26 M against 1.16 M discarded), because LRS scales its
+# estimates by the fraction of the time limit consumed. So a replay that still consulted
+# the clock could not reproduce the recording run, and the diff would show it.
+#
+# Runs 2 and 3 both get a -t well clear of what they need, for opposite reasons. Run 3
+# must not be cut short, and run 2 must be certain to *reach* -al: the same 1-second
+# budget yields anywhere from 6 400 to 7 200 activations here, a spread wider than the
+# 10% margin, and a recording run stopped early leaves a short trace that run 3 would
+# replay off the end of.
+#
+# The caller passes only the problem; everything else is appended here, so the -t and
+# -stat given here win over anything the caller might set.
 check_lrs_replay() {
-	run_vampire -sa lrs -p off -lstf lrs-trace $@ -t 10
+	run_vampire -sa lrs -p off $@ -stat full -t 1
+	activations=`grep 'Activations started' checks/vampire-stdout | sed 's/.*| *//'`
+	if test -z "$activations"
+	then
+		echo "LRS replay check failed: calibration run reported no activations"
+		cat checks/vampire-stdout
+		exit 1
+	fi
+	al=`expr $activations \* 9 / 10`
+
+	run_vampire -sa lrs -p off -lstf lrs-trace $@ -al $al -stat full -t 2
 	lrs_fingerprint checks/vampire-stdout > checks/lrs-recorded
-	run_vampire -sa lrs -p off -lltf lrs-trace $@ -t 6
+	run_vampire -sa lrs -p off -lltf lrs-trace $@ -al $al -stat full -t 4
 	lrs_fingerprint checks/vampire-stdout > checks/lrs-replayed
+
+	# a missing statistics block would otherwise make the diff below trivially empty
+	if test `wc -l < checks/lrs-recorded` -lt 5
+	then
+		echo "LRS replay check failed: no SATURATION statistics to compare"
+		cat checks/lrs-recorded
+		exit 1
+	fi
 	diff=`diff checks/lrs-recorded checks/lrs-replayed`
 	if test -n "$diff"
 	then
 		echo "LRS replay check failed: replaying the trace did not reproduce the run"
+		echo "(recorded at -al $al -t 2, replayed at -al $al -t 4)"
 		echo "$diff"
 		exit 1
 	fi
@@ -360,4 +403,4 @@ check_szs_status Unsatisfiable -qa synthesis synthesis/ex2-inverse_of_ixopiy.smt
 check_szs_status Theorem hol/hol1.p
 
 # LRS limit updates are reproducible from a recorded trace, independently of timing
-check_lrs_replay -al 6000 Problems/SWW/SWW620_2.p
+check_lrs_replay Problems/SWW/SWW620_2.p

--- a/checks/sanity
+++ b/checks/sanity
@@ -93,6 +93,37 @@ check_szs_status() {
 	fi
 }
 
+# strip the lines of a statistics block that legitimately differ between two runs
+lrs_fingerprint() {
+	grep '^%' $1 | grep -vE 'Time elapsed|Instructions burned|Peak memory usage|Version|Termination reason|trace file exhausted'
+}
+
+# LRS decides when to refresh its limits partly from the clock, so an LRS run is only
+# reproducible through a recorded trace: -lstf writes each decision (the pops that
+# triggered it) and its estimate, -lltf replays them without consulting any clock.
+# Recording then replaying must reproduce the run exactly.
+#
+# Choose the problem and -al with care, or this checks nothing: the limits have to
+# actually change the search. On SWW620_2.p that starts at -al 6000 -- below it, -sa
+# lrs and -sa otter give identical statistics and so would any broken replay. The two
+# runs also use different -t, which is free but is not what makes the check bite: for
+# the time limit to reach LRS's estimates the run has to approach it, and a run that
+# does is too nondeterministic to belong here.
+# The caller passes no -t; this appends one, so it must come last to win.
+check_lrs_replay() {
+	run_vampire -sa lrs -p off -lstf lrs-trace $@ -t 10
+	lrs_fingerprint checks/vampire-stdout > checks/lrs-recorded
+	run_vampire -sa lrs -p off -lltf lrs-trace $@ -t 6
+	lrs_fingerprint checks/vampire-stdout > checks/lrs-replayed
+	diff=`diff checks/lrs-recorded checks/lrs-replayed`
+	if test -n "$diff"
+	then
+		echo "LRS replay check failed: replaying the trace did not reproduce the run"
+		echo "$diff"
+		exit 1
+	fi
+}
+
 # check SMT status
 check_smtcomp_status() {
 	status=$1
@@ -327,3 +358,6 @@ check_szs_status Unsatisfiable -qa synthesis synthesis/ex2-inverse_of_ixopiy.smt
 
 # Higher-order logic
 check_szs_status Theorem hol/hol1.p
+
+# LRS limit updates are reproducible from a recorded trace, independently of timing
+check_lrs_replay -al 6000 Problems/SWW/SWW620_2.p

--- a/checks/sanity
+++ b/checks/sanity
@@ -93,13 +93,10 @@ check_szs_status() {
 	fi
 }
 
-# The SATURATION block of a -stat full report, without its two rule-off lines. These
-# counters -- activations, passive size, final active/passive, discarded non-redundant
-# clauses -- are precisely what LRS's limits move, so two runs agreeing on all of them
-# have taken the same path. Selecting the lines we care about is deliberate: an earlier
-# version of this check listed the lines to *exclude* instead, and combined with -p off
-# (which suppresses the statistics entirely) it compared two near-empty files and passed
-# no matter what.
+# Pick the SATURATION block of a -stat full report, without its two rule-off lines.
+# These counters -- activations, passive size, final active/passive, discarded
+# non-redundant clauses -- are precisely what LRS's limits move, so two runs
+# agreeing on all of them have taken the same path.
 lrs_fingerprint() {
 	awk '/^% SATURATION/ {b=1; next}
 	     b && /^% ---/  {if (++seps == 2) exit; next}
@@ -114,28 +111,20 @@ lrs_fingerprint() {
 # Three runs, because both the activation limit and the time limit have to be chosen
 # with care or the check compares two runs that were never going to differ:
 #
-#  1. a 1-second run, purely to learn how fast this machine is on this problem. Hard-
+#  1. a 2-second run, purely to learn how fast this machine is on this problem. Hard-
 #     coding an activation limit would make the check machine-dependent: too high and
 #     the recording run runs out of time, too low and the limits never bind.
-#  2. record, bounded by -al at 90% of that count, so the bound is deterministic.
+#  2. record, bounded by -al at 80% of that count, so the bound is deterministic.
 #  3. replay the trace at the same -al but a different -t.
 #
-# The differing -t is what makes the check bite. At a fixed -al on SWW620_2.p, -t 2 and
-# -t 4 reach the same 6200 activations by visibly different routes (33 341 against
-# 52 416 passive clauses, 1.26 M against 1.16 M discarded), because LRS scales its
-# estimates by the fraction of the time limit consumed. So a replay that still consulted
-# the clock could not reproduce the recording run, and the diff would show it.
-#
-# Runs 2 and 3 both get a -t well clear of what they need, for opposite reasons. Run 3
-# must not be cut short, and run 2 must be certain to *reach* -al: the same 1-second
-# budget yields anywhere from 6 400 to 7 200 activations here, a spread wider than the
-# 10% margin, and a recording run stopped early leaves a short trace that run 3 would
-# replay off the end of.
+# Run 2 and 3 are meant to hit the -al. Run 2 still under -t 2 so the LRS gets active.
+# Run 3 shoud bahave the same as 2 (it's readind the trace), althouth the time limit
+# is lifted.
 #
 # The caller passes only the problem; everything else is appended here, so the -t and
 # -stat given here win over anything the caller might set.
 check_lrs_replay() {
-	run_vampire -sa lrs -p off $@ -stat full -t 1
+	run_vampire -sa lrs -p off $@ -stat full -t 2
 	activations=`grep 'Activations started' checks/vampire-stdout | sed 's/.*| *//'`
 	if test -z "$activations"
 	then
@@ -143,11 +132,11 @@ check_lrs_replay() {
 		cat checks/vampire-stdout
 		exit 1
 	fi
-	al=`expr $activations \* 9 / 10`
+	al=`expr $activations \* 4 / 5`
 
 	run_vampire -sa lrs -p off -lstf lrs-trace $@ -al $al -stat full -t 2
 	lrs_fingerprint checks/vampire-stdout > checks/lrs-recorded
-	run_vampire -sa lrs -p off -lltf lrs-trace $@ -al $al -stat full -t 4
+	run_vampire -sa lrs -p off -lltf lrs-trace $@ -al $al -stat full -t 60
 	lrs_fingerprint checks/vampire-stdout > checks/lrs-replayed
 
 	# a missing statistics block would otherwise make the diff below trivially empty

--- a/checks/sanity
+++ b/checks/sanity
@@ -8,14 +8,22 @@
 # where is Vampire? passed by CI
 vampire="`pwd`/$1 --traceback on"
 
+# scratch files (each run's stdout/stderr, the LRS traces) go to a temp directory
+# rather than into the source tree, and are removed however the script ends.
+# absolute, because the runs themselves happen with checks/ as the working directory
+scratch=`mktemp -d "${TMPDIR:-/tmp}/vampire-sanity.XXXXXX"` || exit 1
+trap 'rm -rf "$scratch"' EXIT
+trap 'rm -rf "$scratch"; exit 130' INT
+trap 'rm -rf "$scratch"; exit 143' TERM
+
 run_vampire() {
 	echo $vampire $@
-	(cd checks; $vampire $@ > vampire-stdout 2> vampire-stderr)
-	errors=`grep -E 'SIG|viola|error' checks/vampire-stderr`
+	(cd checks; $vampire $@ > "$scratch/vampire-stdout" 2> "$scratch/vampire-stderr")
+	errors=`grep -E 'SIG|viola|error' "$scratch/vampire-stderr"`
 	if test -n "$errors"
 	then
 		echo "run failed: contains errors"
-		cat checks/vampire-stderr
+		cat "$scratch/vampire-stderr"
 		exit 1
 	fi
 }
@@ -25,7 +33,7 @@ check_exact_output() {
 	expected=checks/$1
 	shift
 	run_vampire $@
-	diff=`diff $expected checks/vampire-stdout`
+	diff=`diff $expected "$scratch/vampire-stdout"`
 	if test -n "$diff"
 	then
 		echo "check against $expected failed: diff follows"
@@ -40,11 +48,11 @@ check_output_contains() {
 	expected="$1"
 	shift
 	run_vampire $@
-	found=`grep -F "$expected" checks/vampire-stdout`
+	found=`grep -F "$expected" "$scratch/vampire-stdout"`
 	if test -z "$found"
 	then
 		echo "check failed: output should contain: $expected"
-		cat checks/vampire-stdout
+		cat "$scratch/vampire-stdout"
 		exit 1
 	fi
 }
@@ -54,11 +62,11 @@ check_output_contains_once() {
 	expected="$1"
 	shift
 	run_vampire $@
-	count=`grep -cF "$expected" checks/vampire-stdout`
+	count=`grep -cF "$expected" "$scratch/vampire-stdout"`
 	if test "$count" != 1
 	then
 		echo "check failed: output should contain exactly once (found $count times): $expected"
-		cat checks/vampire-stdout
+		cat "$scratch/vampire-stdout"
 		exit 1
 	fi
 }
@@ -70,11 +78,11 @@ check_rejected() {
 	expected="$1"
 	shift
 	run_vampire $@
-	found=`grep -F "$expected" checks/vampire-stdout`
+	found=`grep -F "$expected" "$scratch/vampire-stdout"`
 	if test -z "$found"
 	then
 		echo "rejection check failed: expected a message containing: $expected"
-		cat checks/vampire-stdout checks/vampire-stderr
+		cat "$scratch/vampire-stdout" "$scratch/vampire-stderr"
 		exit 1
 	fi
 }
@@ -84,11 +92,11 @@ check_szs_status() {
 	status=$1
 	shift
 	run_vampire $@
-	szs=`grep -E "^% SZS status $status for .+$" checks/vampire-stdout`
+	szs=`grep -E "^% SZS status $status for .+$" "$scratch/vampire-stdout"`
 	if test -z "$szs"
 	then
 		echo "SZS check failed: should have been SZS $status"
-		cat checks/vampire-stdout checks/vampire-stderr
+		cat "$scratch/vampire-stdout" "$scratch/vampire-stderr"
 		exit 1
 	fi
 }
@@ -125,28 +133,28 @@ lrs_fingerprint() {
 # -stat given here win over anything the caller might set.
 check_lrs_replay() {
 	run_vampire -sa lrs -p off $@ -stat full -t 2
-	activations=`grep 'Activations started' checks/vampire-stdout | sed 's/.*| *//'`
+	activations=`grep 'Activations started' "$scratch/vampire-stdout" | sed 's/.*| *//'`
 	if test -z "$activations"
 	then
 		echo "LRS replay check failed: calibration run reported no activations"
-		cat checks/vampire-stdout
+		cat "$scratch/vampire-stdout"
 		exit 1
 	fi
 	al=`expr $activations \* 4 / 5`
 
-	run_vampire -sa lrs -p off -lstf lrs-trace $@ -al $al -stat full -t 2
-	lrs_fingerprint checks/vampire-stdout > checks/lrs-recorded
-	run_vampire -sa lrs -p off -lltf lrs-trace $@ -al $al -stat full -t 60
-	lrs_fingerprint checks/vampire-stdout > checks/lrs-replayed
+	run_vampire -sa lrs -p off -lstf "$scratch/lrs-trace" $@ -al $al -stat full -t 2
+	lrs_fingerprint "$scratch/vampire-stdout" > "$scratch/lrs-recorded"
+	run_vampire -sa lrs -p off -lltf "$scratch/lrs-trace" $@ -al $al -stat full -t 60
+	lrs_fingerprint "$scratch/vampire-stdout" > "$scratch/lrs-replayed"
 
 	# a missing statistics block would otherwise make the diff below trivially empty
-	if test `wc -l < checks/lrs-recorded` -lt 5
+	if test `wc -l < "$scratch/lrs-recorded"` -lt 5
 	then
 		echo "LRS replay check failed: no SATURATION statistics to compare"
-		cat checks/lrs-recorded
+		cat "$scratch/lrs-recorded"
 		exit 1
 	fi
-	diff=`diff checks/lrs-recorded checks/lrs-replayed`
+	diff=`diff "$scratch/lrs-recorded" "$scratch/lrs-replayed"`
 	if test -n "$diff"
 	then
 		echo "LRS replay check failed: replaying the trace did not reproduce the run"
@@ -161,11 +169,11 @@ check_smtcomp_status() {
 	status=$1
 	shift
 	run_vampire $@
-	result=`grep -E "^$status$" checks/vampire-stdout`
+	result=`grep -E "^$status$" "$scratch/vampire-stdout"`
 	if test -z "$result"
 	then
 		echo "$SMT check failed: should have been $status"
-		cat checks/vampire-stdout checks/vampire-stderr
+		cat "$scratch/vampire-stdout" "$scratch/vampire-stderr"
 		exit 1
 	fi
 }


### PR DESCRIPTION
Mainly:
- LRS was found to spend large fractions of Vampire's time budget on repeated updates of its estimate
In a nutshell, it would fire too often (looking like it was once per 50 activations, it was actually once per 50 pops from unprocessed) This PR proposes a solution where updates are not performed if they would happen too often. It tries to keep the time/instructions spent performing LRS updates under 5% of the overall budget.

Because the LRS estimate is essentially a linear scan of the passive set, it is memory intensive and often takes a lot of time (if not so many instructions). Therefore, the fix is more a win for the time-limited than for instruction limited runs. Also, the longer the runs, the larger the win. Here TPTP (v9.3.1 ALL) results for `-t 60`:

```
Sort by SAT
1114 ['problemsALLlocal_tstat11142_tstat-on_t60s.pkl']
1117 ['problemsALLlocal_tstat11156_tstat-on_t60s.pkl']

Sort by UNS
13343 ['problemsALLlocal_tstat11142_tstat-on_t60s.pkl']
13469 ['problemsALLlocal_tstat11156_tstat-on_t60s.pkl']

Total 1120 / 13509

Num only-by (UNS):
   problemsALLlocal_tstat11142_tstat-on_t60s.pkl 40
   problemsALLlocal_tstat11156_tstat-on_t60s.pkl 166

Greedy cover (UNS):
# problemsALLlocal_tstat11156_tstat-on_t60s.pkl contributes 13469 total 13469
# problemsALLlocal_tstat11142_tstat-on_t60s.pkl contributes 40 total 13343
Total 13509
```

In addition:
- no ugly goto in `SaturationAlgorithm::doUnprocessedLoop`
- options to save/load LRS traces for 100% reproducibility (if needed; off by default)
